### PR TITLE
fix(viewer): POV walk camera toppled/rolled on diagonal mouse-look (§CPE_WALK_ROLL_SNAP)

### DIFF
--- a/viewer/cpe_walk.js
+++ b/viewer/cpe_walk.js
@@ -225,6 +225,14 @@
   // ══════════════════ pointer-lock mouse-look + WASD — pattern copied from
   // navigate_controls.js:28-56 (canvas.requestPointerLock, mousemove yaw/pitch with clamp,
   // pointerlockchange flag), adapted to drive `_vfCam` instead of the main nav camera. ══════════
+  // §CPE_WALK_ROLL_SNAP fix (2026-08-11, prompts/CPE_POV_WALK_PATHING.md) — `_vfCam.rotation.order`
+  // is set to 'YXZ' once at mount (see start()), NOT the three.js default 'XYZ'. Under 'XYZ', pitch
+  // is composed around the WORLD X axis after yaw, so any diagonal mouse move (yaw!=0 AND pitch!=0
+  // at once — i.e. nearly all real mouse input) bakes real roll into the camera; under 'YXZ' (the
+  // convention three.js's own PointerLockControls uses for exactly this reason), pitch is applied
+  // around the camera's own local X axis BEFORE yaw sweeps it around world Y, so the camera can
+  // never roll for any yaw/pitch combination — matching OrbitControls' behavior (canvas mouse nav),
+  // which gets the same guarantee for free by parameterizing on clamped spherical phi/theta instead.
   function _onMouseMove(e) {
     if (!_active || !_pointerLocked) return;
     _yaw -= e.movementX * MOUSE_SENSITIVITY;
@@ -500,15 +508,27 @@
         (sp.scrubbed ? ') — spawning at the scrubbed path point (accelerator)' :
                        ') — start of the authorable stretch (self-sufficient default)'));
     }
-    _vfCam.rotation.reorder && _vfCam.rotation.reorder('XYZ');
-    _yaw = _vfCam.rotation.y; _pitch = _vfCam.rotation.x;
+    // §CPE_WALK_ROLL_SNAP fix — see _onMouseMove's header comment for why 'YXZ'. Re-derive yaw/pitch
+    // from the inherited forward vector rather than reading .rotation.x/.y directly: the incoming
+    // vfCam pose was positioned by cinema_path_editor.js's _walkSpawnPose/_applyVFPose via a raw
+    // camera.lookAt(target) (default up, never reordered) — when that lookAt's target sits close to
+    // straight up/down from the camera (a steep gaze), the lookAt itself can bake real roll into the
+    // resulting quaternion. Reading the forward vector and re-deriving yaw/pitch from it DROPS any
+    // such roll instead of misreading a slice of it as pitch.
+    _vfCam.rotation.order = 'YXZ';
+    var _fwd0 = new THREE.Vector3(0, 0, -1).applyQuaternion(_vfCam.quaternion);
+    _pitch = Math.asin(Math.max(-1, Math.min(1, _fwd0.y)));
+    _yaw = Math.atan2(-_fwd0.x, -_fwd0.z);
     if (_resumePose) {
       _yaw = _resumePose.yaw; _pitch = _resumePose.pitch;
-      _vfCam.rotation.set(_pitch, _yaw, 0);
       console.log('§CPE_WALK_SPAWN resume pos=(' + _resumePose.x.toFixed(2) + ',' + _resumePose.y.toFixed(2) +
         ',' + _resumePose.z.toFixed(2) + ') yaw=' + (_yaw * 180 / Math.PI).toFixed(1) +
         'deg pitch=' + (_pitch * 180 / Math.PI).toFixed(1) + 'deg — continuing where the last walk stopped');
     }
+    // Apply immediately, both branches — previously only the resume branch did this, leaving a fresh
+    // spawn showing whatever roll the inherited lookAt() pose had on screen until the FIRST mousemove
+    // silently snapped it away. That silent snap was the "topples upside-down" bug report.
+    _vfCam.rotation.set(_pitch, _yaw, 0);
     _keys = { w: false, a: false, s: false, d: false };
     _frame = 0; _snapCount = 0; _lastT = 0;
     // §CPE_WALK_GAMEPAD_NAV — a pad already connected BEFORE this mount (event fired while walk mode

--- a/viewer/sw.js
+++ b/viewer/sw.js
@@ -8,7 +8,7 @@
 // Cache-first for heavy assets (.wasm, images). DB files skip SW (IndexedDB handles them).
 //
 // DEPLOY: bump CACHE_VERSION on every OCI upload. Old caches are purged on activate.
