### PR TITLE
fix(4d): §KERNEL_OPS_SCHED_VERSION — stale materialized kernel_ops never reached the tier2-after-tier1 fix

### DIFF
--- a/viewer/sw.js
+++ b/viewer/sw.js
@@ -8,7 +8,7 @@
 // Cache-first for heavy assets (.wasm, images). DB files skip SW (IndexedDB handles them).
 //
 // DEPLOY: bump CACHE_VERSION on every OCI upload. Old caches are purged on activate.
-const CACHE_VERSION = 'v980';   // bump on each deploy; per-change detail is the git commit message.
+const CACHE_VERSION = 'v981';   // bump on each deploy; per-change detail is the git commit message.
 const CACHE_PREFIX = 'bim-ootb-';
 const CACHE_NAME = CACHE_PREFIX + CACHE_VERSION;
 

--- a/viewer/tests/witness_kernel_ops_sched_version.js
+++ b/viewer/tests/witness_kernel_ops_sched_version.js
@@ -1,0 +1,188 @@
+#!/usr/bin/env node
+// witness_kernel_ops_sched_version.js — §KERNEL_OPS_SCHED_VERSION (2026-08-11).
+//
+// ISSUE this witness proves/disproves: a building whose kernel_ops ELEMENT_PLACE rows were
+// materialized under an OLDER schedule-generation algorithm (e.g. before §TIER2_AFTER_TIER1's
+// tier2Shift existed) gets those stale rows silently REUSED forever — _activateAsync only
+// regenerates when kernel_ops is completely EMPTY (viewer/time_machine.js, near "No cache — try
+// loading existing kernel_ops"). _GANTT_CACHE_VERSION already gates the separate IndexedDB 'gantt'
+// JSON cache but never this table, so a fixed algorithm never reaches an already-opened building.
+//
+// Reported live: HHS_Office_Federated kept showing MEP Rough-in starting BEFORE Architecture
+// finished — §TIER_SERIAL's own witness (witness_tier_serial_display.js) could not have caught this
+// because it calls _twoTierRemap directly in-memory, never through kernel_ops materialize-or-reuse.
+//
+//   W-KOS-1  _kernelOpsSchedStale flags ops with NO _genVersion field as stale — this is literally
+//            what every kernel_ops row written before this fix looks like (the field did not exist).
+//   W-KOS-2  _kernelOpsSchedStale flags ops with an OLDER numeric _genVersion as stale.
+//   W-KOS-3  _kernelOpsSchedStale does NOT flag ops stamped with the CURRENT _GANTT_CACHE_VERSION —
+//            a healthy building must not pay a regenerate cost on every single open.
+//   W-KOS-4  Real magnitude, EVERY shipped building (not just HHS): using the SAME real element
+//            build + computeSchedule + _twoTierRemap pipeline witness_tier_serial_display.js already
+//            proves correct, the RAW (pre-remap) generative schedule vs the DISPLAYED (remapped)
+//            schedule differ by _twoTierRemap's own reported tier2ShiftDays. A stale, pre-fix
+//            kernel_ops table (materialized with no _genVersion, at whatever timestamps the OLD
+//            code wrote — RAW-equivalent since no shift existed yet) reused as-is would show that
+//            many real days of Architecture/MEP overlap on the ACTUAL 3D reveal. shiftDays>0 on a
+//            building is exactly the size of the regression this fix closes for it.
+//
+// Command: BLD_DIR=~/bim-ootb/buildings node viewer/tests/witness_kernel_ops_sched_version.js
+// Read the § log lines, not exit code alone.
+'use strict';
+const fs = require('fs');
+const path = require('path');
+const vm = require('vm');
+const initSqlJs = require(path.join(__dirname, '..', '..', 'modeller', 'lib', 'sql-wasm.js'));
+
+let pass = 0, fail = 0;
+function assert(cond, msg) { if (cond) { pass++; console.log('  PASS ' + msg); } else { fail++; console.log('  FAIL ' + msg); } }
+function finish() {
+  console.log('\n§KERNEL_OPS_SCHED_VERSION_SUMMARY pass=' + pass + ' fail=' + fail);
+  process.exit(fail ? 1 : 0);
+}
+
+const ScheduleGate = require(path.join(__dirname, '..', 'schedule_gate.js'));
+const ScheduleAuthor = require(path.join(__dirname, '..', 'schedule_author.js'));
+const tmSrc = fs.readFileSync(path.join(__dirname, '..', 'time_machine.js'), 'utf8');
+
+function sliceFn(src, name) {
+  const idx = src.indexOf('function ' + name + '(');
+  if (idx < 0) throw new Error(name + ' not found');
+  let depth = 0, i = idx, seenOpen = false;
+  for (; i < src.length; i++) {
+    if (src[i] === '{') { depth++; seenOpen = true; }
+    else if (src[i] === '}') { depth--; if (seenOpen && depth === 0) return src.slice(idx, i + 1); }
+  }
+  throw new Error('unbalanced braces for ' + name);
+}
+
+// The version-check clause in _activateAsync must call this EXACT function name — assert wired,
+// not just present, so a future refactor that silently drops the call still fails this witness.
+if (tmSrc.indexOf('_kernelOpsSchedStale(_placeOps, _GANTT_CACHE_VERSION)') < 0) {
+  assert(false, 'W-KOS-0 _activateAsync calls _kernelOpsSchedStale(_placeOps, _GANTT_CACHE_VERSION)');
+  finish();
+}
+const genVersionLine = '_genVersion:_GANTT_CACHE_VERSION';
+if (tmSrc.indexOf(genVersionLine) < 0) {
+  assert(false, 'W-KOS-0b materialize path stamps _genVersion:_GANTT_CACHE_VERSION on every ELEMENT_PLACE op');
+  finish();
+}
+
+const tierOrderLine = "var _TIER1_ORDER = ['Substructure', 'Superstructure', 'Architecture'];";
+if (tmSrc.indexOf(tierOrderLine) < 0) { assert(false, 'W-KOS-0c _TIER1_ORDER constant found in time_machine.js'); finish(); }
+
+const sliced = [
+  tierOrderLine,
+  sliceFn(tmSrc, '_kernelOpsSchedStale'),
+  sliceFn(tmSrc, '_promoteRoofLoadPath'),
+  sliceFn(tmSrc, '_buildXrayElements'),
+  sliceFn(tmSrc, '_tier1Extents'),
+  sliceFn(tmSrc, '_tier1Serialize'),
+  sliceFn(tmSrc, '_tier1Protrusion'),
+  sliceFn(tmSrc, '_tierAuditRegate'),
+  sliceFn(tmSrc, '_twoTierRemap')
+].join('\n');
+
+// ── W-KOS-1/2/3: the predicate in isolation, no DB, no window ──
+const sandbox0 = { console: console };
+vm.createContext(sandbox0);
+vm.runInContext(sliceFn(tmSrc, '_kernelOpsSchedStale') + '\nthis.__stale = _kernelOpsSchedStale;', sandbox0);
+const stale = sandbox0.__stale;
+
+const CUR = 9;
+assert(stale([{ parameters: { cls: 'IfcSlab' } }], CUR) === true,
+  'W-KOS-1 ops with no _genVersion field (every pre-fix row) flagged stale');
+assert(stale([{ parameters: { cls: 'IfcSlab', _genVersion: 8 } }], CUR) === true,
+  'W-KOS-2 ops with OLDER _genVersion=8 (current=' + CUR + ') flagged stale');
+assert(stale([{ parameters: { cls: 'IfcSlab', _genVersion: CUR } }], CUR) === false,
+  'W-KOS-3 ops correctly stamped _genVersion=' + CUR + ' NOT flagged (no needless regenerate)');
+assert(stale([], CUR) === false, 'W-KOS-3b empty ops array NOT flagged (nothing to invalidate yet)');
+
+// ── W-KOS-4: real per-building magnitude, same pipeline witness_tier_serial_display.js proves ──
+const BLD_DIR = process.env.BLD_DIR || path.join(require('os').homedir(), 'bim-ootb', 'buildings');
+const DB_FILE = { LTU_AHouse: 'LTU_AHouse_meta.db' };
+const BUILDINGS = ['Terminal', 'Hospital', 'Duplex', 'HHS_Office_Federated', 'Clinic', 'LTU_AHouse', 'JKR'];
+
+function loadRatesTable() {
+  const txt = fs.readFileSync(path.join(__dirname, '..', 'rates.js'), 'utf8');
+  const start = txt.indexOf('var RATES = {');
+  const defIdx = txt.indexOf('var SEQUENCE_DEFAULT');
+  const end = txt.indexOf('};', defIdx) + 2;
+  return (new Function(txt.slice(start, end) + '\n return RATES;'))();
+}
+
+(async () => {
+  const SQL = await initSqlJs({ wasmBinary: fs.readFileSync(path.join(__dirname, '..', '..', 'modeller', 'lib', 'sql-wasm.wasm')) });
+  const rulesJson = JSON.parse(fs.readFileSync(path.join(__dirname, '..', 'rates', 'sequence_rules.json'), 'utf8'));
+  const SR = rulesJson.SEQUENCE_RULES, SD = rulesJson.SEQUENCE_DEFAULT, LR = rulesJson.LABOR_RATES;
+  const NO = rulesJson.NAME_OVERRIDES || [];
+  const RATES = loadRatesTable();
+  let anyRealOverlap = false;
+
+  for (const bld of BUILDINGS) {
+    const dbPath = path.join(BLD_DIR, DB_FILE[bld] || (bld + '_extracted.db'));
+    if (!fs.existsSync(dbPath)) { assert(false, 'W-KOS-4 fixture missing: ' + dbPath); continue; }
+    const db = new SQL.Database(fs.readFileSync(dbPath));
+
+    const sandbox = {
+      console: { log: () => {}, warn: () => {} }, performance: { now: () => Date.now() },
+      window: { SEQUENCE_RULES: SR, SEQUENCE_DEFAULT: SD, SEQUENCE_NAME_OVERRIDES: NO },
+      ScheduleGate: ScheduleGate, Math: Math, A: () => ({ db: db })
+    };
+    vm.createContext(sandbox);
+    vm.runInContext(sliced + '\nthis.__bxe = _buildXrayElements; this.__remap = _twoTierRemap;', sandbox);
+    const els = sandbox.__bxe();
+    if (!els || !els.length) { assert(false, 'W-KOS-4 ' + bld + ' element build produced nothing'); db.close(); continue; }
+
+    const nameOf = {};
+    const nr = db.exec("SELECT guid, ifc_class, COALESCE(element_name,'') FROM elements_meta");
+    if (nr.length) nr[0].values.forEach(v => { nameOf[v[0]] = v[2]; });
+    const frag = ScheduleAuthor._classFragmentation(db, RATES);
+    const lin = ScheduleAuthor._linearWeighting(db, RATES);
+    db.close();
+
+    const geoEls = els.filter(e => !(e.x0 === e.x1 && e.y0 === e.y1 && e.base_z === e.top_z));
+    geoEls.forEach(e => {
+      const cls = e.cls, name = nameOf[e.guid] || '';
+      const rule = ScheduleAuthor.matchNameOverride(cls, name, NO) || ScheduleAuthor.matchRule(cls, SR, SD);
+      if (!e.phase) e.phase = rule.phase;
+      e.resource = rule.resource || '_DEFAULT';
+      const realQty = (frag.fragmented[cls] && frag.area[e.guid] != null) ? frag.area[e.guid] : null;
+      const span = Math.max(e.x1 - e.x0, e.y1 - e.y0, e.top_z - e.base_z);
+      const avgLen = lin.avgLength[cls];
+      const lengthRatio = (realQty == null && span > 0 && avgLen > 0) ? span / avgLen : null;
+      e.installSecs = ScheduleAuthor._installSecs(cls, rule, LR, realQty, lengthRatio);
+    });
+    const maxCrews = {};
+    for (const rk in LR) if (LR[rk].max_crews) maxCrews[rk] = LR[rk].max_crews;
+
+    const quiet = console.log; console.log = () => {};
+    let sched;
+    try { sched = ScheduleGate.computeSchedule(geoEls, 0, 1, maxCrews); } finally { console.log = quiet; }
+
+    const items = geoEls.map(e => ({ guid: e.guid, s: sched[e.guid].start, e: sched[e.guid].end,
+      bz: e.base_z, tz: e.top_z, x0: e.x0, x1: e.x1, y0: e.y0, y1: e.y1, cls: e.cls, seq: e.seq, phase: e.phase }));
+    sandbox.console = { log: () => {}, warn: () => {} };
+    vm.runInContext('this.__items = null; this.__lastStats = null;', sandbox);
+    sandbox.__items = items;
+    vm.runInContext('this.__lastStats = this.__remap(this.__items);', sandbox);
+    const stats = sandbox.__lastStats;
+
+    // A materialize BEFORE this fix wrote raw computeSchedule() times straight into kernel_ops (no
+    // remap existed) — stamp those OLD-style rows (no _genVersion) and confirm the predicate flags
+    // them, tying the abstract predicate to this building's REAL data shape.
+    const oldStyleOps = [{ parameters: { cls: geoEls[0].cls, phase: geoEls[0].phase } }];
+    assert(stale(oldStyleOps, CUR) === true,
+      'W-KOS-4 ' + bld + ' OLD-style materialized op (no _genVersion) flagged stale — would regenerate');
+
+    const shiftDays = stats ? stats.tier2ShiftDays : 0;
+    console.log('§KERNEL_OPS_SCHED_VERSION_MAGNITUDE bld=' + bld +
+      ' tier2ShiftDaysIfStaleOpsWereReused=' + shiftDays.toFixed(1) +
+      ' (0=no real regression for this building, >0=days of Architecture/MEP overlap a stale' +
+      ' kernel_ops table would show on the actual 3D reveal until this fix regenerates it)');
+    if (shiftDays > 0) anyRealOverlap = true;
+  }
+
+  assert(anyRealOverlap, 'W-KOS-5 at least one shipped building has tier2ShiftDays>0 — proves this is a real, non-hypothetical regression, not just a theoretical predicate');
+  finish();
+})();

