### PR TITLE
fix(4d): §MIDAIR_REPAIR — nothing appears before the first thing it touches (5,561 → 0)

### DIFF
--- a/viewer/schedule_gate.js
+++ b/viewer/schedule_gate.js
@@ -750,7 +750,10 @@
     return { zones: zones, edges: edges };
   }
 
-  var API = { computeSchedule: computeSchedule, collapsePhase: collapsePhase, elementsInPhase: elementsInPhase, auditFloating: auditFloating, deriveBandRanks: deriveBandRanks, deriveZones: deriveZones, CELL: CELL, BIG_ELEMENT_VOL: BIG_ELEMENT_VOL };
+  // EPS/GAP exported alongside CELL so a consumer of the same geometry (time_machine.js
+  // §MIDAIR_REPAIR) can test contact with THIS module's measured constants instead of re-typing
+  // them — a second copy is a second thing to drift.
+  var API = { computeSchedule: computeSchedule, collapsePhase: collapsePhase, elementsInPhase: elementsInPhase, auditFloating: auditFloating, deriveBandRanks: deriveBandRanks, deriveZones: deriveZones, CELL: CELL, EPS: EPS, GAP: GAP, BIG_ELEMENT_VOL: BIG_ELEMENT_VOL };
   global.ScheduleGate = API;
   if (typeof module !== 'undefined' && module.exports) module.exports = API;
 })(typeof window !== 'undefined' ? window : (typeof globalThis !== 'undefined' ? globalThis : this));

--- a/viewer/sw.js
+++ b/viewer/sw.js
@@ -8,7 +8,7 @@
 // Cache-first for heavy assets (.wasm, images). DB files skip SW (IndexedDB handles them).
 //
 // DEPLOY: bump CACHE_VERSION on every OCI upload. Old caches are purged on activate.
-const CACHE_VERSION = 'v991';   // bump on each deploy; per-change detail is the git commit message.
+const CACHE_VERSION = 'v992';   // bump on each deploy; per-change detail is the git commit message.
 const CACHE_PREFIX = 'bim-ootb-';
 const CACHE_NAME = CACHE_PREFIX + CACHE_VERSION;
 

