### PR TITLE
feat(5d): §CREW_DEMAND + §HR_COST — per-trade labour cost, and the crew premise disproved

### DIFF
--- a/viewer/sw.js
+++ b/viewer/sw.js
@@ -8,7 +8,7 @@
 // Cache-first for heavy assets (.wasm, images). DB files skip SW (IndexedDB handles them).
 //
 // DEPLOY: bump CACHE_VERSION on every OCI upload. Old caches are purged on activate.
-const CACHE_VERSION = 'v1002';   // bump on each deploy; per-change detail is the git commit message.
+const CACHE_VERSION = 'v1003';   // bump on each deploy; per-change detail is the git commit message.
 const CACHE_PREFIX = 'bim-ootb-';
 const CACHE_NAME = CACHE_PREFIX + CACHE_VERSION;
 

--- a/viewer/tests/witness_crew_demand.js
+++ b/viewer/tests/witness_crew_demand.js
@@ -1,0 +1,146 @@
+#!/usr/bin/env node
+// WITNESS — W-CREW — §CREW_DEMAND + §HR_COST
+// Spec: bim-compiler prompts/4D_SCHEDULE_PERFECTION.md item 4.
+//
+// ISSUE THIS PROVES OR DISPROVES:
+//   The claim under investigation was "max_crews is a small-job list (1-3 gangs per trade) applied
+//   unchanged to a 63k-element hospital, and that is what drives MEP Rough-in to 128-174%
+//   occupancy." If true, crews are the binding constraint and want scaling. If false, the shipped
+//   table is fine and the 128-174% figure was being read wrong.
+//
+//   It is FALSE, and this witness is what establishes that. "Occupancy" as §DAY_GAP_PHASE_OCC
+//   defines it is work-days ÷ window-days — a SINGLE-CREW-EQUIVALENT ratio. Exceeding 100% only
+//   means more than one crew is busy on average, which is the ordinary case. The binding question
+//   is capacity: crews x projectDays crew-days available vs crew-days demanded.
+//
+//   The witness therefore asserts the opposite of what the original item-4 spec assumed, and says
+//   so: no trade is over capacity on any shipped building. Kept as a REGRESSION bar — if a future
+//   rates/geometry change pushes a trade over 100% utilisation, that is a real finding and this
+//   goes red.
+//
+// GATES:
+//   G-CREW-CAPACITY  (BLOCKING) no trade exceeds 100% utilisation (demand crew-days vs
+//                    crews x projectDays) on any shipped building. This is the claim that
+//                    disproves "crew-starved" and it is the one that must not silently rot.
+//   G-CREW-FIXED     max_crews_fixed in rates/sequence_rules.json is honoured verbatim and wins
+//                    over max_crews — the user-editable path ("they edit it, regenerate 4D anew").
+//   G-HR-INVARIANT   §HR_COST total is INVARIANT to crew count: doubling every trade's crews
+//                    leaves personDays and cost identical. Proves the 5D number is labour content,
+//                    not a crew-count artefact — the thing most likely to be misread.
+//   G-HR-NONZERO     every building reports a positive HR cost over >=1 trade with a rate.
+'use strict';
+const fs = require('fs');
+const path = require('path');
+const HOME = require('os').homedir();
+const VIEWER_DIR = path.join(__dirname, '..');
+const SQLJS_DIR = process.env.SQLJS_DIR || path.join(HOME, 'bim-ootb', 'modeller', 'lib');
+const initSqlJs = require(path.join(SQLJS_DIR, 'sql-wasm.js'));
+const ScheduleAuthor = require(path.join(VIEWER_DIR, 'schedule_author.js'));
+const BLD_DIR = process.env.BLD_DIR || path.join(HOME, 'bim-ootb', 'buildings');
+const DB_FILE = { LTU_AHouse: 'LTU_AHouse_meta.db' };
+const BUILDINGS = (process.env.ONLY || 'Terminal,Hospital,Duplex,HHS_Office_Federated,Clinic,LTU_AHouse,JKR').split(',');
+
+const results = [];
+function gate(name, pass, detail) {
+  results.push({ name, pass, detail });
+  console.log(`${pass ? 'PASS' : 'FAIL'}  ${name}  ${detail}`);
+}
+
+function loadRatesTable() {
+  const txt = fs.readFileSync(path.join(VIEWER_DIR, 'rates.js'), 'utf8');
+  const start = txt.indexOf('var RATES = {');
+  const defIdx = txt.indexOf('var SEQUENCE_DEFAULT');
+  return (new Function(txt.slice(start, txt.indexOf('};', defIdx) + 2) + '\n return RATES;'))();
+}
+
+// Mirrors injectGantt's own crew/cost arithmetic (time_machine.js §CREW_DEMAND/§HR_COST) against
+// the same inputs. crewMul lets G-HR-INVARIANT re-run with more crews and compare.
+function computeFor(els, LR, projectDays, crewMul) {
+  const maxCrews = {};
+  for (const r in LR) {
+    if (LR[r].max_crews_fixed != null) maxCrews[r] = LR[r].max_crews_fixed;
+    else if (LR[r].max_crews) maxCrews[r] = LR[r].max_crews * (crewMul || 1);
+  }
+  const workDays = {};
+  els.forEach(e => { const r = e.resource || '_DEFAULT';
+    workDays[r] = (workDays[r] || 0) + (e.installSecs || 0) / 28800; });
+  let worstUtil = 0, worstTrade = null, hrTotal = 0, hrPD = 0, trades = 0;
+  for (const r in workDays) {
+    const lr = LR[r]; if (!lr) continue;
+    const crews = maxCrews[r] || 1;
+    const util = 100 * workDays[r] / (crews * projectDays);
+    if (util > worstUtil) { worstUtil = util; worstTrade = r; }
+    if (lr.rate_per_day) {
+      const pd = workDays[r] * (lr.crew_size || 1);
+      hrPD += pd; hrTotal += pd * lr.rate_per_day; trades++;
+    }
+  }
+  return { worstUtil, worstTrade, hrTotal, hrPD, trades, maxCrews };
+}
+
+(async () => {
+  const SQL = await initSqlJs({ wasmBinary: fs.readFileSync(path.join(SQLJS_DIR, 'sql-wasm.wasm')) });
+  const rules = JSON.parse(fs.readFileSync(path.join(VIEWER_DIR, 'rates', 'sequence_rules.json'), 'utf8'));
+  const SR = rules.SEQUENCE_RULES, SD = rules.SEQUENCE_DEFAULT, LR = rules.LABOR_RATES;
+  const NO = rules.NAME_OVERRIDES || [];
+  const RATES = loadRatesTable();
+
+  let overCap = [], zeroCost = [], invariantBad = [], ran = 0;
+
+  for (const bld of BUILDINGS) {
+    const dbPath = path.join(BLD_DIR, DB_FILE[bld] || (bld + '_extracted.db'));
+    if (!fs.existsSync(dbPath)) { console.log(`      (skip ${bld} — fixture missing)`); continue; }
+    const db = new SQL.Database(fs.readFileSync(dbPath));
+    const r = db.exec('SELECT m.guid, m.ifc_class, COALESCE(m.element_name,\'\') ' +
+      'FROM elements_meta m ' +
+      "WHERE m.ifc_class != 'IfcOpeningElement' AND m.ifc_class != 'IfcSpace'");
+    if (!r.length) { db.close(); continue; }
+    const frag = ScheduleAuthor._classFragmentation(db, RATES);
+    const lin = ScheduleAuthor._linearWeighting(db, RATES);
+    const els = r[0].values.map(v => {
+      const cls = v[1], nm = v[2];
+      const rule = ScheduleAuthor.matchNameOverride(cls, nm, NO) || ScheduleAuthor.matchRule(cls, SR, SD);
+      const realQty = (frag.fragmented[cls] && frag.area[v[0]] != null) ? frag.area[v[0]] : null;
+      return { guid: v[0], cls, resource: rule.resource || '_DEFAULT',
+               installSecs: ScheduleAuthor._installSecs(cls, rule, LR, realQty, null) };
+    });
+    let tot = 0; els.forEach(e => { tot += e.installSecs; });
+    const projectDays = Math.max(10, Math.ceil(tot * 1000 / 86400000));
+
+    const a = computeFor(els, LR, projectDays, 1);
+    const b = computeFor(els, LR, projectDays, 2);   // double every crew — cost must not move
+    ran++;
+
+    if (a.worstUtil > 100) overCap.push(`${bld}:${a.worstTrade}=${a.worstUtil.toFixed(1)}%`);
+    if (!(a.hrTotal > 0 && a.trades > 0)) zeroCost.push(bld);
+    if (Math.abs(a.hrTotal - b.hrTotal) > 0.01 || Math.abs(a.hrPD - b.hrPD) > 0.01) invariantBad.push(bld);
+
+    console.log(`      ${bld}: projectDays=${projectDays} worstUtil=${a.worstUtil.toFixed(1)}% (${a.worstTrade}) ` +
+      `hrCost=${Math.round(a.hrTotal)} personDays=${a.hrPD.toFixed(0)} trades=${a.trades} ` +
+      `| crews x2 -> cost=${Math.round(b.hrTotal)} (must be identical)`);
+    db.close();
+  }
+
+  gate('G-CREW-CAPACITY', overCap.length === 0 && ran > 0,
+    overCap.length ? 'OVER CAPACITY: ' + overCap.join(' ')
+      : `no trade over 100% utilisation on any of ${ran} buildings — the shipped max_crews table is NOT the binding constraint, ` +
+        `which disproves the "crew-starved MEP" premise item 4 started from`);
+  gate('G-HR-INVARIANT', invariantBad.length === 0 && ran > 0,
+    invariantBad.length ? 'cost moved with crew count on: ' + invariantBad.join(' ')
+      : 'doubling every trade\'s crews leaves personDays and cost identical on all ' + ran +
+        ' — the 5D number is labour content, not a crew-count artefact');
+  gate('G-HR-NONZERO', zeroCost.length === 0 && ran > 0,
+    zeroCost.length ? 'zero HR cost on: ' + zeroCost.join(' ') : `positive HR cost on all ${ran} buildings`);
+
+  // G-CREW-FIXED is a pure contract check on the override path — no DB needed.
+  const probe = { A: { max_crews: 2, max_crews_fixed: 9, rate_per_day: 1, crew_size: 1 },
+                  B: { max_crews: 3, rate_per_day: 1, crew_size: 1 } };
+  const mc = computeFor([], probe, 10, 1).maxCrews;
+  gate('G-CREW-FIXED', mc.A === 9 && mc.B === 3,
+    `max_crews_fixed honoured verbatim (A base=2 fixed=9 -> ${mc.A}; B base=3 no override -> ${mc.B}) ` +
+    `— the user-editable "edit it, regenerate 4D anew" path`);
+
+  const passed = results.filter(r => r.pass).length;
+  console.log(`\n§CREW_WITNESS ${passed}/${results.length} gates passed`);
+  process.exit(passed === results.length ? 0 : 1);
+})();

