### PR TITLE
perf(cinema): §MAXQ_STAGE_KEEP — photo staging survives the bake's frame loop; frontier check indexed

### DIFF
--- a/viewer/cinema_maxq.js
+++ b/viewer/cinema_maxq.js
@@ -139,7 +139,7 @@
     return _wpSched.ends[k - 1];
   }
 
-  function _workPacingReset() { _wpSched = null; _wpTried = false; }
+  function _workPacingReset() { _wpSched = null; _wpTried = false; _fcIdx = null; }
 
   // ══ §CPE_BUILDUP_TOPOUT (2026-08-02) — the ending beats dwell on the FINISHED building ═════════
   // User, on the 1761-frame Hospital bake: "the top roof solar panels never gets to be shown - it
@@ -411,6 +411,10 @@
                          // and the whole building oscillates color frame-to-frame.
   var IDB_NAME = 'bim_ootb_cinema_maxq', IDB_STORE = 'frames';
   var _active = false, _cancel = false;
+  // §MAXQ_STAGE_KEEP / R1: guid→object index for the §SHADOW_FRONTIER_AT_CAPTURE check — built
+  // lazily per _metaGen inside the bake loop, freed with _workPacingReset() so the Maps don't
+  // outlive the bake.
+  var _fcIdx = null;
   // §MAXQ_WAKELOCK (user 2026-07-19: left the machine, bake paused until they came back — the
   // screen slept and rAF throttled with it). Hold a screen wake lock for the duration of the
   // bake+stitch so an unattended machine keeps rendering; re-acquire on visibilitychange (the
@@ -1218,12 +1222,23 @@
         // the tail of the movie. Stop here and salvage whatever was captured before the loss,
         // same treatment as the IDB-connection-lost path below.
         if (A._webglContextLost) { _glLost = true; console.log('§MAXQ_GL_LOST i=' + i + ' salvaging ' + framesDone + ' already-captured frames'); break; }
-        if (A._stillRefineActive) A.stopStillRefine(true);
+        // §MAXQ_STAGE_KEEP (CPE_4D_PERF_MEM_FINDINGS.md §2c/R1, Witness: witness_maxq_stage_keep.js):
+        // keepStaging=true — the photo staging (ground/puddles/HDRI/fog/sky) is per-BAKE state; only
+        // the TAA/AO accumulation is per-frame. Tearing staging down here and rebuilding it in the
+        // startStillRefine below cost the whole teardown→restage cycle on every frame (the measured
+        // §BAKE_FAST_PATH_COST "~660ms/frame unaccounted"). Per-frame sun still moves: _sunArcStep
+        // below calls updateSky + shadowMap.needsUpdate itself. The end-of-bake stopStillRefine
+        // calls stay full-teardown, so the scene restore on exit is unchanged.
+        if (A._stillRefineActive) A.stopStillRefine(true, true);
         // §MAXQ_HIDDEN_PAUSE: park BEFORE the cook, not after. Waiting here means the frame is
         // begun with the tab already visible, so the fold has a real rAF loop to converge on.
         await _awaitVisible('frame ' + i + '/' + nFrames);
         await _raf2('frame ' + i + ' settle');
-        await _sleep(SETTLE_MS);
+        // §MAXQ_STAGE_KEEP: SETTLE_MS existed to keep the NEXT staging from capturing mid-restore
+        // sun-tint/exposure values as "original" (see its declaration). With staging kept alive
+        // there is no restore in flight — sleep only when staging is actually down (frame 0, or a
+        // teardown forced by an interaction mid-bake).
+        if (!A._photoStagingOn) await _sleep(SETTLE_MS);
         _freezeRandom();
         var _tn = nFrames > 1 ? i / (nFrames - 1) : 0;
         var pose = poseAt(_tn);  // tNorm hits 1.0 on the last frame so the pull-back completes
