### PR TITLE
perf(cinema): §CPE_REPLAN_LAZY — cache the invariant plan prefix, one compute per editor session

### DIFF
--- a/viewer/effects.js
+++ b/viewer/effects.js
@@ -4595,6 +4595,17 @@ async function setupEffects(A, renderer, scene, camera) {
   // curves". Three bands = six waypoints, but stored and edited as three (user: "in a way the 3
   // bands are actually 6 waypoints... but efficiently folded into 3").
   var _cpeBands = null;
+  // §CPE_REPLAN_LAZY (CINEMA_DELIGHT_BATCH.md:40-66 spec; CPE_4D_PERF_MEM_FINDINGS.md §3-R3 —
+  // Witness: witness_cpe_replan_lazy.js): the plan prefix (§CINEMA_SPACE candidate scan +
+  // §CINEMA_DIVE settle + §CINEMA_EXIT door scoring/route) depends only on the MODEL and the
+  // camera basis — §CPE_PREVIEW_DIVERGENCE pins the basis at editor open, so during an editing
+  // session the prefix recomputed byte-identically on every band drag (~550ms of the measured
+  // 600-1000ms §CPE_REPLAN_SLOW, 8 consecutive drags byte-identical on Terminal). Cache it keyed
+  // on (building, _metaGen, camPos, yaw0, pitch0); a key change or A.cinemaPrefixInvalidate()
+  // (the "re-derive entry" control) recomputes. The cached §CINEMA_DIVE/§CINEMA_EXIT lines are
+  // replayed VERBATIM on a hit — witness_cpe_preview_divergence.js parses them for equality, and
+  // equality is exactly what the cache guarantees.
+  var _cinemaPrefixCache = null;
   // §CPE_HOSE (spec: bim-compiler prompts/CINEMA_PATH_EDITOR.md §CPE_HOSE, user 2026-07-28: "what if
   // we make the whole path editable... just dragging a point where the whole path is like a long
   // rubber hose, reacting only by proximity to the point been dragged, and the rest just curves
@@ -5123,6 +5134,17 @@ async function setupEffects(A, renderer, scene, camera) {
     var yaw0 = Math.atan2(_dir0.z, _dir0.x);
     var pitch0 = Math.asin(Math.max(-1, Math.min(1, _dir0.y)));
 
+    // §CPE_REPLAN_LAZY — prefix cache key + hit test (see the module-scope comment at
+    // _cinemaPrefixCache). Everything from here to just past `outWp.push(exitOuter)` is the
+    // cacheable prefix; the restore branch is at the end of that span.
+    var _ppT0 = (typeof performance !== 'undefined') ? performance.now() : 0;
+    var _ppKey = (A.activeBuilding || '') + '|' + (A._metaGen || 0) + '|' +
+      [camPos0.x, camPos0.y, camPos0.z, yaw0, pitch0].map(function (v) { return v.toFixed(4); }).join(',');
+    var _ppHit = !!(_cinemaPrefixCache && _cinemaPrefixCache.key === _ppKey);
+    var _ppc = null;
+    if (_ppHit) _ppc = JSON.parse(_cinemaPrefixCache.json);
+    if (!_ppHit) {
+
     // ══ §CINEMA_SPACE — largest interior space, ALWAYS searched (2026-07-20 user ruling: "abandon
     // the 'next largest room' idea... It is disastrous for sure. Just back to original 'go to
     // largest space within 4 sec'. Let user play with it"). No floor-level weighting, no multi-
@@ -5274,7 +5296,7 @@ async function setupEffects(A, renderer, scene, camera) {
     var diveDist = Math.hypot(settle.x - camPos0.x, settle.y - camPos0.y, settle.z - camPos0.z);
     var CINEMA_TRAVEL_THRESHOLD_M = 3;
     var hadToTravel = diveDist > CINEMA_TRAVEL_THRESHOLD_M;
-    console.log('§CINEMA_DIVE src=' + diveSrc + ' space="' + diveName + '" areaM2=' + diveArea.toFixed(1) +
+    var _ppDiveLine = '§CINEMA_DIVE src=' + diveSrc + ' space="' + diveName + '" areaM2=' + diveArea.toFixed(1) +
       ' settle=(' + settle.x.toFixed(1) + ',' + settle.y.toFixed(1) + ',' + settle.z.toFixed(1) + ')' +
       ' floorY=' + (floorY === null ? 'n/a' : floorY.toFixed(2)) + ' eye=' + CINEMA_EYE_M +
       ' fanMin=' + fan.min.toFixed(1) + ' fanMax=' + fan.max.toFixed(1) + ' fanMean=' + fan.mean.toFixed(1) +
@@ -5283,7 +5305,8 @@ async function setupEffects(A, renderer, scene, camera) {
       ' fanMinGlazing=' + fan.minGlazing + ' nudgeCap=' + nudgeCap +
       ' enclosed=' + (enclosedFrac * 100).toFixed(0) + '%' +
       ' yaw0=' + (yaw0 * 180 / Math.PI).toFixed(1) + '° pitch0=' + (pitch0 * 180 / Math.PI).toFixed(1) + '°' +
-      ' diveDist=' + diveDist.toFixed(1) + 'm');
+      ' diveDist=' + diveDist.toFixed(1) + 'm';
+    console.log(_ppDiveLine);
 
     // ══ §CINEMA_EXIT — chosen at the 4-second mark by POSITION **and** FACING ══════════════════
     // WAS: one global `entrance = widest-ground-door` for the whole building — every film on a
@@ -5353,12 +5376,13 @@ async function setupEffects(A, renderer, scene, camera) {
       exitSrc = 'facade-fallback';
     }
     exitScored.sort(function(a, b) { return a.cost - b.cost; });
-    console.log('§CINEMA_EXIT chosen=' + chosenExit.guid + ' name="' + chosenExit.name + '" dist=' +
+    var _ppExitLine = '§CINEMA_EXIT chosen=' + chosenExit.guid + ' name="' + chosenExit.name + '" dist=' +
       chosenExit.dist.toFixed(1) + ' facingDot=' + chosenExit.facingDot.toFixed(3) +
       ' perimFactor=' + (chosenExit.perim || 1).toFixed(2) + ' cost=' +
       chosenExit.cost.toFixed(1) + ' src=' + exitSrc + ' candidates=' + exitScored.length +
       ' runnerUp=' + (exitScored[1] ? exitScored[1].guid + '@' + exitScored[1].cost.toFixed(1) : 'none') +
-      ' hadToTravel=' + hadToTravel + ' diveDist=' + diveDist.toFixed(1) + 'm mood=' + (hadToTravel ? 'rushed' : 'graceful'));
+      ' hadToTravel=' + hadToTravel + ' diveDist=' + diveDist.toFixed(1) + 'm mood=' + (hadToTravel ? 'rushed' : 'graceful');
+    console.log(_ppExitLine);
 
     // Route out: ride the building's OWN room/corridor graph when it has one (wall-legal, the same
     // RoomGraph the Fly tour uses); straight line otherwise — then a wall clip is the model's data
@@ -5397,6 +5421,31 @@ async function setupEffects(A, renderer, scene, camera) {
                       y: chosenExit.p.y + CINEMA_EYE_M,
                       z: chosenExit.p.z + odz * Math.max(8, envelope * 0.15) };
     outWp.push(exitOuter);
+    // §CPE_REPLAN_LAZY — store the freshly-computed prefix. JSON round-trip so every later replan
+    // gets fresh copies (the suffix mutates outWp; a shared reference would corrupt the cache).
+    _cinemaPrefixCache = { key: _ppKey,
+      prefixMs: ((typeof performance !== 'undefined') ? performance.now() : 0) - _ppT0,
+      json: JSON.stringify({ settle: settle, fan: fan, diveDist: diveDist, hadToTravel: hadToTravel,
+        chosenExit: chosenExit, exitSrc: exitSrc, exitScored: exitScored, outWp: outWp,
+        outRoute: outRoute, exitOuter: exitOuter, spaceCandsLen: spaceCands.length,
+        odx: odx, odz: odz,
+        diveLine: _ppDiveLine, exitLine: _ppExitLine }) };
+    console.log('§CPE_REPLAN_LAZY miss=1 prefixMs=' + _cinemaPrefixCache.prefixMs.toFixed(1) + ' key=' + _ppKey.slice(0, 40));
+    } else {
+      // §CPE_REPLAN_LAZY — cache hit: restore every prefix output the suffix consumes and replay
+      // the §CINEMA_DIVE/§CINEMA_EXIT lines VERBATIM (identical by construction — the cache key
+      // pins every input the prefix reads; witness_cpe_preview_divergence.js keeps parsing them).
+      var settle = _ppc.settle, fan = _ppc.fan, diveDist = _ppc.diveDist,
+          hadToTravel = _ppc.hadToTravel, chosenExit = _ppc.chosenExit, exitSrc = _ppc.exitSrc,
+          exitScored = _ppc.exitScored, outWp = _ppc.outWp, outRoute = _ppc.outRoute,
+          exitOuter = _ppc.exitOuter, spaceCands = new Array(_ppc.spaceCandsLen),
+          odx = _ppc.odx, odz = _ppc.odz;   // Beat 3/4 outward-push fallback — read by the suffix's
+          // gaze fallback and the §Beat-4 seam measurement; the ONE prefix output the first cut of
+          // this cache missed (found by witness G-RL-EQUIV at 0.098m divergence, fixed same day).
+      console.log(_ppc.diveLine);
+      console.log(_ppc.exitLine);
+      console.log('§CPE_REPLAN_LAZY hit=1 savedMs=' + _cinemaPrefixCache.prefixMs.toFixed(1) + ' key=' + _ppKey.slice(0, 40));
+    }
     // ══ §CINEMA_PATH_EDITOR (prompts/CINEMA_PATH_EDITOR.md §CINEMA_PATH_EDITOR_MODEL item 1):
     // AUTHORED waypoints replace the derived walk-out wholesale. Waypoints are the ONLY authored
     // data in this whole feature — position plus camera height, nothing else. The camera ANGLE is
@@ -7543,6 +7592,14 @@ async function setupEffects(A, renderer, scene, camera) {
       c.quaternion.copy(sq); c.updateMatrixWorld(true);
     }
   }
+
+  // §CPE_REPLAN_LAZY — the "re-derive entry" control (the spec's own ask: re-deriving the entry is
+  // a real thing the user may WANT — a different room to dive into, a different exit door — it just
+  // must not happen eight times by accident while dragging a stick).
+  A.cinemaPrefixInvalidate = function(reason) {
+    _cinemaPrefixCache = null;
+    console.log('§CPE_REPLAN_LAZY invalidated reason=' + (reason || 'manual'));
+  };
 
   A.cinemaPathPlan = function(durationSec, ov) {
     // `undefined` means "use whatever is stored/staged"; an explicit null means "derived, ignore any

--- a/viewer/sw.js
+++ b/viewer/sw.js
@@ -8,7 +8,7 @@
 // Cache-first for heavy assets (.wasm, images). DB files skip SW (IndexedDB handles them).
 //
 // DEPLOY: bump CACHE_VERSION on every OCI upload. Old caches are purged on activate.
-const CACHE_VERSION = 'v993';   // bump on each deploy; per-change detail is the git commit message.
+const CACHE_VERSION = 'v994';   // bump on each deploy; per-change detail is the git commit message.
 const CACHE_PREFIX = 'bim-ootb-';
 const CACHE_NAME = CACHE_PREFIX + CACHE_VERSION;
 

--- a/viewer/viewer.html
+++ b/viewer/viewer.html
@@ -822,7 +822,7 @@ html.bim-embedded, html.bim-embedded body { background: #0b0b0b; }
 <script src="qrcode.min.js?v=1" onerror="console.warn('§LOAD_FAIL qrcode.min.js — QR sharing disabled')"></script>
 <script src="config.js?v=4" onerror="console.warn('§LOAD_FAIL config.js')"></script>
 <script src="db_resolve.js?v=2" onerror="console.warn('§LOAD_FAIL db_resolve.js')"></script>
-<script src="effects.js?v=15" onerror="console.warn('§LOAD_FAIL effects.js')"></script>
+<script src="effects.js?v=16" onerror="console.warn('§LOAD_FAIL effects.js')"></script>
 <script src="effects_gi_poc.js?v=3" onerror="console.warn('§LOAD_FAIL effects_gi_poc.js')"></script>
 <script src="lib/mp4_mux.js?v=1" onerror="console.warn('§LOAD_FAIL mp4_mux.js — MaxQ falls back to webm')"></script>
 <script src="cinema_path_editor.js?v=14" onerror="console.warn('§LOAD_FAIL cinema_path_editor.js — Alt+C path editing disabled')"></script>

--- a/witness_cpe_replan_lazy.js
+++ b/witness_cpe_replan_lazy.js
@@ -1,0 +1,132 @@
+#!/usr/bin/env node
+// WITNESS — §CPE_REPLAN_LAZY (spec: bim-compiler prompts/CINEMA_DELIGHT_BATCH.md:40-66;
+// study: CPE_4D_PERF_MEM_FINDINGS.md §3-R3).
+//
+// ISSUE: _cinemaPathPlan recomputed its invariant prefix (§CINEMA_SPACE scan + §CINEMA_DIVE settle
+// + §CINEMA_EXIT scoring/route — ~550ms of the measured 600-1000ms §CPE_REPLAN_SLOW) BYTE-IDENTICALLY
+// on every band drag (8 consecutive drags identical, Terminal 48k), and Alt+C open ran the full plan
+// 3× (~560ms, §CINEMA_PLAN_MS 291+133+135). Fix: cache the prefix keyed on
+// (building, _metaGen, camPos, yaw0, pitch0) — pinned for the whole session by §CPE_PREVIEW_DIVERGENCE.
+//
+// GATES (spec's own bar: "Gate it on equivalence, not on speed"):
+//   G-RL-EQUIV   THE BLOCKING GATE (W-REPLAN-CACHE): for N band-edit variants, the CACHED plan's
+//                sampled poses equal the UNCACHED plan's (invalidate → recompute) within 1e-6 m.
+//   G-RL-LINES   §CINEMA_DIVE + §CINEMA_EXIT lines on a cache hit are byte-identical to the miss's
+//                (witness_cpe_preview_divergence.js parses them — the contract holds).
+//   G-RL-DEDUPE  the editor-open triple plan computes the prefix ONCE (1 miss, ≥1 hit) —
+//                §CPE_PANEL_PERF item 2 closed.
+//   G-RL-INVAL   A.cinemaPrefixInvalidate() forces the next plan to recompute (the re-derive
+//                control's engine half; the panel button is a flagged user decision, not shipped).
+//   G-RL-PERF    informational: prefixMs (miss) vs savedMs (hit) from §CPE_REPLAN_LAZY lines.
+const puppeteer = require('/home/red1/bim-compiler/node_modules/puppeteer');
+const PORT = process.env.PORT || 8518;
+const BLD = process.env.BLD || 'Duplex';
+const sleep = ms => new Promise(r => setTimeout(r, ms));
+
+(async () => {
+  const browser = await puppeteer.launch({
+    headless: 'new', protocolTimeout: 600000,
+    args: ['--no-sandbox', '--disable-dev-shm-usage', '--use-gl=angle', '--use-angle=swiftshader',
+      '--enable-unsafe-swiftshader']
+  });
+  const checks = [];
+  const P = (n, ok, d) => { checks.push({ n, ok, d }); console.log((ok ? 'PASS ' : 'FAIL ') + n + ' — ' + d); };
+  try {
+    const page = await browser.newPage();
+    await page.setViewport({ width: 1200, height: 700 });
+    const logs = [];
+    page.on('console', m => logs.push(m.text()));
+    page.on('pageerror', e => logs.push('PAGEERROR ' + e.message));
+    await page.goto(`http://localhost:${PORT}/viewer/viewer.html?db=/buildings/${BLD}_extracted.db`,
+      { waitUntil: 'domcontentloaded', timeout: 60000 });
+    await page.waitForFunction(
+      () => window.APP && window.APP.cinemaPathPlan && window.APP.cinemaPathEditor &&
+            window.APP.startMaxQualityOrbit && window.APP._composer, { timeout: 120000 });
+    await sleep(9000);
+    await page.waitForFunction(() => {
+      try { const r = window.APP.dbQuery('SELECT COUNT(*) FROM element_transforms'); return r && r[0][0] > 0; }
+      catch (e) { return false; }
+    }, { timeout: 60000, polling: 2000 });
+
+    // ── G-RL-DEDUPE: open the editor; the (up to 3×) open-time plans share one prefix ──
+    const mark0 = logs.length;
+    await page.evaluate(() => { window.APP.startMaxQualityOrbit({ preview: false, fps: 1, editor: true }); });
+    await page.waitForSelector('#cpe-ok', { timeout: 300000 });
+    await sleep(1000);
+    const openLog = logs.slice(mark0);
+    const misses0 = openLog.filter(l => /§CPE_REPLAN_LAZY miss=1/.test(l)).length;
+    const hits0 = openLog.filter(l => /§CPE_REPLAN_LAZY hit=1/.test(l)).length;
+    const plans0 = openLog.filter(l => /§CINEMA_PLAN_MS/.test(l)).length;
+    P('G-RL-DEDUPE', misses0 === 1 && (plans0 <= 1 || hits0 >= 1),
+      `editor open: plans=${plans0} prefixMiss=${misses0} prefixHit=${hits0} (want 1 miss; every further open-plan a hit)`);
+
+    // ── G-RL-EQUIV + G-RL-LINES: cached vs invalidated-recompute pose equivalence, N variants ──
+    // Drives the PLAN seam directly (the precedent every cinema witness uses). Each variant nudges
+    // the stored band centres — the exact state a drag mutates — then compares poseAt samples
+    // between a cache-hit plan and a forced-recompute plan of the SAME override.
+    const res = await page.evaluate(() => {
+      const A = window.APP;
+      const ed = A._getCinemaPathEdit ? A._getCinemaPathEdit() : null;
+      const base = ed || null;
+      const S = 60, out = [];
+      function samp(plan) {
+        const a = [];
+        for (let i = 0; i <= S; i++) {
+          const p = plan.poseAt(i / S);
+          a.push([p.x, p.y, p.z, p.tx, p.ty, p.tz]);
+        }
+        return a;
+      }
+      function maxd(a, b) {
+        let m = 0;
+        for (let i = 0; i < a.length; i++)
+          for (let j = 0; j < 6; j++) m = Math.max(m, Math.abs(a[i][j] - b[i][j]));
+        return m;
+      }
+      for (let v = 0; v < 4; v++) {
+        let ov = base ? JSON.parse(JSON.stringify(base)) : null;
+        if (ov && ov.bands && ov.bands.length) {
+          for (let bi = 0; bi < ov.bands.length; bi++) {
+            ov.bands[bi].c.x += (v + 1) * 0.7 * (bi % 2 ? 1 : -1);
+            ov.bands[bi].c.z += (v + 1) * 0.4;
+          }
+        }
+        const cached = A.cinemaPathPlan(30, ov);       // prefix cache warm from the open above
+        const cachedSamp = samp(cached);
+        A.cinemaPrefixInvalidate('witness');
+        const fresh = A.cinemaPathPlan(30, ov);        // full recompute, same override
+        const freshSamp = samp(fresh);
+        out.push({ v: v, maxDelta: maxd(cachedSamp, freshSamp), bands: ov && ov.bands ? ov.bands.length : 0 });
+      }
+      return out;
+    });
+    const worst = Math.max.apply(null, res.map(r => r.maxDelta));
+    P('G-RL-EQUIV', worst <= 1e-6,
+      `W-REPLAN-CACHE: ${res.length} band-edit variants, worst pose delta=${worst.toExponential(2)} (bar 1e-6) [${res.map(r => r.maxDelta.toExponential(1)).join(', ')}]`);
+
+    const diveLines = logs.filter(l => /§CINEMA_DIVE /.test(l));
+    const exitLines = logs.filter(l => /§CINEMA_EXIT chosen=/.test(l));
+    const diveUniq = new Set(diveLines).size, exitUniq = new Set(exitLines).size;
+    P('G-RL-LINES', diveLines.length >= 3 && diveUniq === 1 && exitUniq === 1,
+      `§CINEMA_DIVE lines=${diveLines.length} unique=${diveUniq}; §CINEMA_EXIT lines=${exitLines.length} unique=${exitUniq} (hits replay verbatim)`);
+
+    // ── G-RL-INVAL ──
+    const mark1 = logs.length;
+    await page.evaluate(() => { window.APP.cinemaPrefixInvalidate('witness-final'); window.APP.cinemaPathPlan(30, null); });
+    await sleep(300);
+    const tail = logs.slice(mark1);
+    P('G-RL-INVAL', tail.some(l => /§CPE_REPLAN_LAZY invalidated/.test(l)) && tail.some(l => /§CPE_REPLAN_LAZY miss=1/.test(l)),
+      'invalidate → next plan recomputes (miss logged)');
+
+    const missMs = (logs.map(l => l.match(/§CPE_REPLAN_LAZY miss=1 prefixMs=([\d.]+)/)).filter(Boolean)[0] || [])[1];
+    const hitMs = (logs.map(l => l.match(/§CPE_REPLAN_LAZY hit=1 savedMs=([\d.]+)/)).filter(Boolean)[0] || [])[1];
+    P('G-RL-PERF', true, `informational: prefixMs(miss)=${missMs} savedMs(hit)=${hitMs} on ${BLD} under swiftshader`);
+  } catch (e) {
+    P('G-INFRA', false, e.message);
+  } finally {
+    const pass = checks.filter(c => c.ok).length;
+    console.log(`\n§CPE_REPLAN_LAZY WITNESS ${pass}/${checks.length} PASS`);
+    await browser.close();
+    process.exit(pass === checks.length ? 0 : 1);
+  }
+})();


### PR DESCRIPTION
Implements the §CPE_REPLAN_LAZY spec (CINEMA_DELIGHT_BATCH.md:40-66, authored 2026-07-29 with the note *"it pays for every other item in this file. Do it first"*) per the CPE/4D perf study (bim-compiler `prompts/CPE_4D_PERF_MEM_FINDINGS.md` §3-R3).

**Before:** the plan prefix (§CINEMA_SPACE scan + §CINEMA_DIVE settle + §CINEMA_EXIT scoring/route) recomputed **byte-identically on every band drag** — ~550ms of the measured 600-1000ms §CPE_REPLAN_SLOW on Terminal — and Alt+C open ran the full plan 3× (~560ms, §CPE_PANEL_PERF item 2).

**After:** prefix cached per (building, `_metaGen`, camera-basis fingerprint) — pinned for the whole session by §CPE_PREVIEW_DIVERGENCE. §CINEMA_DIVE/§CINEMA_EXIT lines replay verbatim on hits (witness_cpe_preview_divergence.js keeps parsing them). `A.cinemaPrefixInvalidate(reason)` = the re-derive-entry engine; a panel button is deliberately NOT added (protect-#cpe-panel rule) — flagged as a user decision.

**Witness** `witness_cpe_replan_lazy.js` **5/5**: G-RL-EQUIV (the spec's blocking W-REPLAN-CACHE bar) worst pose delta **0.0** across 4 band-edit variants cached-vs-recomputed; 1 miss + 2 hits at editor open; dive/exit lines unique=1 across 11 plans; invalidate forces recompute. The first cut failed G-RL-EQUIV at 0.098m (suffix reads odx/odz — Beat-3/4 outward push); restored, delta 0.

sw v993→v994, effects.js buster v15→v16.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Jkm19ChnTdpjfuFPQFSEQu