### PR TITLE
perf(4d): §TIER_SERIAL_BY_ZONE — backbone barrier scoped per derived zone, programme −27..−47%

### DIFF
--- a/viewer/sw.js
+++ b/viewer/sw.js
@@ -8,7 +8,7 @@
 // Cache-first for heavy assets (.wasm, images). DB files skip SW (IndexedDB handles them).
 //
 // DEPLOY: bump CACHE_VERSION on every OCI upload. Old caches are purged on activate.
-const CACHE_VERSION = 'v1001';   // bump on each deploy; per-change detail is the git commit message.
+const CACHE_VERSION = 'v1002';   // bump on each deploy; per-change detail is the git commit message.
 const CACHE_PREFIX = 'bim-ootb-';
 const CACHE_NAME = CACHE_PREFIX + CACHE_VERSION;
 

--- a/viewer/tests/witness_tier_serial_display.js
+++ b/viewer/tests/witness_tier_serial_display.js
@@ -14,7 +14,14 @@
 // phase-sightability structure (§TIER_MOVIE — each backbone phase owns a contiguous, exclusive
 // slice of the displayed timeline, which is exactly what a linear movie clock renders).
 //
-//   W-TS-1  Tier-1 strictly serial: _twoTierRemap reports tier1OverlapPairs=0 on every building.
+//   W-TS-1  Tier-1 strictly serial WITHIN EACH ZONE: _twoTierRemap reports tier1OverlapPairs=0 on
+//           every building. ⚠ SCOPE CHANGED 2026-08-12 (§TIER_SERIAL_BY_ZONE): the bar is still
+//           zero, but it is now summed per derived storey band rather than over the whole model.
+//           Derived from the user's own 2026-08-02 ruling, which §TIER_SERIAL's header quotes:
+//           "ARCH/STR ... the physical foundation. Separate unrelated disciplines can run parallel
+//           thereafter IF CONSTRUCTION PRACTICE PERMITS" — practice permits walls on level 1 while
+//           level 7 frames. The physical guarantee is untouched: _ogSupportSweep still gates every
+//           element individually against the real support DAG; this is the display grouping on top.
 //           >0 = the backbone still overlaps — the capstone claim is false.
 //   W-TS-2  No new support violations: auditFloating over the REMAPPED times <= auditFloating over
 //           the RAW generative times (display may REPAIR the known floating tail, never grow it).
@@ -73,6 +80,12 @@ if (tmSrc.indexOf(tierOrderLine) < 0) { assert(false, 'W-TS-0 _TIER1_ORDER const
 
 const sliced = [
   tierOrderLine,
+  // §ZONE_INDEX (#1313) + §TIER_SERIAL_BY_ZONE: _buildXrayElements reads the shared memoized zone
+  // index, and the tier functions key off _zoneOf. Both ride along verbatim, same idiom as the rest.
+  'var _zoneMemo = [];',
+  sliceFn(tmSrc, '_zoneIndexBuild'),
+  sliceFn(tmSrc, '_zoneIndex'),
+  sliceFn(tmSrc, '_zoneOf'),
   sliceFn(tmSrc, '_promoteRoofLoadPath'),
   sliceFn(tmSrc, '_buildXrayElements'),
   sliceFn(tmSrc, '_tier1Extents'),
@@ -197,7 +210,13 @@ const D = 86400000;
     // ── the shipped two-tier remap (sliced) ──
     const items = geoEls.map(e => ({ guid: e.guid, s: sched[e.guid].start, e: sched[e.guid].end,
       bz: e.base_z, tz: e.top_z, x0: e.x0, x1: e.x1, y0: e.y0, y1: e.y1,
-      cls: e.cls, seq: e.seq, phase: e.phase }));
+      cls: e.cls, seq: e.seq, phase: e.phase,
+      // §TIER_SERIAL_BY_ZONE: the zone key MUST ride along, exactly as injectGantt's _twItems
+      // carries it. Without it _zoneOf falls back to '_ALL' and this harness would silently
+      // exercise the DEGENERATE single-zone path — i.e. it would pass while proving nothing about
+      // the change. Caught exactly that way on the first run (JKR twoTierDays=110.1 here vs 74.4
+      // from the probe against the same code).
+      storey: e.storey }));
     const tierLines = [];
     sandbox.console = { log: (...a) => tierLines.push(a.join(' ')), warn: () => {} };
     vm.runInContext('this.__lastStats = null;', sandbox);
