### PR TITLE
fix(cpe): §CPE_BUILDUP_ARM_GATE — Alt+C rehearsal armed onto an empty timeline (TM never moved)

### DIFF
--- a/viewer/sw.js
+++ b/viewer/sw.js
@@ -8,7 +8,7 @@
 // Cache-first for heavy assets (.wasm, images). DB files skip SW (IndexedDB handles them).
 //
 // DEPLOY: bump CACHE_VERSION on every OCI upload. Old caches are purged on activate.
-const CACHE_VERSION = 'v997';   // bump on each deploy; per-change detail is the git commit message.
+const CACHE_VERSION = 'v998';   // bump on each deploy; per-change detail is the git commit message.
 const CACHE_PREFIX = 'bim-ootb-';
 const CACHE_NAME = CACHE_PREFIX + CACHE_VERSION;
 

--- a/viewer/time_machine.js
+++ b/viewer/time_machine.js
@@ -8033,12 +8033,35 @@
   // A bake needs Time Machine's op-log without the user having pressed the button. Same wait shape
   // as tmJumpToOrder's own whenReady() — activate() is async (it may have to inject the derived
   // timeline first), so poll for the ops rather than assuming they are there on the next line.
+  //
+  // §CPE_BUILDUP_ARM_GATE (2026-08-12, bim-compiler prompts/CINEMA_PATH_EDITOR.md — Witness:
+  // W-ARM-GATE / witness_cpe_buildup_arm_gate.js). This used to poll `_ops.length` alone, which is
+  // truthy for ONE stale op. Measured on the user's own Hospital run: at arm time `_ops` held
+  // exactly the `BUILDING_OPEN` kernel op (`§TM_OPS_CHECK total=1 place=0`) and the epoch had never
+  // been computed (`_projectStart == _projectEnd == 0`), so this resolved true against a zero-span
+  // 1970 timeline. The rehearsal then armed on it (`§CPE_PREVIEW_BUILDUP armed ops=1 placed=0`) and
+  // every frame's cursor `projectStart + u*(projectEnd-projectStart)` evaluated to the SAME 0 —
+  // 497 frames of `§PERF_TRAVERSE span=0h`, camera flying, nothing building. The real 63,415-op
+  // timeline finished loading (`§WRITE_LOOP_TIMING rows=63415`) seconds AFTER the flight started.
+  // Readiness is "the timeline has a real SPAN", not "the array is non-empty" — the identical bar
+  // ghostGroundArm already applied to the same state (`§GHOST_GROUND skip reason=buildup span is 0`)
+  // and the only consumer that refused it. This is NOT a new wait: the existing 60x500ms poll now
+  // waits for the condition it always meant. A real timeline always has span > 0 (`_projectStart =
+  // _ops[0].start_ts - 1`, `_projectEnd` = max end_ts), so this cannot reject a usable state.
+  function _bakeTimelineReady() { return !!_ops.length && _projectEnd > _projectStart; }
   window.tmActivateForBake = function() {
     return new Promise(function(resolve) {
-      if (_active && _ops.length) return resolve(true);
+      if (_active && _bakeTimelineReady()) return resolve(true);
       if (!_active) { try { activate(); } catch (e) { console.warn('§MAXQ_TIME_ABORT reason=activate ' + e.message); return resolve(false); } }
       var n = 0, iv = setInterval(function() {
-        if (_ops.length || ++n > 60) { clearInterval(iv); resolve(!!_ops.length); }
+        if (_bakeTimelineReady() || ++n > 60) {
+          clearInterval(iv);
+          var ok = _bakeTimelineReady();
+          if (!ok) console.warn('§CPE_BUILDUP_ARM_GATE timeout ops=' + _ops.length +
+            ' projectStart=' + _projectStart + ' projectEnd=' + _projectEnd +
+            ' — no timeline with a real span after ' + n + ' polls; refusing to arm a cursor that cannot move');
+          resolve(ok);
+        }
       }, 500);
     });
   };