--- a/viewer/time_machine.js
+++ b/viewer/time_machine.js
@@ -5164,8 +5164,67 @@
     // §CREW-CAP (2026-07-18): real-world crew count per trade — see schedule_gate.js header.
     // LABOR_RATES[resource].max_crews (rates.js / rates/sequence_rules.json), falls back to
     // schedule_gate.js's own MAX_CREWS_DEFAULT for any resource without an explicit value.
+    // ── §CREW_DEMAND + §HR_COST (2026-08-12, bim-compiler prompts/4D_SCHEDULE_PERFECTION.md
+    // item 4 — Witness: viewer/tests/witness_crew_demand.js W-CREW) ───────────────────────────
+    // User: "as each user imports own IFC set, the script gives them the max resource needed, and
+    // when they edit it it can regenerate 4D anew" + "the 5D set per building will then reflect
+    // the cost of HR used too."
+    //
+    // ⚠ WHAT THIS IS NOT: an auto-scaler. A first cut derived crews as
+    // ceil(workDays(T)/projectDays) and MEASURED AS A NO-OP on all 7 buildings — projectDays is the
+    // all-trade serial total (Hospital 1036, LTU 2329), so no single trade's work can exceed it and
+    // the ceil is always 1, below every baseline. Worse, the premise behind wanting one was wrong:
+    // MEP Rough-in's "130.8% occupancy" is a SINGLE-CREW-EQUIVALENT ratio (work-days ÷ window-days).
+    // Exceeding 100% just means more than one crew is busy on average — which is the normal case.
+    // The real check is capacity: MEP Rough-in draws on 3 trades x 2 crews over a 555-day window
+    // = ~3,330 crew-days available against 725.9 needed. It is NOT crew-starved, and the shipped
+    // table is not the small-job list it looked like. Reporting the numbers instead of "fixing"
+    // something that measures fine.
     var _maxCrews = {};
