### PR TITLE
fix(4d): §GANTT_PHASE_CLOBBER — Gantt bars lost their colours (and their row order) to the task name

### DIFF
--- a/viewer/sw.js
+++ b/viewer/sw.js
@@ -8,7 +8,7 @@
 // Cache-first for heavy assets (.wasm, images). DB files skip SW (IndexedDB handles them).
 //
 // DEPLOY: bump CACHE_VERSION on every OCI upload. Old caches are purged on activate.
-const CACHE_VERSION = 'v999';   // bump on each deploy; per-change detail is the git commit message.
+const CACHE_VERSION = 'v1000';   // bump on each deploy; per-change detail is the git commit message.
 const CACHE_PREFIX = 'bim-ootb-';
 const CACHE_NAME = CACHE_PREFIX + CACHE_VERSION;
 

--- a/viewer/time_machine.js
+++ b/viewer/time_machine.js
@@ -4949,9 +4949,11 @@
     // when the two inline copies were consolidated 2026-08-10).
     var _lp = _promoteRoofLoadPath(elements);
     // §4D_ROOF_LOAD_PATH witness hook (double-underscore debug convention, same as __tmGanttShift):
-    // on the _cap path the ops' `phase` param is overwritten with the task NAME (p.phase = w.name
-    // below), so promotion is no longer observable through kernel_ops — witness_4d_roof_load_path
-    // G-RLP-2/3 read the promoted set here instead. Refreshed on every injectGantt run.
+    // witness_4d_roof_load_path G-RLP-2/3 read the promoted set here rather than from kernel_ops.
+    // This hook was ADDED because the _cap path used to overwrite the ops' `phase` param with the
+    // task NAME, hiding the promotion from kernel_ops; §GANTT_PHASE_CLOBBER (2026-08-12, ~:5238)
+    // ends that clobber, so `phase` is honest in kernel_ops again — the hook stays because reading
+    // the promoted set directly is still the cheaper, more direct assertion. Refreshed every run.
     window.__tmLoadPathPromoted = _lp.guids;
     if (_lp.total) console.log('§GANTT_OVERRIDE ' + _lp.total +
       ' slabs promoted to roof role (seq=8) by load path — base_z above the average midheight of their XY-overlapping walls' +
@@ -5235,7 +5237,24 @@
           var _le = p._end_ts || (_ls + 60000);
           if (_ls < _lsMin) _lsMin = _ls;
           if (_le > _leMax) _leMax = _le;
-          p.phase = w.name;                         // real task name → shows in mini-Gantt
+          // §GANTT_PHASE_CLOBBER (2026-08-12, bim-compiler prompts/4D_SCHEDULE_PERFECTION.md —
+          // Witness: W-PHASE-KEY / witness_gantt_phase_palette.js). This line used to be
+          // `p.phase = w.name`, i.e. it wrote the TASK NAME into the field the whole drawer keys
+          // on. Harmless while task names looked like phases; destructive since zone-level
+          // authoring became the default, because materializeZones names its tasks
+          // "<Phase> — <Storey>". Measured on the user's Hospital session, every op's phase became
+          // "Architecture — Level 1" and three separate things broke at once:
+          //   1. PHASE_COLORS[task.phase] || '#888'  -> all 35 bars grey (also PHASE_INK/PHASE_SHORT)
+          //   2. _phaseRank() = _ROW_PHASE_ORDER.indexOf(phase) -> -1 for every row, so the sort
+          //      falls through to alphabetical: §GANTT_ROW_ORDER printed Architecture … Substructure
+          //      5th — §GANTT_ROW_ORDER (K1)'s ORIGINAL reported bug, back verbatim and silent.
+          //   3. tm-dash-phases buckets by the same field and filters through PHASE_ORDER -> zero
+          //      matches, no §DASH_PHASE line in the entire session, phase progress renders empty.
+          // The name was never made visible by this line anyway: buildGanttTasks reads it from the
+          // task index into `taskName` (~:5694) and the bar detail header renders
+          // `bar.taskName || (bar.phase + ' — ' + bar.storey)` (~:6716). So keep the name, in its
+          // own field, and leave the phase alone — the drawer needs BOTH, not one overwriting the other.
+          p.taskName = w.name;                      // real task name → mini-Gantt detail header
           _allScheduled.push({ guid: g, s: _ls, e: _le, params: p, task: tid,
             bz: _el ? _el.base_z : 0, tz: _el ? _el.top_z : 0,
             x0: _el ? _el.x0 : 0, x1: _el ? _el.x1 : 0,

--- a/witness_gantt_phase_palette.js
+++ b/witness_gantt_phase_palette.js
@@ -1,0 +1,148 @@
+#!/usr/bin/env node
+// witness_gantt_phase_palette.js — W-PHASE-KEY
+// Implementing bim-compiler prompts/4D_SCHEDULE_PERFECTION.md §GANTT_PHASE_CLOBBER
+//
+// THE ISSUE THIS WITNESS PROVES OR DISPROVES:
+//   The Time Machine's Gantt drawer keys colour, ink, short-code and ROW ORDER off one field —
+//   `parameters.phase`. The captured/authored overlay overwrote that field with the TASK NAME, and
+//   since zone-level authoring became the default those names read "<Phase> — <Storey>". Every
+//   lookup then misses: bars go grey, and _phaseRank() returns -1 for every row so the sort falls
+//   through to ALPHABETICAL — which is §GANTT_ROW_ORDER (K1)'s original reported bug ("substructure
+//   which has above ground appearing first"), silently back.
+//
+//   The strings below are the user's own, copied from their Hospital console:
+//     §GANTT_ROW_ORDER phases=["Architecture — Level 1", … ,"Superstructure — Level 7A"]
+//
+// HOW IT FALSIFIES: G-PAL-1 feeds those exact strings through the SHIPPED palette + rank code
+// (sliced from viewer/time_machine.js, not retyped) and must show grey/unranked — if it ever passes,
+// the RED case stopped reproducing and this witness is blind. G-PAL-3 asserts on the source itself:
+// the overlay must not write a task name into the field the palette reads.
+//
+// A witness that only checked "the drawer rendered" would pass on the broken build — it did render,
+// in grey, in the wrong order. The assertions here are the colour string and the rank integer.
+//
+// Run (from the repo root):  node witness_gantt_phase_palette.js
+// Read the log, not the exit code.
+'use strict';
+const fs = require('fs');
+const path = require('path');
+const vm = require('vm');
+const cp = require('child_process');
+
+const TM = path.join(__dirname, 'viewer', 'time_machine.js');
+const workingSrc = fs.readFileSync(TM, 'utf8');
+const shippedSrc = cp.execFileSync('git', ['show', 'origin/main:viewer/time_machine.js'],
+  { cwd: __dirname, maxBuffer: 1 << 28 }).toString();
+
+function sliceBraces(src, marker) {
+  const idx = src.indexOf(marker);
+  if (idx < 0) throw new Error('marker not found: ' + marker);
+  let depth = 0, seen = false, i = idx;
+  for (; i < src.length; i++) {
+    if (src[i] === '{') { depth++; seen = true; }
+    else if (src[i] === '}') { depth--; if (seen && depth === 0) break; }
+  }
+  return src.slice(idx, i + 1) + ';';
+}
+// An IIFE's balanced brace closes the FUNCTION BODY, not the statement — slice through its
+// `})();` terminator instead, or the assembled script is `var X = (function(){…};` and won't parse.
+function sliceIife(src, marker) {
+  const idx = src.indexOf(marker);
+  if (idx < 0) throw new Error('marker not found: ' + marker);
+  const end = src.indexOf('})();', idx);
+  if (end < 0) throw new Error('IIFE terminator not found for: ' + marker);
+  return src.slice(idx, end + 5);
+}
+
+// The shipped palette tables + the shipped row-rank derivation, executed as-is.
+function palette(src) {
+  const ctx = { console: { log() {}, warn() {} }, window: {} };
+  vm.createContext(ctx);
+  vm.runInContext([
+    sliceBraces(src, 'var PHASE_COLORS = {'),
+    sliceBraces(src, 'var PHASE_SHORT = {'),
+    sliceBraces(src, 'var PHASE_INK = {'),
+    // _ROW_PHASE_ORDER is an IIFE assigned to a var; with window.SEQUENCE_RULES absent it takes its
+    // own documented fallback — the same canonical order the engine derives from SEQUENCE_RULES.
+    sliceIife(src, 'var _ROW_PHASE_ORDER = (function ()'),
+    sliceBraces(src, 'function _phaseRank(p)'),
+  ].join('\n'), ctx);
+  return ctx;
+}
+
+const ENGINE_PHASES = ['Substructure', 'Superstructure', 'Architecture',
+                       'MEP Rough-in', 'MEP Final', 'Finishes'];
+
+// The captured overlay's own assignment statement, taken from the source as CODE (comment lines
+// excluded — an early draft of this witness matched the fix's own explanatory comment and reported
+// the fixed tree as broken). Executed, not paraphrased: whatever the shipped line does to `p` is
+// what the drawer will key on.
+function overlayAssign(src) {
+  const line = src.split('\n').filter(function (l) {
+    const t = l.trim();
+    return !t.startsWith('//') && !t.startsWith('*') && /^\s*p\.\w+\s*=\s*w\.name\s*;/.test(l);
+  })[0];
+  if (!line) throw new Error('no `p.<field> = w.name;` assignment found in the captured overlay');
+  return line.trim();
+}
+
+function gates(src, label) {
+  const P = palette(src);
+  const out = { label };
+
+  // G-PAL-1 — the DATA FLOW, end to end: run the shipped overlay statement over one op's params
+  // (a zone task, named the way materializeZones names them), then look the result up in the
+  // shipped palette exactly as the drawer does. This is the user's Hospital case reduced to two
+  // values: the colour string and the rank integer.
+  const stmt = overlayAssign(src);
+  const p = { phase: 'Architecture', storey: 'Level 1' };
+  const w = { name: 'Architecture — Level 1' };
+  vm.runInNewContext(stmt, { p: p, w: w });
+  const key = p.phase;                                   // what PHASE_COLORS/_phaseRank receive
+  const color = P.PHASE_COLORS[key] || '#888';
+  const ink = P.PHASE_INK[key] || '#fff';
+  const short = P.PHASE_SHORT[key] || String(key).substring(0, 3);
+  const rank = P._phaseRank(key);
+  out.g1 = color !== '#888' && rank < P._ROW_PHASE_ORDER.length;
+  console.log('§PHASE_KEY G-PAL-1 ' + label + ' stmt=`' + stmt + '`' +
+    ' → phaseKey="' + key + '" colour=' + color + ' ink=' + ink + ' short=' + short + ' rank=' + rank +
+    ' (of ' + P._ROW_PHASE_ORDER.length + ') taskName=' + JSON.stringify(p.taskName || null) +
+    ' → ' + (out.g1 ? 'palette + row order resolve (PASS)'
+      : 'BAR GREY + row unranked → alphabetical order (FAIL — this is the reported symptom)'));
+
+  // G-PAL-2 — the canonical phases must always resolve; proves the tables themselves are intact,
+  // so a G-PAL-1 failure can only be the KEY, never a missing palette entry.
+  const bad = ENGINE_PHASES.filter(p => !P.PHASE_COLORS[p] || P._phaseRank(p) >= P._ROW_PHASE_ORDER.length);
+  out.g2 = bad.length === 0;
+  console.log('§PHASE_KEY G-PAL-2 ' + label + ' enginePhases=' + ENGINE_PHASES.length +
+    ' unresolved=' + bad.length + ' order=' + JSON.stringify(P._ROW_PHASE_ORDER) +
+    ' → ' + (out.g2 ? 'every real phase has a colour and a rank (PASS)' : 'palette itself is broken (FAIL)'));
+
+  // G-PAL-3 — the task NAME must survive somewhere, or the fix would just be a deletion: the bar
+  // detail header renders `bar.taskName || (bar.phase + ' — ' + bar.storey)`, so the name has to
+  // land in a field that is not the palette's key. Same executed `p` as G-PAL-1.
+  const nameKept = p.taskName === w.name;
+  const phaseIntact = p.phase === 'Architecture';
+  out.g3 = nameKept && phaseIntact;
+  console.log('§PHASE_KEY G-PAL-3 ' + label + ' after the shipped statement: p.phase=' +
+    JSON.stringify(p.phase) + ' p.taskName=' + JSON.stringify(p.taskName || null) +
+    ' → ' + (out.g3 ? 'name kept AND phase left alone (PASS)'
+      : !phaseIntact ? 'the overlay overwrote the field the palette keys on (FAIL)'
+      : 'the task name was dropped entirely (FAIL)'));
+  return out;
+}
+
+console.log('§PHASE_KEY W-PHASE-KEY — §GANTT_PHASE_CLOBBER, shipped vs fixed\n');
+const shipped = gates(shippedSrc, 'SHIPPED(origin/main)');
+console.log('');
+const fixed = gates(workingSrc, 'FIXED(working-tree)');
+
+console.log('\n§PHASE_KEY_RESULT red=' + (shipped.g1 === false && shipped.g3 === false
+  ? 'G-PAL-1 + G-PAL-3 FAIL on origin/main (the bug reproduces)'
+  : 'origin/main PASSES — WITNESS IS BLIND, the RED case no longer reproduces'));
+const green = fixed.g1 && fixed.g2 && fixed.g3;
+console.log('§PHASE_KEY_RESULT green=' + (green ? 'all gates pass on the fix' : 'FIX INCOMPLETE') +
+  ' (G-PAL-1=' + fixed.g1 + ' G-PAL-2=' + fixed.g2 + ' G-PAL-3=' + fixed.g3 + ')');
+const verdict = shipped.g1 === false && shipped.g3 === false && green;
+console.log('§PHASE_KEY_VERDICT ' + (verdict ? 'GREEN — falsifiable and fixed' : 'RED — see gates above'));
+process.exit(verdict ? 0 : 1);


### PR DESCRIPTION
**User:** *"at first load, the TM 4D gantt schedule has nice coloring looks OK but on refresh it goes away"* → *"U have to hunt back those pretty colors."*

## One line, three broken things
`time_machine.js:5238`, in the captured/authored overlay:
```js
p.phase = w.name;   // real task name → shows in mini-Gantt
```
`w.name` is the **task** name. Harmless while task names looked like phases — destructive since zone-level authoring became the default, because `materializeZones` names its tasks `"<Phase> — <Storey>"`. Straight from the user's log:
```
§AUTHOR_ZONES schedule=SCH_AUTHORED zones=35 … §GANTT_SOURCE captured tasks=35 covered=63415
§GANTT_ROW_ORDER phases=["Architecture — Level 1","Architecture — Level 2",…,"Superstructure — Level 7A"]
```
Everything downstream keys on that one field:
1. **Colour** — `PHASE_COLORS[task.phase] || '#888'` misses on all 35 bars. `PHASE_INK` and `PHASE_SHORT` go with it, so labels fall back to `name.substring(0,3)`.
2. **Row order** — `_phaseRank()` is `_ROW_PHASE_ORDER.indexOf(phase)`; −1 for every row, so the sort falls through to alphabetical. The user's own `§GANTT_ROW_ORDER` shows **Substructure 5th** — §GANTT_ROW_ORDER (K1)'s *original reported bug* (*"substructure which has above ground appearing first"*), back and silent.
3. **Dashboard** — `tm-dash-phases` buckets by the same field then filters through `PHASE_ORDER`: zero matches, **not one `§DASH_PHASE` line** in the user's entire session.

**"OK first load, gone on refresh"** follows exactly: the clobber only fires when an authored/captured schedule is already present and covering when `injectGantt` runs — not on a cold open, always on a warm reopen.

## Fix
`p.taskName = w.name`. That line never made the name visible anyway — `buildGanttTasks` reads it from the task index into `taskName` (`:5694`) and the bar detail header renders `bar.taskName || (bar.phase + ' — ' + bar.storey)` (`:6716`). Also corrects the `§4D_ROOF_LOAD_PATH` comment at `:4952`, which cited this clobber as the reason its witness hook exists.

## Witness — `witness_gantt_phase_palette.js` (W-PHASE-KEY)
Executes the **shipped overlay statement** over one op's params, then looks the result up in the **shipped** palette tables and rank function (sliced from `time_machine.js`, not retyped). It asserts a colour string and a rank integer — not "it rendered", which was true on the broken build too, in grey.

```
G-PAL-1 SHIPPED stmt=`p.phase = w.name;`     → phaseKey="Architecture — Level 1" colour=#888 rank=6/6 → FAIL
G-PAL-1 FIXED   stmt=`p.taskName = w.name;`  → phaseKey="Architecture" colour=#5e3f87 ink=#ffffff
                                               short=ARCH rank=2/6 taskName="Architecture — Level 1" → PASS
G-PAL-2 all six engine phases resolve → PASS on both (so a G-PAL-1 failure can only be the KEY)
G-PAL-3 name kept AND phase intact → FAIL shipped, PASS fixed
§PHASE_KEY_VERDICT GREEN — falsifiable and fixed
```

Spec: `bim-compiler prompts/4D_SCHEDULE_PERFECTION.md §GANTT_PHASE_CLOBBER`. `sw.js` `CACHE_VERSION` v999 → v1000.

🤖 Generated with [Claude Code](https://claude.com/claude-code)