@@ -8304,6 +8327,18 @@
   // was written to remove.
   window.tmFollowTimeline = function() {
     if (!_ops.length) { console.warn('§CPE_BUILDUP_SOURCE reject reason=no-ops'); return null; }
+    // §CPE_BUILDUP_ARM_GATE guard 2 (see tmActivateForBake above for the measured failure): a
+    // timeline with no SPAN cannot drive a cursor — `projectStart + u*(projectEnd-projectStart)` is
+    // the same value at every u, so the film freezes on frame 0's state and no log says why. Refuse
+    // it loudly instead of handing back a bkState the caller will faithfully follow to nowhere. The
+    // BAKE (cinema_maxq.js) calls this same verb, so this also stops a film silently recording a
+    // static building. ghostGroundArm/dayCounterLiveStart already refuse this exact state.
+    if (!(_projectEnd > _projectStart)) {
+      console.warn('§CPE_BUILDUP_SOURCE reject reason=zero-span ops=' + _ops.length +
+        ' projectStart=' + _projectStart + ' projectEnd=' + _projectEnd +
+        ' — every frame would ask for the same cursor; the timeline is not loaded yet');
+      return null;
+    }
     var ss = window.tmScheduleSource();
     if (ss.source === 'captured' && typeof window.tmOrderBySchedule === 'function') {
       var cap = window.tmOrderBySchedule();
@@ -8325,6 +8360,15 @@
         if (guid && have[guid]) placed++; else noGeom++;
       }
     } catch (e) { placed = _ops.length; noGeom = 0; }   // counting failed → do not block the film