-const CACHE_VERSION = 'v983';   // bump on each deploy; per-change detail is the git commit message.
+const CACHE_VERSION = 'v984';   // bump on each deploy; per-change detail is the git commit message.
 const CACHE_PREFIX = 'bim-ootb-';
 const CACHE_NAME = CACHE_PREFIX + CACHE_VERSION;
 

--- a/witness_cpe_walk_roll_snap.js
+++ b/witness_cpe_walk_roll_snap.js
@@ -1,0 +1,121 @@
+// WITNESS — §CPE_WALK_ROLL_SNAP fix (prompts/CPE_POV_WALK_PATHING.md, 2026-08-11).
+//
+// ISSUE EACH GATE PROVES OR DISPROVES:
+//   G-ORDER-YXZ      mounting walk mode sets _vfCam.rotation.order to 'YXZ' (three.js's own
+//                     PointerLockControls convention), not the default 'XYZ' — the structural root
+//                     cause of the bug (pitch composed around WORLD X after yaw under 'XYZ' bakes
+//                     roll into any diagonal look).
+//   G-SPAWN-LEVEL    immediately after mount, BEFORE any mousemove, the camera's right vector has
+//                     zero vertical component (no roll) — proves the fresh-spawn branch now applies
+//                     rotation.set(pitch,yaw,0) itself instead of leaving whatever roll the inherited
+//                     lookAt()-built pose had on screen until the first mousemove silently snapped it
+//                     away (that silent snap was the user's "topples upside-down" report).
+//   G-DIAGONAL-NO-ROLL for a spread of combined yaw+pitch poses (including near the +-90deg pitch
+//                     clamp), set via the real _setPoseForTest surface — which calls the SAME
+//                     `_vfCam.rotation.set(pitch, yaw, 0)` line _onMouseMove itself calls, so this
+//                     exercises the actual shared write path, not a reimplementation — the camera's
+//                     right vector stays level (y ~= 0). Direct regression test: under the old 'XYZ'
+//                     order, right.y = sin(pitch)*sin(yaw), nonzero whenever BOTH yaw and pitch are
+//                     nonzero, i.e. on nearly every real diagonal mouse move. A genuine OS pointer
+//                     lock cannot be forced from automation (§CPE_WALK_CHROME_POC precedent, this same
+//                     file's history: synthetic .click() gets NotAllowedError) so _onMouseMove's own
+//                     _pointerLocked gate can't be exercised end-to-end headless; this gate proves the
+//                     maths it depends on instead, at the same call site.
+const puppeteer = require('/home/red1/bim-compiler/node_modules/puppeteer');
+
+const PORT = process.env.PORT || 8534;
+const BLD = process.env.BLD || 'Duplex';
+const EPS = 1e-6;
+const sleep = ms => new Promise(r => setTimeout(r, ms));
+
+async function openEditor(browser) {
+  const page = await browser.newPage();
+  await page.setViewport({ width: 1200, height: 700 });
+  const logs = [];
+  page.on('console', m => logs.push(m.text()));
+  page.on('pageerror', e => logs.push('PAGEERROR ' + e.message));
+  await page.goto(`http://localhost:${PORT}/viewer/viewer.html?db=/buildings/${BLD}_extracted.db`,
+    { waitUntil: 'domcontentloaded', timeout: 60000 });
+  await page.waitForFunction(
+    () => window.APP && window.APP.cinemaPathEditor && window.CpeWalk && window.APP.startMaxQualityOrbit && window.APP._composer,
+    { timeout: 120000 });
+  await sleep(9000);
+  await page.waitForFunction(() => {
+    try { const r = window.APP.dbQuery('SELECT COUNT(*) FROM element_transforms'); return r && r[0][0] > 0; }
+    catch (e) { return false; }
+  }, { timeout: 60000, polling: 2000 });
+  await page.evaluate(() => { window.APP.startMaxQualityOrbit({ preview: false, fps: 1, editor: true }); });
+  await page.waitForSelector('#cpe-ok', { timeout: 300000 });
+  await sleep(800);
+  return { page, logs };
+}
+
+// Reads the live vfCam's right-vector Y component (the roll signature) directly from the page.
+async function rightY(page) {
+  return page.evaluate(() => {
+    const cam = window.APP.cinemaPathEditor.activePOVCamera();
+    if (!cam) return null;
+    const r = new THREE.Vector3(1, 0, 0).applyQuaternion(cam.quaternion);
+    return r.y;
+  });
+}
+
+async function main() {
+  const checks = [];
+  const P = (n, ok, d) => checks.push({ n, ok, d });
+  const browser = await puppeteer.launch({
+    headless: 'new',
+    protocolTimeout: 900000,
+    args: ['--use-gl=angle', '--use-angle=swiftshader', '--no-sandbox', '--enable-unsafe-swiftshader'],
+  });
+  const { page, logs } = await openEditor(browser);
+
+  // ══ mount walk mode (fresh spawn — no resume pose exists yet) ══
+  await page.evaluate(() => window.CpeWalk.toggle());
+  await sleep(150);
+
+  const order = await page.evaluate(() => {
+    const cam = window.APP.cinemaPathEditor.activePOVCamera();
+    return cam ? cam.rotation.order : null;
+  });
+  P('G-ORDER-YXZ mount sets _vfCam.rotation.order to YXZ, not the XYZ default', order === 'YXZ', `order=${order}`);
+
+  const spawnRightY = await rightY(page);
+  P('G-SPAWN-LEVEL fresh spawn is level (right.y ~= 0) before any mousemove — no lingering lookAt() roll',
+    spawnRightY !== null && Math.abs(spawnRightY) < EPS, `right.y=${spawnRightY}`);
+
+  // ══ G-DIAGONAL-NO-ROLL — drive combined yaw+pitch via the real _setPoseForTest surface ══
+  const combos = [
+    { yaw: 45 * Math.PI / 180, pitch: 30 * Math.PI / 180 },
+    { yaw: -60 * Math.PI / 180, pitch: 50 * Math.PI / 180 },
+    { yaw: 170 * Math.PI / 180, pitch: -40 * Math.PI / 180 },
+    { yaw: -170 * Math.PI / 180, pitch: 80 * Math.PI / 180 },   // near the +-90deg pitch clamp
+    { yaw: 10 * Math.PI / 180, pitch: -89 * Math.PI / 180 },
+  ];
+  let diagPass = true, diagDetail = [];
+  for (const c of combos) {
+    await page.evaluate((yaw, pitch) => {
+      window.CpeWalk._setPoseForTest({ x: 0, y: 1.6, z: 0 }, yaw, pitch);
+    }, c.yaw, c.pitch);
+    const ry = await rightY(page);
+    const ok = ry !== null && Math.abs(ry) < 1e-9;
+    if (!ok) diagPass = false;
+    diagDetail.push(`yaw=${(c.yaw * 180 / Math.PI).toFixed(0)} pitch=${(c.pitch * 180 / Math.PI).toFixed(0)} right.y=${ry}`);
+  }
+  P('G-DIAGONAL-NO-ROLL combined yaw+pitch poses stay level (right.y ~= 0) across 5 combos incl. near +-90deg',
+    diagPass, diagDetail.join(' | '));
+
+  console.log('\n' + '='.repeat(78));
+  let allPass = true;
+  for (const c of checks) {
+    console.log(`  ${c.ok ? 'PASS' : 'FAIL'}  ${c.n}`);
+    console.log(`          ${c.d}`);
+    if (!c.ok) allPass = false;
+  }
+  console.log('='.repeat(78));
+  console.log(allPass ? `\nWITNESS PASS (${checks.length}/${checks.length})` : `\nWITNESS FAIL`);
+  await browser.close();
+  process.exit(allPass ? 0 : 1);
+}
+
+main().catch(e => { console.error('INFRA-ERROR', e); process.exit(2); });


