### PR TITLE
fix(viewer): §SWUPDATE_FIRST_CLAIM — no "Update ready" toast on the first controller

### DIFF
--- a/viewer/sw.js
+++ b/viewer/sw.js
@@ -8,7 +8,7 @@
 // Cache-first for heavy assets (.wasm, images). DB files skip SW (IndexedDB handles them).
 //
 // DEPLOY: bump CACHE_VERSION on every OCI upload. Old caches are purged on activate.
-const CACHE_VERSION = 'v998';   // bump on each deploy; per-change detail is the git commit message.
+const CACHE_VERSION = 'v999';   // bump on each deploy; per-change detail is the git commit message.
 const CACHE_PREFIX = 'bim-ootb-';
 const CACHE_NAME = CACHE_PREFIX + CACHE_VERSION;
 

--- a/viewer/viewer.html
+++ b/viewer/viewer.html
@@ -1048,9 +1048,26 @@ if('serviceWorker' in navigator){
   // activates and claims control on its own -- listening for `controllerchange` is enough, no
   // message-roundtrip needed. NEVER auto-reload silently (could interrupt a live MaxQ bake) --
   // only a tap reloads, matching the spec's rule 4.
+  // §SWUPDATE_FIRST_CLAIM (2026-08-12, user: "why would a 'Update Ready - Tap Reset' message
+  // appear upon loading a building after SW reset"): `controllerchange` fires for TWO different
+  // events, and only one of them is an update. After a SW reset/unregister (or a first visit) the
+  // page loads with NO controller — `§BUILD_VERSION (no active controller yet)` in the user's log —
+  // then the freshly-registered worker installs (`§PRECACHE-TRIM install set=140`), skipWaiting()s,
+  // and clients.claim()s the page. controller goes null -> worker, `controllerchange` fires, and the
+  // toast claimed "Update ready" for what is really this page's FIRST controller. Nothing was
+  // updated and reloading changes nothing — pure noise, in the middle of a 229MB building load.
+  // The sibling ERP shells already carry exactly this guard and say why in their own comment
+  // ("NEVER on the first-install clients.claim() controllerchange"); the viewer port missed it.
+  // An update, by definition, REPLACES a controller that was already there.
+  var _swHadController = !!navigator.serviceWorker.controller;
   navigator.serviceWorker.addEventListener('controllerchange', function(){
     if (window.__swReloaded) return;  // one-shot guard, never loop
-    console.log('§SWUPDATE_TOAST controllerchange — new version active, showing toast');
+    if (!_swHadController) {
+      console.log('§SWUPDATE_TOAST skip reason=first-claim (page had no controller at load; ' +
+        'this is the initial install taking over, not a new version) — no toast');
+      return;
+    }
+    console.log('§SWUPDATE_TOAST controllerchange — new version active, showing toast (hadController=true)');
     var t = document.createElement('div');
     t.id = 'swUpdateToast';
     t.style.cssText = 'position:fixed;left:50%;bottom:24px;transform:translateX(-50%);' +


### PR DESCRIPTION
**User:** *"why would a 'Update Ready - Tap Reset' message appear upon loading a building after SW reset"*

Because `controllerchange` fires for **two** different events and only one of them is an update. Their log, in order:

```
§BUILD_VERSION (no active controller yet — reload once to confirm)
sw.js?v=538 §PRECACHE-TRIM install set=140 deferred=4
…mid-load, during the 229MB geo fetch:
§SWUPDATE_TOAST controllerchange — new version active, showing toast
```

After a SW reset the page loads **uncontrolled**. The freshly registered worker installs, `skipWaiting()`s and `clients.claim()`s the page, so `controller` goes `null → worker` and `controllerchange` fires. Nothing was updated; tapping reload changes nothing. Pure noise, dropped on the user in the middle of a load.

**Guard:** capture `navigator.serviceWorker.controller` at registration — a toast requires that there *was* a controller to replace. First claim now logs `§SWUPDATE_TOAST skip reason=first-claim` instead of showing UI. Real-update behaviour untouched.

**Not a new idea:** `erp/glassbowl.html:157` and `erp/glassbowl_gravity.html:117` already carry this exact guard and name the reason in their own comments — *"NEVER on the first-install clients.claim() controllerchange"*. The viewer port of §SWUPDATE_TOAST (#1289) missed it.

Verified: all 4 inline `<script>` blocks in `viewer.html` parse clean. `sw.js` `CACHE_VERSION` v998 → v999.

🤖 Generated with [Claude Code](https://claude.com/claude-code)