--- a/viewer/tests/probe_midair_census.js
+++ b/viewer/tests/probe_midair_census.js
@@ -1,0 +1,188 @@
+#!/usr/bin/env node
+// probe_midair_census.js — the USER'S acceptance bar, measured directly (2026-08-12,
+// bim-compiler prompts/4D_SCHEDULE_PERFECTION.md "not a single item hanging in midair").
+//
+// ISSUE this probe exposes: auditFloating() counts an element as "floating" ONLY when a support
+// it KNOWS about finishes after it starts. Two populations it can never flag are exactly what a
+// viewer sees as hanging in midair:
+//   (a) MIDAIR   — real supporters exist in the model, but NONE of them is even visible yet at the
+//                  moment this element appears (auditFloating's structGrid pools exclude most
+//                  classes, and seq<=4 structure-pool members are never support-checked at all).
+//   (b) ORPHAN   — nothing in the whole model touches this element anywhere. No schedule change
+//                  can ever fix it; it hangs forever. A data/extraction fact, reported not gated.
+// Everything is measured against the DISPLAY timeline (the shipped two-tier remap) — the times the
+// movie actually plays — not the raw generative schedule.
+//
+// Command (from viewer/):  BLD_DIR=~/bim-ootb/buildings node tests/probe_midair_census.js
+// Read the log, not the exit code.
+'use strict';
+const fs = require('fs');
+const path = require('path');
+const vm = require('vm');
+const initSqlJs = require(path.join(__dirname, '..', '..', 'modeller', 'lib', 'sql-wasm.js'));
+const ScheduleGate = require(path.join(__dirname, '..', 'schedule_gate.js'));
+const ScheduleAuthor = require(path.join(__dirname, '..', 'schedule_author.js'));
+const tmSrc = fs.readFileSync(path.join(__dirname, '..', 'time_machine.js'), 'utf8');
+const gateSrc = fs.readFileSync(path.join(__dirname, '..', 'schedule_gate.js'), 'utf8');
+
+// constants EXTRACTED from the shipped module (never re-typed here — they must not drift)
+const CELL = ScheduleGate.CELL;
+const EPS = parseFloat(/var EPS\s*=\s*([0-9.]+)/.exec(gateSrc)[1]);
+const GAP = parseFloat(/var GAP\s*=\s*([0-9.]+)/.exec(gateSrc)[1]);
+
+function sliceFn(src, name) {
+  const idx = src.indexOf('function ' + name + '(');
+  if (idx < 0) throw new Error(name + ' not found');
+  let depth = 0, i = idx, seenOpen = false;
+  for (; i < src.length; i++) {
+    if (src[i] === '{') { depth++; seenOpen = true; }
+    else if (src[i] === '}') { depth--; if (seenOpen && depth === 0) return src.slice(idx, i + 1); }
+  }
+  throw new Error('unbalanced braces for ' + name);
+}
+const tierOrderLine = "var _TIER1_ORDER = ['Substructure', 'Superstructure', 'Architecture'];";
+const sliced = [tierOrderLine,
+  sliceFn(tmSrc, '_promoteRoofLoadPath'), sliceFn(tmSrc, '_buildXrayElements'),
+  sliceFn(tmSrc, '_tier1Extents'), sliceFn(tmSrc, '_tier1Serialize'),
+  sliceFn(tmSrc, '_tier1Protrusion'), sliceFn(tmSrc, '_tierAuditRegate'),
+  sliceFn(tmSrc, '_twoTierRemap')].join('\n');
+
+function loadRatesTable() {
+  const txt = fs.readFileSync(path.join(__dirname, '..', 'rates.js'), 'utf8');
+  const start = txt.indexOf('var RATES = {');
+  const defIdx = txt.indexOf('var SEQUENCE_DEFAULT');
+  return (new Function(txt.slice(start, txt.indexOf('};', defIdx) + 2) + '\n return RATES;'))();
+}
+
+const BLD_DIR = process.env.BLD_DIR || path.join(require('os').homedir(), 'bim-ootb', 'buildings');
+const DB_FILE = { LTU_AHouse: 'LTU_AHouse_meta.db' };
+const BUILDINGS = (process.env.ONLY || 'Terminal,Hospital,Duplex,HHS_Office_Federated,Clinic,LTU_AHouse,JKR').split(',');
+const D = 86400000;
+
+function cellsOf(e) {
+  const o = [];
+  for (let i = Math.floor(e.x0 / CELL); i <= Math.floor(e.x1 / CELL); i++)
+    for (let j = Math.floor(e.y0 / CELL); j <= Math.floor(e.y1 / CELL); j++) o.push(i + ',' + j);
+  return o;
+}
+const overlap = (a, b) => a.x0 <= b.x1 && a.x1 >= b.x0 && a.y0 <= b.y1 && a.y1 >= b.y0;
+
+(async () => {
+  const SQL = await initSqlJs({ wasmBinary: fs.readFileSync(path.join(__dirname, '..', '..', 'modeller', 'lib', 'sql-wasm.wasm')) });
+  const rulesJson = JSON.parse(fs.readFileSync(path.join(__dirname, '..', 'rates', 'sequence_rules.json'), 'utf8'));
+  const SR = rulesJson.SEQUENCE_RULES, SD = rulesJson.SEQUENCE_DEFAULT, LR = rulesJson.LABOR_RATES;
+  const NO = rulesJson.NAME_OVERRIDES || [];
+  const RATES = loadRatesTable();
+
+  for (const bld of BUILDINGS) {
+    const dbPath = path.join(BLD_DIR, DB_FILE[bld] || (bld + '_extracted.db'));
+    if (!fs.existsSync(dbPath)) { console.log('§MIDAIR ' + bld + ' fixture missing: ' + dbPath); continue; }
+    const db = new SQL.Database(fs.readFileSync(dbPath));
+    const sandbox = { console: { log: () => {}, warn: () => {} }, performance: { now: () => Date.now() },
+      window: { SEQUENCE_RULES: SR, SEQUENCE_DEFAULT: SD, SEQUENCE_NAME_OVERRIDES: NO },
+      ScheduleGate: ScheduleGate, Math: Math, A: () => ({ db: db }) };
+    vm.createContext(sandbox);
+    vm.runInContext(sliced + '\nthis.__bxe = _buildXrayElements; this.__remap = _twoTierRemap;', sandbox);
+    const els = sandbox.__bxe();
+    if (!els || !els.length) { console.log('§MIDAIR ' + bld + ' element build produced nothing'); db.close(); continue; }
+
+    const nameOf = {};
+    const nr = db.exec("SELECT guid, ifc_class, COALESCE(element_name,'') FROM elements_meta");
+    if (nr.length) nr[0].values.forEach(v => { nameOf[v[0]] = v[2]; });
+
+    const frag = ScheduleAuthor._classFragmentation(db, RATES);
+    const lin = ScheduleAuthor._linearWeighting(db, RATES);
+    const geoEls = els.filter(e => !(e.x0 === e.x1 && e.y0 === e.y1 && e.base_z === e.top_z));
+    geoEls.forEach(e => {
+      const rule = ScheduleAuthor.matchNameOverride(e.cls, nameOf[e.guid] || '', NO) || ScheduleAuthor.matchRule(e.cls, SR, SD);
+      if (!e.phase) e.phase = rule.phase;
+      e.resource = rule.resource || '_DEFAULT';
+      const realQty = (frag.fragmented[e.cls] && frag.area[e.guid] != null) ? frag.area[e.guid] : null;
+      const span = Math.max(e.x1 - e.x0, e.y1 - e.y0, e.top_z - e.base_z);
+      const avgLen = lin.avgLength[e.cls];
+      const lengthRatio = (realQty == null && span > 0 && avgLen > 0) ? span / avgLen : null;
+      e.installSecs = ScheduleAuthor._installSecs(e.cls, rule, LR, realQty, lengthRatio);
+    });
+    db.close();
+    const maxCrews = {};
+    for (const rk in LR) if (LR[rk].max_crews) maxCrews[rk] = LR[rk].max_crews;
+
+    const quiet = console.log; console.log = () => {};
+    let sched;
+    try { sched = ScheduleGate.computeSchedule(geoEls, 0, 1, maxCrews); } finally { console.log = quiet; }
+
+    // DISPLAY timeline — what the movie plays (shipped two-tier remap, sliced not reimplemented)
+    const items = geoEls.map(e => ({ guid: e.guid, s: sched[e.guid].start, e: sched[e.guid].end,
+      bz: e.base_z, tz: e.top_z, x0: e.x0, x1: e.x1, y0: e.y0, y1: e.y1, cls: e.cls, seq: e.seq, phase: e.phase }));
+    sandbox.console = { log: () => {}, warn: () => {} };
+    sandbox.__items = items;
+    vm.runInContext('this.__remap(this.__items);', sandbox);
+    const disp = {};
+    items.forEach(it => { disp[it.guid] = { start: it.s, end: it.e }; });
+
+    // ── spatial index over EVERY element (no class/pool filter — this is the physical world) ──
+    const grid = {};
+    geoEls.forEach(e => { cellsOf(e).forEach(c => (grid[c] = grid[c] || []).push(e)); });
+
+    let nMidair = 0, nOrphan = 0, nGrounded = 0, nOk = 0, nStrict = 0;
+    const midairBy = {}, orphanBy = {}, worst = [];
+    for (const T of geoEls) {
+      const cs = cellsOf(T);
+      let localMinBase = Infinity, earliestSupportStart = Infinity, earliestSupportEnd = Infinity, supporters = 0, hostLater = 0;
+      const seen = {};
+      for (const c of cs) {
+        const arr = grid[c]; if (!arr) continue;
+        for (const S of arr) {
+          if (S.guid === T.guid || seen[S.guid]) continue;
+          if (!overlap(S, T)) continue;
+          seen[S.guid] = 1;
+          if (S.base_z < localMinBase) localMinBase = S.base_z;
+          // physical contact, direction-blind (bearing below | carrier above | side-embedded host)
+          const bearing = S.base_z < T.base_z - EPS && S.top_z >= T.base_z - GAP;
+          const carrier = S.base_z >= T.top_z - GAP && S.top_z > T.top_z + EPS;
+          const sideHost = S.base_z <= T.base_z + EPS && S.top_z >= T.top_z - EPS;   // T embedded in S
+          if (!bearing && !carrier && !sideHost) continue;
+          supporters++;
+          const ds = disp[S.guid].start;
+          if (ds < earliestSupportStart) earliestSupportStart = ds;
+          const de = disp[S.guid].end;
+          if (de < earliestSupportEnd) earliestSupportEnd = de;
+        }
+      }
+      // grounded = nothing in my own XY footprint starts lower than I do (I AM the ground layer here)
+      const grounded = !(localMinBase < T.base_z - GAP);
+      const myStart = disp[T.guid].start;
+      if (supporters === 0) {
+        if (grounded) { nGrounded++; } else { nOrphan++; orphanBy[T.cls] = (orphanBy[T.cls] || 0) + 1; }
+        continue;
+      }
+      // stricter bar, measured alongside: nothing I touch is even FINISHED when I appear
+      if (!grounded && earliestSupportEnd > myStart + 1) nStrict++;
+      if (earliestSupportStart <= myStart + 1) { nOk++; continue; }
+      if (grounded) { nGrounded++; continue; }
+      nMidair++;
+      midairBy[T.cls] = (midairBy[T.cls] || 0) + 1;
+      worst.push({ guid: T.guid, cls: T.cls, seq: T.seq, phase: T.phase, name: nameOf[T.guid] || '',
+        bz: T.base_z, start: myStart / D, supFirst: earliestSupportStart / D, gapD: (earliestSupportStart - myStart) / D });
+      void hostLater;
+    }
+    worst.sort((a, b) => b.gapD - a.gapD);
+    const top = k => Object.keys(k).sort((a, b) => k[b] - k[a]).slice(0, 6).map(c => c + ':' + k[c]).join(' ');
+    console.log('§MIDAIR ' + bld + ' total=' + geoEls.length + ' midair=' + nMidair + ' orphan=' + nOrphan +
+      ' grounded=' + nGrounded + ' ok=' + nOk + ' strictBar_noFinishedContact=' + nStrict);
+    if (nMidair) console.log('  §MIDAIR_CLASSES ' + bld + ' ' + top(midairBy));
+    if (nOrphan) console.log('  §ORPHAN_CLASSES ' + bld + ' ' + top(orphanBy));
+    if (process.env.HIST) {   // where on the played timeline the hangings actually land
+      let dMin = Infinity, dMax = -Infinity;
+      geoEls.forEach(e => { const d = disp[e.guid]; if (d.start < dMin) dMin = d.start; if (d.end > dMax) dMax = d.end; });
+      const span = (dMax - dMin) / D;
+      const buckets = new Array(20).fill(0);
+      worst.forEach(w => { const pct = (w.start * D - dMin) / (dMax - dMin); buckets[Math.min(19, Math.floor(pct * 20))]++; });
+      console.log('  §MIDAIR_WHEN ' + bld + ' totalDays=' + span.toFixed(1) + ' by 5%-bucket: ' +
+        buckets.map((n, i) => n ? (i * 5) + '%(d' + (span * i / 20).toFixed(0) + ')=' + n : null).filter(Boolean).join(' '));
+    }
+    worst.slice(0, 8).forEach(w => console.log('  §MIDAIR_WORST ' + bld + ' ' + w.cls + ' seq=' + w.seq +
+      ' phase=' + w.phase + ' bz=' + w.bz.toFixed(2) + ' start=' + w.start.toFixed(1) + 'd firstSupport=' +
+      w.supFirst.toFixed(1) + 'd early=' + w.gapD.toFixed(1) + 'd "' + w.name.slice(0, 46) + '"'));
+  }
+})();

