### PR TITLE
fix(cinema): §MOVIE_SHADOW_TM — bake shadow strength matched to Time Machine exactly

### DIFF
--- a/viewer/effects.js
+++ b/viewer/effects.js
@@ -2471,7 +2471,18 @@ async function setupEffects(A, renderer, scene, camera) {
   var PHOTO_SUN_COLOR = 0xffa55c;       // warm golden-hour sun, not neutral white
   var PHOTO_AMBIENT_COLOR = 0x8a6a55;   // warm dim ambient — shadow side reads dusk-toned, not grey
   var PHOTO_HEMI_SKY_COLOR = 0x6a5a7a;  // dusky violet-warm sky half of the hemi light
-  var PHOTO_SUN_INTENSITY_SCALE = 0.7;  // dimmer than full daylight — evening, not noon
+  // §MOVIE_SHADOW_TM (2026-08-12, user, verbatim: "MAKE SHADOW FOR MOVIE MAKER AS STRONG AS IN TM").
+  // These three scales are what made baked shadows read lighter than Time Machine's own shadow play.
+  // Measured against scene.js's native lights (sun 4.4, ambient 0.785, hemi 1.257 — TM's sun/fill
+  // ratio 4.4/2.042 = 2.155):
+  //     was  sun x0.7 = 3.08, ambient x1.15 = 0.903, hemi x1.25 = 1.571  -> ratio 1.245
+  //     i.e. 57.8% of TM's contrast, 42% weaker. Two moves compounded — the sun scaled DOWN while
+  //     the fill scaled UP (0.7 / 1.2115 = 0.578).
+  // Set to 1.0 so the bake uses TM's own balance verbatim; ratio is now 2.155, identical to TM.
+  // The old dusk-dimmed values are recorded above, not deleted, because everything else here
+  // (PHOTO_SUN_COLOR, the fog/exposure/albedo constants) was tuned against them and is deliberately
+  // left untouched — this changes the light BALANCE only, nothing about colour or exposure.
+  var PHOTO_SUN_INTENSITY_SCALE = 1.0;  // was 0.7 — §MOVIE_SHADOW_TM, match TM's shadow strength
   var PHOTO_EXPOSURE_SCALE = 0.85;      // slightly underexposed overall — "materials in little light"
   // §PHOTO_EXPOSURE_LIFT (2026-07-27, user: "Scene still too dark drab"). The still was rendering at
   // 0.45 x 0.85 = 0.3825 — about a stop and a half under three.js's default, which is most of why
@@ -2574,8 +2585,8 @@ async function setupEffects(A, renderer, scene, camera) {
   // scene toward the same brightness, which dilutes the RELATIVE contrast the shadow and the
   // discrete point-light addons depend on to read as distinct. Dialed back — some lift over the
   // raw sin(6 deg) ground darkness, not enough to wash out contrast.
-  var PHOTO_HEMI_INTENSITY_SCALE = 1.25;
-  var PHOTO_AMBIENT_INTENSITY_SCALE = 1.15;
+  var PHOTO_HEMI_INTENSITY_SCALE = 1.0;    // was 1.25 — §MOVIE_SHADOW_TM (fill no longer lifted above TM's)
+  var PHOTO_AMBIENT_INTENSITY_SCALE = 1.0;  // was 1.15 — §MOVIE_SHADOW_TM (fill no longer lifted above TM's)
   // §GROUND_ALBEDO — the multiplicative lever the two paragraphs above never had. Everything they
   // describe is ADDITIVE (emissive add; hemi/ambient fill), which is exactly why both flattened the
   // cast shadow; this one scales lit and shadowed ground by the same factor. The claim that the
@@ -3243,6 +3254,14 @@ async function setupEffects(A, renderer, scene, camera) {
         A.hemi.intensity = A._nightSaved.hemiI * PHOTO_HEMI_INTENSITY_SCALE;
         A.hemi.color.setHex(PHOTO_HEMI_SKY_COLOR);
         A.renderer.toneMappingExposure = A._nightSaved.exposure * PHOTO_EXPOSURE_SCALE * PHOTO_EXPOSURE_LIFT;
+        // §MOVIE_SHADOW_TM: shadow strength is sun/(ambient+hemi). Logged so it can be checked
+        // against TM's own numbers numerically instead of by eye (FUNDAMENTAL LAW — code and maths
+        // is the truth, never screenshots). TM native = 4.4/(0.785+1.257) = 2.155.
+        var _fill = A.ambient.intensity + A.hemi.intensity;
+        console.log('§MOVIE_SHADOW_TM sun=' + A.sun.intensity.toFixed(3) +
+          ' ambient=' + A.ambient.intensity.toFixed(3) + ' hemi=' + A.hemi.intensity.toFixed(3) +
+          ' fill=' + _fill.toFixed(3) + ' sunFillRatio=' + (_fill ? (A.sun.intensity / _fill).toFixed(3) : 'inf') +
+          ' (TM native ratio 2.155 — equal means the bake matches TM shadow strength)');
       }
     }
     // §PHOTO_FOG_ORDER_FIX (2026-07-16, RESUME BRIEF ADDENDUM item 2 — "sky/ground darkness, one

--- a/viewer/sw.js
+++ b/viewer/sw.js
@@ -8,7 +8,7 @@
 // Cache-first for heavy assets (.wasm, images). DB files skip SW (IndexedDB handles them).
 //
 // DEPLOY: bump CACHE_VERSION on every OCI upload. Old caches are purged on activate.
-const CACHE_VERSION = 'v1003';   // bump on each deploy; per-change detail is the git commit message.
+const CACHE_VERSION = 'v1004';   // bump on each deploy; per-change detail is the git commit message.
 const CACHE_PREFIX = 'bim-ootb-';
 const CACHE_NAME = CACHE_PREFIX + CACHE_VERSION;
 


### PR DESCRIPTION
> "MAKE SHADOW FOR MOVIE MAKER AS STRONG AS IN TM" · "MATCHING TM FOR THE SHADOW STRENGTH ONLY - no bringing over any other that can drift"

Shadow strength is `sun / (ambient + hemi)`. Measured against `scene.js`'s shipped native lights (sun 4.4, ambient 0.785, hemi 1.257):

```
TM native   sun=4.400  fill=2.042  ratio=2.155
MaxQ bake   sun=3.080  fill=2.474  ratio=1.245   ← 57.8% of TM, 42% weaker
```

Two moves compounded: sun scaled **down** 0.7× while fill was scaled **up** to 1.2115× combined — `0.7 / 1.2115 = 0.578`. That is the measured cause of *"at the moment they rather light."*

Compounding it: `§SUN_ARC` animates the sun's **angle** every frame (55°→6°), but these three scales are applied **once** at photo-mode entry and never move — so the noon frames were lit with dusk-tuned values.

## Fix
The three scales set to `1.0`, so the bake uses TM's own balance verbatim:

```
MaxQ bake   sun=4.400  fill=2.042  ratio=2.155   → EXACT match
```

Verified arithmetically by reading both shipped files, no browser needed.

## Strength only — nothing else carried over
The **entire diff** is those three constants plus one log line. Untouched: `PHOTO_SUN_COLOR`, `PHOTO_AMBIENT_COLOR`, `PHOTO_HEMI_SKY_COLOR`, the exposure lift, fog, ground albedo, env-map boost, `PHOTO_SUN_ELEVATION` and both `§SUN_ARC` endpoints. The dusk **look** is unchanged; only the light balance moves. Verified by grepping the diff — the sole hit on any of those names is a comment stating they are left alone.

New `§MOVIE_SHADOW_TM` log line prints sun/ambient/hemi/fill/ratio at staging so the match stays checkable against TM's 2.155 numerically rather than by eye.

`sw.js` CACHE_VERSION **v1003 → v1004**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)