-    for (var _mcRes in LR) if (LR[_mcRes].max_crews) _maxCrews[_mcRes] = LR[_mcRes].max_crews;
+    for (var _mcRes in LR) {
+      if (LR[_mcRes].max_crews_fixed != null) _maxCrews[_mcRes] = LR[_mcRes].max_crews_fixed;
+      else if (LR[_mcRes].max_crews) _maxCrews[_mcRes] = LR[_mcRes].max_crews;
+    }
+    // Per-trade labour content, straight from the installSecs the scheduler itself uses
+    // (28800s = the 8h crew-day getInstallSecs divides by).
+    var _crewWorkDays = {};
+    elements.forEach(function (el) {
+      var _r = el.resource || '_DEFAULT';
+      _crewWorkDays[_r] = (_crewWorkDays[_r] || 0) + (el.installSecs || 0) / 28800;
+    });
+    // §CREW_DEMAND — "the max resource needed", reported per trade so a user can see what to edit.
+    // capacity = crews x projectDays crew-days; utilisation = demand / capacity. A trade over 100%
+    // genuinely cannot fit and wants more crews; everything under is headroom.
+    var _cdLog = [];
+    for (var _cd in _crewWorkDays) {
+      var _cdr = LR[_cd]; if (!_cdr) continue;
+      var _crews = _maxCrews[_cd] || 1;
+      var _cap = _crews * projectDays;
+      _cdLog.push(_cd + ' demand=' + _crewWorkDays[_cd].toFixed(1) + 'cd crews=' + _crews +
+        (_cdr.max_crews_fixed != null ? '(FIXED)' : '') +
+        ' capacity=' + _cap.toFixed(0) + 'cd util=' + (_cap ? (100 * _crewWorkDays[_cd] / _cap).toFixed(1) : '?') + '%');
+    }
+    console.log('§CREW_DEMAND projectDays=' + projectDays + ' — ' + _cdLog.join(' | ') +
+      ' (util>100% = that trade cannot fit and wants more crews; set max_crews_fixed in ' +
+      'rates/sequence_rules.json and regenerate to apply an edit)');
+
+    // §HR_COST (5D) — the labour the schedule commits, per trade. personDays = crew-days x
+    // crew_size (a 6-hand gang spends 6 person-days per crew-day); cost = personDays x rate_per_day.
+    // ⚠ Reading note that matters for 5D: crew COUNT does not change this total — the same labour
+    // content done by more hands in less time. Crews change WHEN the cost lands, not how much.
+    // That time-phasing is what makes it 5D rather than a bill of quantities.
+    var _hrTotal = 0, _hrPD = 0, _hrLog = [];
+    for (var _hr in _crewWorkDays) {
+      var _hrR = LR[_hr]; if (!_hrR || !_hrR.rate_per_day) continue;
+      var _pd = _crewWorkDays[_hr] * (_hrR.crew_size || 1);
+      var _cost = _pd * _hrR.rate_per_day;
+      _hrTotal += _cost; _hrPD += _pd;
+      _hrLog.push(_hr + ' personDays=' + _pd.toFixed(1) + ' @' + _hrR.rate_per_day + '/d = ' + Math.round(_cost));
+    }
+    console.log('§HR_COST total=' + Math.round(_hrTotal) + ' personDays=' + _hrPD.toFixed(1) +
+      ' across ' + _hrLog.length + ' trades — ' + _hrLog.join(' | ') +
+      ' (crew count changes WHEN this lands, not the total)');
+
     // §4D_NOGEO: geometry-less elements are EXCLUDED from the support-gated schedule (they poison
     // it at day 0) and parked at the project end below — present in the movie's totals, never in
     // its physics.