--- a/viewer/tests/probe_named_element_times.js
+++ b/viewer/tests/probe_named_element_times.js
@@ -1,0 +1,123 @@
+#!/usr/bin/env node
+// probe_named_element_times.js — pre/post §MIDAIR_REPAIR display times for elements whose name
+// matches a substring. Exists to answer a specific live report ("the glass roof comes on first",
+// "the stairs hang in midair") with the two numbers that settle it, instead of a whole-building
+// aggregate. Reuses the shipped functions by slicing, never reimplements them.
+//
+// Command (from viewer/):  BLD=Terminal NAMEQ="Basic Roof:Glass" BLD_DIR=~/bim-ootb/buildings \
+//                          node tests/probe_named_element_times.js
+'use strict';
+const fs = require('fs');
+const path = require('path');
+const vm = require('vm');
+const initSqlJs = require(path.join(__dirname, '..', '..', 'modeller', 'lib', 'sql-wasm.js'));
+const ScheduleGate = require(path.join(__dirname, '..', 'schedule_gate.js'));
+const ScheduleAuthor = require(path.join(__dirname, '..', 'schedule_author.js'));
+const tmSrc = fs.readFileSync(path.join(__dirname, '..', 'time_machine.js'), 'utf8');
+
+function sliceFn(src, name) {
+  const idx = src.indexOf('function ' + name + '(');
+  if (idx < 0) throw new Error(name + ' not found');
+  let depth = 0, i = idx, seenOpen = false;
+  for (; i < src.length; i++) {
+    if (src[i] === '{') { depth++; seenOpen = true; }
+    else if (src[i] === '}') { depth--; if (seenOpen && depth === 0) return src.slice(idx, i + 1); }
+  }
+  throw new Error('unbalanced braces for ' + name);
+}
+const sliced = ["var _TIER1_ORDER = ['Substructure', 'Superstructure', 'Architecture'];",
+  sliceFn(tmSrc, '_promoteRoofLoadPath'), sliceFn(tmSrc, '_buildXrayElements'),
+  sliceFn(tmSrc, '_tier1Extents'), sliceFn(tmSrc, '_tier1Serialize'),
+  sliceFn(tmSrc, '_tier1Protrusion'), sliceFn(tmSrc, '_tierAuditRegate'),
+  sliceFn(tmSrc, '_twoTierRemap'), sliceFn(tmSrc, '_midairRepair')].join('\n');
+
+function loadRatesTable() {
+  const txt = fs.readFileSync(path.join(__dirname, '..', 'rates.js'), 'utf8');
+  const start = txt.indexOf('var RATES = {');
+  const defIdx = txt.indexOf('var SEQUENCE_DEFAULT');
+  return (new Function(txt.slice(start, txt.indexOf('};', defIdx) + 2) + '\n return RATES;'))();
+}
+
+const BLD_DIR = process.env.BLD_DIR || path.join(require('os').homedir(), 'bim-ootb', 'buildings');
+const DB_FILE = { LTU_AHouse: 'LTU_AHouse_meta.db' };
+const bld = process.env.BLD || 'Terminal';
+const NAMEQ = (process.env.NAMEQ || 'Basic Roof:Glass').toLowerCase();
+const D = 86400000;
+
+(async () => {
+  const SQL = await initSqlJs({ wasmBinary: fs.readFileSync(path.join(__dirname, '..', '..', 'modeller', 'lib', 'sql-wasm.wasm')) });
+  const rulesJson = JSON.parse(fs.readFileSync(path.join(__dirname, '..', 'rates', 'sequence_rules.json'), 'utf8'));
+  const SR = rulesJson.SEQUENCE_RULES, SD = rulesJson.SEQUENCE_DEFAULT, LR = rulesJson.LABOR_RATES;
+  const NO = rulesJson.NAME_OVERRIDES || [];
+  const RATES = loadRatesTable();
+  const db = new SQL.Database(fs.readFileSync(path.join(BLD_DIR, DB_FILE[bld] || (bld + '_extracted.db'))));
+  const sandbox = { console: { log: () => {}, warn: () => {} }, performance: { now: () => Date.now() },
+    window: { SEQUENCE_RULES: SR, SEQUENCE_DEFAULT: SD, SEQUENCE_NAME_OVERRIDES: NO },
+    ScheduleGate: ScheduleGate, Math: Math, A: () => ({ db: db }) };
+  vm.createContext(sandbox);
+  vm.runInContext(sliced + '\nthis.__bxe = _buildXrayElements; this.__remap = _twoTierRemap; this.__repair = _midairRepair;', sandbox);
+  const els = sandbox.__bxe();
+  const nameOf = {};
+  const nr = db.exec("SELECT guid, ifc_class, COALESCE(element_name,'') FROM elements_meta");
+  if (nr.length) nr[0].values.forEach(v => { nameOf[v[0]] = v[2]; });
+  const frag = ScheduleAuthor._classFragmentation(db, RATES);
+  const lin = ScheduleAuthor._linearWeighting(db, RATES);
+  const geoEls = els.filter(e => !(e.x0 === e.x1 && e.y0 === e.y1 && e.base_z === e.top_z));
+  geoEls.forEach(e => {
+    const rule = ScheduleAuthor.matchNameOverride(e.cls, nameOf[e.guid] || '', NO) || ScheduleAuthor.matchRule(e.cls, SR, SD);
+    if (!e.phase) e.phase = rule.phase;
+    e.resource = rule.resource || '_DEFAULT';
+    const realQty = (frag.fragmented[e.cls] && frag.area[e.guid] != null) ? frag.area[e.guid] : null;
+    const span = Math.max(e.x1 - e.x0, e.y1 - e.y0, e.top_z - e.base_z);
+    const avgLen = lin.avgLength[e.cls];
+    const lengthRatio = (realQty == null && span > 0 && avgLen > 0) ? span / avgLen : null;
+    e.installSecs = ScheduleAuthor._installSecs(e.cls, rule, LR, realQty, lengthRatio);
+  });
+  db.close();
+  const maxCrews = {};
+  for (const rk in LR) if (LR[rk].max_crews) maxCrews[rk] = LR[rk].max_crews;
+  const quiet = console.log; console.log = () => {};
+  let sched;
+  try { sched = ScheduleGate.computeSchedule(geoEls, 0, 1, maxCrews); } finally { console.log = quiet; }
+  const items = geoEls.map(e => ({ guid: e.guid, s: sched[e.guid].start, e: sched[e.guid].end,
+    bz: e.base_z, tz: e.top_z, x0: e.x0, x1: e.x1, y0: e.y0, y1: e.y1, cls: e.cls, seq: e.seq, phase: e.phase }));
+  sandbox.__items = items;
+  vm.runInContext('this.__remap(this.__items);', sandbox);
+  const before = {};
+  items.forEach(it => { before[it.guid] = it.s; });
+  vm.runInContext('this.__repair(this.__items);', sandbox);
+  // why-diagnostics: the same contact/ground test §MIDAIR_REPAIR applies, printed per match
+  const CELL = ScheduleGate.CELL, EPS = ScheduleGate.EPS, GAP = ScheduleGate.GAP;
+  const cellsOf = e => { const o = [];
+    for (let a = Math.floor(e.x0 / CELL); a <= Math.floor(e.x1 / CELL); a++)
+      for (let b = Math.floor(e.y0 / CELL); b <= Math.floor(e.y1 / CELL); b++) o.push(a + ',' + b);
+    return o; };
+  const grid = {};
+  items.forEach((it, i) => cellsOf(it).forEach(c => (grid[c] = grid[c] || []).push(i)));
+  function diag(T, idx) {
+    let lowest = Infinity, contacts = 0, first = Infinity, firstCls = '-', seen = {};
+    for (const c of cellsOf(T)) { const arr = grid[c]; if (!arr) continue;
+      for (const j of arr) { if (j === idx || seen[j]) continue; const S = items[j];
+        if (!(S.x0 <= T.x1 && S.x1 >= T.x0 && S.y0 <= T.y1 && S.y1 >= T.y0)) continue;
+        seen[j] = 1;
+        if (S.bz < lowest) lowest = S.bz;
+        if ((S.bz < T.bz - EPS && S.tz >= T.bz - GAP) || (S.bz >= T.tz - GAP && S.tz > T.tz + EPS) ||
+            (S.bz <= T.bz + EPS && S.tz >= T.tz - EPS)) {
+          contacts++; if (S.s < first) { first = S.s; firstCls = S.cls + '@' + S.bz.toFixed(2); } } } }
+    return { grounded: !(lowest < T.bz - GAP), lowest: lowest, contacts: contacts,
+      first: first === Infinity ? null : first / D, firstCls: firstCls };
+  }
+  let n = 0;
+  items.forEach((it, idx) => {
+    if ((nameOf[it.guid] || '').toLowerCase().indexOf(NAMEQ) < 0) return;
+    n++;
+    const dg = diag(it, idx);
+    console.log('  §NAMED_WHY grounded=' + dg.grounded + ' lowestInFootprint=' +
+      (isFinite(dg.lowest) ? dg.lowest.toFixed(2) : 'none') + ' contacts=' + dg.contacts +
+      ' firstContactStart=' + (dg.first == null ? 'n/a' : dg.first.toFixed(1) + 'd') + ' via=' + dg.firstCls);
+    console.log('§NAMED ' + bld + ' ' + it.cls + ' seq=' + it.seq + ' phase=' + it.phase +
+      ' bz=' + it.bz.toFixed(2) + ' beforeRepair=' + (before[it.guid] / D).toFixed(1) + 'd afterRepair=' +
+      (it.s / D).toFixed(1) + 'd shift=' + ((it.s - before[it.guid]) / D).toFixed(1) + 'd "' + (nameOf[it.guid] || '').slice(0, 50) + '"');
+  });
+  console.log('§NAMED_TOTAL ' + bld + ' matched=' + n + ' for NAMEQ="' + NAMEQ + '"');
+})();