@@ -210,7 +229,8 @@ const D = 86400000;
     // W-TS-1 — strict serial backbone (dag-wins-excluded extents; the dag-wins population is
     // counted + locked in W-TS-1b, never hidden)
     assert(stats && stats.overlapPairs === 0,
-      'W-TS-1 ' + bld + ' Tier-1 backbone strictly serial (tier1OverlapPairs=' + (stats ? stats.overlapPairs : '?') + ', iterations=' + (stats ? stats.iterations : '?') + ')');
+      'W-TS-1 ' + bld + ' Tier-1 backbone strictly serial WITHIN EACH ZONE (tier1OverlapPairs=' +
+      (stats ? stats.overlapPairs : '?') + ', iterations=' + (stats ? stats.iterations : '?') + ')');
     // §TIER_DAG_WINS lock (measured 2026-08-11, stragglers.log + promoted_deps.log): elements the
     // support DAG itself places inside a LATER backbone phase — support order wins for them.
     // Hospital/Clinic: isolated forward deps (foundation slab / slab-on-grade poured around
@@ -226,8 +246,16 @@ const D = 86400000;
     // are support-POOL members in mutual/co-planar bearing shapes — §SUPPORT_CYCLE reports 25,393
     // cycle-fallback members on the live vintage — the documented warn-only class, not repairable
     // without inventing physics; the old _extracted vintage read 2839).
-    const DAGWINS_BASELINE = { Terminal: 24007, Hospital: 9, Duplex: 0, HHS_Office_Federated: 420, Clinic: 6,
-      LTU_AHouse: 882, JKR: 398 };
+    // ⚠ RE-BASELINED 2026-08-12 for §TIER_SERIAL_BY_ZONE. These are the GLOBAL-barrier era numbers,
+    // kept for the record: Terminal 24007 · Hospital 9 · Duplex 0 · HHS 420 · Clinic 6 · LTU 882 ·
+    // JKR 398. Scoping the barrier per zone legitimately moves them, because "cross-phase" is now
+    // judged inside a zone rather than across the whole model — and the movement is not uniformly
+    // in one direction, which is exactly why it is re-locked rather than absorbed into a tolerance:
+    // Terminal 24007→4003 and JKR 398→205 (far fewer elements forced out of their phase), but
+    // Hospital 9→256 and LTU 882→1017 (more, because a zone's window is tighter than the model's).
+    // Movement from HERE is still a real data/rules change to examine, same contract as before.
+    const DAGWINS_BASELINE = { Terminal: 4003, Hospital: 256, Duplex: 0, HHS_Office_Federated: 420, Clinic: 5,
+      LTU_AHouse: 1017, JKR: 205 };
     assert(stats && stats.dagWins === DAGWINS_BASELINE[bld],
       'W-TS-1b ' + bld + ' DAG-forced cross-phase population locked at ' + DAGWINS_BASELINE[bld] +
       ' (got ' + (stats ? stats.dagWins : '?') + ') — support order wins for these, counted never hidden');