### PR DESCRIPTION
Implementing `bim-compiler prompts/4D_SCHEDULE_PERFECTION.md` item 4 — the last item of the §DAY_GAP lane.
Witness: `viewer/tests/witness_crew_demand.js` (W-CREW) **4/4 on all 7 buildings**.

> *"as each user imports own IFC set, the script gives them the max resource needed, and when they edit it it can regenerate 4D anew"* + *"the 5D set per building will then reflect the cost of HR used too. This is making 5D meaningful for BIM."*

## What shipped
- **`§CREW_DEMAND`** — per trade, on every generate: labour demand in crew-days, crews allocated, capacity (`crews × projectDays`), utilisation %. The "max resource needed" readout, emitted per imported IFC.
- **`max_crews_fixed`** — a per-trade override in `rates/sequence_rules.json`, honoured verbatim over `max_crews`. That's the *edit it, regenerate 4D anew* path: JSON only, no code change. Gated by `G-CREW-FIXED`.
- **`§HR_COST` (5D)** — `personDays = crew-days × crew_size`, `cost = personDays × rate_per_day`, per trade and total:

```
Duplex       28,470      174 person-days
JKR         216,925    1,227
HHS         254,264    1,383
Clinic      465,748    2,709
LTU_AHouse 2,696,098   15,822
```

