### PR TITLE
perf(4d): §XRAY_CACHE_MEMO + §TM_WARM — R4, both doctrine halves ruled by the user

### DIFF
--- a/viewer/cinema_path_editor.js
+++ b/viewer/cinema_path_editor.js
@@ -2991,6 +2991,14 @@
         console.warn('§CPE_SKIP no waypoints to seed bands from — proceeding unchanged');
         return resolve({ action: 'ok', override: null, durationSec: ctx.durationSec });
       }
+      // §TM_WARM (bim-compiler prompts/CPE_4D_PERF_MEM_FINDINGS.md §3c, R4(a) — user ruling
+      // 2026-08-12 "warm data only, never activate"): the editor is the strongest available signal
+      // that a ▶ Play is coming, so precompute TM's DB-derived x-ray elements on IDLE now instead
+      // of on the click. This does NOT open Time Machine — G-CPE-SOLE-OWNER is intact; see
+      // tmWarmXrayElements' own header for the contract and the baseline-perf guard (pure idle, no
+      // timeout, no fallback timer, self-skipping) that keeps it off the editing path.
+      try { if (typeof window.tmWarmXrayElements === 'function') window.tmWarmXrayElements(); } catch (e) {}
+
       // §CPE_REOPEN_DOUBLE (CINEMA_PATH_EDITOR.md — user: "it seems to dupe more bars upon alt-c
       // cancel and resume"). ADOPT the authored bands when the plan was built from them; only SEED
       // when there are none. The two functions have reciprocal fan-out — _cinemaSeedBands emits one

--- a/viewer/sw.js
+++ b/viewer/sw.js
@@ -8,7 +8,7 @@
 // Cache-first for heavy assets (.wasm, images). DB files skip SW (IndexedDB handles them).
 //
 // DEPLOY: bump CACHE_VERSION on every OCI upload. Old caches are purged on activate.
-const CACHE_VERSION = 'v996';   // bump on each deploy; per-change detail is the git commit message.
+const CACHE_VERSION = 'v997';   // bump on each deploy; per-change detail is the git commit message.
 const CACHE_PREFIX = 'bim-ootb-';
 const CACHE_NAME = CACHE_PREFIX + CACHE_VERSION;
 