@@ -309,9 +337,17 @@ const D = 86400000;
     console.log('§TIER_MOVIE bld=' + bld + ' backboneShares ' + parts.join(' ') +
       ' | dagWinsRidingLaterWindows=' + (stats ? stats.dagWins : '?') +
       ' | tier2 n=' + t2N + ' runningConcurrentWithBackbone=' + t2Concurrent +
-      ' (' + (t2N ? (t2Concurrent / t2N * 100).toFixed(0) : 0) + '%) — serialized backbone slices are exclusive+contiguous, Tier 2 fills alongside');
-    assert(positive && shareSum <= 100.5,
-      'W-TS-6 ' + bld + ' backbone movie slices well-formed (each present serialized phase >0 span; exclusive shares sum ' + shareSum.toFixed(1) + '% <= 100%)');
+      ' (' + (t2N ? (t2Concurrent / t2N * 100).toFixed(0) : 0) + '%) — backbone slices exclusive+contiguous WITHIN each zone, zones overlap, Tier 2 fills alongside');
+    // §TIER_SERIAL_BY_ZONE: the <=100% bound is RETIRED, not relaxed. It encoded the global
+    // barrier's premise — that backbone phase slices are exclusive across the WHOLE film, so their
+    // shares cannot sum past it. With a per-zone barrier, different zones' backbone slices overlap
+    // in time BY DESIGN (level 1 walls while level 7 frames), so the sum legitimately exceeds 100%
+    // (measured: Terminal 106.1%, Hospital 102.5%, JKR 102.9%). The exclusivity property has not
+    // been dropped — it moved to W-TS-1, which asserts overlapPairs=0 summed WITHIN each zone.
+    // Reported here so the number stays visible, asserted there where it now means something.
+    assert(positive,
+      'W-TS-6 ' + bld + ' backbone movie slices well-formed (each present serialized phase >0 span; ' +
+      'shares sum ' + shareSum.toFixed(1) + '% — >100% expected under per-zone serialization, exclusivity now gated by W-TS-1)');
   }
 
   finish();

--- a/viewer/time_machine.js
+++ b/viewer/time_machine.js
@@ -3957,11 +3957,34 @@
 
   // Backbone phase extents over the SERIALIZABLE population — elements marked _t1Straggler are
   // excluded (see §TIER_STRAGGLER in _twoTierRemap: the measured, DAG-forced cross-phase tail).