--- a/viewer/tests/witness_midair_zero.js
+++ b/viewer/tests/witness_midair_zero.js
@@ -1,0 +1,200 @@
+#!/usr/bin/env node
+// witness_midair_zero.js — §MIDAIR_REPAIR (2026-08-12, bim-compiler
+// prompts/4D_SCHEDULE_PERFECTION.md — the acceptance bar in the user's own words:
+// "all i want is not to see a single item hanging in midair that is all").
+//
+// ISSUE this witness proves/disproves: does any element APPEAR in the movie before the first
+// element it physically touches appears? ScheduleGate.auditFloating cannot answer that — its
+// support pools are seq<=4 + promoted slabs + walls, so an element whose only neighbours are
+// outside those pools (and every seq<=4 member, which no gate checks at all) is reported clean
+// while hanging in plain sight. This witness judges the DISPLAY timeline — the times kernel_ops
+// is written from, i.e. what the movie plays — with an INDEPENDENT census: it re-derives contact
+// and ground-layer geometry itself rather than calling the shipped repair's own helpers, so a
+// repair that is mis-wired, mis-scoped, or silently a no-op FAILS here instead of self-certifying.
+//
+//   W-MZ-1  Pre-repair census REPORTED per building (the gap this fix exists to close, measured
+//           2026-08-12: Terminal 161, Hospital 165, Duplex 19, HHS 156, Clinic 345, LTU 4605,
+//           JKR 110). Reported, not gated — it is the before-number, and it changes whenever any
+//           upstream gate changes.
+//   W-MZ-2  THE BAR: post-repair midair == 0 on every shipped building. Any non-zero = a real
+//           element a viewer will see hanging.
+//   W-MZ-3  Monotone: zero elements start EARLIER after the repair than before it (moving earlier
+//           is the one direction that can break support order — §TIER_SERIAL W-TS-3's property).
+//   W-MZ-4  Orphans (touch NOTHING anywhere in the model — no schedule can fix them) are counted
+//           and LOCKED at their measured baselines: a change is a real extraction/data change to
+//           examine, never absorbed silently.
+//   W-MZ-5  Wiring: _midairRepair is actually CALLED on the kernel_ops path in injectGantt. The
+//           §DOOR_WINDOW_HOST_WALL lesson — a gate wired at zero (or one of two) call sites is
+//           silently a no-op and measurably fixes nothing.
+//
+// Approximation caveat (same as witness_tier_serial_display.js): durations come from
+// ScheduleAuthor._installSecs with real class fragmentation + linear weighting — the same
+// single-source formula injectGantt's getInstallSecs uses. Real per-element numbers, node-side.
+//
+// Command: BLD_DIR=~/bim-ootb/buildings node tests/witness_midair_zero.js   (from viewer/)
+// Read the § log lines, not the exit code alone.
+'use strict';
+const fs = require('fs');
+const path = require('path');
+const vm = require('vm');
+const initSqlJs = require(path.join(__dirname, '..', '..', 'modeller', 'lib', 'sql-wasm.js'));
+const ScheduleGate = require(path.join(__dirname, '..', 'schedule_gate.js'));
+const ScheduleAuthor = require(path.join(__dirname, '..', 'schedule_author.js'));
+const tmSrc = fs.readFileSync(path.join(__dirname, '..', 'time_machine.js'), 'utf8');
+
+let pass = 0, fail = 0;
+function assert(cond, msg) { if (cond) { pass++; console.log('  PASS ' + msg); } else { fail++; console.log('  FAIL ' + msg); } }
+function finish() { console.log('\n§MIDAIR_ZERO_SUMMARY pass=' + pass + ' fail=' + fail); process.exit(fail ? 1 : 0); }
+
+function sliceFn(src, name) {
+  const idx = src.indexOf('function ' + name + '(');
+  if (idx < 0) throw new Error(name + ' not found');
+  let depth = 0, i = idx, seenOpen = false;
+  for (; i < src.length; i++) {
+    if (src[i] === '{') { depth++; seenOpen = true; }
+    else if (src[i] === '}') { depth--; if (seenOpen && depth === 0) return src.slice(idx, i + 1); }
+  }
+  throw new Error('unbalanced braces for ' + name);
+}
+const tierOrderLine = "var _TIER1_ORDER = ['Substructure', 'Superstructure', 'Architecture'];";
+const sliced = [tierOrderLine,
+  sliceFn(tmSrc, '_promoteRoofLoadPath'), sliceFn(tmSrc, '_buildXrayElements'),
+  sliceFn(tmSrc, '_tier1Extents'), sliceFn(tmSrc, '_tier1Serialize'),
+  sliceFn(tmSrc, '_tier1Protrusion'), sliceFn(tmSrc, '_tierAuditRegate'),
+  sliceFn(tmSrc, '_twoTierRemap'), sliceFn(tmSrc, '_midairRepair')].join('\n');
+
+// W-MZ-5 — the repair must be called on the kernel_ops path, not merely defined
+assert(/_twoTierRemap\(_twItems\);[\s\S]{0,600}_midairRepair\(_twItems\)/.test(tmSrc),
+  'W-MZ-5 _midairRepair called on the kernel_ops path, right after _twoTierRemap (a defined-but-uncalled repair is a silent no-op)');
+
+function loadRatesTable() {
+  const txt = fs.readFileSync(path.join(__dirname, '..', 'rates.js'), 'utf8');
+  const start = txt.indexOf('var RATES = {');
+  const defIdx = txt.indexOf('var SEQUENCE_DEFAULT');
+  return (new Function(txt.slice(start, txt.indexOf('};', defIdx) + 2) + '\n return RATES;'))();
+}
+
+const BLD_DIR = process.env.BLD_DIR || path.join(require('os').homedir(), 'bim-ootb', 'buildings');
+const DB_FILE = { LTU_AHouse: 'LTU_AHouse_meta.db' };
+const BUILDINGS = (process.env.ONLY || 'Terminal,Hospital,Duplex,HHS_Office_Federated,Clinic,LTU_AHouse,JKR').split(',');
+// Measured 2026-08-12 (probe_midair_census.js, pre-repair, DISPLAY timeline). Orphans are an
+// EXTRACTION fact — elements whose bbox touches nothing anywhere in the model — so they are locked,
+// not gated to zero: no scheduling change can ever move them.
+const ORPHAN_BASELINE = { Terminal: 7, Hospital: 35, Duplex: 1, HHS_Office_Federated: 36, Clinic: 27,
+  LTU_AHouse: 865, JKR: 1 };
+const CELL = ScheduleGate.CELL, EPS = ScheduleGate.EPS, GAP = ScheduleGate.GAP;
+const D = 86400000;
+
+// ── the INDEPENDENT judge (deliberately not the shipped repair's own helpers) ──
+function census(items) {
+  const grid = {};
+  const cellsOf = e => { const o = [];
+    for (let a = Math.floor(e.x0 / CELL); a <= Math.floor(e.x1 / CELL); a++)
+      for (let b = Math.floor(e.y0 / CELL); b <= Math.floor(e.y1 / CELL); b++) o.push(a + ',' + b);
+    return o; };
+  items.forEach((it, i) => cellsOf(it).forEach(c => (grid[c] = grid[c] || []).push(i)));
+  let midair = 0, orphan = 0, grounded = 0, ok = 0;
+  const worst = [];
+  items.forEach((T, i) => {
+    let lowest = Infinity, firstContact = Infinity, contacts = 0;
+    const seen = {};
+    for (const c of cellsOf(T)) {
+      const arr = grid[c]; if (!arr) continue;
+      for (const j of arr) {
+        if (j === i || seen[j]) continue;
+        const S = items[j];
+        if (!(S.x0 <= T.x1 && S.x1 >= T.x0 && S.y0 <= T.y1 && S.y1 >= T.y0)) continue;
+        seen[j] = 1;
+        if (S.bz < lowest) lowest = S.bz;
+        const bearing = S.bz < T.bz - EPS && S.tz >= T.bz - GAP;
+        const carrier = S.bz >= T.tz - GAP && S.tz > T.tz + EPS;
+        const embedded = S.bz <= T.bz + EPS && S.tz >= T.tz - EPS;
+        if (!bearing && !carrier && !embedded) continue;
+        contacts++;
+        if (S.s < firstContact) firstContact = S.s;
+      }
+    }
+    const isGround = !(lowest < T.bz - GAP);
+    if (!contacts) { if (isGround) grounded++; else orphan++; return; }
+    if (firstContact <= T.s + 1) { ok++; return; }
+    if (isGround) { grounded++; return; }
+    midair++;
+    worst.push({ cls: T.cls, seq: T.seq, phase: T.phase, bz: T.bz, start: T.s / D, sup: firstContact / D });
+  });
+  worst.sort((a, b) => (b.sup - b.start) - (a.sup - a.start));
+  return { midair, orphan, grounded, ok, worst };
+}
+
+(async () => {
+  const SQL = await initSqlJs({ wasmBinary: fs.readFileSync(path.join(__dirname, '..', '..', 'modeller', 'lib', 'sql-wasm.wasm')) });
+  const rulesJson = JSON.parse(fs.readFileSync(path.join(__dirname, '..', 'rates', 'sequence_rules.json'), 'utf8'));
+  const SR = rulesJson.SEQUENCE_RULES, SD = rulesJson.SEQUENCE_DEFAULT, LR = rulesJson.LABOR_RATES;
+  const NO = rulesJson.NAME_OVERRIDES || [];
+  const RATES = loadRatesTable();
+
+  for (const bld of BUILDINGS) {
+    const dbPath = path.join(BLD_DIR, DB_FILE[bld] || (bld + '_extracted.db'));
+    if (!fs.existsSync(dbPath)) { assert(false, 'W-MZ fixture missing: ' + dbPath); continue; }
+    const db = new SQL.Database(fs.readFileSync(dbPath));
+    const sandbox = { console: { log: () => {}, warn: () => {} }, performance: { now: () => Date.now() },
+      window: { SEQUENCE_RULES: SR, SEQUENCE_DEFAULT: SD, SEQUENCE_NAME_OVERRIDES: NO },
+      ScheduleGate: ScheduleGate, Math: Math, A: () => ({ db: db }) };
+    vm.createContext(sandbox);
+    vm.runInContext(sliced + '\nthis.__bxe = _buildXrayElements; this.__remap = _twoTierRemap; this.__repair = _midairRepair;', sandbox);
+    const els = sandbox.__bxe();
+    if (!els || !els.length) { assert(false, 'W-MZ ' + bld + ' element build produced nothing'); db.close(); continue; }
+
+    const nameOf = {};
+    const nr = db.exec("SELECT guid, ifc_class, COALESCE(element_name,'') FROM elements_meta");
+    if (nr.length) nr[0].values.forEach(v => { nameOf[v[0]] = v[2]; });
+    const frag = ScheduleAuthor._classFragmentation(db, RATES);
+    const lin = ScheduleAuthor._linearWeighting(db, RATES);
+    const geoEls = els.filter(e => !(e.x0 === e.x1 && e.y0 === e.y1 && e.base_z === e.top_z));
+    geoEls.forEach(e => {
+      const rule = ScheduleAuthor.matchNameOverride(e.cls, nameOf[e.guid] || '', NO) || ScheduleAuthor.matchRule(e.cls, SR, SD);
+      if (!e.phase) e.phase = rule.phase;
+      e.resource = rule.resource || '_DEFAULT';
+      const realQty = (frag.fragmented[e.cls] && frag.area[e.guid] != null) ? frag.area[e.guid] : null;
+      const span = Math.max(e.x1 - e.x0, e.y1 - e.y0, e.top_z - e.base_z);
+      const avgLen = lin.avgLength[e.cls];
+      const lengthRatio = (realQty == null && span > 0 && avgLen > 0) ? span / avgLen : null;
+      e.installSecs = ScheduleAuthor._installSecs(e.cls, rule, LR, realQty, lengthRatio);
+    });
+    db.close();
+    const maxCrews = {};
+    for (const rk in LR) if (LR[rk].max_crews) maxCrews[rk] = LR[rk].max_crews;
+
+    const quiet = console.log; console.log = () => {};
+    let sched;
+    try { sched = ScheduleGate.computeSchedule(geoEls, 0, 1, maxCrews); } finally { console.log = quiet; }
+
+    const items = geoEls.map(e => ({ guid: e.guid, s: sched[e.guid].start, e: sched[e.guid].end,
+      bz: e.base_z, tz: e.top_z, x0: e.x0, x1: e.x1, y0: e.y0, y1: e.y1, cls: e.cls, seq: e.seq, phase: e.phase }));
+    sandbox.__items = items;
+    vm.runInContext('this.__remap(this.__items);', sandbox);      // DISPLAY timeline, shipped remap
+
+    const before = census(items);
+    const preStart = items.map(it => it.s);
+    console.log('§MIDAIR_BEFORE ' + bld + ' midair=' + before.midair + ' orphan=' + before.orphan +
+      ' grounded=' + before.grounded + ' ok=' + before.ok + ' total=' + items.length);
+    before.worst.slice(0, 3).forEach(w => console.log('    worst ' + w.cls + ' seq=' + w.seq + ' bz=' + w.bz.toFixed(2) +
+      ' start=' + w.start.toFixed(1) + 'd firstSupport=' + w.sup.toFixed(1) + 'd'));
+
+    const repairLines = [];
+    sandbox.console = { log: (...a) => repairLines.push(a.join(' ')), warn: (...a) => repairLines.push(a.join(' ')) };
+    vm.runInContext('this.__repair(this.__items);', sandbox);
+    console.log((repairLines.find(l => l.indexOf('§MIDAIR_REPAIR') === 0) || '§MIDAIR_REPAIR <no log captured>') + '  [' + bld + ']');
+
+    const after = census(items);
+    assert(after.midair === 0, 'W-MZ-2 ' + bld + ' ZERO elements appear before the first thing they touch (got ' +
+      after.midair + (after.worst.length ? ', worst ' + after.worst[0].cls + ' start=' + after.worst[0].start.toFixed(1) +
+      'd firstSupport=' + after.worst[0].sup.toFixed(1) + 'd' : '') + ')');
+    let earlier = 0;
+    items.forEach((it, i) => { if (it.s < preStart[i] - 1) earlier++; });
+    assert(earlier === 0, 'W-MZ-3 ' + bld + ' repair moved nothing EARLIER (got ' + earlier + ')');
+    assert(after.orphan === ORPHAN_BASELINE[bld],
+      'W-MZ-4 ' + bld + ' orphans (touch nothing in the model) locked at ' + ORPHAN_BASELINE[bld] + ' (got ' + after.orphan +
+      ') — an extraction limit, reported never gated');
+  }
+  finish();
+})();