--- a/viewer/tests/witness_xray_cache_memo.js
+++ b/viewer/tests/witness_xray_cache_memo.js
@@ -1,0 +1,179 @@
+#!/usr/bin/env node
+// WITNESS — W-XRAY-MEMO — §XRAY_CACHE_MEMO + §TM_WARM
+// Spec: bim-compiler prompts/CPE_4D_PERF_MEM_FINDINGS.md §3c (R4, user ruling 2026-08-12).
+//
+// ISSUE THIS PROVES OR DISPROVES:
+//   The x-ray support-edge cache (74,942 edges / ~0.7s on Hospital) rebuilt on EVERY TM activation,
+//   including the §GANTT_CACHE_HIT fast path where injectGantt never runs. It is a pure function of
+//   (DB elements) + (_ops end_ts), so identical inputs were recomputing a byte-identical map.
+//   The fix memoizes it on _metaGen + an _ops signature. The DANGER the fix introduces is a FALSE
+//   HIT — serving a stale staging map after the schedule moved, which is a wrong-render bug, not a
+//   perf one. So the blocking bar is EQUIVALENCE and KEY DISCIPLINE, never speed.
+//
+//   It also proves §TM_WARM does what the ruling allowed and nothing more: warm the DERIVED DATA,
+//   never activate. G-CPE-SOLE-OWNER ("only a real Play opens Time Machine") must still hold.
+//
+// GATES:
+//   G-XM-WARM      tmWarmXrayElements() with TM OFF: TM stays inactive, _ops stays empty, the
+//                  kernel_ops row count is unchanged (no DB write), the panel stays hidden, and the
+//                  elements memo becomes populated. Proves the warm contract's four "must nots".
+//   G-XM-EQUIV     (BLOCKING) map built fresh == map restored from the memo, compared KEY BY KEY.
+//                  mismatch=0 required. This is the bar; timing is not.
+//   G-XM-KEY       move one op's end_ts -> MUST miss and rebuild; move it back -> MUST hit.
+//                  Proves the memo cannot serve a stale map across a schedule change.
+//   G-XM-RESET     after deactivate(), _tmXraySolidifyTs is {} and both counters are 0 —
+//                  §Z_STACK_XRAY_STAGING's "nothing may survive TM being switched off" is intact.
+//                  A memo surviving is not the same as state surviving.
+//   G-XM-PERF      informational only: elemMs/edgeMs split from the new §XRAY_CACHE_BUILD line.
+//                  Recorded, never asserted (headless swiftshader is not a perf instrument —
+//                  CPE_4D_PERF_MEM_FINDINGS.md §6).
+const puppeteer = require('/home/red1/bim-compiler/node_modules/puppeteer');
+const PORT = process.env.FIX_PORT || 8519;
+const BLD = process.env.BLD || 'Duplex';
+const sleep = ms => new Promise(r => setTimeout(r, ms));
+// Load budget is environment, not behaviour: Hospital under headless swiftshader blew the 120s
+// default (witnessed: "Waiting failed: 120000ms exceeded" before a single gate ran). Configurable
+// so a big building can be measured without editing the file. See CPE_4D_PERF_MEM_FINDINGS.md §6.
+const LOAD_MS = +(process.env.LOAD_MS || 120000);
+const SETTLE_MS = +(process.env.SETTLE_MS || 9000);
+
+const results = [];
+function gate(name, pass, detail) {
+  results.push({ name, pass, detail });
+  console.log(`${pass ? 'PASS' : 'FAIL'}  ${name}  ${detail}`);
+}
+
+(async () => {
+  const browser = await puppeteer.launch({
+    headless: 'new',
+    args: ['--no-sandbox', '--use-gl=swiftshader', '--enable-unsafe-swiftshader']
+  });
+  const logs = [];
+  try {
+    const page = await browser.newPage();
+    await page.setViewport({ width: 1200, height: 700 });
+    page.on('console', m => logs.push(m.text()));
+    page.on('pageerror', e => logs.push('PAGEERROR ' + e.message));
+    await page.goto(`http://localhost:${PORT}/viewer/viewer.html?db=/buildings/${BLD}_extracted.db`,
+      { waitUntil: 'domcontentloaded', timeout: 60000 });
+    await page.waitForFunction(() => window.APP && window.APP.dbQuery && window.tmActivateForBake,
+      { timeout: LOAD_MS });
+    await sleep(SETTLE_MS);
+    await page.waitForFunction(() => {
+      try { return window.APP.dbQuery('SELECT COUNT(*) FROM element_transforms')[0][0] > 0; }
+      catch (e) { return false; }
+    }, { timeout: LOAD_MS, polling: 2000 });
+    await page.waitForFunction(() => !window.APP.streaming, { timeout: LOAD_MS, polling: 1000 });
+
+    // ── G-XM-WARM: the warm contract, asserted BEFORE any activation ──────────────────────────
+    const koCount = () => page.evaluate(() => {
+      try { return window.APP.dbQuery('SELECT COUNT(*) FROM kernel_ops')[0][0]; } catch (e) { return -1; }
+    });
+    const koBefore = await koCount();
+    const warmBefore = await page.evaluate(() => window.__tmXrayProbe());
+    const scheduled = await page.evaluate(() => window.tmWarmXrayElements());
+    // requestIdleCallback has no timeout by design (baseline-perf guard) — give the browser real
+    // idle time rather than forcing it.
+    await sleep(4000);
+    const warmAfter = await page.evaluate(() => window.__tmXrayProbe());
+    const koAfter = await koCount();
+    const panelShown = await page.evaluate(() => {
+      const p = document.getElementById('time-machine-panel');
+      return !!(p && p.style.display && p.style.display !== 'none');
+    });
+    const warmLine = logs.find(l => /§TM_WARM/.test(l)) || '(none)';
+    const warmOK = scheduled === true && warmAfter.active === false && warmAfter.ops === 0 &&
+                   koAfter === koBefore && panelShown === false && warmAfter.elemMemo === true &&
+                   warmBefore.elemMemo === false;
+    gate('G-XM-WARM', warmOK,
+      `scheduled=${scheduled} active=${warmAfter.active} ops=${warmAfter.ops} ` +
+      `kernel_ops ${koBefore}->${koAfter} panel=${panelShown} ` +
+      `elemMemo ${warmBefore.elemMemo}->${warmAfter.elemMemo} | ${warmLine}`);
+
+    // ── activate for the rest ─────────────────────────────────────────────────────────────────
+    let ok = false;
+    for (let i = 0; i < 20 && !ok; i++) ok = await page.evaluate(() => window.tmActivateForBake());
+    if (!ok) throw new Error('TM activation failed on port ' + PORT);
+
+    // ── Ensure a NON-EMPTY defect population before the equivalence bar ───────────────────────
+    // Witnessed on the first run: Duplex's staged population is legitimately 0 (no element whose
+    // last carrier finishes after its own reveal), so comparing two empty maps would prove nothing
+    // and the gate would pass vacuously. Shift one op's end_ts until a real population exists —
+    // that is exactly the "carrier finishes late" condition the feature is about.
+    let popShift = 0;
+    for (const shift of [0, 86400000, 86400000 * 6, 86400000 * 30]) {
+      if (shift) { await page.evaluate(s => window.__tmXrayProbe('nudge', s), shift); popShift += shift; }
+      const p = await page.evaluate(() => { window.__tmXrayProbe('clearMemo'); window.__tmXrayProbe('rebuild'); return window.__tmXrayProbe(); });
+      if (p.staged > 0) break;
+    }
+    const pop = await page.evaluate(() => window.__tmXrayProbe());
+    console.log(`      (defect population for the equivalence bar: staged=${pop.staged} after end_ts shift of ${popShift / 86400000}d)`);
+
+    // ── G-XM-EQUIV (BLOCKING): fresh map vs memo-restored map, key by key ─────────────────────
+    // Force a cold build (memo cleared) and snapshot; then rebuild again — that second call must
+    // be a memo HIT — and snapshot again. The two maps must be identical entry for entry.
+    const fresh = await page.evaluate(() => { window.__tmXrayProbe('clearMemo'); window.__tmXrayProbe('rebuild'); return window.__tmXrayProbe('map'); });
+    const nLogsBefore = logs.length;
+    const hitted = await page.evaluate(() => { window.__tmXrayProbe('rebuild'); return window.__tmXrayProbe('map'); });
+    const hitLine = logs.slice(nLogsBefore).find(l => /§XRAY_CACHE_BUILD/.test(l)) || '(none)';
+    let mismatch = 0, missingA = 0, missingB = 0;
+    const kf = Object.keys(fresh.map), kh = Object.keys(hitted.map);
+    for (const k of kf) {
+      if (!(k in hitted.map)) { missingB++; continue; }
+      if (hitted.map[k] !== fresh.map[k]) mismatch++;
+    }
+    for (const k of kh) if (!(k in fresh.map)) missingA++;
+    const equivOK = mismatch === 0 && missingA === 0 && missingB === 0 &&
+                    kf.length === kh.length && kf.length > 0 &&
+                    /edgeMemo=hit/.test(hitLine) && hitted.solidified === 0;
+    gate('G-XM-EQUIV', equivOK,
+      `n=${kf.length}/${kh.length} mismatch=${mismatch} missingA=${missingA} missingB=${missingB} ` +
+      `solidifiedResetTo=${hitted.solidified} | ${hitLine}`);
+
+    // ── G-XM-KEY: a schedule change MUST force a miss; undoing it MUST restore the hit ────────
+    // The restore leg is what proves the memo is TWO slots: a single slot would have been evicted
+    // by the nudged build and would miss here (that is exactly what the first run showed). The
+    // derived-order round trip in the cinema bake (tmApplyDerivedOrder → tmRestoreDerivedOrder)
+    // walks this same alternation, which is why it is a gate and not a nicety.
+    const nBeforeNudge = logs.length;
+    const nudged = await page.evaluate(() => { window.__tmXrayProbe('nudge', 86400000); window.__tmXrayProbe('rebuild'); return window.__tmXrayProbe(); });
+    const nudgeLine = logs.slice(nBeforeNudge).find(l => /§XRAY_CACHE_BUILD/.test(l)) || '(none)';
+    const nBeforeRestore = logs.length;
+    const restored = await page.evaluate(() => { window.__tmXrayProbe('nudge', -86400000); window.__tmXrayProbe('rebuild'); return window.__tmXrayProbe('map'); });
+    const restoreLine = logs.slice(nBeforeRestore).find(l => /§XRAY_CACHE_BUILD/.test(l)) || '(none)';
+    let restMismatch = 0;
+    for (const k of Object.keys(fresh.map)) if (restored.map[k] !== fresh.map[k]) restMismatch++;
+    const keyOK = /edgeMemo=miss/.test(nudgeLine) && /edgeMemo=hit/.test(restoreLine) &&
+                  restMismatch === 0 && Object.keys(restored.map).length === kf.length;
+    gate('G-XM-KEY', keyOK,
+      `nudge->${/edgeMemo=miss/.test(nudgeLine) ? 'MISS' : 'HIT(BAD)'} ` +
+      `restore->${/edgeMemo=hit/.test(restoreLine) ? 'HIT' : 'MISS'} ` +
+      `restoredMismatch=${restMismatch} staged(nudged)=${nudged.staged}`);
+
+    // ── G-XM-RESET: the §Z_STACK_XRAY_STAGING invariant is untouched by the memo ──────────────
+    const afterOff = await page.evaluate(() => {
+      window.__tmXrayProbe('deactivate');   // the same verb the panel's close button calls
+      return new Promise(r => setTimeout(() => r(window.__tmXrayProbe()), 1200));
+    });
+    const resetOK = afterOff.active === false && afterOff.n === 0 &&
+                    afterOff.staged === 0 && afterOff.solidified === 0 && afterOff.edgeMemo > 0;
+    gate('G-XM-RESET', resetOK,
+      `active=${afterOff.active} mapEntries=${afterOff.n} staged=${afterOff.staged} ` +
+      `solidified=${afterOff.solidified} memoSurvives=${afterOff.edgeMemo} ` +
+      `(state resets, memo survives — that is the ruling)`);
+
+    // ── G-XM-PERF: informational split, never asserted ────────────────────────────────────────
+    const perfLines = logs.filter(l => /§XRAY_CACHE_BUILD/.test(l));
+    gate('G-XM-PERF', true, `builds=${perfLines.length} | ${perfLines.slice(0, 4).join(' || ')}`);
+
+    const errs = logs.filter(l => /PAGEERROR/.test(l));
+    gate('G-XM-NOERR', errs.length === 0, `pageErrors=${errs.length} ${errs.slice(0, 2).join(' | ')}`);
+  } catch (e) {
+    gate('G-XM-RUN', false, 'harness error: ' + e.message);
+  } finally {
+    await browser.close();
+  }
+  const passed = results.filter(r => r.pass).length;
+  console.log(`\n§XRAY_MEMO_WITNESS ${passed}/${results.length} gates passed`);
+  process.exit(passed === results.length ? 0 : 1);
+})();