+  // §TIER_SERIAL_BY_ZONE (2026-08-12, bim-compiler prompts/4D_SCHEDULE_PERFECTION.md
+  // §TIER_SERIAL_BY_ZONE — Witness: viewer/tests/witness_tier_serial_zone.js W-TSZ) ─────────────
+  // The backbone barrier was GLOBAL: every Superstructure element ANYWHERE finished before any
+  // Architecture element started. Measured cost: the remap inflated the programme 1.71x-3.71x over
+  // the generative timeline on all 7 buildings (Hospital 314.9d -> 1168.7d), and on LTU it produced
+  // a 29%-of-film dead run.
+  //
+  // DERIVED FROM THE EXISTING RULING, not a new one. §TIER_SERIAL's own header quotes the user's
+  // 2026-08-02 words: "ARCH/STR should be exempt as they are the physical foundation. Separate
+  // unrelated disciplines can run parallel thereafter IF CONSTRUCTION PRACTICE PERMITS." Practice
+  // permits walls on level 1 while level 7 is still framing; a global barrier is a cruder reading
+  // of that sentence than a per-zone one. The physical guarantee is UNCHANGED and is not what this
+  // touches: _ogSupportSweep already gates every element individually against the real support DAG.
+  // This is the display grouping on top of it, and it now says "backbone order holds WITHIN a
+  // zone" instead of "across the whole model".
+  //
+  // The zone comes from §ZONE_INDEX (#1313) — the derived median-Z band, never a configured list,
+  // so this is generic to any IFC. A single-zone model degenerates to EXACTLY the old global
+  // behaviour, which is what keeps the change safe on models without storey data.
+  function _zoneOf(it) { return (it && it.storey) || '_ALL'; }
+
+  // ext[zone][phase] = {minS,maxE}. Straggler-excluded exactly as before.
   function _tier1Extents(items) {
     var ext = {};
     items.forEach(function (it) {
       if (it._t1Straggler || _TIER1_ORDER.indexOf(it.phase) < 0) return;
-      var x = ext[it.phase] || (ext[it.phase] = { minS: Infinity, maxE: -Infinity });
+      var z = ext[_zoneOf(it)] || (ext[_zoneOf(it)] = {});
+      var x = z[it.phase] || (z[it.phase] = { minS: Infinity, maxE: -Infinity });
       if (it.s < x.minS) x.minS = it.s;
       if (it.e > x.maxE) x.maxE = it.e;
     });
@@ -3976,16 +3999,20 @@
   // governed purely by _tierAuditRegate instead.
   function _tier1Serialize(items) {
     var ext = _tier1Extents(items);
-    var deltas = {}, prevEnd = -Infinity;
-    _TIER1_ORDER.forEach(function (ph) {
-      var x = ext[ph]; if (!x) return;   // phase absent (e.g. HHS models no Substructure)
-      var d = prevEnd > x.minS ? prevEnd - x.minS : 0;
-      deltas[ph] = d;
-      prevEnd = x.maxE + d;
-    });
+    var deltas = {};                     // deltas[zone][phase]
+    for (var z in ext) {
+      var zd = deltas[z] = {}, prevEnd = -Infinity;
+      _TIER1_ORDER.forEach(function (ph) {
+        var x = ext[z][ph]; if (!x) return;   // phase absent in THIS zone (common: no Substructure upstairs)
+        var d = prevEnd > x.minS ? prevEnd - x.minS : 0;
+        zd[ph] = d;
+        prevEnd = x.maxE + d;
+      });
+    }
     items.forEach(function (it) {
       if (it._t1Straggler) return;       // stragglers ride the regate, never the group shift
-      var d = deltas[it.phase];
+      var zd = deltas[_zoneOf(it)];
+      var d = zd && zd[it.phase];
       if (d) { it.s += d; it.e += d; }
     });
     return deltas;
@@ -3994,12 +4021,17 @@
   // 0 = the Tier-1 chain is strictly serial: for consecutive PRESENT backbone phases, phase k's
   // last end <= phase k+1's first start (transitive across the chain — each window is well-formed).
   // Straggler-excluded by _tier1Extents; the straggler count itself is reported, never hidden.
+  // §TIER_SERIAL_BY_ZONE: counted WITHIN each zone and summed. W-TS-1's bar is unchanged in
+  // meaning — "the backbone chain is serial" — but its scope is now the zone, which is the whole
+  // point of the change; a single-zone model reduces to the identical global count.
   function _tier1Protrusion(items) {
     var ext = _tier1Extents(items);
-    var present = _TIER1_ORDER.filter(function (ph) { return ext[ph]; });
     var overlapping = 0;
-    for (var i = 0; i + 1 < present.length; i++) {
-      if (ext[present[i]].maxE > ext[present[i + 1]].minS) overlapping++;
+    for (var z in ext) {
+      var present = _TIER1_ORDER.filter(function (ph) { return ext[z][ph]; });
+      for (var i = 0; i + 1 < present.length; i++) {
+        if (ext[z][present[i]].maxE > ext[z][present[i + 1]].minS) overlapping++;
+      }
     }
     return overlapping;
   }
@@ -4301,15 +4333,17 @@
       if (!overlap) break;
       // mark this round's DAG-forced cross-phase elements, then re-serialize without them
       var ext = _tier1Extents(items);
-      var present = _TIER1_ORDER.filter(function (ph) { return ext[ph]; });
       var marked = 0;
-      for (var i = 0; i + 1 < present.length; i++) {
-        var ph = present[i], nextMinS = ext[present[i + 1]].minS;
-        if (ext[ph].maxE <= nextMinS) continue;
-        items.forEach(function (it) {
-          if (it._t1Straggler || it.phase !== ph) return;
-          if (it.e > nextMinS) { it._t1Straggler = true; marked++; }
-        });
+      for (var z in ext) {                       // §TIER_SERIAL_BY_ZONE: absorb per zone
+        var present = _TIER1_ORDER.filter(function (ph) { return ext[z][ph]; });
+        for (var i = 0; i + 1 < present.length; i++) {
+          var ph = present[i], nextMinS = ext[z][present[i + 1]].minS, zk = z;
+          if (ext[z][ph].maxE <= nextMinS) continue;
+          items.forEach(function (it) {
+            if (it._t1Straggler || it.phase !== ph || _zoneOf(it) !== zk) return;
+            if (it.e > nextMinS) { it._t1Straggler = true; marked++; }
+          });
+        }
       }
       dagWins += marked;
       if (!marked) break;   // nothing left to absorb — residual overlap reported honestly below
@@ -4321,18 +4355,28 @@
     // Uniform later-shift only: safe by construction, since pushing every Tier-2 element later by
     // the SAME amount preserves all of Tier 2's own internal order and only pushes starts further
     // past their already-satisfied support minimum, never before it.
-    var tier1End = -Infinity, tier2MinStart = Infinity;
+    // §TIER_SERIAL_BY_ZONE: "Tier 2 THEREAFTER" is now evaluated per zone — MEP on a floor waits
+    // for that floor's backbone, not for the whole building's. The user's same-day correction
+    // ("after Tier 1 finishes, not concurrent with it") is preserved in its zone: within any zone
+    // no Tier-2 element starts before that zone's Tier-1 is complete. A single-zone model is
+    // byte-identical to the previous global shift.
+    var t1EndZ = {}, t2MinZ = {};
     items.forEach(function (it) {
-      if (_TIER1_ORDER.indexOf(it.phase) >= 0) { if (it.e > tier1End) tier1End = it.e; }
-      else if (it.s < tier2MinStart) tier2MinStart = it.s;
+      var z = _zoneOf(it);
+      if (_TIER1_ORDER.indexOf(it.phase) >= 0) {
+        if (!(z in t1EndZ) || it.e > t1EndZ[z]) t1EndZ[z] = it.e;
+      } else if (!(z in t2MinZ) || it.s < t2MinZ[z]) t2MinZ[z] = it.s;
     });
     var tier2Shift = 0;
-    if (isFinite(tier1End) && isFinite(tier2MinStart) && tier2MinStart < tier1End) {
-      tier2Shift = tier1End - tier2MinStart;
-      items.forEach(function (it) {
-        if (_TIER1_ORDER.indexOf(it.phase) < 0) { it.s += tier2Shift; it.e += tier2Shift; }
-      });
-    }
+    items.forEach(function (it) {
+      if (_TIER1_ORDER.indexOf(it.phase) >= 0) return;
+      var z = _zoneOf(it);
+      // A zone with Tier-2 but no Tier-1 (MEP in an unbanded pocket) has nothing to wait for here;
+      // _ogSupportSweep still gates it individually, so it is left where the generative layer put it.
+      if (!(z in t1EndZ)) return;
+      var d = t1EndZ[z] - t2MinZ[z];
+      if (d > 0) { it.s += d; it.e += d; if (d > tier2Shift) tier2Shift = d; }
+    });
     var base = Infinity, endAll = -Infinity, ext2 = {};
     items.forEach(function (it) {
       if (it.s < base) base = it.s;
@@ -5139,7 +5183,8 @@
       var _ts = _sched[el.guid];
       return { guid: el.guid, s: _ts ? _ts.start : baseMs, e: _ts ? _ts.end : baseMs + 60000,
         bz: el.base_z, tz: el.top_z, x0: el.x0, x1: el.x1, y0: el.y0, y1: el.y1,
-        cls: el.cls, seq: el.seq, phase: el.phase };
+        cls: el.cls, seq: el.seq, phase: el.phase,
+        storey: el.storey };   // §TIER_SERIAL_BY_ZONE: the §ZONE_INDEX band, already median-Z repaired
     });
     var _twStats = _twoTierRemap(_twItems);
     // §MIDAIR_REPAIR (2026-08-12) — last stop before kernel_ops: nothing may appear before the


### PR DESCRIPTION
Implementing `bim-compiler prompts/4D_SCHEDULE_PERFECTION.md §TIER_SERIAL_BY_ZONE`, on top of §ZONE_INDEX (#1313).
Witness: `witness_tier_serial_display.js` **57/0**.

## Derived from the existing ruling, not a new one
§TIER_SERIAL's own header quotes the user's 2026-08-02 words: *"ARCH/STR should be exempt as they are the physical foundation. Separate unrelated disciplines can run parallel thereafter **if construction practice permits**."* Practice permits walls on level 1 while level 7 is still framing. The **global** barrier was the cruder reading of that sentence.

The barrier (`_tier1Extents` / `_tier1Serialize` / `_tier1Protrusion`, the straggler-absorption loop, and §TIER2_AFTER_TIER1) is now scoped to the derived §ZONE_INDEX band. **A single-zone model degenerates to exactly the previous global behaviour** — which is what keeps this safe on models with no storey data. The zone key is the median-Z band, never a configured list: generic to any IFC.

**Physical guarantee untouched.** `_ogSupportSweep` already gates every element individually against the real support DAG; this is the display grouping on top of it. W-TS-2 confirms displayed floating ≤ generative on all 7 — LTU actually *improves*, 334 → 328.

## Measured (probe and witness agree exactly)
```
            generative → displayed        ratio before → after
Hospital        314.9 →  616.7               3.71x → 1.96x
Terminal        113.1 →  236.0               3.32x → 2.09x
LTU_AHouse      810.9 → 1322.4               2.39x → 1.63x
Clinic          143.7 →  278.4               2.78x → 1.94x
JKR              36.4 →   74.4               3.02x → 2.05x
HHS_Office       46.1 →   83.4               2.65x → 1.81x
Duplex           10.5 →   13.2               1.71x → 1.26x
```

## The complaint this actually fixes
*"Day 1-14 too much too fast and then delay build up until Day 48"* — Hospital's opening goes from a burst followed by two dead bands to a steady ramp:
```
Hospital before  [2228,   0,   0,  915,    0, 4452, ...]
Hospital after   [1715,3499,3916, 3669,    0, 4336, ...]
LTU before   [514,4086,3541,4553, 0,0,0,0,0, 2, ...]   ← five consecutive dead bands
LTU after    [922,7248,7428,8260,8407,15525,3546, ...] ← none
```
Per-phase occupancy improves with it: Hospital Superstructure 24.4% → **40.6%**, Architecture 18.1% → **24.0%**.

Remaining dead runs now sit at the **end** of the film (Hospital 84–97%, LTU 94–99%) — that is the straggler tail (`§DAY_GAP_TAIL`), still open and tracked separately.

## Witness contract changes — deliberate, documented in place
- **W-TS-1**: bar still zero, but **scope is now per zone** (summed across zones). Exclusivity did not weaken; it is now judged where it means something.
- **W-TS-6**: the `shares sum <= 100%` bound is **retired, not relaxed**. It encoded the global premise that backbone slices are exclusive across the whole film. Under a per-zone barrier, zones overlap **by design**, so the sum legitimately exceeds 100% (Terminal 106.1%, Hospital 102.5%, JKR 102.9%). Still reported; exclusivity is asserted by W-TS-1 instead.
- **W-TS-1b re-baselined**, movement recorded in both directions rather than absorbed into a tolerance: Terminal 24007→**4003**, JKR 398→**205** (far fewer elements forced out of their phase), but Hospital 9→**256**, LTU 882→**1017** (more, because a zone's window is tighter than the model's).

## Harness bug found and fixed
The witness built its items **without `storey`**, so `_zoneOf` fell back to `'_ALL'` and the entire suite silently exercised the **degenerate single-zone path** — reporting 57/0 while proving nothing about the change. Caught by diffing its `§TIER_COST` against the probe on the same code (JKR 110.1 vs 74.4). The zone key now rides along exactly as `injectGantt`'s `_twItems` carries it.

`sw.js` CACHE_VERSION **v1001 → v1002**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)