## What did NOT ship — item 4's premise is disproven, measured
The spec claimed `max_crews` is *"a small-job crew list (1–3 gangs) applied unchanged to a 63k-element hospital"*, driving MEP Rough-in to 128–174% occupancy, and wanted an autoscaler. **Both halves are wrong:**

1. A first cut derived `crews = ceil(workDays(T)/projectDays)` and **measured as a no-op on all 7 buildings** — `projectDays` is the all-trade serial total (Hospital 1036, LTU 2329), so no single trade's work can exceed it and the ceil is always 1, below every baseline.
2. **The 128–174% figure was being read wrong.** `§DAY_GAP_PHASE_OCC`'s "occupancy" is work-days ÷ window-days — a *single-crew-equivalent* ratio. Over 100% only means more than one crew is busy on average, which is the ordinary case. The binding question is capacity: MEP Rough-in draws on 3 trades × 2 crews over a 555-day window = **~3,330 crew-days available against 725.9 demanded**.

`G-CREW-CAPACITY` confirms it across all 7 — worst utilisation is PLUMBER at **31.0%–92.8%, never over 100%**. The shipped table is not the binding constraint and needs no scaling. Kept as a **regression bar**: if rates or geometry later push a trade past 100%, that's a real finding and this goes red.

## The 5D reading note, gated not just documented
`G-HR-INVARIANT`: **doubling every trade's crews leaves personDays and cost identical on all 7.** Crew count changes *when* the cost lands, not how much — the same labour content by more hands in less time. That time-phasing is what makes it 5D rather than a bill of quantities, and the log line says so where a reader will see it.

`sw.js` CACHE_VERSION **v1002 → v1003**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)