--- a/viewer/time_machine.js
+++ b/viewer/time_machine.js
@@ -3708,21 +3708,110 @@
       ' (elements whose last support carrier finishes after their own reveal)');
   }
 
+  // ── §XRAY_CACHE_MEMO (2026-08-12, bim-compiler prompts/CPE_4D_PERF_MEM_FINDINGS.md §3c —
+  // Implementing R4(b), user ruling "memoize on an input key, keep the reset" — Witness:
+  // viewer/tests/witness_xray_cache_memo.js W-XRAY-MEMO) ────────────────────────────────────────
+  // The rebuild below ran on EVERY activation (~0.7s / 74,942 edges on Hospital), including the
+  // §GANTT_CACHE_HIT fast path. It is a PURE FUNCTION of (elements from the DB) + (_ops end_ts),
+  // so an identical-input re-activation was recomputing a byte-identical map.
+  //
+  // What is memoized and what is NOT — this distinction IS the doctrine compliance:
+  //   MEMOIZED: the derived map (guid → solidify ms) + its "staged total". Pure, input-keyed.
+  //   NOT MEMOIZED (still reset on TM-off, unchanged at :deactivate): _tmXraySolidifiedN and the
+  //   per-object _tm_xrayStaged flags — the RUNTIME STAGING STATE. §Z_STACK_XRAY_STAGING's
+  //   "nothing may survive TM being switched off" is about that state, and it still doesn't.
+  // A memo surviving is not the same as state surviving.
+  //
+  // Safe to alias rather than deep-copy: the ONLY writes to _tmXraySolidifyTs[...] are inside
+  // _buildXraySupportCache (which rebuilds it wholesale); every other site REASSIGNS the var
+  // (`= {}`), never mutates the object, so deactivate()'s reset cannot corrupt the memo.
+  //
+  // TWO SLOTS, not one — and the reason is the MAXQ/Alt-C round trip specifically. A single slot
+  // makes tmApplyDerivedOrder → tmRestoreDerivedOrder miss in BOTH directions: the derived re-key
+  // evicts the real-order map, then restoring evicts the derived one. Two slots (most-recent +
+  // previous) make that alternation hit both ways, which is exactly the path the cinema bake walks.
+  // Witnessed: with one slot, G-XM-KEY's restore leg came back MISS.
+  var _xrayElemMemo = null;    // { key, elements }  — DB-derived, _ops-independent (warmable)
+  var _xrayCacheMemo = [];     // [{ key, ts, staged }, ...] most-recent first, capped at 2
+
+  function _xrayMemoFind(key) {
+    for (var i = 0; i < _xrayCacheMemo.length; i++) if (_xrayCacheMemo[i].key === key) return _xrayCacheMemo[i];
+    return null;
+  }
+  function _xrayMemoPut(key, ts, staged) {
+    for (var i = 0; i < _xrayCacheMemo.length; i++) {
+      if (_xrayCacheMemo[i].key === key) { _xrayCacheMemo.splice(i, 1); break; }
+    }
+    _xrayCacheMemo.unshift({ key: key, ts: ts, staged: staged });
+    if (_xrayCacheMemo.length > 2) _xrayCacheMemo.length = 2;
+  }
+
+  // _metaGen is in both keys per the ruling. It OVER-invalidates for the elements half (it bumps on
+  // streaming/eviction, which cannot change a DB SELECT) — that is the deliberately safe direction:
+  // a miss costs a rebuild, a false hit is a wrong-render bug.
+  function _xrayMemoGen() {
+    var app = A();
+    return (app && app._metaGen != null) ? (app._metaGen | 0) : -1;
+  }
+
+  // Build the elements list, or serve it from the memo. Shared by the rebuild and by §TM_WARM.
+  function _xrayElementsMemoized() {
+    var app = A();
+    var key = ((app && app.activeBuilding) || '?') + '|' + _xrayMemoGen();
+    if (_xrayElemMemo && _xrayElemMemo.key === key) return { elements: _xrayElemMemo.elements, hit: true };
+    var els = _buildXrayElements();
+    if (els) _xrayElemMemo = { key: key, elements: els };
+    return { elements: els, hit: false };
+  }
+
   // Shared entry point: rebuild the xray cache from whatever _ops currently holds. Called from
   // _finishActivate (every TM activation) AND from tmRestoreDerivedOrder (MAXQ → back to the real
   // construction order, where the cache IS valid again and must not stay cleared).
   function _tmRebuildXrayCache() {
     var _xt0 = performance.now();
     var _xrSched = {};
+    // opsSig: rolling hash over (guid, end_ts), computed in the pass that already builds _xrSched —
+    // no extra traversal. This is what makes every re-key path self-correcting WITHOUT a special
+    // case: tmApplyDerivedOrder (camera-path re-key) and _tmResyncAfterRetime (drag/ruler/group/
+    // undo) both move end_ts, so the sig changes and the memo is forced to miss.
+    var _sigH = 0x811c9dc5, _sigN = 0;
     for (var _xi = 0; _xi < _ops.length; _xi++) {
       var _xo = _ops[_xi];
       var _xg = _xo.output_guid || (_xo.input_guids && _xo.input_guids.length && _xo.input_guids[0]);
-      if (_xg) _xrSched[_xg] = { end: _xo.end_ts };
+      if (_xg) {
+        _xrSched[_xg] = { end: _xo.end_ts };
+        _sigN++;
+        for (var _sc = 0; _sc < _xg.length; _sc++) {
+          _sigH ^= _xg.charCodeAt(_sc); _sigH = (_sigH * 0x01000193) >>> 0;
+        }
+        _sigH ^= (_xo.end_ts | 0); _sigH = (_sigH * 0x01000193) >>> 0;
+      }
     }
-    var _xrElements = _buildXrayElements();
+    var _opsSig = _ops.length + ':' + _sigN + ':' + _sigH.toString(16);
+    var _key = _xrayMemoGen() + '|' + _opsSig;
+
+    var _memoHit = _xrayMemoFind(_key);
+    if (_memoHit) {
+      _tmXraySolidifyTs = _memoHit.ts;
+      _tmXrayStagedTotal = _memoHit.staged;
+      _tmXraySolidifiedN = 0;   // runtime progress ALWAYS restarts — never memoized
+      console.log('§XRAY_CACHE_BUILD elemMs=0.0 edgeMs=0.0 total_ms=' +
+        (performance.now() - _xt0).toFixed(1) + ' elemMemo=hit edgeMemo=hit staged=' + _tmXrayStagedTotal);
+      return;
+    }
+
+    var _e0 = performance.now();
+    var _em = _xrayElementsMemoized();
+    var _elemMs = performance.now() - _e0;
+    var _xrElements = _em.elements;
+    var _g0 = performance.now();
     if (_xrElements) _buildXraySupportCache(_xrElements, _xrSched);
     else { _tmXraySolidifyTs = {}; _tmXrayStagedTotal = 0; _tmXraySolidifiedN = 0; }
-    console.log('§XRAY_CACHE_BUILD total_ms=' + (performance.now() - _xt0).toFixed(1));
+    var _edgeMs = performance.now() - _g0;
+    if (_xrElements) _xrayMemoPut(_key, _tmXraySolidifyTs, _tmXrayStagedTotal);
+    console.log('§XRAY_CACHE_BUILD elemMs=' + _elemMs.toFixed(1) + ' edgeMs=' + _edgeMs.toFixed(1) +
+      ' total_ms=' + (performance.now() - _xt0).toFixed(1) +
+      ' elemMemo=' + (_em.hit ? 'hit' : 'miss') + ' edgeMemo=miss staged=' + _tmXrayStagedTotal);
   }
 
   // ── §TIER_SERIAL (2026-08-11, bim-compiler prompts/4D_SCHEDULE_PERFECTION.md §SPEC 2026-08-11