@@ -1289,28 +1304,50 @@
           var _fGuids = window.__tmFrontierGuidsNow;
           var _fTrue = 0, _fFalse = 0, _fMatched = 0;
           var _fBatchTrue = 0, _fBatchFalse = 0, _fBatchObjs = 0;
-          A.scene.traverse(function(o) {
-            if (o.isMesh && o.userData && o.userData.guid && _fGuids.has(o.userData.guid)) {
-              _fMatched++;
-              if (o.castShadow) _fTrue++; else _fFalse++;
-              return;
-            }
-            // Steel beams/columns (isSteel, time_machine.js) are the most likely frontier class
-            // to be batched/instanced, not individually meshed -- castShadow there is a BATCH-wide
-            // flag (shared by every slot in that object, frontier or not), so this reports the
-            // batch's own flag whenever ANY of its slots is currently a frontier guid, not a
-            // per-instance answer -- the finest-grained truth this rendering architecture allows.
-            if (o.isBatchedMesh && A._batchMeta && A._batchMeta[o.id]) {
-              var _bm = A._batchMeta[o.id];
-              for (var _bi = 0; _bi < _bm.length; _bi++) {
-                if (_fGuids.has(_bm[_bi].guid)) { _fBatchObjs++; if (o.castShadow) _fBatchTrue++; else _fBatchFalse++; return; }
+          // §MAXQ_STAGE_KEEP / R1 (CPE_4D_PERF_MEM_FINDINGS.md §2c): the answer this check gives is
+          // unchanged, but a full scene.traverse with a linear _batchMeta/_instanceMeta scan per
+          // batched object ran EVERY captured frame. Index guid→object ONCE per _metaGen (the same
+          // staleness key TM's own event index uses — streaming/re-stream bumps it, sprite churn
+          // does not), then answer each frame from the frontier set alone (O(frontier), not
+          // O(scene×slots)). Counting semantics preserved exactly: individual meshes tally per
+          // MESH; a batched/instanced object tallies ONCE if ANY of its slots is frontier — the
+          // same batch-wide-castShadow caveat as before (see the retained comment below).
+          // Steel beams/columns (isSteel, time_machine.js) are the most likely frontier class
+          // to be batched/instanced, not individually meshed -- castShadow there is a BATCH-wide
+          // flag (shared by every slot in that object, frontier or not), so this reports the
+          // batch's own flag whenever ANY of its slots is currently a frontier guid, not a
+          // per-instance answer -- the finest-grained truth this rendering architecture allows.
+          if (!_fcIdx || _fcIdx.gen !== A._metaGen) {
+            var _fcT0 = performance.now();
+            _fcIdx = { gen: A._metaGen, mesh: new Map(), group: new Map() };
+            A.scene.traverse(function(o) {
+              // Same branch precedence as the traverse this replaces: an isMesh with its own
+              // userData.guid answers as an individual mesh first (BatchedMesh/InstancedMesh
+              // included, matching the original's first-branch test); its slot guids still
+              // register below so the batch answer exists for OTHER frontier slots.
+              if (o.isMesh && o.userData && o.userData.guid) {
+                var _ml = _fcIdx.mesh.get(o.userData.guid);
+                if (_ml) _ml.push(o); else _fcIdx.mesh.set(o.userData.guid, [o]);
               }
-            } else if (o.isInstancedMesh && A._instanceMeta && A._instanceMeta[o.id]) {
-              var _im = A._instanceMeta[o.id];
-              for (var _ii = 0; _ii < _im.length; _ii++) {
-                if (_fGuids.has(_im[_ii].guid)) { _fBatchObjs++; if (o.castShadow) _fBatchTrue++; else _fBatchFalse++; return; }
+              if (o.isBatchedMesh && A._batchMeta && A._batchMeta[o.id]) {
+                var _bm = A._batchMeta[o.id];
+                for (var _bi = 0; _bi < _bm.length; _bi++)
+                  if (!_fcIdx.group.has(_bm[_bi].guid)) _fcIdx.group.set(_bm[_bi].guid, o);
+              } else if (o.isInstancedMesh && A._instanceMeta && A._instanceMeta[o.id]) {
+                var _im = A._instanceMeta[o.id];
+                for (var _ii = 0; _ii < _im.length; _ii++)
+                  if (!_fcIdx.group.has(_im[_ii].guid)) _fcIdx.group.set(_im[_ii].guid, o);
               }
-            }
+            });
+            console.log('§SHADOW_FRONTIER_IDX built gen=' + _fcIdx.gen + ' meshGuids=' + _fcIdx.mesh.size +
+              ' groupGuids=' + _fcIdx.group.size + ' ms=' + (performance.now() - _fcT0).toFixed(1));
+          }
+          var _fSeenGroups = new Set();
+          _fGuids.forEach(function(g) {
+            var _ml = _fcIdx.mesh.get(g);
+            if (_ml) { for (var _mi = 0; _mi < _ml.length; _mi++) { _fMatched++; if (_ml[_mi].castShadow) _fTrue++; else _fFalse++; } return; }
+            var _go = _fcIdx.group.get(g);
+            if (_go && !_fSeenGroups.has(_go)) { _fSeenGroups.add(_go); _fBatchObjs++; if (_go.castShadow) _fBatchTrue++; else _fBatchFalse++; }
           });
           console.log('§SHADOW_FRONTIER_AT_CAPTURE frame=' + i + ' frontierGuids=' + _fGuids.size +
             ' singleMesh_matched=' + _fMatched + ' castShadowTrue=' + _fTrue + ' castShadowFalse=' + _fFalse +

--- a/viewer/effects.js
+++ b/viewer/effects.js
@@ -4166,7 +4166,13 @@ async function setupEffects(A, renderer, scene, camera) {
   // triggered it, making the effect nearly impossible to actually see. Absorb that incidental
   // nudge with a short grace window; a real subsequent interaction still cancels normally.
   var STILL_REFINE_GRACE_MS = 500;
-  A.stopStillRefine = function(force) {
+  // `keepStaging` (§MAXQ_STAGE_KEEP — CPE_4D_PERF_MEM_FINDINGS.md §2c/R1, Witness:
+  // witness_maxq_stage_keep.js): the MaxQ bake loop stops/restarts the refine EVERY frame; passing
+  // keepStaging=true lets it keep _applyPhotoStaging's per-BAKE state (ground/puddles/HDRI/fog/sky)
+  // alive across frames instead of tearing it down and rebuilding it per frame. Per-FRAME lighting
+  // still updates via _sunArcStep (it calls updateSky + shadowMap.needsUpdate itself). Every
+  // non-bake caller omits the arg and keeps the full-teardown behavior unchanged.
+  A.stopStillRefine = function(force, keepStaging) {
     if (!A._stillRefineActive) {
       // §STAGE2_DISARM (review finding 6): during soft-park a real selection/UI interaction must
       // kill the whole cycle AND revert the kept-alive staging — otherwise the dusk mood silently
@@ -4179,7 +4185,7 @@ async function setupEffects(A, renderer, scene, camera) {
     }
     if (!force && _stillRefineStartMs && (performance.now() - _stillRefineStartMs) < STILL_REFINE_GRACE_MS) return;
     _autoStageArm(false);  // explicit/selection-driven stop cancels the auto re-arm too
-    _teardownStillRefine('cancelled (interaction)');
+    _teardownStillRefine('cancelled (interaction)', keepStaging);
   };
   // §STAGE1_STAGE2 (2026-07-16, sandbox spike — feat/ssgi-composer-poc — NOT the shipped Alt+S
   // path, an experimental auto-staging layer on top of it): "Stage 1" = mood persists through

--- a/viewer/sw.js
+++ b/viewer/sw.js
@@ -8,7 +8,7 @@
 // Cache-first for heavy assets (.wasm, images). DB files skip SW (IndexedDB handles them).
 //
 // DEPLOY: bump CACHE_VERSION on every OCI upload. Old caches are purged on activate.
-const CACHE_VERSION = 'v995';   // bump on each deploy; per-change detail is the git commit message.
+const CACHE_VERSION = 'v996';   // bump on each deploy; per-change detail is the git commit message.
 const CACHE_PREFIX = 'bim-ootb-';
 const CACHE_NAME = CACHE_PREFIX + CACHE_VERSION;
 

--- a/viewer/viewer.html
+++ b/viewer/viewer.html
@@ -822,13 +822,13 @@ html.bim-embedded, html.bim-embedded body { background: #0b0b0b; }
 <script src="qrcode.min.js?v=1" onerror="console.warn('§LOAD_FAIL qrcode.min.js — QR sharing disabled')"></script>
 <script src="config.js?v=4" onerror="console.warn('§LOAD_FAIL config.js')"></script>
 <script src="db_resolve.js?v=2" onerror="console.warn('§LOAD_FAIL db_resolve.js')"></script>
-<script src="effects.js?v=16" onerror="console.warn('§LOAD_FAIL effects.js')"></script>
+<script src="effects.js?v=17" onerror="console.warn('§LOAD_FAIL effects.js')"></script>
 <script src="effects_gi_poc.js?v=3" onerror="console.warn('§LOAD_FAIL effects_gi_poc.js')"></script>
 <script src="lib/mp4_mux.js?v=1" onerror="console.warn('§LOAD_FAIL mp4_mux.js — MaxQ falls back to webm')"></script>
 <script src="cinema_path_editor.js?v=14" onerror="console.warn('§LOAD_FAIL cinema_path_editor.js — Alt+C path editing disabled')"></script>
 <script src="cpe_walk.js?v=6" onerror="console.warn('§LOAD_FAIL cpe_walk.js — CPE walk-mode disabled')"></script>
 <script src="cpe_xr.js?v=1" onerror="console.warn('§LOAD_FAIL cpe_xr.js — VR entry disabled')"></script>
-<script src="cinema_maxq.js?v=4" onerror="console.warn('§LOAD_FAIL cinema_maxq.js — Alt+M MaxQ export disabled')"></script>
+<script src="cinema_maxq.js?v=5" onerror="console.warn('§LOAD_FAIL cinema_maxq.js — Alt+M MaxQ export disabled')"></script>
 <script src="input_registry.js?v=1" onerror="console.warn('§LOAD_FAIL input_registry.js')"></script>
 <script src="../common/pill_builder.js?v=1" onerror="console.warn('§LOAD_FAIL pill_builder.js')"></script>
 <script src="list_builder.js?v=1" onerror="console.warn('§LOAD_FAIL list_builder.js')"></script>

--- a/witness_maxq_stage_keep.js
+++ b/witness_maxq_stage_keep.js
@@ -1,0 +1,141 @@
+#!/usr/bin/env node
+// WITNESS — §MAXQ_STAGE_KEEP (R1, bim-compiler prompts/CPE_4D_PERF_MEM_FINDINGS.md §2c/§3-R1).
+//
+// ISSUE: the MaxQ bake tore down and rebuilt the ENTIRE photo staging (ground/puddles/HDRI/fog/
+// sky) on EVERY captured frame — plus a 250ms SETTLE_MS sleep per frame guarding against capturing
+// mid-restore values — the measured §BAKE_FAST_PATH_COST "~660ms/frame unaccounted staging churn"
+// (~9 min of a 21.6-min Hospital bake). #1300's §SHADOW_FRONTIER_AT_CAPTURE additionally ran a
+// full scene.traverse with linear batch-meta scans per frame. The fix keeps staging alive across
+// frames (keepStaging), sleeps only when staging is actually down, and answers the frontier check
+// from a per-_metaGen guid→object index.
+//
+// ISSUE EACH GATE PROVES OR DISPROVES (run with BASE=1 against unpatched code for the RED side):
+//   G-STAGE-ONCE   §PHOTO_STAGING applied EXACTLY ONCE for an N-frame bake (fix). On unpatched
+//                  code it applies ~N times — if this gate passes there too, it proves nothing;
+//                  the A/B run is the witness, not this single count.
+//   G-STAGE-KEPT   the per-frame stop logs "(staging kept)" — the keepStaging path actually ran
+//                  (not just an accidental single staging via some other route).
+//   G-SUN-ARC      §SUN_ARC_STEP elevation still CHANGES per frame with staging kept — the
+//                  per-frame sun (the whole point of e313fc5) survived the optimization.
+//   G-RESTORE      after the bake finishes, _photoStagingOn === false — the end-of-bake teardown
+//                  still restores the scene (fog/sun/ground back).
+//   G-FRONTIER-EQ  (editor+buildup path) §SHADOW_FRONTIER_AT_CAPTURE per-frame count lines are
+//                  BYTE-IDENTICAL between baseline (port 8399, origin/main traverse) and fix
+//                  (port 8517, indexed) — the refactor changed the cost, not one answer.
+//   G-PERF         informational: frames captured, wall ms/frame both sides — the before/after.
+//
+// PRECONDITIONS: two static serves — 8399 = /tmp/wt-sandbox (origin/main baseline),
+// 8517 = /tmp/wt-bake-stage (the fix). Duplex_extracted.db symlinked into both buildings/ dirs.
+const puppeteer = require('/home/red1/bim-compiler/node_modules/puppeteer');
+const BLD = 'Duplex';
+const FIX_PORT = process.env.FIX_PORT || 8517;
+const BASE_PORT = process.env.BASE_PORT || 8399;
+const sleep = ms => new Promise(r => setTimeout(r, ms));
+
+async function waitForLog(logs, re, timeoutMs) {
+  const t0 = Date.now();
+  for (;;) {
+    const hit = logs.find(l => re.test(l));
+    if (hit) return hit;
+    if (Date.now() - t0 > timeoutMs) return null;
+    await sleep(300);
+  }
+}
+
+// Drive the REAL user path: open editor → click OK → bake continues WITH buildup (default-on),
+// run to §MAXQ_DONE/§MAXQ_WEBM. forceWebm skips mp4. fps=1 keeps the frame count small (plan
+// duration in seconds ≈ frame count).
+async function bake(browser, port, logs, errs) {
+  const page = await browser.newPage();
+  await page.setViewport({ width: 1200, height: 700 });
+  page.on('console', m => logs.push(m.text()));
+  page.on('pageerror', e => { errs.push(e.message); logs.push('PAGEERROR ' + e.message); });
+  await page.goto(`http://localhost:${port}/viewer/viewer.html?db=/buildings/${BLD}_extracted.db`,
+    { waitUntil: 'domcontentloaded', timeout: 60000 });
+  await page.waitForFunction(
+    () => window.APP && window.APP.cinemaPathPlan && window.APP.cinemaPathEditor &&
+          window.APP.startMaxQualityOrbit && window.APP._composer,
+    { timeout: 120000 });
+  await sleep(9000);
+  await page.waitForFunction(() => {
+    try { const r = window.APP.dbQuery('SELECT COUNT(*) FROM element_transforms'); return r && r[0][0] > 0; }
+    catch (e) { return false; }
+  }, { timeout: 60000, polling: 2000 });
+  await page.evaluate(() => { window.APP.startMaxQualityOrbit({ preview: false, fps: 1, editor: true, forceWebm: true }); });
+  await page.waitForSelector('#cpe-ok', { timeout: 300000 });
+  await sleep(1500);
+  const t0 = Date.now();
+  await page.evaluate(() => { document.getElementById('cpe-ok').click(); });
+  const done = await waitForLog(logs, /§MAXQ_(DONE|WEBM|MP4)\b/, 1200000);
+  const wallMs = Date.now() - t0;
+  const stagingOn = await page.evaluate(() => !!window.APP._photoStagingOn);
+  await page.close();
+  return { done, wallMs, stagingOn };
+}
+
+function tally(logs) {
+  const stagingApplied = logs.filter(l => /§PHOTO_STAGING on\b/.test(l)).length;
+  const stagingSkipped = logs.filter(l => /§PHOTO_STAGING already on/.test(l)).length;
+  const kept = logs.filter(l => /§STILL_REFINE .*\(staging kept\)/.test(l)).length;
+  const arc = logs.filter(l => /§SUN_ARC_STEP/.test(l))
+    .map(l => parseFloat((l.match(/elevation=([-\d.]+)/) || [])[1])).filter(Number.isFinite);
+  const frontier = logs.filter(l => /§SHADOW_FRONTIER_AT_CAPTURE/.test(l))
+    .map(l => l.replace(/^.*§SHADOW/, '§SHADOW').trim());
+  const frames = logs.filter(l => /§MAXQ_FRAME i=/.test(l)).length;
+  return { stagingApplied, stagingSkipped, kept, arc, frontier, frames };
+}
+
+(async () => {
+  const browser = await puppeteer.launch({
+    headless: 'new', protocolTimeout: 1200000,
+    args: ['--no-sandbox', '--disable-dev-shm-usage', '--use-gl=angle', '--use-angle=swiftshader',
+      '--enable-unsafe-swiftshader']
+  });
+  const checks = [];
+  const P = (n, ok, d) => { checks.push({ n, ok, d }); console.log((ok ? 'PASS ' : 'FAIL ') + n + ' — ' + d); };
+  try {
+    // ── baseline side (origin/main) ──
+    const bLogs = [], bErrs = [];
+    const b = await bake(browser, BASE_PORT, bLogs, bErrs);
+    const bt = tally(bLogs);
+    console.log('§WITNESS_BASELINE done=' + !!b.done + ' frames=' + bt.frames + ' wallMs=' + b.wallMs +
+      ' stagingApplied=' + bt.stagingApplied + ' frontierLines=' + bt.frontier.length);
+    // ── fix side ──
+    const fLogs = [], fErrs = [];
+    const f = await bake(browser, FIX_PORT, fLogs, fErrs);
+    const ft = tally(fLogs);
+    console.log('§WITNESS_FIX done=' + !!f.done + ' frames=' + ft.frames + ' wallMs=' + f.wallMs +
+      ' stagingApplied=' + ft.stagingApplied + ' stagingSkipped=' + ft.stagingSkipped + ' kept=' + ft.kept);
+
+    P('G-BAKE-COMPLETES', !!b.done && !!f.done && bErrs.length === 0 && fErrs.length === 0,
+      `baseline=${b.done ? 'done' : 'TIMEOUT'} fix=${f.done ? 'done' : 'TIMEOUT'} pageerrors=${bErrs.length}/${fErrs.length}`);
+    // First run of this witness (2026-08-12) FAILed here at fix=2: the pre-bake still-photo phase
+    // (cinema_maxq.js:1131 startStillRefine → :1150 stopStillRefine(true), BEFORE the frame loop)
+    // legitimately applies + fully tears down staging once — that phase is untouched by the fix.
+    // The contract is "the FRAME LOOP applies staging once, not once per frame": pre-phase + loop
+    // = ≤2 total, and the per-frame class (≈1 per frame on baseline) must be gone.
+    P('G-STAGE-ONCE', ft.stagingApplied <= 2 && bt.stagingApplied >= ft.frames &&
+      (bt.stagingApplied - ft.stagingApplied) >= ft.frames - 2,
+      `fix stagingApplied=${ft.stagingApplied} (pre-phase + one per bake, want <=2), baseline=${bt.stagingApplied} (≈once per frame — the RED side)`);
+    P('G-STAGE-KEPT', ft.kept >= Math.max(1, ft.frames - 2) && bt.kept === 0,
+      `fix "(staging kept)" lines=${ft.kept} frames=${ft.frames}; baseline kept=${bt.kept}`);
+    const arcSpread = a => a.length >= 2 ? Math.abs(a[a.length - 1] - a[0]) : 0;
+    P('G-SUN-ARC', ft.arc.length >= 2 && arcSpread(ft.arc) > 0.5 &&
+      Math.abs(arcSpread(ft.arc) - arcSpread(bt.arc)) < 0.11,
+      `fix arc ${ft.arc[0]}→${ft.arc[ft.arc.length - 1]} (n=${ft.arc.length}), baseline spread=${arcSpread(bt.arc).toFixed(1)}`);
+    P('G-RESTORE', f.stagingOn === false, `_photoStagingOn after bake=${f.stagingOn}`);
+    const eq = bt.frontier.length === ft.frontier.length &&
+      bt.frontier.every((l, i) => l === ft.frontier[i]);
+    P('G-FRONTIER-EQ', bt.frontier.length > 0 && eq,
+      `lines base=${bt.frontier.length} fix=${ft.frontier.length} identical=${eq}` +
+      (eq ? '' : ' firstDiff=' + JSON.stringify([bt.frontier.find((l, i) => l !== ft.frontier[i]), ft.frontier.find((l, i) => l !== bt.frontier[i])])));
+    P('G-PERF', true, `informational: baseline ${Math.round(b.wallMs / Math.max(1, bt.frames))}ms/frame vs fix ${Math.round(f.wallMs / Math.max(1, ft.frames))}ms/frame (Duplex, swiftshader — direction only, GPU-blind)`);
+  } catch (e) {
+    P('G-INFRA', false, e.message);
+  } finally {
+    const pass = checks.filter(c => c.ok).length;
+    console.log(`\n§MAXQ_STAGE_KEEP WITNESS ${pass}/${checks.length} PASS`);
+    await browser.close();
+    process.exit(pass === checks.length ? 0 : 1);
+  }
+})();


### PR DESCRIPTION
Implements R1 of the CPE/4D perf study (bim-compiler `prompts/CPE_4D_PERF_MEM_FINDINGS.md` §2c/§3-R1) — the largest measured bake cost in the corpus.

**Before:** every captured frame tore the whole photo staging down and rebuilt it (`stopStillRefine(true)` → `_teardownPhotoStaging` → `_applyPhotoStaging`: puddles, ground texture, HDRI, `updateSky`) plus a hard 250ms `SETTLE_MS` sleep — §BAKE_FAST_PATH_COST's measured **~660ms/frame unaccounted churn ≈ 9 min of a 21.6-min Hospital bake**. #1300's frontier castShadow check added a full `scene.traverse` + linear batch-meta scans per frame.

**After:** staging applies once per bake (`keepStaging` through the per-frame refine stop; the pre-bake still phase is untouched); `SETTLE_MS` sleeps only when staging is actually down; the frontier check answers from a `_metaGen`-keyed guid→object index — counting semantics and log line preserved exactly. Per-frame sun (§SUN_ARC) untouched — `_sunArcStep` does its own `updateSky` + `shadowMap.needsUpdate`.

**Witness** `witness_maxq_stage_keep.js` **7/7** (A/B real 28-frame Duplex bakes, unpatched vs fix): staging applied **2 vs 29**; "(staging kept)" 27/28; §SUN_ARC spread 55→6° preserved both sides; **§SHADOW_FRONTIER_AT_CAPTURE lines byte-identical (12/12)**; scene restore clean; zero page errors. Post-merge smoke on top of #1304-#1306: 4-frame bake, stagingApplied=2, 0 errors.

⚠ swiftshader wall-time is direction-only (36s software frames swamp the saved slice) — the honest before/after is the next real-GPU bake's `§MAXQ_FRAME elapsedMs` tail rate vs the recorded 2,184 ms/frame.

sw v995→v996, effects v17, cinema_maxq v5.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Jkm19ChnTdpjfuFPQFSEQu