### PR DESCRIPTION
## Summary
- POV walk (Alt+C > shoes) used the default THREE.Euler 'XYZ' order for its mouse-look camera — under that order, pitch composes around the WORLD X axis after yaw, so any diagonal mouse move (both axes changing together, i.e. nearly all real mouse input) baked real roll into the camera. Switched to `'YXZ'` (three.js's own PointerLockControls convention), which never rolls for any yaw/pitch combo — same guarantee OrbitControls (canvas mouse/finger nav) already gives.
- Also fixed the fresh-spawn branch of `start()`: it read yaw/pitch straight off the inherited camera's Euler components without ever re-leveling it (only the resume branch did that) — any roll baked in by the editor's own `lookAt()`-based spawn pose sat on screen until the first mousemove silently snapped it away. Now derives yaw/pitch from the forward vector (roll-immune) and levels immediately in both branches.
- Full diagnosis: `prompts/CPE_POV_WALK_PATHING.md` §CPE_WALK_ROLL_SNAP.

## Test plan
- [x] New witness `witness_cpe_walk_roll_snap.js`, 3/3 PASS on the fix.
- [x] Confirmed the SAME witness FAILS 2/3 gates on pre-fix code (`git stash`) — right.y up to 0.66 on ordinary diagonal-look combos, proving this is a real regression catch, not a tautology.
- [x] Regression: `witness_cpe_walk_edit.js` 24/24 PASS, `witness_cpe_walk_ctrldrag_fix.js` 4/4 PASS, unaffected.
- [x] `sw.js` CACHE_VERSION bumped v983→v984.

🤖 Generated with [Claude Code](https://claude.com/claude-code)