@@ -7415,12 +7504,18 @@
       app._forceNoMerge = true;
       var bld = app.activeBuilding;
       console.log('§TM_UNMERGE re-streaming ' + (bld || '?') + ' without merge (TM needs per-element slots)');
+      // §TM_UNMERGE duration (2026-08-12, CPE_4D_PERF_MEM_FINDINGS.md §3c R4 part (c)): this
+      // branch re-streams the WHOLE building on the first-Play click path — a cost that scales with
+      // building size and, until this line, was invisible in every witness that pre-streams
+      // unmerged. Unmeasured, it hides inside "first Play felt slow".
+      var _umT0 = performance.now();
       app.clearStreamed();
       if (bld) { app.streamBuilding(bld); }
       // Wait for re-stream to finish, then activate
       var _reWait = setInterval(function() {
         if (app.buildingsRendered && app.buildingsRendered.size > 0 && !app.streaming) {
           clearInterval(_reWait);
+          console.log('§TM_UNMERGE done bld=' + (bld || '?') + ' ms=' + (performance.now() - _umT0).toFixed(1));
           activate();
         }
       }, 500);
@@ -7948,6 +8043,54 @@
     });
   };
 
+  // ── §TM_WARM (2026-08-12, bim-compiler prompts/CPE_4D_PERF_MEM_FINDINGS.md §3c —
+  // Implementing R4(a), user ruling "warm data only, never activate" — Witness: W-XRAY-MEMO #3) ──
+  // G-CPE-SOLE-OWNER ("only a real Play opens Time Machine") holds by its LETTER here: this
+  // precomputes DERIVED DATA into the memo and nothing else. It does not call activate(), does not
+  // set _active, does not touch _ops, does not show the panel, and runs no DB write.
+  //
+  // Why only the elements half: _ops is NOT warmable and deliberately is not warmed — both load
+  // paths in _activateAsync have side effects the ruling forbids (the §GANTT_CACHE_HIT branch
+  // DELETEs+INSERTs kernel_ops; the cold branch runs the full injectGantt recompute). So the
+  // support-edge pass (which needs _ops for its schedMap) still runs on first Play; §XRAY_CACHE_MEMO
+  // is what makes every activation AFTER the first free. Stated plainly so nobody reads this as
+  // "first Play is now 0 ms" — it is not.
+  //
+  // ⚠ BASELINE-PERF GUARD (user directive 2026-08-12: "it is performing very well now! Thus do take
+  // care not to disturb that baseline perf"). _buildXrayElements() is ONE synchronous chunk (a
+  // SELECT + a map over up to 125k rows) — once started it cannot yield, so an ill-timed warm is a
+  // long task = a visible hitch mid-edit. Hence: pure-idle, NO requestIdleCallback timeout (never
+  // forced — if the browser never idles, warm never happens and nothing is worse than today), and
+  // NO setTimeout fallback (a fallback timer is exactly the "runs at a bad moment" case this guard
+  // exists to prevent). Skipped outright while streaming, while TM is active, or if already warm.
+  window.tmWarmXrayElements = function() {
+    var app = A();
+    if (!app || !app.db) return false;
+    if (_active) return false;                 // TM already owns this — nothing to warm
+    if (app.streaming) return false;           // mirrors _dlodEngaged's !streaming gate
+    // The busy flags dlod_nav.js:53 already names as "not idle": Cinema (_cinemaOrbitActive/
+    // _maxqActive) and the Photoreal still refine (_stillRefineActive). Extracted from that list
+    // rather than invented — there is no _bakeActive on APP.
+    if (app._maxqActive || app._cinemaOrbitActive || app._stillRefineActive) return false;
+    if (typeof window.requestIdleCallback !== 'function') return false;   // no fallback, by design
+    var key = ((app && app.activeBuilding) || '?') + '|' + _xrayMemoGen();
+    if (_xrayElemMemo && _xrayElemMemo.key === key) return false;         // already warm
+    window.requestIdleCallback(function() {
+      var a2 = A();
+      // Re-check at fire time: idle may land minutes later, after a Play/bake/stream started.
+      if (!a2 || !a2.db || _active || a2.streaming || a2._maxqActive || a2._cinemaOrbitActive || a2._stillRefineActive) {
+        console.log('§TM_WARM skipped — state changed before idle fired');
+        return;
+      }
+      var t0 = performance.now();
+      var em = _xrayElementsMemoized();
+      console.log('§TM_WARM elements=' + ((em.elements && em.elements.length) || 0) +
+        ' ms=' + (performance.now() - t0).toFixed(1) + ' memo=' + (em.hit ? 'hit' : 'miss') +
+        ' active=' + _active + ' ops=' + _ops.length + ' (TM not activated)');
+    });
+    return true;
+  };
+
   // Mode D: re-key the derived order so the reveal follows the CAMERA PATH instead of the Z-bands.
   // This adds NO new render path — `renderAtTime` is untouched. It consumes `_ops` purely as "sorted
   // ascending by start_ts, break past the cursor", so re-keying the timestamps IS the feature.