--- a/viewer/time_machine.js
+++ b/viewer/time_machine.js
@@ -4133,6 +4133,147 @@
       base: base, end: endAll, extents: ext2 };
   }
 
+  // ══ §MIDAIR_REPAIR (2026-08-12, bim-compiler prompts/4D_SCHEDULE_PERFECTION.md) ══════════════
+  // The acceptance bar, user's own words: "all i want is not to see a single item hanging in
+  // midair that is all" — and "no band aid fix, just generalised solution."
+  //
+  // WHY the existing proof trail could not deliver that. ScheduleGate.auditFloating counts an
+  // element as floating only when a support it KNOWS ABOUT finishes after that element starts, and
+  // the pools it knows about are narrow: structGrid = seq<=4 plus promoted slabs, wallGrid = walls.
+  // So two populations are invisible to it, and both are exactly what an eye sees as hanging:
+  //   (a) an element whose only real neighbours are outside those pools (a post on a curtain-wall
+  //       plate, a fitting on a proxy, a stair tread on a stringer) — auditFloating finds no
+  //       candidate at all, records `se=0`, and reports it clean;
+  //   (b) a seq<=4 structure-pool member — never support-checked in EITHER direction (the gates in
+  //       schedule_gate.js all run in placeNonst). MEASURED live report: HHS's stair flights are
+  //       authored as IfcSlab, so seq=4, so no gate ever ran — 2 of them appeared on day 1.5 with
+  //       their first real neighbour on day 8.5, and 2 more on day 9.6 against day 49.7. That is
+  //       the "stairs hanging in midair" the user watched, and it needed no temporary-works excuse.
+  // MEASURED, before this function existed (probe_midair_census.js, DISPLAY timeline, all 7 shipped
+  // buildings): Terminal 161, Hospital 165, Duplex 19, HHS 156, Clinic 345, LTU_AHouse 4605, JKR 110
+  // elements appear with NOTHING they touch yet visible — 5,561 total, while auditFloating reported
+  // its usual locked baselines. This is the gap between "the witnesses pass" and "the movie is right".
+  //
+  // THE RULE, stated once, class-blind and pool-blind: AN ELEMENT MAY NOT APPEAR BEFORE THE FIRST
+  // ELEMENT IT PHYSICALLY TOUCHES APPEARS. Contact is the union of the three relations the shipped
+  // gates already model, applied without any class or pool filter — bearing-below (I rest on S),
+  // carrier-above (I hang from S), embedded (S spans my whole height at my XY). Exempt: an element
+  // that IS the ground layer of its own footprint (nothing overlapping it starts lower) — it rests
+  // on unmodelled soil, the same exemption auditFloating's §SUPPORT_UNCHECKED 1c already carries.
+  //
+  // WHY IT IS SAFE, not another reshaping. It is the WEAKEST rule that closes the gap: FIRST (min)
+  // contact, not last (max) — so it fires only for an element whose EVERY neighbour is still
+  // invisible, and cannot re-time the 99% that already sit on something. It only ever moves an
+  // element LATER (monotonicity, the property §TIER_SERIAL W-TS-3 depends on, is preserved by
+  // construction). It terminates: every raise sets a start to some other element's CURRENT start,
+  // so the global maximum start never grows, and the sweep is capped besides.
+  // It runs on the DISPLAY timeline, after _twoTierRemap, because that is the last layer before
+  // kernel_ops — a repair in the generative layer would be undone by the Tier-2 shift moving a
+  // carrier out from under its consumer.
+  //
+  // TIER-1 SERIALIZATION LOSES TO SUPPORT ORDER, and that is the established doctrine here, not a
+  // new licence: §TIER_DAG_WINS already accepts backbone elements crossing a phase window when the
+  // support DAG forces it ("counted, never hidden"). t1Moved reports the same population for this
+  // rule. Physics beats phase tidiness — an element cannot exist before what holds it.
+  //
+  // ORPHANS ARE REPORTED, NEVER MOVED: an element that touches nothing anywhere in the model has no
+  // schedule that can fix it (it hangs at every instant, including the last frame). That is an
+  // extraction/authoring fact — measured 972 across the 7 buildings — and it is logged for exactly
+  // the same reason §SUPPORT_UNCHECKED is: so a data limit is never mistaken for a scheduling bug.
+  function _midairRepair(items) {
+    var stats = { moved: 0, sweeps: 0, orphans: 0, grounded: 0, residual: 0, strictResidual: 0, t1Moved: 0, maxShiftMs: 0, total: items ? items.length : 0, ms: 0 };
+    if (!items || !items.length) return stats;
+    var _t0 = (typeof performance !== 'undefined' && performance.now) ? performance.now() : Date.now();
+    var SG = (typeof ScheduleGate !== 'undefined') ? ScheduleGate : null;
+    if (!SG || !SG.CELL) { console.warn('§MIDAIR_REPAIR ScheduleGate not loaded — repair skipped'); return stats; }
+    var CELL = SG.CELL, EPS = SG.EPS, GAP = SG.GAP;   // the shipped constants, never re-typed here
+    var n = items.length, i, j, k, c, S, T, arr, cs;
+    var grid = {};
+    function cellsOf(e) {
+      var o = [], a, b;
+      for (a = Math.floor(e.x0 / CELL); a <= Math.floor(e.x1 / CELL); a++)
+        for (b = Math.floor(e.y0 / CELL); b <= Math.floor(e.y1 / CELL); b++) o.push(a + ',' + b);
+      return o;
+    }
+    for (i = 0; i < n; i++) { cs = cellsOf(items[i]); for (c = 0; c < cs.length; c++) (grid[cs[c]] || (grid[cs[c]] = [])).push(i); }
+    // contact graph + ground layer, built ONCE (geometry does not change as times shift)
+    var contacts = new Array(n), grounded = new Uint8Array(n), stamp = new Int32Array(n);
+    for (i = 0; i < n; i++) {
+      T = items[i]; cs = cellsOf(T);
+      var lowest = Infinity, list = null;
+      for (c = 0; c < cs.length; c++) {
+        arr = grid[cs[c]]; if (!arr) continue;
+        for (k = 0; k < arr.length; k++) {
+          j = arr[k]; if (j === i || stamp[j] === i + 1) continue;
+          S = items[j];
+          if (!(S.x0 <= T.x1 && S.x1 >= T.x0 && S.y0 <= T.y1 && S.y1 >= T.y0)) continue;
+          stamp[j] = i + 1;
+          if (S.bz < lowest) lowest = S.bz;
+          if ((S.bz < T.bz - EPS && S.tz >= T.bz - GAP) ||        // bearing below — I rest on S
+              (S.bz >= T.tz - GAP && S.tz > T.tz + EPS) ||        // carrier above — I hang from S
+              (S.bz <= T.bz + EPS && S.tz >= T.tz - EPS)) {       // embedded — S spans my height
+            (list || (list = [])).push(j);
+          }
+        }
+      }
+      grounded[i] = (lowest < T.bz - GAP) ? 0 : 1;                // 1 ⇒ I am my footprint's ground layer
+      contacts[i] = list;
+      if (grounded[i]) stats.grounded++; else if (!list) stats.orphans++;
+    }
+    var movedFlag = new Uint8Array(n), first, d, changed;
+    // ── THE STRICTER BAR, MEASURED AND DELIBERATELY NOT ENFORCED (2026-08-12) ──────────────────
+    // §SUPPORT_CHECK's doctrine is end-based ("nothing may start before its physical support
+    // FINISHES"), so a stricter version of this repair was built and measured: move every element
+    // to the first FINISH among the things it touches (frozen pre-repair ends, single pass — an
+    // end-based fixpoint provably diverges here, since contact is near-symmetric and each raise
+    // adds a duration rather than reusing an existing time).
+    // MEASURED RESULT, why it is NOT shipped: on Terminal it moved 700 elements by up to 103 days
+    // and STILL left 624 of them appearing before any contact finished (Duplex: 23 moved, 22 still
+    // violating) — because the contacts move too, so the bar recedes as you chase it. Reaching it
+    // for real means serializing neighbours against each other, i.e. exactly the global floor gate
+    // §4D_BAND_MONOTONIC's own header rules out ("would serialize the project and destroy the trade
+    // train"). It is also not the visual truth: renderAtTime shows an element from its START
+    // (frontier = orange glow, "being installed"), so a slab arriving over a glowing, half-built
+    // column is on screen resting on something, not hanging in midair.
+    // strictResidual below reports that population every run — a named, measured limit, never a
+    // silent one. Revisit only with a real user report that a half-built support reads as floating.
+    // ── THE REPAIR (fixpoint): nothing appears before the first thing it touches has APPEARED ──
+    while (stats.sweeps < 12) {
+      stats.sweeps++; changed = 0;
+      for (i = 0; i < n; i++) {
+        var list2 = contacts[i]; if (!list2 || grounded[i]) continue;
+        first = Infinity;
+        for (k = 0; k < list2.length; k++) { var s2 = items[list2[k]].s; if (s2 < first) first = s2; }
+        if (first > items[i].s + 1) {                              // 1ms tolerance, auditFloating's own
+          d = first - items[i].s;
+          items[i].s += d; items[i].e += d;
+          if (d > stats.maxShiftMs) stats.maxShiftMs = d;
+          if (!movedFlag[i]) { movedFlag[i] = 1; stats.moved++; if (_TIER1_ORDER.indexOf(items[i].phase) >= 0) stats.t1Moved++; }
+          changed++;
+        }
+      }
+      if (!changed) break;
+    }
+    for (i = 0; i < n; i++) {                                      // honest residual after the cap
+      var list3 = contacts[i]; if (!list3 || grounded[i]) continue;
+      first = Infinity;
+      for (k = 0; k < list3.length; k++) { var s3 = items[list3[k]].s; if (s3 < first) first = s3; }
+      if (first > items[i].s + 1) stats.residual++;
+      var firstE = Infinity;
+      for (k = 0; k < list3.length; k++) { var e3 = items[list3[k]].e; if (e3 < firstE) firstE = e3; }
+      if (firstE > items[i].s + 1) stats.strictResidual++;   // reported, not gated — see PASS 1 header
+    }
+    stats.ms = Math.round(((typeof performance !== 'undefined' && performance.now) ? performance.now() : Date.now()) - _t0);
+    console.log('§MIDAIR_REPAIR moved=' + stats.moved + ' sweeps=' + stats.sweeps +
+      ' residual=' + stats.residual + ' (0=no element appears before what it touches) strictResidual=' +
+      stats.strictResidual + ' (appear before any contact FINISHES — the stricter end-based bar, measured and deliberately not enforced, see header) t1Moved=' +
+      stats.t1Moved + ' (support order wins over backbone serialization, same doctrine as §TIER_DAG_WINS)' +
+      ' maxShiftDays=' + (stats.maxShiftMs / 86400000).toFixed(1) +
+      ' orphans=' + stats.orphans + ' (touch NOTHING in the model — extraction limit, unfixable by any schedule)' +
+      ' grounded=' + stats.grounded + ' total=' + stats.total + ' ms=' + stats.ms);
+    return stats;
+  }
+
   // §GANTT_LOCK_INTEGRITY (2026-08-07, bim-compiler prompts/4D_SCHEDULE_PERFECTION.md) — the
   // lock-back verification core. Pure READ: rebuilds geometry via _buildXrayElements() (works on
   // the §GANTT_CACHE_HIT path too) and audits the CURRENT op times — the post-edit truth, whatever