+    // §CPE_BUILDUP_ARM_GATE guard 2b: `placed` is this function's own count of ops that can actually
+    // APPEAR. Zero of them means the reveal has nothing to reveal no matter where the cursor goes —
+    // the user's failing run reported exactly `placed=0` and armed anyway. A counting FAILURE above
+    // degrades to placed=_ops.length (never 0), so this only ever fires on a real, measured zero.
+    if (placed === 0) {
+      console.warn('§CPE_BUILDUP_SOURCE reject reason=nothing-placed ops=' + _ops.length +
+        ' noGeom=' + noGeom + ' — no op in this timeline maps to geometry; there is nothing to build');
+      return null;
+    }
     var iso = function(ms) { return isFinite(ms) ? new Date(ms).toISOString().slice(0, 10) : '?'; };
     console.log('§CPE_BUILDUP_SOURCE mode=T reason=generated-timeline ops=' + _ops.length +
       ' placed=' + placed + ' noGeom=' + noGeom +

--- a/witness_cpe_buildup_arm_gate.js
+++ b/witness_cpe_buildup_arm_gate.js
@@ -1,0 +1,206 @@
+#!/usr/bin/env node
+// witness_cpe_buildup_arm_gate.js — W-ARM-GATE
+// Implementing bim-compiler prompts/CINEMA_PATH_EDITOR.md §CPE_BUILDUP_ARM_GATE
+//
+// THE ISSUE THIS WITNESS PROVES OR DISPROVES:
+//   The Alt+C rehearsal armed its buildup onto a timeline that was not loaded yet — `_ops` held one
+//   stale BUILDING_OPEN kernel op and the epoch was still 0/0 — so every frame asked for the SAME
+//   cursor and the building never built (user's Hospital run: `§CPE_PREVIEW_BUILDUP armed ops=1
+//   placed=0`, then 497 frames of `§PERF_TRAVERSE span=0h`).
+//   A witness that only asserts "the arm resolved true" would PASS on the broken build — the arm DID
+//   resolve true. So the assertion here is the NUMBER the film actually consumes: the cursor
+//   `projectStart + u*(projectEnd-projectStart)` at u=0, 0.5, 1 must be three DIFFERENT values.
+//
+// HOW IT FALSIFIES: the same harness runs twice — once against the shipped `origin/main` source
+// (must FAIL G-ARM-1) and once against the working tree (must PASS all). A run where both sources
+// pass is not evidence; it means the RED case stopped reproducing and the witness is blind.
+//
+// Virtual clock: setInterval/setTimeout inside the sandbox are driven by this file, so the 60x500ms
+// poll costs no wall-clock time and the "timeline lands 2.4s later" ordering is exact, not a race.
+//
+// Run (from the repo root):  node witness_cpe_buildup_arm_gate.js
+// Read the log, not the exit code.
+'use strict';
+const fs = require('fs');
+const path = require('path');
+const vm = require('vm');
+const cp = require('child_process');
+
+const TM = path.join(__dirname, 'viewer', 'time_machine.js');
+const workingSrc = fs.readFileSync(TM, 'utf8');
+const shippedSrc = cp.execFileSync('git', ['show', 'origin/main:viewer/time_machine.js'],
+  { cwd: __dirname, maxBuffer: 1 << 28 }).toString();
+
+// ── slice a top-level assignment/declaration out of the module by brace matching ───────────────
+function slice(src, marker, optional) {
+  const idx = src.indexOf(marker);
+  if (idx < 0) {
+    if (optional) return '';
+    throw new Error('marker not found: ' + marker);
+  }
+  let depth = 0, seen = false, i = idx;
+  for (; i < src.length; i++) {
+    if (src[i] === '{') { depth++; seen = true; }
+    else if (src[i] === '}') { depth--; if (seen && depth === 0) break; }
+  }
+  return src.slice(idx, i + 1) + ';';
+}
+
+// ── one sandboxed Time Machine, with only the module state these two verbs touch ───────────────
+// `loadAfterTicks` reproduces the real ordering: activate() kicks an async load and the 63,415-op
+// timeline (with its real epoch) only lands some polls later.
+function makeTM(src, opts) {
+  const logs = [];
+  const timers = [];           // virtual clock: {id, fn, everyTicks, nextAt, cleared}
+  let now = 0, nextId = 1;
+  const ctx = {
+    _ops: opts.opsAtArm.slice(),
+    _active: opts.activeAtArm,
+    _projectStart: opts.startAtArm,
+    _projectEnd: opts.endAtArm,
+    activateCalls: 0,
+    console: {
+      log: (m) => logs.push(String(m)),
+      warn: (m) => logs.push(String(m)),
+    },
+    setInterval: (fn, ms) => {
+      const t = { id: nextId++, fn, every: ms, next: now + ms, cleared: false };
+      timers.push(t); return t.id;
+    },
+    clearInterval: (id) => { const t = timers.find(t => t.id === id); if (t) t.cleared = true; },
+    // tmFollowTimeline's collaborators — stubbed to the shape the real ones return.
+    A: () => ({ dbQuery: () => opts.geomGuids.map(g => [g]) }),
+  };
+  ctx.window = ctx;            // the module assigns onto `window`; bare reads hit the same object
+  ctx.window.tmScheduleSource = () => ({ source: 'timeline', leafTasks: 35, capOps: 0,
+                                         capActive: false, covered: 0, total: ctx._ops.length, pct: 0 });
+  ctx.activate = function () {
+    ctx.activateCalls++;
+    if (opts.loadAfterMs != null) ctx._loadAt = now + opts.loadAfterMs;
+  };
+  vm.createContext(ctx);
+  vm.runInContext([
+    slice(src, 'function _bakeTimelineReady()', true),
+    slice(src, 'window.tmActivateForBake = function'),
+    slice(src, 'window.tmFollowTimeline = function'),
+  ].join('\n'), ctx);
+
+  // Drive the virtual clock. `await null` between steps lets the Promise continuation run.
+  async function run(maxMs) {
+    while (now <= maxMs) {
+      if (ctx._loadAt != null && now >= ctx._loadAt) {
+        ctx._ops = opts.opsAfterLoad.slice();
+        ctx._projectStart = opts.startAfterLoad;
+        ctx._projectEnd = opts.endAfterLoad;
+        ctx._active = true;
+        ctx._loadAt = null;
+      }
+      const due = timers.filter(t => !t.cleared && t.next <= now);
+      for (const t of due) { t.next = now + t.every; t.fn(); }
+      for (let k = 0; k < 20; k++) await null;     // flush microtasks (promise resolutions)
+      if (ctx._armDone) break;
+      now += 100;
+    }
+  }
+  return { ctx, logs, run, armAt: () => ctx._armedAtMs };
+}
+
+// The film's own per-frame cursor expression (cinema_path_editor.js `_previewFly` fallback):
+//   bkMs = projectStart + u * (projectEnd - projectStart)
+function cursorSeries(bk) {
+  if (!bk) return null;
+  return [0, 0.5, 1].map(u => bk.projectStart + u * (bk.projectEnd - bk.projectStart));
+}
+
+const HOSPITAL_OPEN_OP = { output_guid: null, input_guids: [], start_ts: 0, end_ts: 0 };
+function realOps(n, guids) {
+  const out = [];
+  for (let i = 0; i < n; i++) {
+    out.push({ output_guid: guids[i % guids.length], input_guids: [],
+               start_ts: 1.7e12 + i * 86400000, end_ts: 1.7e12 + (i + 1) * 86400000 });
+  }
+  return out;
+}
+
+// ── the three gates ────────────────────────────────────────────────────────────────────────────
+async function gate(src, label) {
+  const out = { label, lines: [] };
+  const say = (s) => { out.lines.push(s); console.log(s); };
+
+  // G-ARM-1 — the user's exact state: ONE stale BUILDING_OPEN op, epoch 0/0, real timeline lands later.
+  {
+    const guids = ['g1', 'g2', 'g3'];
+    const tm = makeTM(src, {
+      opsAtArm: [HOSPITAL_OPEN_OP], activeAtArm: false, startAtArm: 0, endAtArm: 0,
+      loadAfterMs: 2400,
+      opsAfterLoad: realOps(12, guids), startAfterLoad: 1.7e12 - 1, endAfterLoad: 1.7e12 + 12 * 86400000,
+      geomGuids: guids,
+    });
+    let armed = null;
+    tm.ctx.window.tmActivateForBake().then(ok => { armed = ok; tm.ctx._armDone = true; tm.ctx._armedAtMs = null; });
+    await tm.run(40000);
+    const bk = armed ? tm.ctx.window.tmFollowTimeline() : null;
+    const cur = cursorSeries(bk);
+    const moves = !!cur && new Set(cur).size === 3;
+    out.g1 = moves;
+    say('§ARM_GATE G-ARM-1 ' + label + ' armed=' + armed +
+        ' bk=' + (bk ? 'ops=' + bk.ops + ' placed=' + bk.placed + ' span=' + (bk.projectEnd - bk.projectStart) + 'ms' : 'null') +
+        ' cursor@u[0,.5,1]=' + (cur ? cur.map(v => Math.round(v)).join(',') : 'n/a') +
+        ' → ' + (moves ? 'ADVANCES (PASS)' : 'FROZEN — the film cannot build (FAIL)'));
+  }
+
+  // G-ARM-2 — a real, loaded timeline must still arm and still be followed (no false rejection).
+  {
+    const guids = ['g1', 'g2', 'g3'];
+    const tm = makeTM(src, {
+      opsAtArm: realOps(9, guids), activeAtArm: true,
+      startAtArm: 1.7e12 - 1, endAtArm: 1.7e12 + 9 * 86400000,
+      loadAfterMs: null, opsAfterLoad: [], startAfterLoad: 0, endAfterLoad: 0, geomGuids: guids,
+    });
+    let armed = null;
+    tm.ctx.window.tmActivateForBake().then(ok => { armed = ok; tm.ctx._armDone = true; });
+    await tm.run(5000);
+    const bk = armed ? tm.ctx.window.tmFollowTimeline() : null;
+    const cur = cursorSeries(bk);
+    const ok = armed === true && !!cur && new Set(cur).size === 3;
+    out.g2 = ok;
+    say('§ARM_GATE G-ARM-2 ' + label + ' armed=' + armed +
+        ' bk=' + (bk ? 'ops=' + bk.ops + ' placed=' + bk.placed : 'null') +
+        ' cursor=' + (cur ? cur.map(v => Math.round(v)).join(',') : 'n/a') +
+        ' → ' + (ok ? 'usable timeline NOT rejected (PASS)' : 'REGRESSION: a real timeline was refused (FAIL)'));
+  }
+
+  // G-ARM-3 — ops that never map to geometry: nothing can appear, so the arm must refuse, not pretend.
+  {
+    const tm = makeTM(src, {
+      opsAtArm: realOps(5, ['ghost1', 'ghost2']), activeAtArm: true,
+      startAtArm: 1.7e12 - 1, endAtArm: 1.7e12 + 5 * 86400000,
+      loadAfterMs: null, opsAfterLoad: [], startAfterLoad: 0, endAfterLoad: 0,
+      geomGuids: ['someone-else'],           // no op guid is present in element_transforms
+    });
+    tm.ctx._armDone = true;
+    await tm.run(0);
+    const bk = tm.ctx.window.tmFollowTimeline();
+    const ok = bk === null;
+    out.g3 = ok;
+    say('§ARM_GATE G-ARM-3 ' + label + ' bk=' + (bk ? 'placed=' + bk.placed + ' (returned anyway)' : 'null') +
+        ' → ' + (ok ? 'refused, nothing to reveal (PASS)' : 'armed with placed=0 (FAIL)'));
+  }
+  return out;
+}
+
+(async function () {
+  console.log('§ARM_GATE W-ARM-GATE — §CPE_BUILDUP_ARM_GATE, two sources, one harness\n');
+  const shipped = await gate(shippedSrc, 'SHIPPED(origin/main)');
+  console.log('');
+  const fixed = await gate(workingSrc, 'FIXED(working-tree)');
+
+  console.log('\n§ARM_GATE_RESULT red=' + (shipped.g1 === false ? 'G-ARM-1 FAILS on origin/main (the bug reproduces)'
+    : 'G-ARM-1 PASSES on origin/main — WITNESS IS BLIND, the RED case no longer reproduces'));
+  const green = fixed.g1 && fixed.g2 && fixed.g3;
+  console.log('§ARM_GATE_RESULT green=' + (green ? 'all gates pass on the fix' : 'FIX INCOMPLETE') +
+    ' (G-ARM-1=' + fixed.g1 + ' G-ARM-2=' + fixed.g2 + ' G-ARM-3=' + fixed.g3 + ')');
+  const verdict = (shipped.g1 === false) && green;
+  console.log('§ARM_GATE_VERDICT ' + (verdict ? 'GREEN — falsifiable and fixed' : 'RED — see gates above'));
+  process.exit(verdict ? 0 : 1);
+})();


### PR DESCRIPTION
**User report:** *"in Alt-C movie making TM does not move, seems disengaged"* → *"chrome reset SW, refreshed twice, still TM not moving at all, nothing built during pov preview."* Their run is `§BUILD_VERSION v997` / `§CPE_LOADED v24` — the tip with R4. Not a cache problem.

## Root cause, from their own Hospital console
```
§TM_OPS_CHECK total=1 place=0
§CPE_BUILDUP_SOURCE mode=T ops=1 placed=0 window=1970-01-01..1970-01-01
§GHOST_GROUND skip reason=buildup span is 0 (projectStart=0 projectEnd=0)
§CPE_PREVIEW_BUILDUP armed mode=T ops=1 placed=0 setupMs=5850
§PERF_TRAVERSE span=0h          ← every one of 497 frames
…after the flight had already started:
§WRITE_LOOP_TIMING rows=63415 → §GANTT_CACHE_SAVE ops=63416 → §PERF_TRAVERSE span=503952h
```
`tmActivateForBake` polled `_ops.length`, which is truthy for **one stale `BUILDING_OPEN` kernel op**, while the epoch was still `0/0`. It resolved `true` against a zero-span 1970 timeline, so the film's per-frame cursor `projectStart + u*(projectEnd-projectStart)` was **0 at every u**. Camera flew, nothing built.

`ghostGroundArm` and the day counter got the **same** `bkState` and refused it. The one consumer that drives the cursor did not. That asymmetry is the bug.

## Fix — two guards, `viewer/time_machine.js`
1. `tmActivateForBake`: `_bakeTimelineReady()` = `_ops.length && _projectEnd > _projectStart`. Not a new wait — the existing 60×500 ms poll now waits for the condition it always meant, and logs `§CPE_BUILDUP_ARM_GATE timeout` if it never arrives.
2. `tmFollowTimeline`: refuse (`null` + loud `§CPE_BUILDUP_SOURCE reject`) on zero span or `placed === 0`. `cinema_maxq.js` calls the same verb, so a **bake** can't silently record a static building either.

A real timeline always has span > 0 (`_projectStart = _ops[0].start_ts - 1`), so neither guard can reject a usable state, including a single-op model.

## Witness — `witness_cpe_buildup_arm_gate.js` (W-ARM-GATE)
One harness, two sources (`origin/main` vs working tree), virtual clock so the poll costs no wall time. It asserts **the number the film consumes** — the cursor at u=0/0.5/1 must be three different values — not "the arm returned true", which is true on the broken build too.

```
G-ARM-1 SHIPPED(origin/main) armed=true bk=ops=1 placed=0 span=0ms cursor@u[0,.5,1]=0,0,0 → FROZEN (FAIL)
G-ARM-1 FIXED   armed=true bk=ops=12 placed=12 span=1036800001ms cursor=1699999999999,1700518400000,1701036800000 → ADVANCES (PASS)
G-ARM-2 real timeline not rejected → PASS on both (no regression)
G-ARM-3 placed=0 → FAIL shipped, PASS fixed
§ARM_GATE_VERDICT GREEN — falsifiable and fixed
```

Spec: `bim-compiler prompts/CINEMA_PATH_EDITOR.md §CPE_BUILDUP_ARM_GATE`. `sw.js` `CACHE_VERSION` v997 → v998.

🤖 Generated with [Claude Code](https://claude.com/claude-code)