--- a/viewer/time_machine.js
+++ b/viewer/time_machine.js
@@ -4509,7 +4509,7 @@
       var s = _disp[el.guid] || { start: _schedEnd, end: _schedEnd + 60000 };   // §4D_NOGEO park at the DISPLAY end (§TIER_SERIAL), was baseMs (day 0)
       _gStmt.run([s.start, 'ELEMENT_PLACE',
          JSON.stringify({phase:el.phase, cls:el.cls, name:el.name, storey:el.storey,
-           resource:el.resource, _end_ts:s.end}),
+           resource:el.resource, _end_ts:s.end, _genVersion:_GANTT_CACHE_VERSION}),
          JSON.stringify([el.guid]), el.guid]);
       count++;
       if (s.end > _projEnd) _projEnd = s.end;
@@ -6915,6 +6915,15 @@
     return n;
   }
 
+  // §KERNEL_OPS_SCHED_VERSION (2026-08-11): pure predicate, no db/window — placeOps materialized
+  // under an OLDER schedule-generation algorithm (missing/mismatched _genVersion stamp) must never
+  // be silently reused. currentVersion is _GANTT_CACHE_VERSION, passed in rather than closed over so
+  // this stays independently testable (same idiom as _tier1Extents/_tier1Serialize below).
+  function _kernelOpsSchedStale(placeOps, currentVersion) {
+    return !!(placeOps && placeOps.length && placeOps[0].parameters &&
+      placeOps[0].parameters._genVersion !== currentVersion);
+  }
+
   // ── Activate / Deactivate ──
   function setToolbarHighlight(on) {
     var btn = document.getElementById('time-machine-btn');
@@ -7035,6 +7044,20 @@
         try { app.db.run("DELETE FROM kernel_ops WHERE op_type = 'ELEMENT_PLACE'"); } catch(e) {}
         _placeOps = [];
         console.log('§TIME_MACHINE cleared stale unweighted ops — will re-inject');
+      }
+      // §KERNEL_OPS_SCHED_VERSION (2026-08-11): a building opened before this session's fix to the
+      // schedule-generation algorithm (e.g. §TIER2_AFTER_TIER1) has kernel_ops ELEMENT_PLACE rows
+      // materialized from the OLD algorithm, cached inside this building's IndexedDB-cached DB blob.
+      // _GANTT_CACHE_VERSION already gates the separate 'gantt' JSON cache but never this table, so a
+      // fixed schedule algorithm silently never reached an already-opened building — reported live:
+      // HHS_Office_Federated still showing MEP Rough-in starting 20.8d before Architecture finished,
+      // §TIER_SERIAL's own witness (which reads the freshly-recomputed _disp, not kernel_ops) could
+      // not have caught it. Stamp+check closes the same gap _end_ts's check closes for schema shape.
+      if (_kernelOpsSchedStale(_placeOps, _GANTT_CACHE_VERSION)) {
+        try { app.db.run("DELETE FROM kernel_ops WHERE op_type = 'ELEMENT_PLACE'"); } catch(e) {}
+        console.log('§KERNEL_OPS_SCHED_VERSION stale genVersion=' + _placeOps[0].parameters._genVersion +
+          ' current=' + _GANTT_CACHE_VERSION + ' — cleared ' + _placeOps.length + ' ops, will re-inject');
+        _placeOps = [];
       }
       if (_placeOps.length) { _ops = _placeOps; _ganttDirty = true; }
       console.log('§TM_OPS_CHECK total=' + _ops.length + ' place=' + _placeOps.length);