@@ -4508,6 +4649,9 @@
         cls: el.cls, seq: el.seq, phase: el.phase };
     });
     var _twStats = _twoTierRemap(_twItems);
+    // §MIDAIR_REPAIR (2026-08-12) — last stop before kernel_ops: nothing may appear before the
+    // first thing it touches appears. Class-blind, pool-blind, later-only. See its own header.
+    _midairRepair(_twItems);
     var _disp = {};
     _twItems.forEach(function (it) { _disp[it.guid] = { start: it.s, end: it.e }; });
     var _schedEnd = baseMs;
@@ -6850,7 +6994,8 @@
   // huts going first before the walls" AFTER a hard reset, because §GANTT_CACHE_HIT served a
   // gantt:v4 entry generated under the old ordering. A hard reset cannot clear it — the entry is in
   // IndexedDB, not the HTTP cache. This bump is that fix's second half.
-  var _GANTT_CACHE_VERSION = 10;   // §DOOR_WINDOW_HOST_WALL (2026-08-11): door/window now gated on its host wall's finish (schedule_gate.js openingGate) — MUST bump on every change to computeSchedule's gating, or a building already materialized under an older version keeps replaying it forever (§KERNEL_OPS_SCHED_VERSION exists specifically to catch this bump).
+  var _GANTT_CACHE_VERSION = 11;   // §MIDAIR_REPAIR (2026-08-12): display times now repaired so nothing appears before the first element it touches — MUST bump on every change to computeSchedule's gating OR the display remap, or a building already materialized under an older version keeps replaying it forever (§KERNEL_OPS_SCHED_VERSION exists specifically to catch this bump).
+                                   // v10 was §DOOR_WINDOW_HOST_WALL (2026-08-11): door/window gated on its host wall's finish (schedule_gate.js openingGate)
                                    // v9 was §TIER_SERIAL (2026-08-11): two-tier display remap (serial backbone + concurrent pool)
                                   // v7 was §4D_BAND_MONOTONIC (2026-08-02): PASS B cross-storey trade gate
   //                                 changes generated ordering for 35,484 non-structure elements.