@@ -8400,6 +8543,24 @@
   // streaming.js calls this (feature-detected, optional — same pattern as window.__sfxTM) after
   // each flush; no-ops when TM isn't active, so zero cost/behavior change for non-TM viewing.
   window.tmResweep = function() { if (_active) renderAtTime(_cursor); };
+  // W-XRAY-MEMO test hook (§XRAY_CACHE_MEMO): read the x-ray staging map + memo state, and drive
+  // the memo's key discipline deterministically. Diagnostic only — no production caller, same
+  // contract as __tmSnapshotVisible. `map` returns the FULL guid→ms map so the witness can assert
+  // byte-identical restore key-by-key rather than trusting a digest.
+  window.__tmXrayProbe = function (op, arg) {
+    if (op === 'clearMemo') { _xrayElemMemo = null; _xrayCacheMemo = []; }
+    else if (op === 'rebuild') { _tmRebuildXrayCache(); }
+    else if (op === 'nudge') {   // move one op's end_ts → the key MUST miss
+      if (_ops.length) _ops[0].end_ts += (arg || 0);
+    }
+    else if (op === 'deactivate') { deactivate(); }   // the same verb the panel's close button calls
+    var keys = Object.keys(_tmXraySolidifyTs);
+    var out = { n: keys.length, staged: _tmXrayStagedTotal, solidified: _tmXraySolidifiedN,
+                elemMemo: !!_xrayElemMemo, edgeMemo: _xrayCacheMemo.length,
+                active: _active, ops: _ops.length };
+    if (op === 'map') { out.map = {}; for (var i = 0; i < keys.length; i++) out.map[keys[i]] = _tmXraySolidifyTs[keys[i]]; }
+    return out;
+  };
   // Test hook: simulate a playback tick (small cursor advance + roll bump) so a probe can exercise
   // the incremental (delta) path deterministically without the cinema UI. Diagnostic only.
   window.__tmStep = function (dms) { if (!_active) return null; _gspRoll++;


### PR DESCRIPTION
Implementing `bim-compiler prompts/CPE_4D_PERF_MEM_FINDINGS.md §3c`.
Witness: `viewer/tests/witness_xray_cache_memo.js` (W-XRAY-MEMO).

R4 was the one item of the R1-R5 perf batch left `⛔ BLOCKED` — not on code, on two documented doctrines. The user ruled both on 2026-08-12, taking the recommended option each time.

## (a) "warm data only, never activate" → `§TM_WARM`
CPE `open()` precomputes TM's DB-derived x-ray elements on **idle**. It does **not** call `activate()`: `_active` stays false, `_ops` stays empty, no panel, no DB write, no `§TM_UNMERGE` re-stream. **G-CPE-SOLE-OWNER holds by its letter** — nothing "opens" Time Machine.

`_ops` is deliberately **not** warmed: both load paths in `_activateAsync` have side effects the ruling forbids (the `§GANTT_CACHE_HIT` branch `DELETE`s+`INSERT`s kernel_ops; the cold branch runs the full `injectGantt`).

**Honest scope — this does NOT zero the 2.05s first Play.** Warm removes the elements-build slice from the click path; the memo below removes the whole rebuild from every activation *after* the first. The 74,942-edge pass still runs once per session on first Play.

## (b) "memoize on an input key, keep the reset" → `§XRAY_CACHE_MEMO`
The support cache (74,942 edges / ~0.7s on Hospital) rebuilt on **every** activation, including the `§GANTT_CACHE_HIT` fast path where `injectGantt` never runs. Now memoized on `_metaGen` + an `_ops` signature (FNV-style rolling hash over `guid`+`end_ts`, computed inside the pass that already builds `schedMap` — no extra traversal).

**The invariant is untouched.** Runtime staging state (`_tmXraySolidifiedN`, per-object `_tm_xrayStaged`) still resets on TM-off exactly as before. `§Z_STACK_XRAY_STAGING`'s *"nothing may survive TM being switched off"* is about that state, and it still doesn't. A memo surviving is not the same as state surviving.

Every re-key path is self-correcting **without a special case**, because they all move `end_ts`: `tmApplyDerivedOrder` (MAXQ camera-path re-key), `_tmResyncAfterRetime` (drag/ruler/group/undo), `tmRestoreDerivedOrder`. Its existing explicit clear at `:8042` is left alone.

## (c) `§TM_UNMERGE` duration — never blocked, just never done
That branch re-streams the **whole building** on the first-Play click path. Until now it was invisible in any witness that pre-streams unmerged, hiding inside "first Play felt slow". Now logs `§TM_UNMERGE done bld=… ms=…`.

## Two things the witness caught — fixed in the CODE, not the gate
1. **The memo needs 2 slots, not 1.** A single slot makes the MAXQ/Alt-C round trip (`tmApplyDerivedOrder` → `tmRestoreDerivedOrder`) miss in **both** directions: the derived re-key evicts the real-order map, then restoring evicts the derived one. First run: `G-XM-KEY restore->MISS`. With 2 slots: `restore->HIT`.
2. **Duplex's staged population is legitimately 0** — no element there has a carrier finishing after its own reveal, so the naive equivalence bar compared two *empty* maps and would have passed vacuously. The witness now shifts one op's `end_ts` until `staged > 0` (a real "carrier finishes late" condition) before comparing.

Also corrected pre-commit: a warm guard referenced `app._bakeActive`, which **does not exist on APP**. Replaced with the real busy flags `dlod_nav.js:53` already names — `_maxqActive` / `_cinemaOrbitActive` / `_stillRefineActive`.

## Baseline-perf guard (user directive, mid-implementation)
> "it is performing very well now! Thus do take care not to disturb that baseline perf"

Everything here is **strictly additive**: a memo consulted before work that otherwise runs verbatim, an idle-only precompute, and one log line. No existing path is reordered, removed, or made to run more often.

`_buildXrayElements()` is ONE synchronous chunk (a SELECT + a map over up to 125k rows) — once started it cannot yield, so an ill-timed warm would be a long task = a visible hitch mid-edit. Hence the warm is:
- `requestIdleCallback` with **no `timeout`** — never forced. If the browser never idles, warm never runs and nothing is worse than today.
- **no `setTimeout` fallback** — a fallback timer is exactly the "runs at a bad moment" case this guard prevents.
- skipped outright while streaming, while TM is active, while a cinema/MaxQ/still-refine is running, or if already warm — and **re-checked at fire time**, since idle may land minutes later.

## New instrumentation
`§XRAY_CACHE_BUILD` now splits: `elemMs=… edgeMs=… total_ms=… elemMemo=hit|miss edgeMemo=hit|miss staged=…`. Which half dominated had never been measured.

## Witness — W-XRAY-MEMO, Duplex 6/6 (against the committed code)
```
PASS  G-XM-WARM   scheduled=true active=false ops=0 kernel_ops 1->1 panel=false
                  elemMemo false->true | §TM_WARM elements=1122 ms=9.2 (TM not activated)
      (defect population for the equivalence bar: staged=3 after end_ts shift of 1d)
PASS  G-XM-EQUIV  n=3/3 mismatch=0 missingA=0 missingB=0 solidifiedResetTo=0 | edgeMemo=hit
PASS  G-XM-KEY    nudge->MISS restore->HIT restoredMismatch=0
PASS  G-XM-RESET  active=false mapEntries=0 staged=0 solidified=0 memoSurvives=2
PASS  G-XM-PERF   builds=7 (informational — swiftshader is not a perf instrument, §6)
PASS  G-XM-NOERR  pageErrors=0
```
The blocking bar is **G-XM-EQUIV** (`mismatch=0`, compared key by key), not timing. A false hit — serving a stale staging map after the schedule moved — would be a wrong-render bug, which is the danger this fix introduces and the reason equivalence gates it.

A Hospital run for a larger equivalence population is in progress; the first attempt died on environment, not code (`Waiting failed: 120000ms exceeded` before any gate ran — headless swiftshader load, see `§6`). The witness's load budget is now `LOAD_MS`/`SETTLE_MS`-configurable because of it.

`sw.js` CACHE_VERSION **v996 → v997** (R1 took v996; a shared version across two deploys ships stale files to anyone who cached between them).

🤖 Generated with [Claude Code](https://claude.com/claude-code)