### PR TITLE
instrument(photo): §SHADOW_FRONTIER_AT_CAPTURE — real castShadow check on frontier geometry

### DIFF
--- a/viewer/cinema_maxq.js
+++ b/viewer/cinema_maxq.js
@@ -1280,6 +1280,42 @@
         if (A._sunArcStep) A._sunArcStep(_tn);
         var ok = await _waitFoldDone(30000, 'cook of frame ' + i + '/' + nFrames);
         await _raf2('frame ' + i + ' capture');
+        // §SHADOW_FRONTIER_AT_CAPTURE (2026-08-12) — the real answer, checked at the real moment:
+        // does the actively-installing (frontier) geometry have castShadow=true right now, right
+        // before this exact frame gets saved? Only logs when there's something under construction
+        // to check (self-throttling). window.__tmFrontierGuidsNow is set by time_machine.js's own
+        // renderAtTime(), the same tick that just ran inside _raf2() above.
+        if (window.__tmFrontierGuidsNow && window.__tmFrontierGuidsNow.size > 0) {
+          var _fGuids = window.__tmFrontierGuidsNow;
+          var _fTrue = 0, _fFalse = 0, _fMatched = 0;
+          var _fBatchTrue = 0, _fBatchFalse = 0, _fBatchObjs = 0;
+          A.scene.traverse(function(o) {
+            if (o.isMesh && o.userData && o.userData.guid && _fGuids.has(o.userData.guid)) {
+              _fMatched++;
+              if (o.castShadow) _fTrue++; else _fFalse++;
+              return;
+            }
+            // Steel beams/columns (isSteel, time_machine.js) are the most likely frontier class
+            // to be batched/instanced, not individually meshed -- castShadow there is a BATCH-wide
+            // flag (shared by every slot in that object, frontier or not), so this reports the
+            // batch's own flag whenever ANY of its slots is currently a frontier guid, not a
+            // per-instance answer -- the finest-grained truth this rendering architecture allows.
+            if (o.isBatchedMesh && A._batchMeta && A._batchMeta[o.id]) {
+              var _bm = A._batchMeta[o.id];
+              for (var _bi = 0; _bi < _bm.length; _bi++) {
+                if (_fGuids.has(_bm[_bi].guid)) { _fBatchObjs++; if (o.castShadow) _fBatchTrue++; else _fBatchFalse++; return; }
+              }
+            } else if (o.isInstancedMesh && A._instanceMeta && A._instanceMeta[o.id]) {
+              var _im = A._instanceMeta[o.id];
+              for (var _ii = 0; _ii < _im.length; _ii++) {
+                if (_fGuids.has(_im[_ii].guid)) { _fBatchObjs++; if (o.castShadow) _fBatchTrue++; else _fBatchFalse++; return; }
+              }
+            }
+          });
+          console.log('§SHADOW_FRONTIER_AT_CAPTURE frame=' + i + ' frontierGuids=' + _fGuids.size +
+            ' singleMesh_matched=' + _fMatched + ' castShadowTrue=' + _fTrue + ' castShadowFalse=' + _fFalse +
+            ' batchObjsContainingFrontier=' + _fBatchObjs + ' batchCastShadowTrue=' + _fBatchTrue + ' batchCastShadowFalse=' + _fBatchFalse);
+        }
         _restoreRandom();
         // A timeout can now only mean a genuinely slow frame, since hidden time no longer counts
         // against the budget. Counted rather than merely warned: the total is what lets the run

--- a/viewer/sw.js
+++ b/viewer/sw.js
@@ -8,7 +8,7 @@
 // Cache-first for heavy assets (.wasm, images). DB files skip SW (IndexedDB handles them).
 //
 // DEPLOY: bump CACHE_VERSION on every OCI upload. Old caches are purged on activate.
-const CACHE_VERSION = 'v990';   // bump on each deploy; per-change detail is the git commit message.
+const CACHE_VERSION = 'v991';   // bump on each deploy; per-change detail is the git commit message.
 const CACHE_PREFIX = 'bim-ootb-';
 const CACHE_NAME = CACHE_PREFIX + CACHE_VERSION;
 

--- a/viewer/time_machine.js
+++ b/viewer/time_machine.js
@@ -1364,6 +1364,19 @@
     if (_incrOK) _incrStats.delta++; else _incrStats.full++;
     _lastShadowOn = _shadowNow;
 
+    // §SHADOW_FRONTIER_AT_CAPTURE (2026-08-12, real user report: "not casting shadows inside
+    // early construction"): existing §SHADOW_FRONTIER casters/receivers counters only increment
+    // when app._shadowOn (native Sunglass toggle) is true -- always false during a PHOTO_SHADOW/
+    // MaxQ bake, so that log reads 0/0 every bake regardless of whether the PHOTO_SHADOW system's
+    // OWN separate reassert (effects.js _reassertPhotoShadowCoverage) actually corrects it -- an
+    // unrelated internal counter, not proof either way. Built directly from `frontier` (already
+    // fully populated above, straight from the schedule ops) rather than captured during the
+    // scene traversal below -- an earlier version tried the traversal and came back empty every
+    // time: steel beams/columns (isSteel above) are exactly the elements most likely rendered via
+    // BatchedMesh/InstancedMesh, which never carry a single userData.guid the "single mesh" branch
+    // below can match against. Reading straight from `frontier` is correct regardless of which
+    // rendering path a given guid ends up on.
+    window.__tmFrontierGuidsNow = new Set(Object.keys(frontier));
     var _perfT0 = performance.now(), _perfObjs = 0, _perfSkipped = 0, _perfHideForProxy = 0;
     app.scene.traverse(function(obj) {
       _perfObjs++;


### PR DESCRIPTION
Details in commit message. Self-verified before shipping.