### PR DESCRIPTION
## The bar
User, this session: *"all i want is not to see a single item hanging in midair that is all"* — and *"no band aid fix, just generalised solution."*

## Why six green PRs had not delivered it
`auditFloating` counts an element as floating **only when a support it already knows about finishes late**, and its pools are narrow (`structGrid` = seq<=4 + promoted slabs, `wallGrid` = walls). Two populations are invisible to it, and both are exactly what the eye reads as hanging:
- an element whose only real neighbours sit outside those pools;
- **every `seq<=4` structure-pool member** — all four gates in `schedule_gate.js` run in `placeNonst`, so structure is never support-checked in either direction.

Measured on the DISPLAY timeline (what `kernel_ops` is written from), before this change, with every shipped witness green:

| building | total | appear with nothing they touch on screen | orphans |
|---|---|---|---|
| Terminal | 48,428 | 161 | 7 |
| Hospital | 63,182 | 165 | 35 |
| Duplex | 1,119 | 19 | 1 |
| HHS_Office_Federated | 6,839 | 156 | 36 |
| Clinic | 16,071 | 345 | 27 |
| LTU_AHouse | 122,330 | 4,605 | 865 |
| JKR | 8,985 | 110 | 1 |
| **total** | **266,954** | **5,561** | **972** |