### PR DESCRIPTION
## Summary
- A building opened before PR #1286 (§TIER2_AFTER_TIER1) has its `kernel_ops` ELEMENT_PLACE rows materialized from the OLD schedule algorithm, cached in its IndexedDB DB blob. `_activateAsync` only regenerates when the table is *empty*, so a fixed schedule algorithm silently never reaches an already-opened building — `_GANTT_CACHE_VERSION` already gated the separate `'gantt'` JSON cache, but never this table.
- Reported live: HHS_Office_Federated still showed MEP Rough-in starting before Architecture finished, weeks after #1286/#1287 shipped. Root-caused via witness, not visual — `_disp` (the Gantt-panel timeline) was correct, but `kernel_ops` (what `renderAtTime`/the MaxQ bake actually reveal-order from) carried the stale raw pre-shift schedule from an earlier session.
- Fix: stamp `_genVersion` on every materialized op; new pure `_kernelOpsSchedStale()` detects a version mismatch and forces re-materialize — same pattern as the existing `_end_ts` staleness check right above it.
- `sw.js` CACHE_VERSION v980→v981 (missed on #1288).

## Test plan
- [x] `viewer/tests/witness_kernel_ops_sched_version.js` (new) — 12/12 PASS. W-KOS-1/2/3 unit-test the predicate; W-KOS-4/5 measure the real per-building magnitude across all 7 shipped buildings using the same real-DB pipeline `witness_tier_serial_display.js` already proves correct: Terminal 184.7d, Hospital 564.8d, Duplex 7.5d, HHS_Office_Federated 52.7d, Clinic 196.1d, LTU_AHouse 936.0d, JKR 52.3d of Architecture/MEP overlap a stale table would show — every shipped building is exposed if opened before this fix.
- [x] `viewer/tests/witness_tier_serial_display.js` re-run against the patched file — still 57/57, no regression.
- [x] `node --check viewer/time_machine.js` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MS7ArCFpWXF1aGdSSPaPVV