## The rule
**An element may not appear before the first element it physically touches appears.** Contact = the three relations the gates already model (bearing-below, carrier-above, embedded), with no class or pool filter. Exempt: the ground layer of its own footprint (unmodelled soil — `§SUPPORT_UNCHECKED` 1c's own exemption).

Safe by construction: FIRST (min) contact not last, so it cannot re-time the 99% already resting on something; later-only, so `§TIER_SERIAL` W-TS-3 monotonicity holds; terminating, since every raise assigns an existing start. Lives in `time_machine.js _midairRepair()` right after `_twoTierRemap` — the last layer before `kernel_ops`. Tier-1 serialization loses to support order for `t1Moved` elements, the doctrine `§TIER_DAG_WINS` already established.

## Result — `witness_midair_zero.js` 22/22, 7 buildings, 266,954 elements
`residual=0` everywhere, judged by an **independent** census (the witness re-derives contact geometry itself, so a mis-wired repair FAILs instead of self-certifying — the `§DOOR_WINDOW_HOST_WALL` lesson).

moved / sweeps / t1Moved / maxShiftDays / ms — Terminal 175/3/124/103.0d/464ms · Hospital 175/4/137/425.1d/813ms · Duplex 19/3/15/3.8d/23ms · HHS 166/6/100/47.9d/86ms · Clinic 540/3/459/177.4d/173ms · LTU_AHouse 5024/5/1314/1628.7d/1829ms · JKR 112/4/110/26.8d/145ms.

## Two live reports settled by measurement
- **HHS stairs "hanging in midair" — confirmed, root-caused, fixed.** 4 flights authored as `IfcSlab` (⇒ seq=4 ⇒ ungated): 2 appeared day 1.5 vs first neighbour day 8.5, 2 appeared day 9.6 vs day 49.7. Now 8.5d / 49.7d. No temporary-works excuse needed.
- **Terminal glass roof was NOT floating.** Each `Basic Roof:Glass` slab has an `IfcColumn` based at 14.77m under it whose op starts day 3.3–5.0.

## Stricter end-based bar — measured, deliberately not enforced
Moving to the first FINISH moved 700 Terminal elements by up to 103 days and **still** left 624 violating (Duplex: 23 moved, 22 still violating) — the contacts move too. Reaching it means serializing neighbours, i.e. the global floor gate `§4D_BAND_MONOTONIC` rules out. It is also not the visual truth: `renderAtTime` shows an element from its START (frontier glow). `strictResidual` reports that population every run instead.

## Regression sweep (every log read, not exit codes)
`witness_tier_serial_display` 57/0 (all LOCKED baselines intact, incl. Terminal dagWins=24007) · `door_window_host_wall` 10/0 · `kernel_ops_sched_version` 12/0 · `tm_geo_order_cycles` 5/0 · `og_guard_bearing_bound` 9/0 · `big_element_support_coverage` 36/0.

`_GANTT_CACHE_VERSION` 10→11 and `sw.js` `CACHE_VERSION` v991→v992 both bumped in this PR — the two cache landmines this lane has already been bitten by.

Spec: bim-compiler `prompts/4D_SCHEDULE_PERFECTION.md` §MIDAIR_REPAIR (2026-08-12)

🤖 Generated with [Claude Code](https://claude.com/claude-code)