### PR TITLE
fix(4d): §ARCH_AREA_WEIGHT — architecture installs by real size, not one flat rate per element

### DIFF
--- a/viewer/boq_charts.html
+++ b/viewer/boq_charts.html
@@ -977,15 +977,21 @@ async function init() {
   }
 
   // Build unit lookup from RATES: which IFC classes are M, M2, EA, KG
+  // §FOOTING_M3 (2026-08-12): M3 was the one sized unit this BOQ never had a branch for — an M3
+  // class fell to the `else` and billed by COUNT. Latent until IfcFooting was repriced EA→M3
+  // (rates.js §FOOTING_M3); at that point it would have billed 821 footings at the per-m3 rate
+  // each, under-reporting the class by avgVolume (5.66x). Third unit, same shape as M and M2.
   const LINEAR_CLASSES = new Set();   // unit = M
   const AREA_CLASSES = new Set();     // unit = M2
+  const VOLUME_CLASSES = new Set();   // unit = M3
   for (const cls in RATES) {
     if (RATES[cls].unit === 'M')  LINEAR_CLASSES.add(cls);
     if (RATES[cls].unit === 'M2') AREA_CLASSES.add(cls);
+    if (RATES[cls].unit === 'M3') VOLUME_CLASSES.add(cls);
   }
 
   const _t0 = performance.now();
-  let countRows, linearQty = {}, areaQty = {};
+  let countRows, linearQty = {}, areaQty = {}, volQty = {};   // §FOOTING_M3: volQty = unit M3
   var _relayGuids = null;  // S253d: relayed GUIDs from viewer (populated in relay path)
 
   // S253: Fast path — ask viewer for data via BroadcastChannel (no DB load)
@@ -1002,6 +1008,7 @@ async function init() {
         const key = r[0] + '|' + r[1] + '|' + r[2];
         linearQty[key] = r[3];
         areaQty[key] = r[4];
+        volQty[key] = r[5];   // §FOOTING_M3 — undefined from an older viewer, handled at billing
       }
     }
     console.log('§QTO_RELAY_HIT building=' + bldName + ' rows=' + relay.countRows.length +
@@ -1030,7 +1037,7 @@ async function init() {
       if (retry.dimRows) {
         for (const r of retry.dimRows) {
           var k = r[0] + '|' + r[1] + '|' + r[2];
-          linearQty[k] = r[3]; areaQty[k] = r[4];
+          linearQty[k] = r[3]; areaQty[k] = r[4]; volQty[k] = r[5];   // §FOOTING_M3
         }
       }
       console.log('§QTO_RELAY_RETRY_HIT building=' + bldName + ' rows=' + retry.countRows.length);
@@ -1138,7 +1145,8 @@ async function init() {
         " SUM(MAX(t.bbox_x, t.bbox_y, t.bbox_z) *" +
         " CASE WHEN t.bbox_x >= t.bbox_y AND t.bbox_x >= t.bbox_z THEN MAX(t.bbox_y, t.bbox_z)" +
         " WHEN t.bbox_y >= t.bbox_x AND t.bbox_y >= t.bbox_z THEN MAX(t.bbox_x, t.bbox_z)" +
-        " ELSE MAX(t.bbox_x, t.bbox_y) END) as total_area" +
+        " ELSE MAX(t.bbox_x, t.bbox_y) END) as total_area," +
+        " SUM(t.bbox_x * t.bbox_y * t.bbox_z) as total_vol" +   // §FOOTING_M3
         " FROM elements_meta m JOIN element_transforms t ON m.guid = t.guid" +
         " WHERE m.building = '" + _bldSafe + "' AND t.bbox_x IS NOT NULL AND t.bbox_x > 0" +
         " GROUP BY m.discipline, m.ifc_class, m.storey"
@@ -1148,6 +1156,7 @@ async function init() {
           const key = r[0] + '|' + r[1] + '|' + r[2];
           linearQty[key] = r[3];
           areaQty[key] = r[4];
+          volQty[key] = r[5];   // §FOOTING_M3
         }
       }
     } catch(e) { console.warn('§QTO_WARN dimension query error: ' + e.message); }
@@ -1180,6 +1189,13 @@ async function init() {
       }
     } else if (unit === 'M2' && AREA_CLASSES.has(cls)) {
       qty = areaQty[key];
+      if (!qty || qty <= 0) {
+        qty = cnt;
+        qtoWarnCount++;
+        console.warn('§QTO_WARN no bbox for cls=' + cls + ' storey=' + storey + ', using count fallback (' + cnt + ')');
+      }
+    } else if (unit === 'M3' && VOLUME_CLASSES.has(cls)) {
+      qty = volQty[key];   // §FOOTING_M3 — bbox envelope volume, same fallback shape as M/M2
       if (!qty || qty <= 0) {
         qty = cnt;
         qtoWarnCount++;

--- a/viewer/main.js
+++ b/viewer/main.js
@@ -405,7 +405,12 @@ async function initViewer() {
             "SUM(MAX(t.bbox_x, t.bbox_y, t.bbox_z) * " +
             "CASE WHEN t.bbox_x >= t.bbox_y AND t.bbox_x >= t.bbox_z THEN MAX(t.bbox_y, t.bbox_z) " +
             "WHEN t.bbox_y >= t.bbox_x AND t.bbox_y >= t.bbox_z THEN MAX(t.bbox_x, t.bbox_z) " +
-            "ELSE MAX(t.bbox_x, t.bbox_y) END) as total_area " +
+            "ELSE MAX(t.bbox_x, t.bbox_y) END) as total_area, " +
+            // §FOOTING_M3 (2026-08-12): 6th column. IfcFooting is now priced unit:'M3' (rates.js),
+            // and boq_charts' M3 branch bills this SUM. Without it the relay path silently fell
+            // through to count and under-billed the class by avgVolume (5.66x on cidb rates).
+            // Same expression as foldCost/_volumeWeighting/analysis_sidecar vol_m3 — one volume.
+            "SUM(t.bbox_x * t.bbox_y * t.bbox_z) as total_vol " +
             "FROM elements_meta m JOIN element_transforms t ON m.guid = t.guid " +
             "WHERE m.building = '" + bld + "' AND t.bbox_x IS NOT NULL AND t.bbox_x > 0 " +
             "GROUP BY m.discipline, m.ifc_class, m.storey"

--- a/viewer/mep_qto_populate.js
+++ b/viewer/mep_qto_populate.js
@@ -45,11 +45,15 @@ const RATES = tpl.materials || {};
 const RATES_DEFAULT = { rate: 500, unit: 'EA', desc: 'Misc Element' };
 
 // Build unit sets
+// §FOOTING_M3 (2026-08-12): third sized unit, added with the IfcFooting EA→M3 repricing
+// (rates.js §FOOTING_M3). An M3 class previously fell through to count-based billing here.
 const LINEAR_CLASSES = new Set();
 const AREA_CLASSES = new Set();
+const VOLUME_CLASSES = new Set();
 for (const cls in RATES) {
   if (RATES[cls].unit === 'M') LINEAR_CLASSES.add(cls);
   if (RATES[cls].unit === 'M2') AREA_CLASSES.add(cls);
+  if (RATES[cls].unit === 'M3') VOLUME_CLASSES.add(cls);
 }
 
 // Labor calc (simplified from rates.js)
@@ -159,6 +163,22 @@ for (const dbPath of targets) {
     areaMap[r.discipline + '|' + r.ifc_class + '|' + r.storey] = r.total_area;
   }
 
+  // Volume query (M3) — §FOOTING_M3. bbox envelope, the same expression foldCost /
+  // _volumeWeighting / analysis_sidecar.vol_m3 already use. One volume, not a second definition.
+  const volMap = {};
+  const volRows = db.prepare(`
+    SELECT m.discipline, m.ifc_class, m.storey,
+           SUM(t.bbox_x * t.bbox_y * t.bbox_z) as total_vol
+    FROM elements_meta m
+    JOIN element_transforms t ON m.guid = t.guid
+    WHERE m.building = ?
+      AND t.bbox_x IS NOT NULL AND t.bbox_x > 0
+    GROUP BY m.discipline, m.ifc_class, m.storey
+  `).all(bldName);
+  for (const r of volRows) {
+    volMap[r.discipline + '|' + r.ifc_class + '|' + r.storey] = r.total_vol;
+  }
+
   // Process + write cache
   const insert = db.prepare(`INSERT INTO qto_cache
     (ifc_class, storey, discipline, qty, uom, element_count, material_cost, labour_cost, equipment_cost, rate_template, computed_at)
@@ -183,6 +203,9 @@ for (const dbPath of targets) {
         if (!qty || qty <= 0) { qty = cnt; warnCount++; }
       } else if (unit === 'M2' && AREA_CLASSES.has(cls)) {
         qty = areaMap[key];
+        if (!qty || qty <= 0) { qty = cnt; warnCount++; }
+      } else if (unit === 'M3' && VOLUME_CLASSES.has(cls)) {
+        qty = volMap[key];   // §FOOTING_M3
         if (!qty || qty <= 0) { qty = cnt; warnCount++; }
       } else {
         qty = cnt;

--- a/viewer/mep_qto_populate.js
+++ b/viewer/mep_qto_populate.js
@@ -62,7 +62,11 @@ function calcLabor(cls, qty) {
   for (const key in LABOR) {
     const lr = LABOR[key];
     if (lr.productivity && lr.productivity[cls] !== undefined) {
-      const prod = lr.productivity[cls];
+      let prod = lr.productivity[cls];
+      // §FOOTING_M3: qty is real m3 for an M3-priced class, productivity is stored per-element —
+      // scale by the same volFactor the rate was derived with, without touching the shared value.
+      const re = RATES[cls];
+      if (re && re.unit === 'M3' && re.volFactor) prod = prod * re.volFactor;
       const days = qty / prod;
       const cost = days * lr.crew_size * lr.rate_per_day;
       return { cost: Math.round(cost), days, crew: lr.crew_size, trade: lr.trade, tradeKey: key, prod };

--- a/viewer/mep_report.html
+++ b/viewer/mep_report.html
@@ -251,21 +251,24 @@ async function init() {
   var bldSafe = bldName.replace(/'/g, "''");
 
   // Build unit sets from RATES
-  var LINEAR = new Set(), AREA = new Set();
+  // §FOOTING_M3 (2026-08-12): VOL is the third sized unit — added when IfcFooting was repriced
+  // EA→M3 (rates.js §FOOTING_M3). Without it an M3 class fell to the `else` and billed by count.
+  var LINEAR = new Set(), AREA = new Set(), VOL = new Set();
   for (var cls in RATES) {
     if (RATES[cls].unit === 'M') LINEAR.add(cls);
     if (RATES[cls].unit === 'M2') AREA.add(cls);
+    if (RATES[cls].unit === 'M3') VOL.add(cls);
   }
 
   // §T7 ANALYSIS_SIDECAR — REUSE the same currency-free 5D sidecar (OPFS-cached) as
   // boq_charts: its rows are exactly disc/class/storey + count/length/area. First open
   // computes+persists, repeat opens read OPFS (fast + offline). Fallback to the 3 SQL
   // aggregates if the sidecar is unavailable (older browsers / OPFS off).
-  var countRows, linearMap = {}, areaMap = {};
+  var countRows, linearMap = {}, areaMap = {}, volMap = {};   // §FOOTING_M3: volMap = unit M3
   var _5d = (window.AnalysisSidecar && bldName) ? await window.AnalysisSidecar.get5D(db, bldName) : null;
   if (_5d && _5d.rows && _5d.rows.length) {
     countRows = [{ values: _5d.rows.map(function (r) { return [r.disc, r.cls, r.storey, r.count]; }) }];
-    _5d.rows.forEach(function (r) { var k = r.disc + '|' + r.cls + '|' + r.storey; linearMap[k] = r.length_m; areaMap[k] = r.area_m2; });
+    _5d.rows.forEach(function (r) { var k = r.disc + '|' + r.cls + '|' + r.storey; linearMap[k] = r.length_m; areaMap[k] = r.area_m2; volMap[k] = r.vol_m3; });
     console.log('§MEP_5D_SIDECAR source=' + (_5d.basis || 'sidecar') + ' rows=' + _5d.rows.length);
   } else {
     countRows = db.exec("SELECT m.discipline, m.ifc_class, m.storey, COUNT(*) as cnt FROM elements_meta m WHERE m.building = '" + bldSafe + "' GROUP BY m.discipline, m.ifc_class, m.storey");
@@ -276,6 +279,10 @@ async function init() {
     try {
       var aR = db.exec("SELECT m.discipline, m.ifc_class, m.storey, SUM(MAX(t.bbox_x, t.bbox_y, t.bbox_z) * CASE WHEN t.bbox_x >= t.bbox_y AND t.bbox_x >= t.bbox_z THEN MAX(t.bbox_y, t.bbox_z) WHEN t.bbox_y >= t.bbox_x AND t.bbox_y >= t.bbox_z THEN MAX(t.bbox_x, t.bbox_z) ELSE MAX(t.bbox_x, t.bbox_y) END) FROM elements_meta m JOIN element_transforms t ON m.guid = t.guid WHERE m.building = '" + bldSafe + "' AND t.bbox_x IS NOT NULL AND t.bbox_x > 0 GROUP BY m.discipline, m.ifc_class, m.storey");
       if (aR.length) for (var i = 0; i < aR[0].values.length; i++) { var v = aR[0].values[i]; areaMap[v[0]+'|'+v[1]+'|'+v[2]] = v[3]; }
+    } catch(e) {}
+    try {   // §FOOTING_M3 — bbox envelope volume, same shape as the length/area aggregates above
+      var vR = db.exec("SELECT m.discipline, m.ifc_class, m.storey, SUM(t.bbox_x * t.bbox_y * t.bbox_z) FROM elements_meta m JOIN element_transforms t ON m.guid = t.guid WHERE m.building = '" + bldSafe + "' AND t.bbox_x IS NOT NULL AND t.bbox_x > 0 GROUP BY m.discipline, m.ifc_class, m.storey");
+      if (vR.length) for (var i = 0; i < vR[0].values.length; i++) { var v = vR[0].values[i]; volMap[v[0]+'|'+v[1]+'|'+v[2]] = v[3]; }
     } catch(e) {}
   }
   if (!countRows.length || !countRows[0].values.length) {
@@ -303,6 +310,8 @@ async function init() {
       qty = linearMap[key] || cnt;
     } else if (unit === 'M2' && AREA.has(cls)) {
       qty = areaMap[key] || cnt;
+    } else if (unit === 'M3' && VOL.has(cls)) {
+      qty = volMap[key] || cnt;   // §FOOTING_M3
     } else {
       qty = cnt;
     }

--- a/viewer/rates.js
+++ b/viewer/rates.js
@@ -46,7 +46,26 @@ var RATES = {
   IfcRailing:{rate:280,unit:'M',desc:'Railing'},
   IfcStair:{rate:4500,unit:'EA',desc:'Staircase'},
   IfcStairFlight:{rate:2200,unit:'EA',desc:'Stair Flight'},
-  IfcFooting:{rate:320,unit:'EA',desc:'Foundation Footing'},
+  // §FOOTING_M3 (2026-08-12) — EA→M3 is a UNIT correction, not a new commercial rate. A footing
+  // priced per-EA charges a 0.26 m3 pad and a 602 m3 raft identically; measured across the 7 shipped
+  // buildings IfcFooting is 821 real elements, 0.2595..602.0946 m3 — a 2320x spread billed flat.
+  // The m3 rate is DERIVED from the EA rate this table already carried, never invented:
+  //   rate_m3 = rate_EA / avgVolume  = 320 / 4.25074802767622 = 75.280868 → 75.28
+  // avgVolume is the class-wide mean of _VOL_EXPR (t.bbox_x*t.bbox_y*t.bbox_z — the same volume
+  // foldCost/_volumeWeighting already treat as canonical) over all 821 elements:
+  //   SELECT COUNT(*), SUM(t.bbox_x*t.bbox_y*t.bbox_z) FROM elements_meta m
+  //   JOIN element_transforms t ON m.guid=t.guid WHERE m.ifc_class='IfcFooting'
+  //   AND t.bbox_x IS NOT NULL AND t.bbox_x>0 AND (t.bbox_x*t.bbox_y*t.bbox_z)>0
+  //   -- over Terminal/Hospital/Duplex/HHS_Office_Federated/Clinic/LTU_AHouse/JKR
+  //   -- => 821 | 3489.86413072218 | avg 4.25074802767622
+  // So sum(rate_m3 * volume) over that population == rate_EA * 821 EXACTLY (262,720 either way,
+  // this table's currency): the same class total, now distributed by real size. Per BUILDING it
+  // shifts by that building's own avg/class avg (Hospital 5.14/4.25 = +21%, Clinic 1.69/4.25 = -60%)
+  // — that shift IS the correction, and it is the only honest reading of a class-wide unit change.
+  // Every rates/*.json template carries the same conversion against its own EA rate.
+  // IfcPile stays EA: ZERO IfcPile elements exist in any shipped building, so there is no measured
+  // avgVolume to divide by and any m3 rate would be invented. Reprice it when a model ships piles.
+  IfcFooting:{rate:75.28,unit:'M3',desc:'Foundation Footing'},
   IfcPile:{rate:850,unit:'EA',desc:'Foundation Pile'},
   IfcReinforcingBar:{rate:45,unit:'KG',desc:'Reinforcing Steel'},
   IfcFlowSegment:{rate:120,unit:'M',desc:'Flow Segment'},
@@ -110,6 +129,22 @@ var LABOR_RATES = {
     productivity: {IfcBeam:8,IfcColumn:6,IfcPlate:12,IfcMember:10}
   },
   CONCRETE_GANG: {
+    // ⚠ §FOOTING_M3 OPEN ITEM (2026-08-12) — IfcFooting:6 is NOT converted, deliberately, and this
+    // note exists so the consequence is not lost. `productivity` is read with TWO different
+    // quantity semantics by two live paths off the same window.LABOR_RATES object:
+    //   4D  schedule_author._installSecs: 28800/prod seconds PER ELEMENT (then x a mean-1 ratio)
+    //   5D  boq_charts/mep_report/mep_qto_populate calcLabor(cls, qty): days = qty / prod, where
+    //       qty is whatever RATES[cls].unit selects — count for EA, m2 for M2, now m3 for M3.
+    // So repricing IfcFooting EA→M3 silently re-reads "6" from 6 footings/day to 6 m3/day, and the
+    // 5D LABOUR column for footings rises exactly avgVolume-fold: measured 119,045 → 506,031 over
+    // the 821 shipped footings (4.25x; Hospital 80,185→411,897, LTU_AHouse 23,925→68,145, Clinic
+    // 13,920→23,592, Duplex 1,015→2,397; equipment unaffected, IfcFooting has no EQUIPMENT_ALLOCATION).
+    // The MATERIAL column is unaffected and provably neutral — see the §FOOTING_M3 note on RATES.
+    // The neutral conversion would be 6 x 4.25074802767622 = 25.50 m3/day, but that same key drives
+    // the 4D path, where it would shrink every footing task 4.25x and move the programme. Which of
+    // the two readings is intended is an estimating decision, so it is NOT guessed here.
+    // NOTE this ambiguity is pre-existing, not created by §FOOTING_M3: every M/M2-priced class
+    // (IfcSlab:35, IfcWall, IfcCovering…) already runs the same split today. Footing just joined them.
     rate_per_day: 145, crew_size: 6, max_crews: 3, trade: 'Concrete Gang (Mixed)',
     productivity: {IfcSlab:35,IfcFooting:6,IfcPile:4,IfcReinforcingBar:50,IfcRamp:3,IfcRampFlight:3}
   },

--- a/viewer/rates.js
+++ b/viewer/rates.js
@@ -65,7 +65,7 @@ var RATES = {
   // Every rates/*.json template carries the same conversion against its own EA rate.
   // IfcPile stays EA: ZERO IfcPile elements exist in any shipped building, so there is no measured
   // avgVolume to divide by and any m3 rate would be invented. Reprice it when a model ships piles.
-  IfcFooting:{rate:75.28,unit:'M3',desc:'Foundation Footing'},
+  IfcFooting:{rate:75.28,unit:'M3',desc:'Foundation Footing',volFactor:4.25074802767622},
   IfcPile:{rate:850,unit:'EA',desc:'Foundation Pile'},
   IfcReinforcingBar:{rate:45,unit:'KG',desc:'Reinforcing Steel'},
   IfcFlowSegment:{rate:120,unit:'M',desc:'Flow Segment'},
@@ -415,6 +415,12 @@ function calcLabor(ifcClass, qty) {
     var lr = LABOR_RATES[key];
     if (lr.productivity && lr.productivity[ifcClass] !== undefined) {
       var prod = lr.productivity[ifcClass];
+      // §FOOTING_M3 OPEN ITEM resolved (2026-08-12): productivity is stored per-element (4D's own
+      // reading, e.g. "6 footings/day") but qty here is real m3 for an M3-priced class — scale prod
+      // by the SAME volFactor (avg real volume) the rate itself was divided by, so days stays
+      // correct WITHOUT touching the shared LABOR_RATES.productivity value 4D also reads.
+      var re = (typeof RATES !== 'undefined') ? RATES[ifcClass] : null;
+      if (re && re.unit === 'M3' && re.volFactor) prod = prod * re.volFactor;
       var days = qty / prod;
       var cost = days * lr.crew_size * lr.rate_per_day;
       return {cost: Math.round(cost), days: days, crew: lr.crew_size, trade: lr.trade, tradeKey: key, prod: prod};

--- a/viewer/rates/aramco2024_sa.json
+++ b/viewer/rates/aramco2024_sa.json
@@ -182,7 +182,8 @@
       "rate": 64.69,
       "unit": "M3",
       "desc": "Foundation Footing",
-      "smm_section": "D20"
+      "smm_section": "D20",
+      "volFactor": 4.25074802767622
     },
     "IfcPile": {
       "rate": 720,

--- a/viewer/rates/aramco2024_sa.json
+++ b/viewer/rates/aramco2024_sa.json
@@ -179,8 +179,8 @@
       "smm_section": "L30"
     },
     "IfcFooting": {
-      "rate": 275,
-      "unit": "EA",
+      "rate": 64.69,
+      "unit": "M3",
       "desc": "Foundation Footing",
       "smm_section": "D20"
     },

--- a/viewer/rates/asaqs2024_za.json
+++ b/viewer/rates/asaqs2024_za.json
@@ -179,8 +179,8 @@
       "smm_section": "L30"
     },
     "IfcFooting": {
-      "rate": 4500,
-      "unit": "EA",
+      "rate": 1058.64,
+      "unit": "M3",
       "desc": "Foundation Footing",
       "smm_section": "D20"
     },

--- a/viewer/rates/asaqs2024_za.json
+++ b/viewer/rates/asaqs2024_za.json
@@ -182,7 +182,8 @@
       "rate": 1058.64,
       "unit": "M3",
       "desc": "Foundation Footing",
-      "smm_section": "D20"
+      "smm_section": "D20",
+      "volFactor": 4.25074802767622
     },
     "IfcPile": {
       "rate": 9500,

--- a/viewer/rates/bcis2024_uk.json
+++ b/viewer/rates/bcis2024_uk.json
@@ -179,8 +179,8 @@
       "smm_section": "L30"
     },
     "IfcFooting": {
-      "rate": 184,
-      "unit": "EA",
+      "rate": 43.29,
+      "unit": "M3",
       "desc": "Foundation Footing",
       "smm_section": "D20"
     },

--- a/viewer/rates/bcis2024_uk.json
+++ b/viewer/rates/bcis2024_uk.json
@@ -5,7 +5,7 @@
     "currency": "GBP",
     "currency2": "USD",
     "exchange_rate": 0.74,
-    "source": "BCIS (RICS) 2024 — placeholder rates, replace with licensed data",
+    "source": "BCIS (RICS) 2024 \u2014 placeholder rates, replace with licensed data",
     "validity_days": 60,
     "measurement_standard": "NRM2 (RICS)"
   },
@@ -182,7 +182,8 @@
       "rate": 43.29,
       "unit": "M3",
       "desc": "Foundation Footing",
-      "smm_section": "D20"
+      "smm_section": "D20",
+      "volFactor": 4.25074802767622
     },
     "IfcPile": {
       "rate": 490,

--- a/viewer/rates/bki2024_de.json
+++ b/viewer/rates/bki2024_de.json
@@ -182,7 +182,8 @@
       "rate": 43.52,
       "unit": "M3",
       "desc": "Fundament",
-      "smm_section": "D20"
+      "smm_section": "D20",
+      "volFactor": 4.25074802767622
     },
     "IfcPile": {
       "rate": 520,
@@ -446,7 +447,7 @@
     },
     "SCISSOR_LIFT_8M": {
       "rate_per_day": 135,
-      "desc": "Scherenhubbühne 8m"
+      "desc": "Scherenhubb\u00fchne 8m"
     },
     "WELDING_MACHINE": {
       "rate_per_day": 35,
@@ -832,7 +833,7 @@
     "N": "Moebel / Einrichtung",
     "P": "Diverse Bauteile",
     "Q": "Aussenanlagen",
-    "R": "Entwässerung",
+    "R": "Entw\u00e4sserung",
     "S": "Sanitaer",
     "T": "Heizung / Kuehlung",
     "U": "Lueftung / Klimatechnik",

--- a/viewer/rates/bki2024_de.json
+++ b/viewer/rates/bki2024_de.json
@@ -179,8 +179,8 @@
       "smm_section": "L30"
     },
     "IfcFooting": {
-      "rate": 185,
-      "unit": "EA",
+      "rate": 43.52,
+      "unit": "M3",
       "desc": "Fundament",
       "smm_section": "D20"
     },

--- a/viewer/rates/cidb2024_my.json
+++ b/viewer/rates/cidb2024_my.json
@@ -182,7 +182,8 @@
       "rate": 75.28,
       "unit": "M3",
       "desc": "Foundation Footing",
-      "smm_section": "D20"
+      "smm_section": "D20",
+      "volFactor": 4.25074802767622
     },
     "IfcPile": {
       "rate": 850,

--- a/viewer/rates/cidb2024_my.json
+++ b/viewer/rates/cidb2024_my.json
@@ -179,8 +179,8 @@
       "smm_section": "L30"
     },
     "IfcFooting": {
-      "rate": 320,
-      "unit": "EA",
+      "rate": 75.28,
+      "unit": "M3",
       "desc": "Foundation Footing",
       "smm_section": "D20"
     },

--- a/viewer/rates/cype2024_es.json
+++ b/viewer/rates/cype2024_es.json
@@ -179,8 +179,8 @@
       "smm_section": "L30"
     },
     "IfcFooting": {
-      "rate": 73,
-      "unit": "EA",
+      "rate": 17.17,
+      "unit": "M3",
       "desc": "Zapata de cimentacion",
       "smm_section": "D20"
     },

--- a/viewer/rates/cype2024_es.json
+++ b/viewer/rates/cype2024_es.json
@@ -182,7 +182,8 @@
       "rate": 17.17,
       "unit": "M3",
       "desc": "Zapata de cimentacion",
-      "smm_section": "D20"
+      "smm_section": "D20",
+      "volFactor": 4.25074802767622
     },
     "IfcPile": {
       "rate": 195,

--- a/viewer/rates/dpt2024_th.json
+++ b/viewer/rates/dpt2024_th.json
@@ -13,301 +13,302 @@
     "IfcDuct": {
       "rate": 1350,
       "unit": "M",
-      "desc": "ท่อลมเหล็กชุบสังกะสี (เฉลี่ย 400มม.)",
+      "desc": "\u0e17\u0e48\u0e2d\u0e25\u0e21\u0e40\u0e2b\u0e25\u0e47\u0e01\u0e0a\u0e38\u0e1a\u0e2a\u0e31\u0e07\u0e01\u0e30\u0e2a\u0e35 (\u0e40\u0e09\u0e25\u0e35\u0e48\u0e22 400\u0e21\u0e21.)",
       "smm_section": "U10"
     },
     "IfcDuctSegment": {
       "rate": 1350,
       "unit": "M",
-      "desc": "ท่อลมส่วนตรง",
+      "desc": "\u0e17\u0e48\u0e2d\u0e25\u0e21\u0e2a\u0e48\u0e27\u0e19\u0e15\u0e23\u0e07",
       "smm_section": "U10"
     },
     "IfcDuctFitting": {
       "rate": 3100,
       "unit": "EA",
-      "desc": "อุปกรณ์ข้อต่อท่อลม",
+      "desc": "\u0e2d\u0e38\u0e1b\u0e01\u0e23\u0e13\u0e4c\u0e02\u0e49\u0e2d\u0e15\u0e48\u0e2d\u0e17\u0e48\u0e2d\u0e25\u0e21",
       "smm_section": "U10"
     },
     "IfcPipe": {
       "rate": 395,
       "unit": "M",
-      "desc": "ท่อ PVC/HDPE (เฉลี่ย 100มม.)",
+      "desc": "\u0e17\u0e48\u0e2d PVC/HDPE (\u0e40\u0e09\u0e25\u0e35\u0e48\u0e22 100\u0e21\u0e21.)",
       "smm_section": "S10"
     },
     "IfcPipeSegment": {
       "rate": 395,
       "unit": "M",
-      "desc": "ท่อส่วนตรง",
+      "desc": "\u0e17\u0e48\u0e2d\u0e2a\u0e48\u0e27\u0e19\u0e15\u0e23\u0e07",
       "smm_section": "S10"
     },
     "IfcPipeFitting": {
       "rate": 780,
       "unit": "EA",
-      "desc": "อุปกรณ์ข้อต่อท่อ",
+      "desc": "\u0e2d\u0e38\u0e1b\u0e01\u0e23\u0e13\u0e4c\u0e02\u0e49\u0e2d\u0e15\u0e48\u0e2d\u0e17\u0e48\u0e2d",
       "smm_section": "S10"
     },
     "IfcCableCarrier": {
       "rate": 640,
       "unit": "M",
-      "desc": "รางเคเบิลเทรย์ (300มม.)",
+      "desc": "\u0e23\u0e32\u0e07\u0e40\u0e04\u0e40\u0e1a\u0e34\u0e25\u0e40\u0e17\u0e23\u0e22\u0e4c (300\u0e21\u0e21.)",
       "smm_section": "V20"
     },
     "IfcCableCarrierSegment": {
       "rate": 640,
       "unit": "M",
-      "desc": "รางเคเบิลเทรย์ส่วนตรง",
+      "desc": "\u0e23\u0e32\u0e07\u0e40\u0e04\u0e40\u0e1a\u0e34\u0e25\u0e40\u0e17\u0e23\u0e22\u0e4c\u0e2a\u0e48\u0e27\u0e19\u0e15\u0e23\u0e07",
       "smm_section": "V20"
     },
     "IfcBeam": {
       "rate": 5600,
       "unit": "M",
-      "desc": "คานเหล็กรูปพรรณ I-Beam",
+      "desc": "\u0e04\u0e32\u0e19\u0e40\u0e2b\u0e25\u0e47\u0e01\u0e23\u0e39\u0e1b\u0e1e\u0e23\u0e23\u0e13 I-Beam",
       "smm_section": "G10"
     },
     "IfcColumn": {
       "rate": 10200,
       "unit": "M",
-      "desc": "เสาเหล็กรูปพรรณ",
+      "desc": "\u0e40\u0e2a\u0e32\u0e40\u0e2b\u0e25\u0e47\u0e01\u0e23\u0e39\u0e1b\u0e1e\u0e23\u0e23\u0e13",
       "smm_section": "G10"
     },
     "IfcSlab": {
       "rate": 2350,
       "unit": "M2",
-      "desc": "พื้น ค.ส.ล. หนา 250มม.",
+      "desc": "\u0e1e\u0e37\u0e49\u0e19 \u0e04.\u0e2a.\u0e25. \u0e2b\u0e19\u0e32 250\u0e21\u0e21.",
       "smm_section": "E10"
     },
     "IfcWall": {
       "rate": 1180,
       "unit": "M2",
-      "desc": "ผนังก่ออิฐบล็อก 150มม.",
+      "desc": "\u0e1c\u0e19\u0e31\u0e07\u0e01\u0e48\u0e2d\u0e2d\u0e34\u0e10\u0e1a\u0e25\u0e47\u0e2d\u0e01 150\u0e21\u0e21.",
       "smm_section": "F10"
     },
     "IfcWallStandardCase": {
       "rate": 1180,
       "unit": "M2",
-      "desc": "ผนังมาตรฐาน",
+      "desc": "\u0e1c\u0e19\u0e31\u0e07\u0e21\u0e32\u0e15\u0e23\u0e10\u0e32\u0e19",
       "smm_section": "F10"
     },
     "IfcCurtainWall": {
       "rate": 6200,
       "unit": "M2",
-      "desc": "ผนังกระจก",
+      "desc": "\u0e1c\u0e19\u0e31\u0e07\u0e01\u0e23\u0e30\u0e08\u0e01",
       "smm_section": "H10"
     },
     "IfcCovering": {
       "rate": 1520,
       "unit": "M2",
-      "desc": "วัสดุปูพื้น/ฝ้าเพดาน",
+      "desc": "\u0e27\u0e31\u0e2a\u0e14\u0e38\u0e1b\u0e39\u0e1e\u0e37\u0e49\u0e19/\u0e1d\u0e49\u0e32\u0e40\u0e1e\u0e14\u0e32\u0e19",
       "smm_section": "M10"
     },
     "IfcRoof": {
       "rate": 1950,
       "unit": "M2",
-      "desc": "หลังคาเหล็ก",
+      "desc": "\u0e2b\u0e25\u0e31\u0e07\u0e04\u0e32\u0e40\u0e2b\u0e25\u0e47\u0e01",
       "smm_section": "H60"
     },
     "IfcLightFixture": {
       "rate": 3950,
       "unit": "EA",
-      "desc": "โคมไฟ LED",
+      "desc": "\u0e42\u0e04\u0e21\u0e44\u0e1f LED",
       "smm_section": "V40"
     },
     "IfcOutlet": {
       "rate": 1020,
       "unit": "EA",
-      "desc": "เต้ารับไฟฟ้า",
+      "desc": "\u0e40\u0e15\u0e49\u0e32\u0e23\u0e31\u0e1a\u0e44\u0e1f\u0e1f\u0e49\u0e32",
       "smm_section": "V20"
     },
     "IfcDoor": {
       "rate": 23500,
       "unit": "EA",
-      "desc": "ชุดประตู",
+      "desc": "\u0e0a\u0e38\u0e14\u0e1b\u0e23\u0e30\u0e15\u0e39",
       "smm_section": "L20"
     },
     "IfcWindow": {
       "rate": 12800,
       "unit": "EA",
-      "desc": "หน้าต่าง",
+      "desc": "\u0e2b\u0e19\u0e49\u0e32\u0e15\u0e48\u0e32\u0e07",
       "smm_section": "L10"
     },
     "IfcBuildingElementProxy": {
       "rate": 6950,
       "unit": "EA",
-      "desc": "องค์ประกอบอื่นๆ",
+      "desc": "\u0e2d\u0e07\u0e04\u0e4c\u0e1b\u0e23\u0e30\u0e01\u0e2d\u0e1a\u0e2d\u0e37\u0e48\u0e19\u0e46",
       "smm_section": "P10"
     },
     "IfcFlowTerminal": {
       "rate": 28500,
       "unit": "EA",
-      "desc": "ปลายทางระบบปรับอากาศ",
+      "desc": "\u0e1b\u0e25\u0e32\u0e22\u0e17\u0e32\u0e07\u0e23\u0e30\u0e1a\u0e1a\u0e1b\u0e23\u0e31\u0e1a\u0e2d\u0e32\u0e01\u0e32\u0e28",
       "smm_section": "U10"
     },
     "IfcFurnishingElement": {
       "rate": 9800,
       "unit": "EA",
-      "desc": "เครื่องเรือน",
+      "desc": "\u0e40\u0e04\u0e23\u0e37\u0e48\u0e2d\u0e07\u0e40\u0e23\u0e37\u0e2d\u0e19",
       "smm_section": "N10"
     },
     "IfcPlate": {
       "rate": 780,
       "unit": "M2",
-      "desc": "แผ่นเหล็ก",
+      "desc": "\u0e41\u0e1c\u0e48\u0e19\u0e40\u0e2b\u0e25\u0e47\u0e01",
       "smm_section": "G10"
     },
     "IfcMember": {
       "rate": 2600,
       "unit": "M",
-      "desc": "ชิ้นส่วนเหล็ก",
+      "desc": "\u0e0a\u0e34\u0e49\u0e19\u0e2a\u0e48\u0e27\u0e19\u0e40\u0e2b\u0e25\u0e47\u0e01",
       "smm_section": "G10"
     },
     "IfcRailing": {
       "rate": 2300,
       "unit": "M",
-      "desc": "ราวกันตก",
+      "desc": "\u0e23\u0e32\u0e27\u0e01\u0e31\u0e19\u0e15\u0e01",
       "smm_section": "L30"
     },
     "IfcStair": {
       "rate": 36800,
       "unit": "EA",
-      "desc": "บันได",
+      "desc": "\u0e1a\u0e31\u0e19\u0e44\u0e14",
       "smm_section": "L30"
     },
     "IfcStairFlight": {
       "rate": 18000,
       "unit": "EA",
-      "desc": "ช่วงบันได",
+      "desc": "\u0e0a\u0e48\u0e27\u0e07\u0e1a\u0e31\u0e19\u0e44\u0e14",
       "smm_section": "L30"
     },
     "IfcFooting": {
       "rate": 611.66,
       "unit": "M3",
-      "desc": "ฐานรากแผ่",
-      "smm_section": "D20"
+      "desc": "\u0e10\u0e32\u0e19\u0e23\u0e32\u0e01\u0e41\u0e1c\u0e48",
+      "smm_section": "D20",
+      "volFactor": 4.25074802767622
     },
     "IfcPile": {
       "rate": 6950,
       "unit": "EA",
-      "desc": "เสาเข็ม",
+      "desc": "\u0e40\u0e2a\u0e32\u0e40\u0e02\u0e47\u0e21",
       "smm_section": "D30"
     },
     "IfcReinforcingBar": {
       "rate": 370,
       "unit": "KG",
-      "desc": "เหล็กเสริม",
+      "desc": "\u0e40\u0e2b\u0e25\u0e47\u0e01\u0e40\u0e2a\u0e23\u0e34\u0e21",
       "smm_section": "E30"
     },
     "IfcFlowSegment": {
       "rate": 980,
       "unit": "M",
-      "desc": "ท่อส่งระบบ",
+      "desc": "\u0e17\u0e48\u0e2d\u0e2a\u0e48\u0e07\u0e23\u0e30\u0e1a\u0e1a",
       "smm_section": "Y10"
     },
     "IfcFlowFitting": {
       "rate": 1650,
       "unit": "EA",
-      "desc": "ข้อต่อระบบท่อ",
+      "desc": "\u0e02\u0e49\u0e2d\u0e15\u0e48\u0e2d\u0e23\u0e30\u0e1a\u0e1a\u0e17\u0e48\u0e2d",
       "smm_section": "Y10"
     },
     "IfcFlowController": {
       "rate": 3680,
       "unit": "EA",
-      "desc": "อุปกรณ์ควบคุมการไหล",
+      "desc": "\u0e2d\u0e38\u0e1b\u0e01\u0e23\u0e13\u0e4c\u0e04\u0e27\u0e1a\u0e04\u0e38\u0e21\u0e01\u0e32\u0e23\u0e44\u0e2b\u0e25",
       "smm_section": "Y10"
     },
     "IfcEnergyConversionDevice": {
       "rate": 69500,
       "unit": "EA",
-      "desc": "อุปกรณ์แปลงพลังงาน",
+      "desc": "\u0e2d\u0e38\u0e1b\u0e01\u0e23\u0e13\u0e4c\u0e41\u0e1b\u0e25\u0e07\u0e1e\u0e25\u0e31\u0e07\u0e07\u0e32\u0e19",
       "smm_section": "T10"
     },
     "IfcFlowTreatmentDevice": {
       "rate": 9800,
       "unit": "EA",
-      "desc": "อุปกรณ์บำบัด",
+      "desc": "\u0e2d\u0e38\u0e1b\u0e01\u0e23\u0e13\u0e4c\u0e1a\u0e33\u0e1a\u0e31\u0e14",
       "smm_section": "Y10"
     },
     "IfcFlowMovingDevice": {
       "rate": 28500,
       "unit": "EA",
-      "desc": "อุปกรณ์ขับเคลื่อนของไหล",
+      "desc": "\u0e2d\u0e38\u0e1b\u0e01\u0e23\u0e13\u0e4c\u0e02\u0e31\u0e1a\u0e40\u0e04\u0e25\u0e37\u0e48\u0e2d\u0e19\u0e02\u0e2d\u0e07\u0e44\u0e2b\u0e25",
       "smm_section": "T10"
     },
     "IfcFlowStorageDevice": {
       "rate": 41000,
       "unit": "EA",
-      "desc": "อุปกรณ์เก็บกักของไหล",
+      "desc": "\u0e2d\u0e38\u0e1b\u0e01\u0e23\u0e13\u0e4c\u0e40\u0e01\u0e47\u0e1a\u0e01\u0e31\u0e01\u0e02\u0e2d\u0e07\u0e44\u0e2b\u0e25",
       "smm_section": "Y10"
     },
     "IfcElectricAppliance": {
       "rate": 3950,
       "unit": "EA",
-      "desc": "เครื่องใช้ไฟฟ้า",
+      "desc": "\u0e40\u0e04\u0e23\u0e37\u0e48\u0e2d\u0e07\u0e43\u0e0a\u0e49\u0e44\u0e1f\u0e1f\u0e49\u0e32",
       "smm_section": "V20"
     },
     "IfcFurniture": {
       "rate": 12200,
       "unit": "EA",
-      "desc": "เฟอร์นิเจอร์",
+      "desc": "\u0e40\u0e1f\u0e2d\u0e23\u0e4c\u0e19\u0e34\u0e40\u0e08\u0e2d\u0e23\u0e4c",
       "smm_section": "N10"
     },
     "IfcOpeningElement": {
       "rate": 0,
       "unit": "EA",
-      "desc": "ช่องเปิด",
+      "desc": "\u0e0a\u0e48\u0e2d\u0e07\u0e40\u0e1b\u0e34\u0e14",
       "smm_section": ""
     },
     "IfcDistributionElement": {
       "rate": 4100,
       "unit": "EA",
-      "desc": "อุปกรณ์จ่าย",
+      "desc": "\u0e2d\u0e38\u0e1b\u0e01\u0e23\u0e13\u0e4c\u0e08\u0e48\u0e32\u0e22",
       "smm_section": "Y10"
     },
     "IfcFireSuppressionTerminal": {
       "rate": 3680,
       "unit": "EA",
-      "desc": "หัวสปริงเกอร์",
+      "desc": "\u0e2b\u0e31\u0e27\u0e2a\u0e1b\u0e23\u0e34\u0e07\u0e40\u0e01\u0e2d\u0e23\u0e4c",
       "smm_section": "S60"
     },
     "IfcAirTerminal": {
       "rate": 3100,
       "unit": "EA",
-      "desc": "หัวจ่ายลม/ช่องลม",
+      "desc": "\u0e2b\u0e31\u0e27\u0e08\u0e48\u0e32\u0e22\u0e25\u0e21/\u0e0a\u0e48\u0e2d\u0e07\u0e25\u0e21",
       "smm_section": "U10"
     },
     "IfcValve": {
       "rate": 2300,
       "unit": "EA",
-      "desc": "วาล์ว",
+      "desc": "\u0e27\u0e32\u0e25\u0e4c\u0e27",
       "smm_section": "S10"
     },
     "IfcAlarm": {
       "rate": 2850,
       "unit": "EA",
-      "desc": "อุปกรณ์แจ้งเตือนอัคคีภัย",
+      "desc": "\u0e2d\u0e38\u0e1b\u0e01\u0e23\u0e13\u0e4c\u0e41\u0e08\u0e49\u0e07\u0e40\u0e15\u0e37\u0e2d\u0e19\u0e2d\u0e31\u0e04\u0e04\u0e35\u0e20\u0e31\u0e22",
       "smm_section": "W50"
     },
     "IfcController": {
       "rate": 9800,
       "unit": "EA",
-      "desc": "ตัวควบคุมอาคาร",
+      "desc": "\u0e15\u0e31\u0e27\u0e04\u0e27\u0e1a\u0e04\u0e38\u0e21\u0e2d\u0e32\u0e04\u0e32\u0e23",
       "smm_section": "W60"
     },
     "IfcRamp": {
       "rate": 26200,
       "unit": "EA",
-      "desc": "ทางลาด",
+      "desc": "\u0e17\u0e32\u0e07\u0e25\u0e32\u0e14",
       "smm_section": "L30"
     },
     "IfcRampFlight": {
       "rate": 28600,
       "unit": "EA",
-      "desc": "ช่วงทางลาด",
+      "desc": "\u0e0a\u0e48\u0e27\u0e07\u0e17\u0e32\u0e07\u0e25\u0e32\u0e14",
       "smm_section": "L30"
     },
     "IfcBuildingElementPart": {
       "rate": 0,
       "unit": "EA",
-      "desc": "ส่วนประกอบ",
+      "desc": "\u0e2a\u0e48\u0e27\u0e19\u0e1b\u0e23\u0e30\u0e01\u0e2d\u0e1a",
       "smm_section": ""
     }
   },
@@ -315,7 +316,7 @@
     "HVAC_TECH": {
       "rate_per_day": 1500,
       "crew_size": 2,
-      "trade": "ช่างเทคนิคระบบปรับอากาศ (ฝีมือ)",
+      "trade": "\u0e0a\u0e48\u0e32\u0e07\u0e40\u0e17\u0e04\u0e19\u0e34\u0e04\u0e23\u0e30\u0e1a\u0e1a\u0e1b\u0e23\u0e31\u0e1a\u0e2d\u0e32\u0e01\u0e32\u0e28 (\u0e1d\u0e35\u0e21\u0e37\u0e2d)",
       "productivity": {
         "IfcDuct": 18,
         "IfcDuctSegment": 18,
@@ -329,7 +330,7 @@
     "PLUMBER": {
       "rate_per_day": 1350,
       "crew_size": 2,
-      "trade": "ช่างประปา (ฝีมือ)",
+      "trade": "\u0e0a\u0e48\u0e32\u0e07\u0e1b\u0e23\u0e30\u0e1b\u0e32 (\u0e1d\u0e35\u0e21\u0e37\u0e2d)",
       "productivity": {
         "IfcPipe": 25,
         "IfcPipeSegment": 25,
@@ -346,7 +347,7 @@
     "ELECTRICIAN": {
       "rate_per_day": 1450,
       "crew_size": 2,
-      "trade": "ช่างไฟฟ้า (ฝีมือ)",
+      "trade": "\u0e0a\u0e48\u0e32\u0e07\u0e44\u0e1f\u0e1f\u0e49\u0e32 (\u0e1d\u0e35\u0e21\u0e37\u0e2d)",
       "productivity": {
         "IfcCableCarrier": 30,
         "IfcCableCarrierSegment": 30,
@@ -361,7 +362,7 @@
     "STEEL_ERECTOR": {
       "rate_per_day": 1600,
       "crew_size": 4,
-      "trade": "ช่างเหล็ก (ฝีมือ)",
+      "trade": "\u0e0a\u0e48\u0e32\u0e07\u0e40\u0e2b\u0e25\u0e47\u0e01 (\u0e1d\u0e35\u0e21\u0e37\u0e2d)",
       "productivity": {
         "IfcBeam": 8,
         "IfcColumn": 6,
@@ -372,7 +373,7 @@
     "CONCRETE_GANG": {
       "rate_per_day": 1200,
       "crew_size": 6,
-      "trade": "ทีมงานคอนกรีต (ผสม)",
+      "trade": "\u0e17\u0e35\u0e21\u0e07\u0e32\u0e19\u0e04\u0e2d\u0e19\u0e01\u0e23\u0e35\u0e15 (\u0e1c\u0e2a\u0e21)",
       "productivity": {
         "IfcSlab": 35,
         "IfcFooting": 6,
@@ -385,7 +386,7 @@
     "MASON": {
       "rate_per_day": 1280,
       "crew_size": 3,
-      "trade": "ช่างก่อ (ฝีมือ) + กรรมกร",
+      "trade": "\u0e0a\u0e48\u0e32\u0e07\u0e01\u0e48\u0e2d (\u0e1d\u0e35\u0e21\u0e37\u0e2d) + \u0e01\u0e23\u0e23\u0e21\u0e01\u0e23",
       "productivity": {
         "IfcWall": 12,
         "IfcWallStandardCase": 12,
@@ -396,7 +397,7 @@
     "CARPENTER": {
       "rate_per_day": 1350,
       "crew_size": 2,
-      "trade": "ช่างไม้ (ฝีมือ)",
+      "trade": "\u0e0a\u0e48\u0e32\u0e07\u0e44\u0e21\u0e49 (\u0e1d\u0e35\u0e21\u0e37\u0e2d)",
       "productivity": {
         "IfcDoor": 6,
         "IfcWindow": 6,
@@ -409,7 +410,7 @@
     "ROOFER": {
       "rate_per_day": 1450,
       "crew_size": 3,
-      "trade": "ช่างมุงหลังคา (ฝีมือ)",
+      "trade": "\u0e0a\u0e48\u0e32\u0e07\u0e21\u0e38\u0e07\u0e2b\u0e25\u0e31\u0e07\u0e04\u0e32 (\u0e1d\u0e35\u0e21\u0e37\u0e2d)",
       "productivity": {
         "IfcRoof": 25
       }
@@ -417,7 +418,7 @@
     "FINISHER": {
       "rate_per_day": 1100,
       "crew_size": 2,
-      "trade": "ช่างตกแต่ง (ฝีมือ)",
+      "trade": "\u0e0a\u0e48\u0e32\u0e07\u0e15\u0e01\u0e41\u0e15\u0e48\u0e07 (\u0e1d\u0e35\u0e21\u0e37\u0e2d)",
       "productivity": {
         "IfcCovering": 20,
         "IfcFurniture": 8,
@@ -427,34 +428,34 @@
     "LABORER": {
       "rate_per_day": 770,
       "crew_size": 1,
-      "trade": "กรรมกรทั่วไป",
+      "trade": "\u0e01\u0e23\u0e23\u0e21\u0e01\u0e23\u0e17\u0e31\u0e48\u0e27\u0e44\u0e1b",
       "productivity": {}
     }
   },
   "equipment": {
     "MOBILE_CRANE_20T": {
       "rate_per_day": 15200,
-      "desc": "เครน 20 ตัน"
+      "desc": "\u0e40\u0e04\u0e23\u0e19 20 \u0e15\u0e31\u0e19"
     },
     "TOWER_CRANE": {
       "rate_per_day": 18000,
-      "desc": "ทาวเวอร์เครน"
+      "desc": "\u0e17\u0e32\u0e27\u0e40\u0e27\u0e2d\u0e23\u0e4c\u0e40\u0e04\u0e23\u0e19"
     },
     "CONCRETE_PUMP": {
       "rate_per_day": 7800,
-      "desc": "รถปั๊มคอนกรีต"
+      "desc": "\u0e23\u0e16\u0e1b\u0e31\u0e4a\u0e21\u0e04\u0e2d\u0e19\u0e01\u0e23\u0e35\u0e15"
     },
     "SCISSOR_LIFT_8M": {
       "rate_per_day": 2350,
-      "desc": "กระเช้าไฮดรอลิก 8ม."
+      "desc": "\u0e01\u0e23\u0e30\u0e40\u0e0a\u0e49\u0e32\u0e44\u0e2e\u0e14\u0e23\u0e2d\u0e25\u0e34\u0e01 8\u0e21."
     },
     "WELDING_MACHINE": {
       "rate_per_day": 530,
-      "desc": "เครื่องเชื่อม 300A"
+      "desc": "\u0e40\u0e04\u0e23\u0e37\u0e48\u0e2d\u0e07\u0e40\u0e0a\u0e37\u0e48\u0e2d\u0e21 300A"
     },
     "GENERATOR_5KVA": {
       "rate_per_day": 780,
-      "desc": "เครื่องปั่นไฟ 5KVA"
+      "desc": "\u0e40\u0e04\u0e23\u0e37\u0e48\u0e2d\u0e07\u0e1b\u0e31\u0e48\u0e19\u0e44\u0e1f 5KVA"
     }
   },
   "equipment_allocation": {

--- a/viewer/rates/dpt2024_th.json
+++ b/viewer/rates/dpt2024_th.json
@@ -13,302 +13,302 @@
     "IfcDuct": {
       "rate": 1350,
       "unit": "M",
-      "desc": "\u0e17\u0e48\u0e2d\u0e25\u0e21\u0e40\u0e2b\u0e25\u0e47\u0e01\u0e0a\u0e38\u0e1a\u0e2a\u0e31\u0e07\u0e01\u0e30\u0e2a\u0e35 (\u0e40\u0e09\u0e25\u0e35\u0e48\u0e22 400\u0e21\u0e21.)",
+      "desc": "ท่อลมเหล็กชุบสังกะสี (เฉลี่ย 400มม.)",
       "smm_section": "U10"
     },
     "IfcDuctSegment": {
       "rate": 1350,
       "unit": "M",
-      "desc": "\u0e17\u0e48\u0e2d\u0e25\u0e21\u0e2a\u0e48\u0e27\u0e19\u0e15\u0e23\u0e07",
+      "desc": "ท่อลมส่วนตรง",
       "smm_section": "U10"
     },
     "IfcDuctFitting": {
       "rate": 3100,
       "unit": "EA",
-      "desc": "\u0e2d\u0e38\u0e1b\u0e01\u0e23\u0e13\u0e4c\u0e02\u0e49\u0e2d\u0e15\u0e48\u0e2d\u0e17\u0e48\u0e2d\u0e25\u0e21",
+      "desc": "อุปกรณ์ข้อต่อท่อลม",
       "smm_section": "U10"
     },
     "IfcPipe": {
       "rate": 395,
       "unit": "M",
-      "desc": "\u0e17\u0e48\u0e2d PVC/HDPE (\u0e40\u0e09\u0e25\u0e35\u0e48\u0e22 100\u0e21\u0e21.)",
+      "desc": "ท่อ PVC/HDPE (เฉลี่ย 100มม.)",
       "smm_section": "S10"
     },
     "IfcPipeSegment": {
       "rate": 395,
       "unit": "M",
-      "desc": "\u0e17\u0e48\u0e2d\u0e2a\u0e48\u0e27\u0e19\u0e15\u0e23\u0e07",
+      "desc": "ท่อส่วนตรง",
       "smm_section": "S10"
     },
     "IfcPipeFitting": {
       "rate": 780,
       "unit": "EA",
-      "desc": "\u0e2d\u0e38\u0e1b\u0e01\u0e23\u0e13\u0e4c\u0e02\u0e49\u0e2d\u0e15\u0e48\u0e2d\u0e17\u0e48\u0e2d",
+      "desc": "อุปกรณ์ข้อต่อท่อ",
       "smm_section": "S10"
     },
     "IfcCableCarrier": {
       "rate": 640,
       "unit": "M",
-      "desc": "\u0e23\u0e32\u0e07\u0e40\u0e04\u0e40\u0e1a\u0e34\u0e25\u0e40\u0e17\u0e23\u0e22\u0e4c (300\u0e21\u0e21.)",
+      "desc": "รางเคเบิลเทรย์ (300มม.)",
       "smm_section": "V20"
     },
     "IfcCableCarrierSegment": {
       "rate": 640,
       "unit": "M",
-      "desc": "\u0e23\u0e32\u0e07\u0e40\u0e04\u0e40\u0e1a\u0e34\u0e25\u0e40\u0e17\u0e23\u0e22\u0e4c\u0e2a\u0e48\u0e27\u0e19\u0e15\u0e23\u0e07",
+      "desc": "รางเคเบิลเทรย์ส่วนตรง",
       "smm_section": "V20"
     },
     "IfcBeam": {
       "rate": 5600,
       "unit": "M",
-      "desc": "\u0e04\u0e32\u0e19\u0e40\u0e2b\u0e25\u0e47\u0e01\u0e23\u0e39\u0e1b\u0e1e\u0e23\u0e23\u0e13 I-Beam",
+      "desc": "คานเหล็กรูปพรรณ I-Beam",
       "smm_section": "G10"
     },
     "IfcColumn": {
       "rate": 10200,
       "unit": "M",
-      "desc": "\u0e40\u0e2a\u0e32\u0e40\u0e2b\u0e25\u0e47\u0e01\u0e23\u0e39\u0e1b\u0e1e\u0e23\u0e23\u0e13",
+      "desc": "เสาเหล็กรูปพรรณ",
       "smm_section": "G10"
     },
     "IfcSlab": {
       "rate": 2350,
       "unit": "M2",
-      "desc": "\u0e1e\u0e37\u0e49\u0e19 \u0e04.\u0e2a.\u0e25. \u0e2b\u0e19\u0e32 250\u0e21\u0e21.",
+      "desc": "พื้น ค.ส.ล. หนา 250มม.",
       "smm_section": "E10"
     },
     "IfcWall": {
       "rate": 1180,
       "unit": "M2",
-      "desc": "\u0e1c\u0e19\u0e31\u0e07\u0e01\u0e48\u0e2d\u0e2d\u0e34\u0e10\u0e1a\u0e25\u0e47\u0e2d\u0e01 150\u0e21\u0e21.",
+      "desc": "ผนังก่ออิฐบล็อก 150มม.",
       "smm_section": "F10"
     },
     "IfcWallStandardCase": {
       "rate": 1180,
       "unit": "M2",
-      "desc": "\u0e1c\u0e19\u0e31\u0e07\u0e21\u0e32\u0e15\u0e23\u0e10\u0e32\u0e19",
+      "desc": "ผนังมาตรฐาน",
       "smm_section": "F10"
     },
     "IfcCurtainWall": {
       "rate": 6200,
       "unit": "M2",
-      "desc": "\u0e1c\u0e19\u0e31\u0e07\u0e01\u0e23\u0e30\u0e08\u0e01",
+      "desc": "ผนังกระจก",
       "smm_section": "H10"
     },
     "IfcCovering": {
       "rate": 1520,
       "unit": "M2",
-      "desc": "\u0e27\u0e31\u0e2a\u0e14\u0e38\u0e1b\u0e39\u0e1e\u0e37\u0e49\u0e19/\u0e1d\u0e49\u0e32\u0e40\u0e1e\u0e14\u0e32\u0e19",
+      "desc": "วัสดุปูพื้น/ฝ้าเพดาน",
       "smm_section": "M10"
     },
     "IfcRoof": {
       "rate": 1950,
       "unit": "M2",
-      "desc": "\u0e2b\u0e25\u0e31\u0e07\u0e04\u0e32\u0e40\u0e2b\u0e25\u0e47\u0e01",
+      "desc": "หลังคาเหล็ก",
       "smm_section": "H60"
     },
     "IfcLightFixture": {
       "rate": 3950,
       "unit": "EA",
-      "desc": "\u0e42\u0e04\u0e21\u0e44\u0e1f LED",
+      "desc": "โคมไฟ LED",
       "smm_section": "V40"
     },
     "IfcOutlet": {
       "rate": 1020,
       "unit": "EA",
-      "desc": "\u0e40\u0e15\u0e49\u0e32\u0e23\u0e31\u0e1a\u0e44\u0e1f\u0e1f\u0e49\u0e32",
+      "desc": "เต้ารับไฟฟ้า",
       "smm_section": "V20"
     },
     "IfcDoor": {
       "rate": 23500,
       "unit": "EA",
-      "desc": "\u0e0a\u0e38\u0e14\u0e1b\u0e23\u0e30\u0e15\u0e39",
+      "desc": "ชุดประตู",
       "smm_section": "L20"
     },
     "IfcWindow": {
       "rate": 12800,
       "unit": "EA",
-      "desc": "\u0e2b\u0e19\u0e49\u0e32\u0e15\u0e48\u0e32\u0e07",
+      "desc": "หน้าต่าง",
       "smm_section": "L10"
     },
     "IfcBuildingElementProxy": {
       "rate": 6950,
       "unit": "EA",
-      "desc": "\u0e2d\u0e07\u0e04\u0e4c\u0e1b\u0e23\u0e30\u0e01\u0e2d\u0e1a\u0e2d\u0e37\u0e48\u0e19\u0e46",
+      "desc": "องค์ประกอบอื่นๆ",
       "smm_section": "P10"
     },
     "IfcFlowTerminal": {
       "rate": 28500,
       "unit": "EA",
-      "desc": "\u0e1b\u0e25\u0e32\u0e22\u0e17\u0e32\u0e07\u0e23\u0e30\u0e1a\u0e1a\u0e1b\u0e23\u0e31\u0e1a\u0e2d\u0e32\u0e01\u0e32\u0e28",
+      "desc": "ปลายทางระบบปรับอากาศ",
       "smm_section": "U10"
     },
     "IfcFurnishingElement": {
       "rate": 9800,
       "unit": "EA",
-      "desc": "\u0e40\u0e04\u0e23\u0e37\u0e48\u0e2d\u0e07\u0e40\u0e23\u0e37\u0e2d\u0e19",
+      "desc": "เครื่องเรือน",
       "smm_section": "N10"
     },
     "IfcPlate": {
       "rate": 780,
       "unit": "M2",
-      "desc": "\u0e41\u0e1c\u0e48\u0e19\u0e40\u0e2b\u0e25\u0e47\u0e01",
+      "desc": "แผ่นเหล็ก",
       "smm_section": "G10"
     },
     "IfcMember": {
       "rate": 2600,
       "unit": "M",
-      "desc": "\u0e0a\u0e34\u0e49\u0e19\u0e2a\u0e48\u0e27\u0e19\u0e40\u0e2b\u0e25\u0e47\u0e01",
+      "desc": "ชิ้นส่วนเหล็ก",
       "smm_section": "G10"
     },
     "IfcRailing": {
       "rate": 2300,
       "unit": "M",
-      "desc": "\u0e23\u0e32\u0e27\u0e01\u0e31\u0e19\u0e15\u0e01",
+      "desc": "ราวกันตก",
       "smm_section": "L30"
     },
     "IfcStair": {
       "rate": 36800,
       "unit": "EA",
-      "desc": "\u0e1a\u0e31\u0e19\u0e44\u0e14",
+      "desc": "บันได",
       "smm_section": "L30"
     },
     "IfcStairFlight": {
       "rate": 18000,
       "unit": "EA",
-      "desc": "\u0e0a\u0e48\u0e27\u0e07\u0e1a\u0e31\u0e19\u0e44\u0e14",
+      "desc": "ช่วงบันได",
       "smm_section": "L30"
     },
     "IfcFooting": {
       "rate": 611.66,
       "unit": "M3",
-      "desc": "\u0e10\u0e32\u0e19\u0e23\u0e32\u0e01\u0e41\u0e1c\u0e48",
+      "desc": "ฐานรากแผ่",
       "smm_section": "D20",
       "volFactor": 4.25074802767622
     },
     "IfcPile": {
       "rate": 6950,
       "unit": "EA",
-      "desc": "\u0e40\u0e2a\u0e32\u0e40\u0e02\u0e47\u0e21",
+      "desc": "เสาเข็ม",
       "smm_section": "D30"
     },
     "IfcReinforcingBar": {
       "rate": 370,
       "unit": "KG",
-      "desc": "\u0e40\u0e2b\u0e25\u0e47\u0e01\u0e40\u0e2a\u0e23\u0e34\u0e21",
+      "desc": "เหล็กเสริม",
       "smm_section": "E30"
     },
     "IfcFlowSegment": {
       "rate": 980,
       "unit": "M",
-      "desc": "\u0e17\u0e48\u0e2d\u0e2a\u0e48\u0e07\u0e23\u0e30\u0e1a\u0e1a",
+      "desc": "ท่อส่งระบบ",
       "smm_section": "Y10"
     },
     "IfcFlowFitting": {
       "rate": 1650,
       "unit": "EA",
-      "desc": "\u0e02\u0e49\u0e2d\u0e15\u0e48\u0e2d\u0e23\u0e30\u0e1a\u0e1a\u0e17\u0e48\u0e2d",
+      "desc": "ข้อต่อระบบท่อ",
       "smm_section": "Y10"
     },
     "IfcFlowController": {
       "rate": 3680,
       "unit": "EA",
-      "desc": "\u0e2d\u0e38\u0e1b\u0e01\u0e23\u0e13\u0e4c\u0e04\u0e27\u0e1a\u0e04\u0e38\u0e21\u0e01\u0e32\u0e23\u0e44\u0e2b\u0e25",
+      "desc": "อุปกรณ์ควบคุมการไหล",
       "smm_section": "Y10"
     },
     "IfcEnergyConversionDevice": {
       "rate": 69500,
       "unit": "EA",
-      "desc": "\u0e2d\u0e38\u0e1b\u0e01\u0e23\u0e13\u0e4c\u0e41\u0e1b\u0e25\u0e07\u0e1e\u0e25\u0e31\u0e07\u0e07\u0e32\u0e19",
+      "desc": "อุปกรณ์แปลงพลังงาน",
       "smm_section": "T10"
     },
     "IfcFlowTreatmentDevice": {
       "rate": 9800,
       "unit": "EA",
-      "desc": "\u0e2d\u0e38\u0e1b\u0e01\u0e23\u0e13\u0e4c\u0e1a\u0e33\u0e1a\u0e31\u0e14",
+      "desc": "อุปกรณ์บำบัด",
       "smm_section": "Y10"
     },
     "IfcFlowMovingDevice": {
       "rate": 28500,
       "unit": "EA",
-      "desc": "\u0e2d\u0e38\u0e1b\u0e01\u0e23\u0e13\u0e4c\u0e02\u0e31\u0e1a\u0e40\u0e04\u0e25\u0e37\u0e48\u0e2d\u0e19\u0e02\u0e2d\u0e07\u0e44\u0e2b\u0e25",
+      "desc": "อุปกรณ์ขับเคลื่อนของไหล",
       "smm_section": "T10"
     },
     "IfcFlowStorageDevice": {
       "rate": 41000,
       "unit": "EA",
-      "desc": "\u0e2d\u0e38\u0e1b\u0e01\u0e23\u0e13\u0e4c\u0e40\u0e01\u0e47\u0e1a\u0e01\u0e31\u0e01\u0e02\u0e2d\u0e07\u0e44\u0e2b\u0e25",
+      "desc": "อุปกรณ์เก็บกักของไหล",
       "smm_section": "Y10"
     },
     "IfcElectricAppliance": {
       "rate": 3950,
       "unit": "EA",
-      "desc": "\u0e40\u0e04\u0e23\u0e37\u0e48\u0e2d\u0e07\u0e43\u0e0a\u0e49\u0e44\u0e1f\u0e1f\u0e49\u0e32",
+      "desc": "เครื่องใช้ไฟฟ้า",
       "smm_section": "V20"
     },
     "IfcFurniture": {
       "rate": 12200,
       "unit": "EA",
-      "desc": "\u0e40\u0e1f\u0e2d\u0e23\u0e4c\u0e19\u0e34\u0e40\u0e08\u0e2d\u0e23\u0e4c",
+      "desc": "เฟอร์นิเจอร์",
       "smm_section": "N10"
     },
     "IfcOpeningElement": {
       "rate": 0,
       "unit": "EA",
-      "desc": "\u0e0a\u0e48\u0e2d\u0e07\u0e40\u0e1b\u0e34\u0e14",
+      "desc": "ช่องเปิด",
       "smm_section": ""
     },
     "IfcDistributionElement": {
       "rate": 4100,
       "unit": "EA",
-      "desc": "\u0e2d\u0e38\u0e1b\u0e01\u0e23\u0e13\u0e4c\u0e08\u0e48\u0e32\u0e22",
+      "desc": "อุปกรณ์จ่าย",
       "smm_section": "Y10"
     },
     "IfcFireSuppressionTerminal": {
       "rate": 3680,
       "unit": "EA",
-      "desc": "\u0e2b\u0e31\u0e27\u0e2a\u0e1b\u0e23\u0e34\u0e07\u0e40\u0e01\u0e2d\u0e23\u0e4c",
+      "desc": "หัวสปริงเกอร์",
       "smm_section": "S60"
     },
     "IfcAirTerminal": {
       "rate": 3100,
       "unit": "EA",
-      "desc": "\u0e2b\u0e31\u0e27\u0e08\u0e48\u0e32\u0e22\u0e25\u0e21/\u0e0a\u0e48\u0e2d\u0e07\u0e25\u0e21",
+      "desc": "หัวจ่ายลม/ช่องลม",
       "smm_section": "U10"
     },
     "IfcValve": {
       "rate": 2300,
       "unit": "EA",
-      "desc": "\u0e27\u0e32\u0e25\u0e4c\u0e27",
+      "desc": "วาล์ว",
       "smm_section": "S10"
     },
     "IfcAlarm": {
       "rate": 2850,
       "unit": "EA",
-      "desc": "\u0e2d\u0e38\u0e1b\u0e01\u0e23\u0e13\u0e4c\u0e41\u0e08\u0e49\u0e07\u0e40\u0e15\u0e37\u0e2d\u0e19\u0e2d\u0e31\u0e04\u0e04\u0e35\u0e20\u0e31\u0e22",
+      "desc": "อุปกรณ์แจ้งเตือนอัคคีภัย",
       "smm_section": "W50"
     },
     "IfcController": {
       "rate": 9800,
       "unit": "EA",
-      "desc": "\u0e15\u0e31\u0e27\u0e04\u0e27\u0e1a\u0e04\u0e38\u0e21\u0e2d\u0e32\u0e04\u0e32\u0e23",
+      "desc": "ตัวควบคุมอาคาร",
       "smm_section": "W60"
     },
     "IfcRamp": {
       "rate": 26200,
       "unit": "EA",
-      "desc": "\u0e17\u0e32\u0e07\u0e25\u0e32\u0e14",
+      "desc": "ทางลาด",
       "smm_section": "L30"
     },
     "IfcRampFlight": {
       "rate": 28600,
       "unit": "EA",
-      "desc": "\u0e0a\u0e48\u0e27\u0e07\u0e17\u0e32\u0e07\u0e25\u0e32\u0e14",
+      "desc": "ช่วงทางลาด",
       "smm_section": "L30"
     },
     "IfcBuildingElementPart": {
       "rate": 0,
       "unit": "EA",
-      "desc": "\u0e2a\u0e48\u0e27\u0e19\u0e1b\u0e23\u0e30\u0e01\u0e2d\u0e1a",
+      "desc": "ส่วนประกอบ",
       "smm_section": ""
     }
   },
@@ -316,7 +316,7 @@
     "HVAC_TECH": {
       "rate_per_day": 1500,
       "crew_size": 2,
-      "trade": "\u0e0a\u0e48\u0e32\u0e07\u0e40\u0e17\u0e04\u0e19\u0e34\u0e04\u0e23\u0e30\u0e1a\u0e1a\u0e1b\u0e23\u0e31\u0e1a\u0e2d\u0e32\u0e01\u0e32\u0e28 (\u0e1d\u0e35\u0e21\u0e37\u0e2d)",
+      "trade": "ช่างเทคนิคระบบปรับอากาศ (ฝีมือ)",
       "productivity": {
         "IfcDuct": 18,
         "IfcDuctSegment": 18,
@@ -330,7 +330,7 @@
     "PLUMBER": {
       "rate_per_day": 1350,
       "crew_size": 2,
-      "trade": "\u0e0a\u0e48\u0e32\u0e07\u0e1b\u0e23\u0e30\u0e1b\u0e32 (\u0e1d\u0e35\u0e21\u0e37\u0e2d)",
+      "trade": "ช่างประปา (ฝีมือ)",
       "productivity": {
         "IfcPipe": 25,
         "IfcPipeSegment": 25,
@@ -347,7 +347,7 @@
     "ELECTRICIAN": {
       "rate_per_day": 1450,
       "crew_size": 2,
-      "trade": "\u0e0a\u0e48\u0e32\u0e07\u0e44\u0e1f\u0e1f\u0e49\u0e32 (\u0e1d\u0e35\u0e21\u0e37\u0e2d)",
+      "trade": "ช่างไฟฟ้า (ฝีมือ)",
       "productivity": {
         "IfcCableCarrier": 30,
         "IfcCableCarrierSegment": 30,
@@ -362,7 +362,7 @@
     "STEEL_ERECTOR": {
       "rate_per_day": 1600,
       "crew_size": 4,
-      "trade": "\u0e0a\u0e48\u0e32\u0e07\u0e40\u0e2b\u0e25\u0e47\u0e01 (\u0e1d\u0e35\u0e21\u0e37\u0e2d)",
+      "trade": "ช่างเหล็ก (ฝีมือ)",
       "productivity": {
         "IfcBeam": 8,
         "IfcColumn": 6,
@@ -373,7 +373,7 @@
     "CONCRETE_GANG": {
       "rate_per_day": 1200,
       "crew_size": 6,
-      "trade": "\u0e17\u0e35\u0e21\u0e07\u0e32\u0e19\u0e04\u0e2d\u0e19\u0e01\u0e23\u0e35\u0e15 (\u0e1c\u0e2a\u0e21)",
+      "trade": "ทีมงานคอนกรีต (ผสม)",
       "productivity": {
         "IfcSlab": 35,
         "IfcFooting": 6,
@@ -386,7 +386,7 @@
     "MASON": {
       "rate_per_day": 1280,
       "crew_size": 3,
-      "trade": "\u0e0a\u0e48\u0e32\u0e07\u0e01\u0e48\u0e2d (\u0e1d\u0e35\u0e21\u0e37\u0e2d) + \u0e01\u0e23\u0e23\u0e21\u0e01\u0e23",
+      "trade": "ช่างก่อ (ฝีมือ) + กรรมกร",
       "productivity": {
         "IfcWall": 12,
         "IfcWallStandardCase": 12,
@@ -397,7 +397,7 @@
     "CARPENTER": {
       "rate_per_day": 1350,
       "crew_size": 2,
-      "trade": "\u0e0a\u0e48\u0e32\u0e07\u0e44\u0e21\u0e49 (\u0e1d\u0e35\u0e21\u0e37\u0e2d)",
+      "trade": "ช่างไม้ (ฝีมือ)",
       "productivity": {
         "IfcDoor": 6,
         "IfcWindow": 6,
@@ -410,7 +410,7 @@
     "ROOFER": {
       "rate_per_day": 1450,
       "crew_size": 3,
-      "trade": "\u0e0a\u0e48\u0e32\u0e07\u0e21\u0e38\u0e07\u0e2b\u0e25\u0e31\u0e07\u0e04\u0e32 (\u0e1d\u0e35\u0e21\u0e37\u0e2d)",
+      "trade": "ช่างมุงหลังคา (ฝีมือ)",
       "productivity": {
         "IfcRoof": 25
       }
@@ -418,7 +418,7 @@
     "FINISHER": {
       "rate_per_day": 1100,
       "crew_size": 2,
-      "trade": "\u0e0a\u0e48\u0e32\u0e07\u0e15\u0e01\u0e41\u0e15\u0e48\u0e07 (\u0e1d\u0e35\u0e21\u0e37\u0e2d)",
+      "trade": "ช่างตกแต่ง (ฝีมือ)",
       "productivity": {
         "IfcCovering": 20,
         "IfcFurniture": 8,
@@ -428,34 +428,34 @@
     "LABORER": {
       "rate_per_day": 770,
       "crew_size": 1,
-      "trade": "\u0e01\u0e23\u0e23\u0e21\u0e01\u0e23\u0e17\u0e31\u0e48\u0e27\u0e44\u0e1b",
+      "trade": "กรรมกรทั่วไป",
       "productivity": {}
     }
   },
   "equipment": {
     "MOBILE_CRANE_20T": {
       "rate_per_day": 15200,
-      "desc": "\u0e40\u0e04\u0e23\u0e19 20 \u0e15\u0e31\u0e19"
+      "desc": "เครน 20 ตัน"
     },
     "TOWER_CRANE": {
       "rate_per_day": 18000,
-      "desc": "\u0e17\u0e32\u0e27\u0e40\u0e27\u0e2d\u0e23\u0e4c\u0e40\u0e04\u0e23\u0e19"
+      "desc": "ทาวเวอร์เครน"
     },
     "CONCRETE_PUMP": {
       "rate_per_day": 7800,
-      "desc": "\u0e23\u0e16\u0e1b\u0e31\u0e4a\u0e21\u0e04\u0e2d\u0e19\u0e01\u0e23\u0e35\u0e15"
+      "desc": "รถปั๊มคอนกรีต"
     },
     "SCISSOR_LIFT_8M": {
       "rate_per_day": 2350,
-      "desc": "\u0e01\u0e23\u0e30\u0e40\u0e0a\u0e49\u0e32\u0e44\u0e2e\u0e14\u0e23\u0e2d\u0e25\u0e34\u0e01 8\u0e21."
+      "desc": "กระเช้าไฮดรอลิก 8ม."
     },
     "WELDING_MACHINE": {
       "rate_per_day": 530,
-      "desc": "\u0e40\u0e04\u0e23\u0e37\u0e48\u0e2d\u0e07\u0e40\u0e0a\u0e37\u0e48\u0e2d\u0e21 300A"
+      "desc": "เครื่องเชื่อม 300A"
     },
     "GENERATOR_5KVA": {
       "rate_per_day": 780,
-      "desc": "\u0e40\u0e04\u0e23\u0e37\u0e48\u0e2d\u0e07\u0e1b\u0e31\u0e48\u0e19\u0e44\u0e1f 5KVA"
+      "desc": "เครื่องปั่นไฟ 5KVA"
     }
   },
   "equipment_allocation": {

--- a/viewer/rates/dpt2024_th.json
+++ b/viewer/rates/dpt2024_th.json
@@ -179,8 +179,8 @@
       "smm_section": "L30"
     },
     "IfcFooting": {
-      "rate": 2600,
-      "unit": "EA",
+      "rate": 611.66,
+      "unit": "M3",
       "desc": "ฐานรากแผ่",
       "smm_section": "D20"
     },

--- a/viewer/rates/gb50500_cn.json
+++ b/viewer/rates/gb50500_cn.json
@@ -179,8 +179,8 @@
       "smm_section": "L30"
     },
     "IfcFooting": {
-      "rate": 520,
-      "unit": "EA",
+      "rate": 122.33,
+      "unit": "M3",
       "desc": "基础",
       "smm_section": "D20"
     },

--- a/viewer/rates/gb50500_cn.json
+++ b/viewer/rates/gb50500_cn.json
@@ -13,302 +13,302 @@
     "IfcDuct": {
       "rate": 268,
       "unit": "M",
-      "desc": "\u9540\u950c\u94a2\u677f\u98ce\u7ba1\uff08\u5e73\u5747400mm\uff09",
+      "desc": "镀锌钢板风管（平均400mm）",
       "smm_section": "U10"
     },
     "IfcDuctSegment": {
       "rate": 268,
       "unit": "M",
-      "desc": "\u98ce\u7ba1\u6bb5",
+      "desc": "风管段",
       "smm_section": "U10"
     },
     "IfcDuctFitting": {
       "rate": 620,
       "unit": "EA",
-      "desc": "\u98ce\u7ba1\u914d\u4ef6\uff08\u5f2f\u5934\u3001\u4e09\u901a\uff09",
+      "desc": "风管配件（弯头、三通）",
       "smm_section": "U10"
     },
     "IfcPipe": {
       "rate": 78,
       "unit": "M",
-      "desc": "PVC/HDPE\u7ba1\u9053\uff08\u5e73\u5747100mm\uff09",
+      "desc": "PVC/HDPE管道（平均100mm）",
       "smm_section": "S10"
     },
     "IfcPipeSegment": {
       "rate": 78,
       "unit": "M",
-      "desc": "\u7ba1\u9053\u6bb5",
+      "desc": "管道段",
       "smm_section": "S10"
     },
     "IfcPipeFitting": {
       "rate": 155,
       "unit": "EA",
-      "desc": "\u7ba1\u9053\u914d\u4ef6",
+      "desc": "管道配件",
       "smm_section": "S10"
     },
     "IfcCableCarrier": {
       "rate": 126,
       "unit": "M",
-      "desc": "\u7535\u7f06\u6865\u67b6\uff08300mm\uff09",
+      "desc": "电缆桥架（300mm）",
       "smm_section": "V20"
     },
     "IfcCableCarrierSegment": {
       "rate": 126,
       "unit": "M",
-      "desc": "\u7535\u7f06\u6865\u67b6\u6bb5",
+      "desc": "电缆桥架段",
       "smm_section": "V20"
     },
     "IfcBeam": {
       "rate": 1105,
       "unit": "M",
-      "desc": "\u7ed3\u6784\u94a2\u5de5\u5b57\u6881",
+      "desc": "结构钢工字梁",
       "smm_section": "G10"
     },
     "IfcColumn": {
       "rate": 2030,
       "unit": "M",
-      "desc": "\u7ed3\u6784\u94a2\u67f1",
+      "desc": "结构钢柱",
       "smm_section": "G10"
     },
     "IfcSlab": {
       "rate": 462,
       "unit": "M2",
-      "desc": "\u94a2\u7b4b\u6df7\u51dd\u571f\u697c\u677f 250mm",
+      "desc": "钢筋混凝土楼板 250mm",
       "smm_section": "E10"
     },
     "IfcWall": {
       "rate": 235,
       "unit": "M2",
-      "desc": "\u780c\u5757\u5899 150mm",
+      "desc": "砌块墙 150mm",
       "smm_section": "F10"
     },
     "IfcWallStandardCase": {
       "rate": 235,
       "unit": "M2",
-      "desc": "\u6807\u51c6\u5899\u4f53",
+      "desc": "标准墙体",
       "smm_section": "F10"
     },
     "IfcCurtainWall": {
       "rate": 1220,
       "unit": "M2",
-      "desc": "\u5e55\u5899",
+      "desc": "幕墙",
       "smm_section": "H10"
     },
     "IfcCovering": {
       "rate": 300,
       "unit": "M2",
-      "desc": "\u5730\u9762/\u5929\u68da\u9970\u9762",
+      "desc": "地面/天棚饰面",
       "smm_section": "M10"
     },
     "IfcRoof": {
       "rate": 386,
       "unit": "M2",
-      "desc": "\u91d1\u5c5e\u5c4b\u9762",
+      "desc": "金属屋面",
       "smm_section": "H60"
     },
     "IfcLightFixture": {
       "rate": 788,
       "unit": "EA",
-      "desc": "LED\u706f\u5177",
+      "desc": "LED灯具",
       "smm_section": "V40"
     },
     "IfcOutlet": {
       "rate": 203,
       "unit": "EA",
-      "desc": "\u7535\u6e90\u63d2\u5ea7",
+      "desc": "电源插座",
       "smm_section": "V20"
     },
     "IfcDoor": {
       "rate": 4630,
       "unit": "EA",
-      "desc": "\u95e8\u5957\u88c5",
+      "desc": "门套装",
       "smm_section": "L20"
     },
     "IfcWindow": {
       "rate": 2565,
       "unit": "EA",
-      "desc": "\u7a97\u6237",
+      "desc": "窗户",
       "smm_section": "L10"
     },
     "IfcBuildingElementProxy": {
       "rate": 1380,
       "unit": "EA",
-      "desc": "\u5176\u4ed6\u6784\u4ef6",
+      "desc": "其他构件",
       "smm_section": "P10"
     },
     "IfcFlowTerminal": {
       "rate": 5685,
       "unit": "EA",
-      "desc": "\u6696\u901a\u672b\u7aef\u8bbe\u5907",
+      "desc": "暖通末端设备",
       "smm_section": "U10"
     },
     "IfcFurnishingElement": {
       "rate": 1950,
       "unit": "EA",
-      "desc": "\u5bb6\u5177",
+      "desc": "家具",
       "smm_section": "N10"
     },
     "IfcPlate": {
       "rate": 154,
       "unit": "M2",
-      "desc": "\u94a2\u677f",
+      "desc": "钢板",
       "smm_section": "G10"
     },
     "IfcMember": {
       "rate": 520,
       "unit": "M",
-      "desc": "\u94a2\u6784\u4ef6",
+      "desc": "钢构件",
       "smm_section": "G10"
     },
     "IfcRailing": {
       "rate": 455,
       "unit": "M",
-      "desc": "\u680f\u6746",
+      "desc": "栏杆",
       "smm_section": "L30"
     },
     "IfcStair": {
       "rate": 7308,
       "unit": "EA",
-      "desc": "\u697c\u68af",
+      "desc": "楼梯",
       "smm_section": "L30"
     },
     "IfcStairFlight": {
       "rate": 3572,
       "unit": "EA",
-      "desc": "\u697c\u68af\u68af\u6bb5",
+      "desc": "楼梯梯段",
       "smm_section": "L30"
     },
     "IfcFooting": {
       "rate": 122.33,
       "unit": "M3",
-      "desc": "\u57fa\u7840",
+      "desc": "基础",
       "smm_section": "D20",
       "volFactor": 4.25074802767622
     },
     "IfcPile": {
       "rate": 1380,
       "unit": "EA",
-      "desc": "\u6869\u57fa",
+      "desc": "桩基",
       "smm_section": "D30"
     },
     "IfcReinforcingBar": {
       "rate": 73,
       "unit": "KG",
-      "desc": "\u94a2\u7b4b",
+      "desc": "钢筋",
       "smm_section": "E30"
     },
     "IfcFlowSegment": {
       "rate": 195,
       "unit": "M",
-      "desc": "\u6d41\u4f53\u7ba1\u6bb5",
+      "desc": "流体管段",
       "smm_section": "Y10"
     },
     "IfcFlowFitting": {
       "rate": 325,
       "unit": "EA",
-      "desc": "\u6d41\u4f53\u914d\u4ef6",
+      "desc": "流体配件",
       "smm_section": "Y10"
     },
     "IfcFlowController": {
       "rate": 731,
       "unit": "EA",
-      "desc": "\u6d41\u4f53\u63a7\u5236\u8bbe\u5907",
+      "desc": "流体控制设备",
       "smm_section": "Y10"
     },
     "IfcEnergyConversionDevice": {
       "rate": 13804,
       "unit": "EA",
-      "desc": "\u80fd\u91cf\u8f6c\u6362\u8bbe\u5907",
+      "desc": "能量转换设备",
       "smm_section": "T10"
     },
     "IfcFlowTreatmentDevice": {
       "rate": 1950,
       "unit": "EA",
-      "desc": "\u6d41\u4f53\u5904\u7406\u8bbe\u5907",
+      "desc": "流体处理设备",
       "smm_section": "Y10"
     },
     "IfcFlowMovingDevice": {
       "rate": 5685,
       "unit": "EA",
-      "desc": "\u6d41\u4f53\u8f93\u9001\u8bbe\u5907",
+      "desc": "流体输送设备",
       "smm_section": "T10"
     },
     "IfcFlowStorageDevice": {
       "rate": 8120,
       "unit": "EA",
-      "desc": "\u6d41\u4f53\u50a8\u5b58\u8bbe\u5907",
+      "desc": "流体储存设备",
       "smm_section": "Y10"
     },
     "IfcElectricAppliance": {
       "rate": 788,
       "unit": "EA",
-      "desc": "\u7535\u6c14\u8bbe\u5907",
+      "desc": "电气设备",
       "smm_section": "V20"
     },
     "IfcFurniture": {
       "rate": 2436,
       "unit": "EA",
-      "desc": "\u5bb6\u5177",
+      "desc": "家具",
       "smm_section": "N10"
     },
     "IfcOpeningElement": {
       "rate": 0,
       "unit": "EA",
-      "desc": "\u6d1e\u53e3",
+      "desc": "洞口",
       "smm_section": ""
     },
     "IfcDistributionElement": {
       "rate": 380,
       "unit": "EA",
-      "desc": "\u5206\u914d\u8bbe\u5907",
+      "desc": "分配设备",
       "smm_section": "Y10"
     },
     "IfcFireSuppressionTerminal": {
       "rate": 350,
       "unit": "EA",
-      "desc": "\u55b7\u6dcb\u5934",
+      "desc": "喷淋头",
       "smm_section": "S60"
     },
     "IfcAirTerminal": {
       "rate": 300,
       "unit": "EA",
-      "desc": "\u98ce\u53e3/\u683c\u6805",
+      "desc": "风口/格栅",
       "smm_section": "U10"
     },
     "IfcValve": {
       "rate": 230,
       "unit": "EA",
-      "desc": "\u9600\u95e8",
+      "desc": "阀门",
       "smm_section": "S10"
     },
     "IfcAlarm": {
       "rate": 280,
       "unit": "EA",
-      "desc": "\u706b\u707e\u62a5\u8b66\u5668",
+      "desc": "火灾报警器",
       "smm_section": "W50"
     },
     "IfcController": {
       "rate": 980,
       "unit": "EA",
-      "desc": "\u697c\u5b87\u63a7\u5236\u5668",
+      "desc": "楼宇控制器",
       "smm_section": "W60"
     },
     "IfcRamp": {
       "rate": 2600,
       "unit": "EA",
-      "desc": "\u5761\u9053",
+      "desc": "坡道",
       "smm_section": "L30"
     },
     "IfcRampFlight": {
       "rate": 2850,
       "unit": "EA",
-      "desc": "\u5761\u9053\u6bb5",
+      "desc": "坡道段",
       "smm_section": "L30"
     },
     "IfcBuildingElementPart": {
       "rate": 0,
       "unit": "EA",
-      "desc": "\u6784\u4ef6\u90e8\u5206",
+      "desc": "构件部分",
       "smm_section": ""
     }
   },
@@ -316,7 +316,7 @@
     "HVAC_TECH": {
       "rate_per_day": 450,
       "crew_size": 2,
-      "trade": "\u6696\u901a\u6280\u5de5\uff08\u9ad8\u7ea7\uff09",
+      "trade": "暖通技工（高级）",
       "productivity": {
         "IfcDuct": 18,
         "IfcDuctSegment": 18,
@@ -330,7 +330,7 @@
     "PLUMBER": {
       "rate_per_day": 400,
       "crew_size": 2,
-      "trade": "\u7ba1\u9053\u5de5\uff08\u9ad8\u7ea7\uff09",
+      "trade": "管道工（高级）",
       "productivity": {
         "IfcPipe": 25,
         "IfcPipeSegment": 25,
@@ -347,7 +347,7 @@
     "ELECTRICIAN": {
       "rate_per_day": 420,
       "crew_size": 2,
-      "trade": "\u7535\u5de5\uff08\u9ad8\u7ea7\uff09",
+      "trade": "电工（高级）",
       "productivity": {
         "IfcCableCarrier": 30,
         "IfcCableCarrierSegment": 30,
@@ -362,7 +362,7 @@
     "STEEL_ERECTOR": {
       "rate_per_day": 480,
       "crew_size": 4,
-      "trade": "\u94a2\u7ed3\u6784\u5b89\u88c5\u5de5\uff08\u9ad8\u7ea7\uff09",
+      "trade": "钢结构安装工（高级）",
       "productivity": {
         "IfcBeam": 8,
         "IfcColumn": 6,
@@ -373,7 +373,7 @@
     "CONCRETE_GANG": {
       "rate_per_day": 350,
       "crew_size": 6,
-      "trade": "\u6df7\u51dd\u571f\u65bd\u5de5\u73ed\u7ec4",
+      "trade": "混凝土施工班组",
       "productivity": {
         "IfcSlab": 35,
         "IfcFooting": 6,
@@ -386,7 +386,7 @@
     "MASON": {
       "rate_per_day": 380,
       "crew_size": 3,
-      "trade": "\u780c\u7b51\u5de5\uff08\u9ad8\u7ea7\uff09+ \u666e\u5de5",
+      "trade": "砌筑工（高级）+ 普工",
       "productivity": {
         "IfcWall": 12,
         "IfcWallStandardCase": 12,
@@ -397,7 +397,7 @@
     "CARPENTER": {
       "rate_per_day": 400,
       "crew_size": 2,
-      "trade": "\u6728\u5de5\uff08\u9ad8\u7ea7\uff09",
+      "trade": "木工（高级）",
       "productivity": {
         "IfcDoor": 6,
         "IfcWindow": 6,
@@ -410,7 +410,7 @@
     "ROOFER": {
       "rate_per_day": 420,
       "crew_size": 3,
-      "trade": "\u9632\u6c34\u5de5\uff08\u9ad8\u7ea7\uff09",
+      "trade": "防水工（高级）",
       "productivity": {
         "IfcRoof": 25
       }
@@ -418,7 +418,7 @@
     "FINISHER": {
       "rate_per_day": 350,
       "crew_size": 2,
-      "trade": "\u88c5\u9970\u5de5\uff08\u9ad8\u7ea7\uff09",
+      "trade": "装饰工（高级）",
       "productivity": {
         "IfcCovering": 20,
         "IfcFurniture": 8,
@@ -428,34 +428,34 @@
     "LABORER": {
       "rate_per_day": 250,
       "crew_size": 1,
-      "trade": "\u666e\u901a\u5de5",
+      "trade": "普通工",
       "productivity": {}
     }
   },
   "equipment": {
     "MOBILE_CRANE_20T": {
       "rate_per_day": 3200,
-      "desc": "\u6c7d\u8f66\u8d77\u91cd\u673a 20\u5428"
+      "desc": "汽车起重机 20吨"
     },
     "TOWER_CRANE": {
       "rate_per_day": 3800,
-      "desc": "\u5854\u5f0f\u8d77\u91cd\u673a"
+      "desc": "塔式起重机"
     },
     "CONCRETE_PUMP": {
       "rate_per_day": 1650,
-      "desc": "\u6df7\u51dd\u571f\u6cf5\u8f66"
+      "desc": "混凝土泵车"
     },
     "SCISSOR_LIFT_8M": {
       "rate_per_day": 500,
-      "desc": "\u526a\u53c9\u5f0f\u5347\u964d\u5e73\u53f0 8m"
+      "desc": "剪叉式升降平台 8m"
     },
     "WELDING_MACHINE": {
       "rate_per_day": 120,
-      "desc": "\u7535\u710a\u673a 300A"
+      "desc": "电焊机 300A"
     },
     "GENERATOR_5KVA": {
       "rate_per_day": 180,
-      "desc": "\u53d1\u7535\u673a 5KVA"
+      "desc": "发电机 5KVA"
     }
   },
   "equipment_allocation": {
@@ -730,7 +730,7 @@
   "work_packages": [
     {
       "id": "PACKAGE 1",
-      "name": "\u57fa\u7840\u5de5\u7a0b",
+      "name": "基础工程",
       "color": "8E44AD",
       "classes": [
         "IfcFooting",
@@ -740,7 +740,7 @@
     },
     {
       "id": "PACKAGE 2",
-      "name": "\u4e3b\u4f53\u7ed3\u6784",
+      "name": "主体结构",
       "color": "2980B9",
       "classes": [
         "IfcColumn",
@@ -752,7 +752,7 @@
     },
     {
       "id": "PACKAGE 3",
-      "name": "\u673a\u7535\u7c97\u88c5",
+      "name": "机电粗装",
       "color": "D35400",
       "classes": [
         "IfcDuct",
@@ -776,7 +776,7 @@
     },
     {
       "id": "PACKAGE 4",
-      "name": "\u5efa\u7b51\u5de5\u7a0b",
+      "name": "建筑工程",
       "color": "ED7D31",
       "classes": [
         "IfcWall",
@@ -794,7 +794,7 @@
     },
     {
       "id": "PACKAGE 5",
-      "name": "\u88c5\u9970\u88c5\u4fee",
+      "name": "装饰装修",
       "color": "27AE60",
       "classes": [
         "IfcCovering",
@@ -804,7 +804,7 @@
     },
     {
       "id": "PACKAGE 6",
-      "name": "\u673a\u7535\u7cbe\u88c5",
+      "name": "机电精装",
       "color": "C0392B",
       "classes": [
         "IfcFlowTerminal",
@@ -819,28 +819,28 @@
     }
   ],
   "smm_sections": {
-    "A": "\u65bd\u5de5\u51c6\u5907",
-    "C": "\u62c6\u9664\u5de5\u7a0b",
-    "D": "\u571f\u65b9/\u57fa\u7840\u5de5\u7a0b",
-    "E": "\u6df7\u51dd\u571f\u5de5\u7a0b",
-    "F": "\u780c\u4f53\u5de5\u7a0b",
-    "G": "\u94a2\u7ed3\u6784\u5de5\u7a0b",
-    "H": "\u5c4b\u9762/\u5e55\u5899\u5de5\u7a0b",
-    "J": "\u9632\u6c34\u5de5\u7a0b",
-    "K": "\u9694\u5899/\u540a\u9876",
-    "L": "\u95e8\u7a97/\u697c\u68af",
-    "M": "\u88c5\u9970\u88c5\u4fee",
-    "N": "\u5bb6\u5177/\u8bbe\u5907",
-    "P": "\u6742\u9879",
-    "Q": "\u5ba4\u5916\u5de5\u7a0b",
-    "R": "\u6392\u6c34\u5de5\u7a0b",
-    "S": "\u7ed9\u6392\u6c34",
-    "T": "\u4f9b\u70ed/\u5236\u51b7",
-    "U": "\u901a\u98ce\u7a7a\u8c03",
-    "V": "\u7535\u6c14\u5de5\u7a0b",
-    "W": "\u667a\u80fd\u5316/\u5b89\u9632",
-    "X": "\u7535\u68af",
-    "Y": "\u673a\u7535\u5de5\u7a0b\uff08\u7efc\u5408\uff09"
+    "A": "施工准备",
+    "C": "拆除工程",
+    "D": "土方/基础工程",
+    "E": "混凝土工程",
+    "F": "砌体工程",
+    "G": "钢结构工程",
+    "H": "屋面/幕墙工程",
+    "J": "防水工程",
+    "K": "隔墙/吊顶",
+    "L": "门窗/楼梯",
+    "M": "装饰装修",
+    "N": "家具/设备",
+    "P": "杂项",
+    "Q": "室外工程",
+    "R": "排水工程",
+    "S": "给排水",
+    "T": "供热/制冷",
+    "U": "通风空调",
+    "V": "电气工程",
+    "W": "智能化/安防",
+    "X": "电梯",
+    "Y": "机电工程（综合）"
   },
   "provisions": {
     "preliminaries_pct": 8,

--- a/viewer/rates/gb50500_cn.json
+++ b/viewer/rates/gb50500_cn.json
@@ -13,301 +13,302 @@
     "IfcDuct": {
       "rate": 268,
       "unit": "M",
-      "desc": "镀锌钢板风管（平均400mm）",
+      "desc": "\u9540\u950c\u94a2\u677f\u98ce\u7ba1\uff08\u5e73\u5747400mm\uff09",
       "smm_section": "U10"
     },
     "IfcDuctSegment": {
       "rate": 268,
       "unit": "M",
-      "desc": "风管段",
+      "desc": "\u98ce\u7ba1\u6bb5",
       "smm_section": "U10"
     },
     "IfcDuctFitting": {
       "rate": 620,
       "unit": "EA",
-      "desc": "风管配件（弯头、三通）",
+      "desc": "\u98ce\u7ba1\u914d\u4ef6\uff08\u5f2f\u5934\u3001\u4e09\u901a\uff09",
       "smm_section": "U10"
     },
     "IfcPipe": {
       "rate": 78,
       "unit": "M",
-      "desc": "PVC/HDPE管道（平均100mm）",
+      "desc": "PVC/HDPE\u7ba1\u9053\uff08\u5e73\u5747100mm\uff09",
       "smm_section": "S10"
     },
     "IfcPipeSegment": {
       "rate": 78,
       "unit": "M",
-      "desc": "管道段",
+      "desc": "\u7ba1\u9053\u6bb5",
       "smm_section": "S10"
     },
     "IfcPipeFitting": {
       "rate": 155,
       "unit": "EA",
-      "desc": "管道配件",
+      "desc": "\u7ba1\u9053\u914d\u4ef6",
       "smm_section": "S10"
     },
     "IfcCableCarrier": {
       "rate": 126,
       "unit": "M",
-      "desc": "电缆桥架（300mm）",
+      "desc": "\u7535\u7f06\u6865\u67b6\uff08300mm\uff09",
       "smm_section": "V20"
     },
     "IfcCableCarrierSegment": {
       "rate": 126,
       "unit": "M",
-      "desc": "电缆桥架段",
+      "desc": "\u7535\u7f06\u6865\u67b6\u6bb5",
       "smm_section": "V20"
     },
     "IfcBeam": {
       "rate": 1105,
       "unit": "M",
-      "desc": "结构钢工字梁",
+      "desc": "\u7ed3\u6784\u94a2\u5de5\u5b57\u6881",
       "smm_section": "G10"
     },
     "IfcColumn": {
       "rate": 2030,
       "unit": "M",
-      "desc": "结构钢柱",
+      "desc": "\u7ed3\u6784\u94a2\u67f1",
       "smm_section": "G10"
     },
     "IfcSlab": {
       "rate": 462,
       "unit": "M2",
-      "desc": "钢筋混凝土楼板 250mm",
+      "desc": "\u94a2\u7b4b\u6df7\u51dd\u571f\u697c\u677f 250mm",
       "smm_section": "E10"
     },
     "IfcWall": {
       "rate": 235,
       "unit": "M2",
-      "desc": "砌块墙 150mm",
+      "desc": "\u780c\u5757\u5899 150mm",
       "smm_section": "F10"
     },
     "IfcWallStandardCase": {
       "rate": 235,
       "unit": "M2",
-      "desc": "标准墙体",
+      "desc": "\u6807\u51c6\u5899\u4f53",
       "smm_section": "F10"
     },
     "IfcCurtainWall": {
       "rate": 1220,
       "unit": "M2",
-      "desc": "幕墙",
+      "desc": "\u5e55\u5899",
       "smm_section": "H10"
     },
     "IfcCovering": {
       "rate": 300,
       "unit": "M2",
-      "desc": "地面/天棚饰面",
+      "desc": "\u5730\u9762/\u5929\u68da\u9970\u9762",
       "smm_section": "M10"
     },
     "IfcRoof": {
       "rate": 386,
       "unit": "M2",
-      "desc": "金属屋面",
+      "desc": "\u91d1\u5c5e\u5c4b\u9762",
       "smm_section": "H60"
     },
     "IfcLightFixture": {
       "rate": 788,
       "unit": "EA",
-      "desc": "LED灯具",
+      "desc": "LED\u706f\u5177",
       "smm_section": "V40"
     },
     "IfcOutlet": {
       "rate": 203,
       "unit": "EA",
-      "desc": "电源插座",
+      "desc": "\u7535\u6e90\u63d2\u5ea7",
       "smm_section": "V20"
     },
     "IfcDoor": {
       "rate": 4630,
       "unit": "EA",
-      "desc": "门套装",
+      "desc": "\u95e8\u5957\u88c5",
       "smm_section": "L20"
     },
     "IfcWindow": {
       "rate": 2565,
       "unit": "EA",
-      "desc": "窗户",
+      "desc": "\u7a97\u6237",
       "smm_section": "L10"
     },
     "IfcBuildingElementProxy": {
       "rate": 1380,
       "unit": "EA",
-      "desc": "其他构件",
+      "desc": "\u5176\u4ed6\u6784\u4ef6",
       "smm_section": "P10"
     },
     "IfcFlowTerminal": {
       "rate": 5685,
       "unit": "EA",
-      "desc": "暖通末端设备",
+      "desc": "\u6696\u901a\u672b\u7aef\u8bbe\u5907",
       "smm_section": "U10"
     },
     "IfcFurnishingElement": {
       "rate": 1950,
       "unit": "EA",
-      "desc": "家具",
+      "desc": "\u5bb6\u5177",
       "smm_section": "N10"
     },
     "IfcPlate": {
       "rate": 154,
       "unit": "M2",
-      "desc": "钢板",
+      "desc": "\u94a2\u677f",
       "smm_section": "G10"
     },
     "IfcMember": {
       "rate": 520,
       "unit": "M",
-      "desc": "钢构件",
+      "desc": "\u94a2\u6784\u4ef6",
       "smm_section": "G10"
     },
     "IfcRailing": {
       "rate": 455,
       "unit": "M",
-      "desc": "栏杆",
+      "desc": "\u680f\u6746",
       "smm_section": "L30"
     },
     "IfcStair": {
       "rate": 7308,
       "unit": "EA",
-      "desc": "楼梯",
+      "desc": "\u697c\u68af",
       "smm_section": "L30"
     },
     "IfcStairFlight": {
       "rate": 3572,
       "unit": "EA",
-      "desc": "楼梯梯段",
+      "desc": "\u697c\u68af\u68af\u6bb5",
       "smm_section": "L30"
     },
     "IfcFooting": {
       "rate": 122.33,
       "unit": "M3",
-      "desc": "基础",
-      "smm_section": "D20"
+      "desc": "\u57fa\u7840",
+      "smm_section": "D20",
+      "volFactor": 4.25074802767622
     },
     "IfcPile": {
       "rate": 1380,
       "unit": "EA",
-      "desc": "桩基",
+      "desc": "\u6869\u57fa",
       "smm_section": "D30"
     },
     "IfcReinforcingBar": {
       "rate": 73,
       "unit": "KG",
-      "desc": "钢筋",
+      "desc": "\u94a2\u7b4b",
       "smm_section": "E30"
     },
     "IfcFlowSegment": {
       "rate": 195,
       "unit": "M",
-      "desc": "流体管段",
+      "desc": "\u6d41\u4f53\u7ba1\u6bb5",
       "smm_section": "Y10"
     },
     "IfcFlowFitting": {
       "rate": 325,
       "unit": "EA",
-      "desc": "流体配件",
+      "desc": "\u6d41\u4f53\u914d\u4ef6",
       "smm_section": "Y10"
     },
     "IfcFlowController": {
       "rate": 731,
       "unit": "EA",
-      "desc": "流体控制设备",
+      "desc": "\u6d41\u4f53\u63a7\u5236\u8bbe\u5907",
       "smm_section": "Y10"
     },
     "IfcEnergyConversionDevice": {
       "rate": 13804,
       "unit": "EA",
-      "desc": "能量转换设备",
+      "desc": "\u80fd\u91cf\u8f6c\u6362\u8bbe\u5907",
       "smm_section": "T10"
     },
     "IfcFlowTreatmentDevice": {
       "rate": 1950,
       "unit": "EA",
-      "desc": "流体处理设备",
+      "desc": "\u6d41\u4f53\u5904\u7406\u8bbe\u5907",
       "smm_section": "Y10"
     },
     "IfcFlowMovingDevice": {
       "rate": 5685,
       "unit": "EA",
-      "desc": "流体输送设备",
+      "desc": "\u6d41\u4f53\u8f93\u9001\u8bbe\u5907",
       "smm_section": "T10"
     },
     "IfcFlowStorageDevice": {
       "rate": 8120,
       "unit": "EA",
-      "desc": "流体储存设备",
+      "desc": "\u6d41\u4f53\u50a8\u5b58\u8bbe\u5907",
       "smm_section": "Y10"
     },
     "IfcElectricAppliance": {
       "rate": 788,
       "unit": "EA",
-      "desc": "电气设备",
+      "desc": "\u7535\u6c14\u8bbe\u5907",
       "smm_section": "V20"
     },
     "IfcFurniture": {
       "rate": 2436,
       "unit": "EA",
-      "desc": "家具",
+      "desc": "\u5bb6\u5177",
       "smm_section": "N10"
     },
     "IfcOpeningElement": {
       "rate": 0,
       "unit": "EA",
-      "desc": "洞口",
+      "desc": "\u6d1e\u53e3",
       "smm_section": ""
     },
     "IfcDistributionElement": {
       "rate": 380,
       "unit": "EA",
-      "desc": "分配设备",
+      "desc": "\u5206\u914d\u8bbe\u5907",
       "smm_section": "Y10"
     },
     "IfcFireSuppressionTerminal": {
       "rate": 350,
       "unit": "EA",
-      "desc": "喷淋头",
+      "desc": "\u55b7\u6dcb\u5934",
       "smm_section": "S60"
     },
     "IfcAirTerminal": {
       "rate": 300,
       "unit": "EA",
-      "desc": "风口/格栅",
+      "desc": "\u98ce\u53e3/\u683c\u6805",
       "smm_section": "U10"
     },
     "IfcValve": {
       "rate": 230,
       "unit": "EA",
-      "desc": "阀门",
+      "desc": "\u9600\u95e8",
       "smm_section": "S10"
     },
     "IfcAlarm": {
       "rate": 280,
       "unit": "EA",
-      "desc": "火灾报警器",
+      "desc": "\u706b\u707e\u62a5\u8b66\u5668",
       "smm_section": "W50"
     },
     "IfcController": {
       "rate": 980,
       "unit": "EA",
-      "desc": "楼宇控制器",
+      "desc": "\u697c\u5b87\u63a7\u5236\u5668",
       "smm_section": "W60"
     },
     "IfcRamp": {
       "rate": 2600,
       "unit": "EA",
-      "desc": "坡道",
+      "desc": "\u5761\u9053",
       "smm_section": "L30"
     },
     "IfcRampFlight": {
       "rate": 2850,
       "unit": "EA",
-      "desc": "坡道段",
+      "desc": "\u5761\u9053\u6bb5",
       "smm_section": "L30"
     },
     "IfcBuildingElementPart": {
       "rate": 0,
       "unit": "EA",
-      "desc": "构件部分",
+      "desc": "\u6784\u4ef6\u90e8\u5206",
       "smm_section": ""
     }
   },
@@ -315,7 +316,7 @@
     "HVAC_TECH": {
       "rate_per_day": 450,
       "crew_size": 2,
-      "trade": "暖通技工（高级）",
+      "trade": "\u6696\u901a\u6280\u5de5\uff08\u9ad8\u7ea7\uff09",
       "productivity": {
         "IfcDuct": 18,
         "IfcDuctSegment": 18,
@@ -329,7 +330,7 @@
     "PLUMBER": {
       "rate_per_day": 400,
       "crew_size": 2,
-      "trade": "管道工（高级）",
+      "trade": "\u7ba1\u9053\u5de5\uff08\u9ad8\u7ea7\uff09",
       "productivity": {
         "IfcPipe": 25,
         "IfcPipeSegment": 25,
@@ -346,7 +347,7 @@
     "ELECTRICIAN": {
       "rate_per_day": 420,
       "crew_size": 2,
-      "trade": "电工（高级）",
+      "trade": "\u7535\u5de5\uff08\u9ad8\u7ea7\uff09",
       "productivity": {
         "IfcCableCarrier": 30,
         "IfcCableCarrierSegment": 30,
@@ -361,7 +362,7 @@
     "STEEL_ERECTOR": {
       "rate_per_day": 480,
       "crew_size": 4,
-      "trade": "钢结构安装工（高级）",
+      "trade": "\u94a2\u7ed3\u6784\u5b89\u88c5\u5de5\uff08\u9ad8\u7ea7\uff09",
       "productivity": {
         "IfcBeam": 8,
         "IfcColumn": 6,
@@ -372,7 +373,7 @@
     "CONCRETE_GANG": {
       "rate_per_day": 350,
       "crew_size": 6,
-      "trade": "混凝土施工班组",
+      "trade": "\u6df7\u51dd\u571f\u65bd\u5de5\u73ed\u7ec4",
       "productivity": {
         "IfcSlab": 35,
         "IfcFooting": 6,
@@ -385,7 +386,7 @@
     "MASON": {
       "rate_per_day": 380,
       "crew_size": 3,
-      "trade": "砌筑工（高级）+ 普工",
+      "trade": "\u780c\u7b51\u5de5\uff08\u9ad8\u7ea7\uff09+ \u666e\u5de5",
       "productivity": {
         "IfcWall": 12,
         "IfcWallStandardCase": 12,
@@ -396,7 +397,7 @@
     "CARPENTER": {
       "rate_per_day": 400,
       "crew_size": 2,
-      "trade": "木工（高级）",
+      "trade": "\u6728\u5de5\uff08\u9ad8\u7ea7\uff09",
       "productivity": {
         "IfcDoor": 6,
         "IfcWindow": 6,
@@ -409,7 +410,7 @@
     "ROOFER": {
       "rate_per_day": 420,
       "crew_size": 3,
-      "trade": "防水工（高级）",
+      "trade": "\u9632\u6c34\u5de5\uff08\u9ad8\u7ea7\uff09",
       "productivity": {
         "IfcRoof": 25
       }
@@ -417,7 +418,7 @@
     "FINISHER": {
       "rate_per_day": 350,
       "crew_size": 2,
-      "trade": "装饰工（高级）",
+      "trade": "\u88c5\u9970\u5de5\uff08\u9ad8\u7ea7\uff09",
       "productivity": {
         "IfcCovering": 20,
         "IfcFurniture": 8,
@@ -427,34 +428,34 @@
     "LABORER": {
       "rate_per_day": 250,
       "crew_size": 1,
-      "trade": "普通工",
+      "trade": "\u666e\u901a\u5de5",
       "productivity": {}
     }
   },
   "equipment": {
     "MOBILE_CRANE_20T": {
       "rate_per_day": 3200,
-      "desc": "汽车起重机 20吨"
+      "desc": "\u6c7d\u8f66\u8d77\u91cd\u673a 20\u5428"
     },
     "TOWER_CRANE": {
       "rate_per_day": 3800,
-      "desc": "塔式起重机"
+      "desc": "\u5854\u5f0f\u8d77\u91cd\u673a"
     },
     "CONCRETE_PUMP": {
       "rate_per_day": 1650,
-      "desc": "混凝土泵车"
+      "desc": "\u6df7\u51dd\u571f\u6cf5\u8f66"
     },
     "SCISSOR_LIFT_8M": {
       "rate_per_day": 500,
-      "desc": "剪叉式升降平台 8m"
+      "desc": "\u526a\u53c9\u5f0f\u5347\u964d\u5e73\u53f0 8m"
     },
     "WELDING_MACHINE": {
       "rate_per_day": 120,
-      "desc": "电焊机 300A"
+      "desc": "\u7535\u710a\u673a 300A"
     },
     "GENERATOR_5KVA": {
       "rate_per_day": 180,
-      "desc": "发电机 5KVA"
+      "desc": "\u53d1\u7535\u673a 5KVA"
     }
   },
   "equipment_allocation": {
@@ -729,7 +730,7 @@
   "work_packages": [
     {
       "id": "PACKAGE 1",
-      "name": "基础工程",
+      "name": "\u57fa\u7840\u5de5\u7a0b",
       "color": "8E44AD",
       "classes": [
         "IfcFooting",
@@ -739,7 +740,7 @@
     },
     {
       "id": "PACKAGE 2",
-      "name": "主体结构",
+      "name": "\u4e3b\u4f53\u7ed3\u6784",
       "color": "2980B9",
       "classes": [
         "IfcColumn",
@@ -751,7 +752,7 @@
     },
     {
       "id": "PACKAGE 3",
-      "name": "机电粗装",
+      "name": "\u673a\u7535\u7c97\u88c5",
       "color": "D35400",
       "classes": [
         "IfcDuct",
@@ -775,7 +776,7 @@
     },
     {
       "id": "PACKAGE 4",
-      "name": "建筑工程",
+      "name": "\u5efa\u7b51\u5de5\u7a0b",
       "color": "ED7D31",
       "classes": [
         "IfcWall",
@@ -793,7 +794,7 @@
     },
     {
       "id": "PACKAGE 5",
-      "name": "装饰装修",
+      "name": "\u88c5\u9970\u88c5\u4fee",
       "color": "27AE60",
       "classes": [
         "IfcCovering",
@@ -803,7 +804,7 @@
     },
     {
       "id": "PACKAGE 6",
-      "name": "机电精装",
+      "name": "\u673a\u7535\u7cbe\u88c5",
       "color": "C0392B",
       "classes": [
         "IfcFlowTerminal",
@@ -818,28 +819,28 @@
     }
   ],
   "smm_sections": {
-    "A": "施工准备",
-    "C": "拆除工程",
-    "D": "土方/基础工程",
-    "E": "混凝土工程",
-    "F": "砌体工程",
-    "G": "钢结构工程",
-    "H": "屋面/幕墙工程",
-    "J": "防水工程",
-    "K": "隔墙/吊顶",
-    "L": "门窗/楼梯",
-    "M": "装饰装修",
-    "N": "家具/设备",
-    "P": "杂项",
-    "Q": "室外工程",
-    "R": "排水工程",
-    "S": "给排水",
-    "T": "供热/制冷",
-    "U": "通风空调",
-    "V": "电气工程",
-    "W": "智能化/安防",
-    "X": "电梯",
-    "Y": "机电工程（综合）"
+    "A": "\u65bd\u5de5\u51c6\u5907",
+    "C": "\u62c6\u9664\u5de5\u7a0b",
+    "D": "\u571f\u65b9/\u57fa\u7840\u5de5\u7a0b",
+    "E": "\u6df7\u51dd\u571f\u5de5\u7a0b",
+    "F": "\u780c\u4f53\u5de5\u7a0b",
+    "G": "\u94a2\u7ed3\u6784\u5de5\u7a0b",
+    "H": "\u5c4b\u9762/\u5e55\u5899\u5de5\u7a0b",
+    "J": "\u9632\u6c34\u5de5\u7a0b",
+    "K": "\u9694\u5899/\u540a\u9876",
+    "L": "\u95e8\u7a97/\u697c\u68af",
+    "M": "\u88c5\u9970\u88c5\u4fee",
+    "N": "\u5bb6\u5177/\u8bbe\u5907",
+    "P": "\u6742\u9879",
+    "Q": "\u5ba4\u5916\u5de5\u7a0b",
+    "R": "\u6392\u6c34\u5de5\u7a0b",
+    "S": "\u7ed9\u6392\u6c34",
+    "T": "\u4f9b\u70ed/\u5236\u51b7",
+    "U": "\u901a\u98ce\u7a7a\u8c03",
+    "V": "\u7535\u6c14\u5de5\u7a0b",
+    "W": "\u667a\u80fd\u5316/\u5b89\u9632",
+    "X": "\u7535\u68af",
+    "Y": "\u673a\u7535\u5de5\u7a0b\uff08\u7efc\u5408\uff09"
   },
   "provisions": {
     "preliminaries_pct": 8,

--- a/viewer/rates/jbci2024_jp.json
+++ b/viewer/rates/jbci2024_jp.json
@@ -179,8 +179,8 @@
       "smm_section": "L30"
     },
     "IfcFooting": {
-      "rate": 14500,
-      "unit": "EA",
+      "rate": 3411.16,
+      "unit": "M3",
       "desc": "基礎フーチング",
       "smm_section": "D20"
     },

--- a/viewer/rates/jbci2024_jp.json
+++ b/viewer/rates/jbci2024_jp.json
@@ -13,301 +13,302 @@
     "IfcDuct": {
       "rate": 5800,
       "unit": "M",
-      "desc": "亜鉛鋼板ダクト（平均400mm）",
+      "desc": "\u4e9c\u925b\u92fc\u677f\u30c0\u30af\u30c8\uff08\u5e73\u5747400mm\uff09",
       "smm_section": "U10"
     },
     "IfcDuctSegment": {
       "rate": 5800,
       "unit": "M",
-      "desc": "ダクトセグメント",
+      "desc": "\u30c0\u30af\u30c8\u30bb\u30b0\u30e1\u30f3\u30c8",
       "smm_section": "U10"
     },
     "IfcDuctFitting": {
       "rate": 12500,
       "unit": "EA",
-      "desc": "ダクト継手（エルボ、ティー）",
+      "desc": "\u30c0\u30af\u30c8\u7d99\u624b\uff08\u30a8\u30eb\u30dc\u3001\u30c6\u30a3\u30fc\uff09",
       "smm_section": "U10"
     },
     "IfcPipe": {
       "rate": 2200,
       "unit": "M",
-      "desc": "配管（SGP/VP 平均100mm）",
+      "desc": "\u914d\u7ba1\uff08SGP/VP \u5e73\u5747100mm\uff09",
       "smm_section": "S10"
     },
     "IfcPipeSegment": {
       "rate": 2200,
       "unit": "M",
-      "desc": "配管セグメント",
+      "desc": "\u914d\u7ba1\u30bb\u30b0\u30e1\u30f3\u30c8",
       "smm_section": "S10"
     },
     "IfcPipeFitting": {
       "rate": 4500,
       "unit": "EA",
-      "desc": "配管継手",
+      "desc": "\u914d\u7ba1\u7d99\u624b",
       "smm_section": "S10"
     },
     "IfcCableCarrier": {
       "rate": 3800,
       "unit": "M",
-      "desc": "ケーブルラック（300mm）",
+      "desc": "\u30b1\u30fc\u30d6\u30eb\u30e9\u30c3\u30af\uff08300mm\uff09",
       "smm_section": "V20"
     },
     "IfcCableCarrierSegment": {
       "rate": 3800,
       "unit": "M",
-      "desc": "ケーブルラックセグメント",
+      "desc": "\u30b1\u30fc\u30d6\u30eb\u30e9\u30c3\u30af\u30bb\u30b0\u30e1\u30f3\u30c8",
       "smm_section": "V20"
     },
     "IfcBeam": {
       "rate": 28000,
       "unit": "M",
-      "desc": "構造用H形鋼梁",
+      "desc": "\u69cb\u9020\u7528H\u5f62\u92fc\u6881",
       "smm_section": "G10"
     },
     "IfcColumn": {
       "rate": 52000,
       "unit": "M",
-      "desc": "構造用鋼柱",
+      "desc": "\u69cb\u9020\u7528\u92fc\u67f1",
       "smm_section": "G10"
     },
     "IfcSlab": {
       "rate": 12800,
       "unit": "M2",
-      "desc": "RC床版 250mm",
+      "desc": "RC\u5e8a\u7248 250mm",
       "smm_section": "E10"
     },
     "IfcWall": {
       "rate": 6500,
       "unit": "M2",
-      "desc": "コンクリートブロック壁 150mm",
+      "desc": "\u30b3\u30f3\u30af\u30ea\u30fc\u30c8\u30d6\u30ed\u30c3\u30af\u58c1 150mm",
       "smm_section": "F10"
     },
     "IfcWallStandardCase": {
       "rate": 6500,
       "unit": "M2",
-      "desc": "標準壁",
+      "desc": "\u6a19\u6e96\u58c1",
       "smm_section": "F10"
     },
     "IfcCurtainWall": {
       "rate": 35000,
       "unit": "M2",
-      "desc": "カーテンウォール",
+      "desc": "\u30ab\u30fc\u30c6\u30f3\u30a6\u30a9\u30fc\u30eb",
       "smm_section": "H10"
     },
     "IfcCovering": {
       "rate": 8500,
       "unit": "M2",
-      "desc": "床・天井仕上げ",
+      "desc": "\u5e8a\u30fb\u5929\u4e95\u4ed5\u4e0a\u3052",
       "smm_section": "M10"
     },
     "IfcRoof": {
       "rate": 11500,
       "unit": "M2",
-      "desc": "金属屋根",
+      "desc": "\u91d1\u5c5e\u5c4b\u6839",
       "smm_section": "H60"
     },
     "IfcLightFixture": {
       "rate": 18500,
       "unit": "EA",
-      "desc": "LED照明器具",
+      "desc": "LED\u7167\u660e\u5668\u5177",
       "smm_section": "V40"
     },
     "IfcOutlet": {
       "rate": 5800,
       "unit": "EA",
-      "desc": "コンセント",
+      "desc": "\u30b3\u30f3\u30bb\u30f3\u30c8",
       "smm_section": "V20"
     },
     "IfcDoor": {
       "rate": 125000,
       "unit": "EA",
-      "desc": "建具セット",
+      "desc": "\u5efa\u5177\u30bb\u30c3\u30c8",
       "smm_section": "L20"
     },
     "IfcWindow": {
       "rate": 72000,
       "unit": "EA",
-      "desc": "窓",
+      "desc": "\u7a93",
       "smm_section": "L10"
     },
     "IfcBuildingElementProxy": {
       "rate": 35000,
       "unit": "EA",
-      "desc": "その他要素",
+      "desc": "\u305d\u306e\u4ed6\u8981\u7d20",
       "smm_section": "P10"
     },
     "IfcFlowTerminal": {
       "rate": 145000,
       "unit": "EA",
-      "desc": "空調端末",
+      "desc": "\u7a7a\u8abf\u7aef\u672b",
       "smm_section": "U10"
     },
     "IfcFurnishingElement": {
       "rate": 48000,
       "unit": "EA",
-      "desc": "家具",
+      "desc": "\u5bb6\u5177",
       "smm_section": "N10"
     },
     "IfcPlate": {
       "rate": 4200,
       "unit": "M2",
-      "desc": "鋼板",
+      "desc": "\u92fc\u677f",
       "smm_section": "G10"
     },
     "IfcMember": {
       "rate": 13500,
       "unit": "M",
-      "desc": "鋼部材",
+      "desc": "\u92fc\u90e8\u6750",
       "smm_section": "G10"
     },
     "IfcRailing": {
       "rate": 12800,
       "unit": "M",
-      "desc": "手摺り",
+      "desc": "\u624b\u647a\u308a",
       "smm_section": "L30"
     },
     "IfcStair": {
       "rate": 185000,
       "unit": "EA",
-      "desc": "階段",
+      "desc": "\u968e\u6bb5",
       "smm_section": "L30"
     },
     "IfcStairFlight": {
       "rate": 92000,
       "unit": "EA",
-      "desc": "階段フライト",
+      "desc": "\u968e\u6bb5\u30d5\u30e9\u30a4\u30c8",
       "smm_section": "L30"
     },
     "IfcFooting": {
       "rate": 3411.16,
       "unit": "M3",
-      "desc": "基礎フーチング",
-      "smm_section": "D20"
+      "desc": "\u57fa\u790e\u30d5\u30fc\u30c1\u30f3\u30b0",
+      "smm_section": "D20",
+      "volFactor": 4.25074802767622
     },
     "IfcPile": {
       "rate": 38000,
       "unit": "EA",
-      "desc": "基礎杭",
+      "desc": "\u57fa\u790e\u676d",
       "smm_section": "D30"
     },
     "IfcReinforcingBar": {
       "rate": 185,
       "unit": "KG",
-      "desc": "鉄筋",
+      "desc": "\u9244\u7b4b",
       "smm_section": "E30"
     },
     "IfcFlowSegment": {
       "rate": 5200,
       "unit": "M",
-      "desc": "流路セグメント",
+      "desc": "\u6d41\u8def\u30bb\u30b0\u30e1\u30f3\u30c8",
       "smm_section": "Y10"
     },
     "IfcFlowFitting": {
       "rate": 8500,
       "unit": "EA",
-      "desc": "流路継手",
+      "desc": "\u6d41\u8def\u7d99\u624b",
       "smm_section": "Y10"
     },
     "IfcFlowController": {
       "rate": 19500,
       "unit": "EA",
-      "desc": "流路制御機器",
+      "desc": "\u6d41\u8def\u5236\u5fa1\u6a5f\u5668",
       "smm_section": "Y10"
     },
     "IfcEnergyConversionDevice": {
       "rate": 380000,
       "unit": "EA",
-      "desc": "エネルギー変換機器",
+      "desc": "\u30a8\u30cd\u30eb\u30ae\u30fc\u5909\u63db\u6a5f\u5668",
       "smm_section": "T10"
     },
     "IfcFlowTreatmentDevice": {
       "rate": 52000,
       "unit": "EA",
-      "desc": "流体処理機器",
+      "desc": "\u6d41\u4f53\u51e6\u7406\u6a5f\u5668",
       "smm_section": "Y10"
     },
     "IfcFlowMovingDevice": {
       "rate": 145000,
       "unit": "EA",
-      "desc": "流体搬送機器",
+      "desc": "\u6d41\u4f53\u642c\u9001\u6a5f\u5668",
       "smm_section": "T10"
     },
     "IfcFlowStorageDevice": {
       "rate": 215000,
       "unit": "EA",
-      "desc": "流体貯蔵機器",
+      "desc": "\u6d41\u4f53\u8caf\u8535\u6a5f\u5668",
       "smm_section": "Y10"
     },
     "IfcElectricAppliance": {
       "rate": 22000,
       "unit": "EA",
-      "desc": "電気機器",
+      "desc": "\u96fb\u6c17\u6a5f\u5668",
       "smm_section": "V20"
     },
     "IfcFurniture": {
       "rate": 62000,
       "unit": "EA",
-      "desc": "家具",
+      "desc": "\u5bb6\u5177",
       "smm_section": "N10"
     },
     "IfcOpeningElement": {
       "rate": 0,
       "unit": "EA",
-      "desc": "開口部",
+      "desc": "\u958b\u53e3\u90e8",
       "smm_section": ""
     },
     "IfcDistributionElement": {
       "rate": 18500,
       "unit": "EA",
-      "desc": "配分装置",
+      "desc": "\u914d\u5206\u88c5\u7f6e",
       "smm_section": "Y10"
     },
     "IfcFireSuppressionTerminal": {
       "rate": 16500,
       "unit": "EA",
-      "desc": "スプリンクラーヘッド",
+      "desc": "\u30b9\u30d7\u30ea\u30f3\u30af\u30e9\u30fc\u30d8\u30c3\u30c9",
       "smm_section": "S60"
     },
     "IfcAirTerminal": {
       "rate": 14000,
       "unit": "EA",
-      "desc": "吹出口/吸込口",
+      "desc": "\u5439\u51fa\u53e3/\u5438\u8fbc\u53e3",
       "smm_section": "U10"
     },
     "IfcValve": {
       "rate": 10500,
       "unit": "EA",
-      "desc": "バルブ",
+      "desc": "\u30d0\u30eb\u30d6",
       "smm_section": "S10"
     },
     "IfcAlarm": {
       "rate": 13000,
       "unit": "EA",
-      "desc": "火災報知器",
+      "desc": "\u706b\u707d\u5831\u77e5\u5668",
       "smm_section": "W50"
     },
     "IfcController": {
       "rate": 45000,
       "unit": "EA",
-      "desc": "ビル管理コントローラ",
+      "desc": "\u30d3\u30eb\u7ba1\u7406\u30b3\u30f3\u30c8\u30ed\u30fc\u30e9",
       "smm_section": "W60"
     },
     "IfcRamp": {
       "rate": 120000,
       "unit": "EA",
-      "desc": "スロープ",
+      "desc": "\u30b9\u30ed\u30fc\u30d7",
       "smm_section": "L30"
     },
     "IfcRampFlight": {
       "rate": 130000,
       "unit": "EA",
-      "desc": "スロープフライト",
+      "desc": "\u30b9\u30ed\u30fc\u30d7\u30d5\u30e9\u30a4\u30c8",
       "smm_section": "L30"
     },
     "IfcBuildingElementPart": {
       "rate": 0,
       "unit": "EA",
-      "desc": "建築部品",
+      "desc": "\u5efa\u7bc9\u90e8\u54c1",
       "smm_section": ""
     }
   },
@@ -315,7 +316,7 @@
     "HVAC_TECH": {
       "rate_per_day": 28500,
       "crew_size": 2,
-      "trade": "空調技能者（熟練）",
+      "trade": "\u7a7a\u8abf\u6280\u80fd\u8005\uff08\u719f\u7df4\uff09",
       "productivity": {
         "IfcDuct": 16,
         "IfcDuctSegment": 16,
@@ -329,7 +330,7 @@
     "PLUMBER": {
       "rate_per_day": 26000,
       "crew_size": 2,
-      "trade": "配管工（熟練）",
+      "trade": "\u914d\u7ba1\u5de5\uff08\u719f\u7df4\uff09",
       "productivity": {
         "IfcPipe": 22,
         "IfcPipeSegment": 22,
@@ -346,7 +347,7 @@
     "ELECTRICIAN": {
       "rate_per_day": 27000,
       "crew_size": 2,
-      "trade": "電気工（熟練）",
+      "trade": "\u96fb\u6c17\u5de5\uff08\u719f\u7df4\uff09",
       "productivity": {
         "IfcCableCarrier": 28,
         "IfcCableCarrierSegment": 28,
@@ -361,7 +362,7 @@
     "STEEL_ERECTOR": {
       "rate_per_day": 30000,
       "crew_size": 4,
-      "trade": "鉄骨工（熟練）",
+      "trade": "\u9244\u9aa8\u5de5\uff08\u719f\u7df4\uff09",
       "productivity": {
         "IfcBeam": 7,
         "IfcColumn": 5,
@@ -372,7 +373,7 @@
     "CONCRETE_GANG": {
       "rate_per_day": 22000,
       "crew_size": 6,
-      "trade": "コンクリート打設班",
+      "trade": "\u30b3\u30f3\u30af\u30ea\u30fc\u30c8\u6253\u8a2d\u73ed",
       "productivity": {
         "IfcSlab": 30,
         "IfcFooting": 6,
@@ -385,7 +386,7 @@
     "MASON": {
       "rate_per_day": 24000,
       "crew_size": 3,
-      "trade": "左官・ブロック工（熟練）+ 普通作業員",
+      "trade": "\u5de6\u5b98\u30fb\u30d6\u30ed\u30c3\u30af\u5de5\uff08\u719f\u7df4\uff09+ \u666e\u901a\u4f5c\u696d\u54e1",
       "productivity": {
         "IfcWall": 10,
         "IfcWallStandardCase": 10,
@@ -396,7 +397,7 @@
     "CARPENTER": {
       "rate_per_day": 26000,
       "crew_size": 2,
-      "trade": "型枠大工（熟練）",
+      "trade": "\u578b\u67a0\u5927\u5de5\uff08\u719f\u7df4\uff09",
       "productivity": {
         "IfcDoor": 6,
         "IfcWindow": 6,
@@ -409,7 +410,7 @@
     "ROOFER": {
       "rate_per_day": 27000,
       "crew_size": 3,
-      "trade": "屋根工（熟練）",
+      "trade": "\u5c4b\u6839\u5de5\uff08\u719f\u7df4\uff09",
       "productivity": {
         "IfcRoof": 25
       }
@@ -417,7 +418,7 @@
     "FINISHER": {
       "rate_per_day": 22000,
       "crew_size": 2,
-      "trade": "内装工（熟練）",
+      "trade": "\u5185\u88c5\u5de5\uff08\u719f\u7df4\uff09",
       "productivity": {
         "IfcCovering": 20,
         "IfcFurniture": 8,
@@ -427,34 +428,34 @@
     "LABORER": {
       "rate_per_day": 17000,
       "crew_size": 1,
-      "trade": "普通作業員",
+      "trade": "\u666e\u901a\u4f5c\u696d\u54e1",
       "productivity": {}
     }
   },
   "equipment": {
     "MOBILE_CRANE_20T": {
       "rate_per_day": 85000,
-      "desc": "移動式クレーン 20トン"
+      "desc": "\u79fb\u52d5\u5f0f\u30af\u30ec\u30fc\u30f3 20\u30c8\u30f3"
     },
     "TOWER_CRANE": {
       "rate_per_day": 120000,
-      "desc": "タワークレーン"
+      "desc": "\u30bf\u30ef\u30fc\u30af\u30ec\u30fc\u30f3"
     },
     "CONCRETE_PUMP": {
       "rate_per_day": 65000,
-      "desc": "コンクリートポンプ車"
+      "desc": "\u30b3\u30f3\u30af\u30ea\u30fc\u30c8\u30dd\u30f3\u30d7\u8eca"
     },
     "SCISSOR_LIFT_8M": {
       "rate_per_day": 15000,
-      "desc": "シザースリフト 8m"
+      "desc": "\u30b7\u30b6\u30fc\u30b9\u30ea\u30d5\u30c8 8m"
     },
     "WELDING_MACHINE": {
       "rate_per_day": 4500,
-      "desc": "溶接機 300A"
+      "desc": "\u6eb6\u63a5\u6a5f 300A"
     },
     "GENERATOR_5KVA": {
       "rate_per_day": 6500,
-      "desc": "発電機 5KVA"
+      "desc": "\u767a\u96fb\u6a5f 5KVA"
     }
   },
   "equipment_allocation": {
@@ -729,7 +730,7 @@
   "work_packages": [
     {
       "id": "PACKAGE 1",
-      "name": "基礎工事",
+      "name": "\u57fa\u790e\u5de5\u4e8b",
       "color": "8E44AD",
       "classes": [
         "IfcFooting",
@@ -739,7 +740,7 @@
     },
     {
       "id": "PACKAGE 2",
-      "name": "躯体工事",
+      "name": "\u8eaf\u4f53\u5de5\u4e8b",
       "color": "2980B9",
       "classes": [
         "IfcColumn",
@@ -751,7 +752,7 @@
     },
     {
       "id": "PACKAGE 3",
-      "name": "設備粗工事",
+      "name": "\u8a2d\u5099\u7c97\u5de5\u4e8b",
       "color": "D35400",
       "classes": [
         "IfcDuct",
@@ -775,7 +776,7 @@
     },
     {
       "id": "PACKAGE 4",
-      "name": "建築工事",
+      "name": "\u5efa\u7bc9\u5de5\u4e8b",
       "color": "ED7D31",
       "classes": [
         "IfcWall",
@@ -793,7 +794,7 @@
     },
     {
       "id": "PACKAGE 5",
-      "name": "仕上工事",
+      "name": "\u4ed5\u4e0a\u5de5\u4e8b",
       "color": "27AE60",
       "classes": [
         "IfcCovering",
@@ -803,7 +804,7 @@
     },
     {
       "id": "PACKAGE 6",
-      "name": "設備仕上工事",
+      "name": "\u8a2d\u5099\u4ed5\u4e0a\u5de5\u4e8b",
       "color": "C0392B",
       "classes": [
         "IfcFlowTerminal",
@@ -818,28 +819,28 @@
     }
   ],
   "smm_sections": {
-    "A": "仮設工事",
-    "C": "既存建物",
-    "D": "地業工事",
-    "E": "コンクリート工事",
-    "F": "組積工事",
-    "G": "鉄骨工事",
-    "H": "屋根・外壁工事",
-    "J": "防水工事",
-    "K": "内装下地工事",
-    "L": "建具・階段工事",
-    "M": "仕上工事",
-    "N": "家具・什器",
-    "P": "雑工事",
-    "Q": "外構工事",
-    "R": "排水設備",
-    "S": "給排水衛生設備",
-    "T": "空気調和設備",
-    "U": "換気設備",
-    "V": "電気設備",
-    "W": "防災・通信設備",
-    "X": "昇降機設備",
-    "Y": "設備工事（総合）"
+    "A": "\u4eee\u8a2d\u5de5\u4e8b",
+    "C": "\u65e2\u5b58\u5efa\u7269",
+    "D": "\u5730\u696d\u5de5\u4e8b",
+    "E": "\u30b3\u30f3\u30af\u30ea\u30fc\u30c8\u5de5\u4e8b",
+    "F": "\u7d44\u7a4d\u5de5\u4e8b",
+    "G": "\u9244\u9aa8\u5de5\u4e8b",
+    "H": "\u5c4b\u6839\u30fb\u5916\u58c1\u5de5\u4e8b",
+    "J": "\u9632\u6c34\u5de5\u4e8b",
+    "K": "\u5185\u88c5\u4e0b\u5730\u5de5\u4e8b",
+    "L": "\u5efa\u5177\u30fb\u968e\u6bb5\u5de5\u4e8b",
+    "M": "\u4ed5\u4e0a\u5de5\u4e8b",
+    "N": "\u5bb6\u5177\u30fb\u4ec0\u5668",
+    "P": "\u96d1\u5de5\u4e8b",
+    "Q": "\u5916\u69cb\u5de5\u4e8b",
+    "R": "\u6392\u6c34\u8a2d\u5099",
+    "S": "\u7d66\u6392\u6c34\u885b\u751f\u8a2d\u5099",
+    "T": "\u7a7a\u6c17\u8abf\u548c\u8a2d\u5099",
+    "U": "\u63db\u6c17\u8a2d\u5099",
+    "V": "\u96fb\u6c17\u8a2d\u5099",
+    "W": "\u9632\u707d\u30fb\u901a\u4fe1\u8a2d\u5099",
+    "X": "\u6607\u964d\u6a5f\u8a2d\u5099",
+    "Y": "\u8a2d\u5099\u5de5\u4e8b\uff08\u7dcf\u5408\uff09"
   },
   "provisions": {
     "preliminaries_pct": 10,

--- a/viewer/rates/jbci2024_jp.json
+++ b/viewer/rates/jbci2024_jp.json
@@ -13,302 +13,302 @@
     "IfcDuct": {
       "rate": 5800,
       "unit": "M",
-      "desc": "\u4e9c\u925b\u92fc\u677f\u30c0\u30af\u30c8\uff08\u5e73\u5747400mm\uff09",
+      "desc": "亜鉛鋼板ダクト（平均400mm）",
       "smm_section": "U10"
     },
     "IfcDuctSegment": {
       "rate": 5800,
       "unit": "M",
-      "desc": "\u30c0\u30af\u30c8\u30bb\u30b0\u30e1\u30f3\u30c8",
+      "desc": "ダクトセグメント",
       "smm_section": "U10"
     },
     "IfcDuctFitting": {
       "rate": 12500,
       "unit": "EA",
-      "desc": "\u30c0\u30af\u30c8\u7d99\u624b\uff08\u30a8\u30eb\u30dc\u3001\u30c6\u30a3\u30fc\uff09",
+      "desc": "ダクト継手（エルボ、ティー）",
       "smm_section": "U10"
     },
     "IfcPipe": {
       "rate": 2200,
       "unit": "M",
-      "desc": "\u914d\u7ba1\uff08SGP/VP \u5e73\u5747100mm\uff09",
+      "desc": "配管（SGP/VP 平均100mm）",
       "smm_section": "S10"
     },
     "IfcPipeSegment": {
       "rate": 2200,
       "unit": "M",
-      "desc": "\u914d\u7ba1\u30bb\u30b0\u30e1\u30f3\u30c8",
+      "desc": "配管セグメント",
       "smm_section": "S10"
     },
     "IfcPipeFitting": {
       "rate": 4500,
       "unit": "EA",
-      "desc": "\u914d\u7ba1\u7d99\u624b",
+      "desc": "配管継手",
       "smm_section": "S10"
     },
     "IfcCableCarrier": {
       "rate": 3800,
       "unit": "M",
-      "desc": "\u30b1\u30fc\u30d6\u30eb\u30e9\u30c3\u30af\uff08300mm\uff09",
+      "desc": "ケーブルラック（300mm）",
       "smm_section": "V20"
     },
     "IfcCableCarrierSegment": {
       "rate": 3800,
       "unit": "M",
-      "desc": "\u30b1\u30fc\u30d6\u30eb\u30e9\u30c3\u30af\u30bb\u30b0\u30e1\u30f3\u30c8",
+      "desc": "ケーブルラックセグメント",
       "smm_section": "V20"
     },
     "IfcBeam": {
       "rate": 28000,
       "unit": "M",
-      "desc": "\u69cb\u9020\u7528H\u5f62\u92fc\u6881",
+      "desc": "構造用H形鋼梁",
       "smm_section": "G10"
     },
     "IfcColumn": {
       "rate": 52000,
       "unit": "M",
-      "desc": "\u69cb\u9020\u7528\u92fc\u67f1",
+      "desc": "構造用鋼柱",
       "smm_section": "G10"
     },
     "IfcSlab": {
       "rate": 12800,
       "unit": "M2",
-      "desc": "RC\u5e8a\u7248 250mm",
+      "desc": "RC床版 250mm",
       "smm_section": "E10"
     },
     "IfcWall": {
       "rate": 6500,
       "unit": "M2",
-      "desc": "\u30b3\u30f3\u30af\u30ea\u30fc\u30c8\u30d6\u30ed\u30c3\u30af\u58c1 150mm",
+      "desc": "コンクリートブロック壁 150mm",
       "smm_section": "F10"
     },
     "IfcWallStandardCase": {
       "rate": 6500,
       "unit": "M2",
-      "desc": "\u6a19\u6e96\u58c1",
+      "desc": "標準壁",
       "smm_section": "F10"
     },
     "IfcCurtainWall": {
       "rate": 35000,
       "unit": "M2",
-      "desc": "\u30ab\u30fc\u30c6\u30f3\u30a6\u30a9\u30fc\u30eb",
+      "desc": "カーテンウォール",
       "smm_section": "H10"
     },
     "IfcCovering": {
       "rate": 8500,
       "unit": "M2",
-      "desc": "\u5e8a\u30fb\u5929\u4e95\u4ed5\u4e0a\u3052",
+      "desc": "床・天井仕上げ",
       "smm_section": "M10"
     },
     "IfcRoof": {
       "rate": 11500,
       "unit": "M2",
-      "desc": "\u91d1\u5c5e\u5c4b\u6839",
+      "desc": "金属屋根",
       "smm_section": "H60"
     },
     "IfcLightFixture": {
       "rate": 18500,
       "unit": "EA",
-      "desc": "LED\u7167\u660e\u5668\u5177",
+      "desc": "LED照明器具",
       "smm_section": "V40"
     },
     "IfcOutlet": {
       "rate": 5800,
       "unit": "EA",
-      "desc": "\u30b3\u30f3\u30bb\u30f3\u30c8",
+      "desc": "コンセント",
       "smm_section": "V20"
     },
     "IfcDoor": {
       "rate": 125000,
       "unit": "EA",
-      "desc": "\u5efa\u5177\u30bb\u30c3\u30c8",
+      "desc": "建具セット",
       "smm_section": "L20"
     },
     "IfcWindow": {
       "rate": 72000,
       "unit": "EA",
-      "desc": "\u7a93",
+      "desc": "窓",
       "smm_section": "L10"
     },
     "IfcBuildingElementProxy": {
       "rate": 35000,
       "unit": "EA",
-      "desc": "\u305d\u306e\u4ed6\u8981\u7d20",
+      "desc": "その他要素",
       "smm_section": "P10"
     },
     "IfcFlowTerminal": {
       "rate": 145000,
       "unit": "EA",
-      "desc": "\u7a7a\u8abf\u7aef\u672b",
+      "desc": "空調端末",
       "smm_section": "U10"
     },
     "IfcFurnishingElement": {
       "rate": 48000,
       "unit": "EA",
-      "desc": "\u5bb6\u5177",
+      "desc": "家具",
       "smm_section": "N10"
     },
     "IfcPlate": {
       "rate": 4200,
       "unit": "M2",
-      "desc": "\u92fc\u677f",
+      "desc": "鋼板",
       "smm_section": "G10"
     },
     "IfcMember": {
       "rate": 13500,
       "unit": "M",
-      "desc": "\u92fc\u90e8\u6750",
+      "desc": "鋼部材",
       "smm_section": "G10"
     },
     "IfcRailing": {
       "rate": 12800,
       "unit": "M",
-      "desc": "\u624b\u647a\u308a",
+      "desc": "手摺り",
       "smm_section": "L30"
     },
     "IfcStair": {
       "rate": 185000,
       "unit": "EA",
-      "desc": "\u968e\u6bb5",
+      "desc": "階段",
       "smm_section": "L30"
     },
     "IfcStairFlight": {
       "rate": 92000,
       "unit": "EA",
-      "desc": "\u968e\u6bb5\u30d5\u30e9\u30a4\u30c8",
+      "desc": "階段フライト",
       "smm_section": "L30"
     },
     "IfcFooting": {
       "rate": 3411.16,
       "unit": "M3",
-      "desc": "\u57fa\u790e\u30d5\u30fc\u30c1\u30f3\u30b0",
+      "desc": "基礎フーチング",
       "smm_section": "D20",
       "volFactor": 4.25074802767622
     },
     "IfcPile": {
       "rate": 38000,
       "unit": "EA",
-      "desc": "\u57fa\u790e\u676d",
+      "desc": "基礎杭",
       "smm_section": "D30"
     },
     "IfcReinforcingBar": {
       "rate": 185,
       "unit": "KG",
-      "desc": "\u9244\u7b4b",
+      "desc": "鉄筋",
       "smm_section": "E30"
     },
     "IfcFlowSegment": {
       "rate": 5200,
       "unit": "M",
-      "desc": "\u6d41\u8def\u30bb\u30b0\u30e1\u30f3\u30c8",
+      "desc": "流路セグメント",
       "smm_section": "Y10"
     },
     "IfcFlowFitting": {
       "rate": 8500,
       "unit": "EA",
-      "desc": "\u6d41\u8def\u7d99\u624b",
+      "desc": "流路継手",
       "smm_section": "Y10"
     },
     "IfcFlowController": {
       "rate": 19500,
       "unit": "EA",
-      "desc": "\u6d41\u8def\u5236\u5fa1\u6a5f\u5668",
+      "desc": "流路制御機器",
       "smm_section": "Y10"
     },
     "IfcEnergyConversionDevice": {
       "rate": 380000,
       "unit": "EA",
-      "desc": "\u30a8\u30cd\u30eb\u30ae\u30fc\u5909\u63db\u6a5f\u5668",
+      "desc": "エネルギー変換機器",
       "smm_section": "T10"
     },
     "IfcFlowTreatmentDevice": {
       "rate": 52000,
       "unit": "EA",
-      "desc": "\u6d41\u4f53\u51e6\u7406\u6a5f\u5668",
+      "desc": "流体処理機器",
       "smm_section": "Y10"
     },
     "IfcFlowMovingDevice": {
       "rate": 145000,
       "unit": "EA",
-      "desc": "\u6d41\u4f53\u642c\u9001\u6a5f\u5668",
+      "desc": "流体搬送機器",
       "smm_section": "T10"
     },
     "IfcFlowStorageDevice": {
       "rate": 215000,
       "unit": "EA",
-      "desc": "\u6d41\u4f53\u8caf\u8535\u6a5f\u5668",
+      "desc": "流体貯蔵機器",
       "smm_section": "Y10"
     },
     "IfcElectricAppliance": {
       "rate": 22000,
       "unit": "EA",
-      "desc": "\u96fb\u6c17\u6a5f\u5668",
+      "desc": "電気機器",
       "smm_section": "V20"
     },
     "IfcFurniture": {
       "rate": 62000,
       "unit": "EA",
-      "desc": "\u5bb6\u5177",
+      "desc": "家具",
       "smm_section": "N10"
     },
     "IfcOpeningElement": {
       "rate": 0,
       "unit": "EA",
-      "desc": "\u958b\u53e3\u90e8",
+      "desc": "開口部",
       "smm_section": ""
     },
     "IfcDistributionElement": {
       "rate": 18500,
       "unit": "EA",
-      "desc": "\u914d\u5206\u88c5\u7f6e",
+      "desc": "配分装置",
       "smm_section": "Y10"
     },
     "IfcFireSuppressionTerminal": {
       "rate": 16500,
       "unit": "EA",
-      "desc": "\u30b9\u30d7\u30ea\u30f3\u30af\u30e9\u30fc\u30d8\u30c3\u30c9",
+      "desc": "スプリンクラーヘッド",
       "smm_section": "S60"
     },
     "IfcAirTerminal": {
       "rate": 14000,
       "unit": "EA",
-      "desc": "\u5439\u51fa\u53e3/\u5438\u8fbc\u53e3",
+      "desc": "吹出口/吸込口",
       "smm_section": "U10"
     },
     "IfcValve": {
       "rate": 10500,
       "unit": "EA",
-      "desc": "\u30d0\u30eb\u30d6",
+      "desc": "バルブ",
       "smm_section": "S10"
     },
     "IfcAlarm": {
       "rate": 13000,
       "unit": "EA",
-      "desc": "\u706b\u707d\u5831\u77e5\u5668",
+      "desc": "火災報知器",
       "smm_section": "W50"
     },
     "IfcController": {
       "rate": 45000,
       "unit": "EA",
-      "desc": "\u30d3\u30eb\u7ba1\u7406\u30b3\u30f3\u30c8\u30ed\u30fc\u30e9",
+      "desc": "ビル管理コントローラ",
       "smm_section": "W60"
     },
     "IfcRamp": {
       "rate": 120000,
       "unit": "EA",
-      "desc": "\u30b9\u30ed\u30fc\u30d7",
+      "desc": "スロープ",
       "smm_section": "L30"
     },
     "IfcRampFlight": {
       "rate": 130000,
       "unit": "EA",
-      "desc": "\u30b9\u30ed\u30fc\u30d7\u30d5\u30e9\u30a4\u30c8",
+      "desc": "スロープフライト",
       "smm_section": "L30"
     },
     "IfcBuildingElementPart": {
       "rate": 0,
       "unit": "EA",
-      "desc": "\u5efa\u7bc9\u90e8\u54c1",
+      "desc": "建築部品",
       "smm_section": ""
     }
   },
@@ -316,7 +316,7 @@
     "HVAC_TECH": {
       "rate_per_day": 28500,
       "crew_size": 2,
-      "trade": "\u7a7a\u8abf\u6280\u80fd\u8005\uff08\u719f\u7df4\uff09",
+      "trade": "空調技能者（熟練）",
       "productivity": {
         "IfcDuct": 16,
         "IfcDuctSegment": 16,
@@ -330,7 +330,7 @@
     "PLUMBER": {
       "rate_per_day": 26000,
       "crew_size": 2,
-      "trade": "\u914d\u7ba1\u5de5\uff08\u719f\u7df4\uff09",
+      "trade": "配管工（熟練）",
       "productivity": {
         "IfcPipe": 22,
         "IfcPipeSegment": 22,
@@ -347,7 +347,7 @@
     "ELECTRICIAN": {
       "rate_per_day": 27000,
       "crew_size": 2,
-      "trade": "\u96fb\u6c17\u5de5\uff08\u719f\u7df4\uff09",
+      "trade": "電気工（熟練）",
       "productivity": {
         "IfcCableCarrier": 28,
         "IfcCableCarrierSegment": 28,
@@ -362,7 +362,7 @@
     "STEEL_ERECTOR": {
       "rate_per_day": 30000,
       "crew_size": 4,
-      "trade": "\u9244\u9aa8\u5de5\uff08\u719f\u7df4\uff09",
+      "trade": "鉄骨工（熟練）",
       "productivity": {
         "IfcBeam": 7,
         "IfcColumn": 5,
@@ -373,7 +373,7 @@
     "CONCRETE_GANG": {
       "rate_per_day": 22000,
       "crew_size": 6,
-      "trade": "\u30b3\u30f3\u30af\u30ea\u30fc\u30c8\u6253\u8a2d\u73ed",
+      "trade": "コンクリート打設班",
       "productivity": {
         "IfcSlab": 30,
         "IfcFooting": 6,
@@ -386,7 +386,7 @@
     "MASON": {
       "rate_per_day": 24000,
       "crew_size": 3,
-      "trade": "\u5de6\u5b98\u30fb\u30d6\u30ed\u30c3\u30af\u5de5\uff08\u719f\u7df4\uff09+ \u666e\u901a\u4f5c\u696d\u54e1",
+      "trade": "左官・ブロック工（熟練）+ 普通作業員",
       "productivity": {
         "IfcWall": 10,
         "IfcWallStandardCase": 10,
@@ -397,7 +397,7 @@
     "CARPENTER": {
       "rate_per_day": 26000,
       "crew_size": 2,
-      "trade": "\u578b\u67a0\u5927\u5de5\uff08\u719f\u7df4\uff09",
+      "trade": "型枠大工（熟練）",
       "productivity": {
         "IfcDoor": 6,
         "IfcWindow": 6,
@@ -410,7 +410,7 @@
     "ROOFER": {
       "rate_per_day": 27000,
       "crew_size": 3,
-      "trade": "\u5c4b\u6839\u5de5\uff08\u719f\u7df4\uff09",
+      "trade": "屋根工（熟練）",
       "productivity": {
         "IfcRoof": 25
       }
@@ -418,7 +418,7 @@
     "FINISHER": {
       "rate_per_day": 22000,
       "crew_size": 2,
-      "trade": "\u5185\u88c5\u5de5\uff08\u719f\u7df4\uff09",
+      "trade": "内装工（熟練）",
       "productivity": {
         "IfcCovering": 20,
         "IfcFurniture": 8,
@@ -428,34 +428,34 @@
     "LABORER": {
       "rate_per_day": 17000,
       "crew_size": 1,
-      "trade": "\u666e\u901a\u4f5c\u696d\u54e1",
+      "trade": "普通作業員",
       "productivity": {}
     }
   },
   "equipment": {
     "MOBILE_CRANE_20T": {
       "rate_per_day": 85000,
-      "desc": "\u79fb\u52d5\u5f0f\u30af\u30ec\u30fc\u30f3 20\u30c8\u30f3"
+      "desc": "移動式クレーン 20トン"
     },
     "TOWER_CRANE": {
       "rate_per_day": 120000,
-      "desc": "\u30bf\u30ef\u30fc\u30af\u30ec\u30fc\u30f3"
+      "desc": "タワークレーン"
     },
     "CONCRETE_PUMP": {
       "rate_per_day": 65000,
-      "desc": "\u30b3\u30f3\u30af\u30ea\u30fc\u30c8\u30dd\u30f3\u30d7\u8eca"
+      "desc": "コンクリートポンプ車"
     },
     "SCISSOR_LIFT_8M": {
       "rate_per_day": 15000,
-      "desc": "\u30b7\u30b6\u30fc\u30b9\u30ea\u30d5\u30c8 8m"
+      "desc": "シザースリフト 8m"
     },
     "WELDING_MACHINE": {
       "rate_per_day": 4500,
-      "desc": "\u6eb6\u63a5\u6a5f 300A"
+      "desc": "溶接機 300A"
     },
     "GENERATOR_5KVA": {
       "rate_per_day": 6500,
-      "desc": "\u767a\u96fb\u6a5f 5KVA"
+      "desc": "発電機 5KVA"
     }
   },
   "equipment_allocation": {
@@ -730,7 +730,7 @@
   "work_packages": [
     {
       "id": "PACKAGE 1",
-      "name": "\u57fa\u790e\u5de5\u4e8b",
+      "name": "基礎工事",
       "color": "8E44AD",
       "classes": [
         "IfcFooting",
@@ -740,7 +740,7 @@
     },
     {
       "id": "PACKAGE 2",
-      "name": "\u8eaf\u4f53\u5de5\u4e8b",
+      "name": "躯体工事",
       "color": "2980B9",
       "classes": [
         "IfcColumn",
@@ -752,7 +752,7 @@
     },
     {
       "id": "PACKAGE 3",
-      "name": "\u8a2d\u5099\u7c97\u5de5\u4e8b",
+      "name": "設備粗工事",
       "color": "D35400",
       "classes": [
         "IfcDuct",
@@ -776,7 +776,7 @@
     },
     {
       "id": "PACKAGE 4",
-      "name": "\u5efa\u7bc9\u5de5\u4e8b",
+      "name": "建築工事",
       "color": "ED7D31",
       "classes": [
         "IfcWall",
@@ -794,7 +794,7 @@
     },
     {
       "id": "PACKAGE 5",
-      "name": "\u4ed5\u4e0a\u5de5\u4e8b",
+      "name": "仕上工事",
       "color": "27AE60",
       "classes": [
         "IfcCovering",
@@ -804,7 +804,7 @@
     },
     {
       "id": "PACKAGE 6",
-      "name": "\u8a2d\u5099\u4ed5\u4e0a\u5de5\u4e8b",
+      "name": "設備仕上工事",
       "color": "C0392B",
       "classes": [
         "IfcFlowTerminal",
@@ -819,28 +819,28 @@
     }
   ],
   "smm_sections": {
-    "A": "\u4eee\u8a2d\u5de5\u4e8b",
-    "C": "\u65e2\u5b58\u5efa\u7269",
-    "D": "\u5730\u696d\u5de5\u4e8b",
-    "E": "\u30b3\u30f3\u30af\u30ea\u30fc\u30c8\u5de5\u4e8b",
-    "F": "\u7d44\u7a4d\u5de5\u4e8b",
-    "G": "\u9244\u9aa8\u5de5\u4e8b",
-    "H": "\u5c4b\u6839\u30fb\u5916\u58c1\u5de5\u4e8b",
-    "J": "\u9632\u6c34\u5de5\u4e8b",
-    "K": "\u5185\u88c5\u4e0b\u5730\u5de5\u4e8b",
-    "L": "\u5efa\u5177\u30fb\u968e\u6bb5\u5de5\u4e8b",
-    "M": "\u4ed5\u4e0a\u5de5\u4e8b",
-    "N": "\u5bb6\u5177\u30fb\u4ec0\u5668",
-    "P": "\u96d1\u5de5\u4e8b",
-    "Q": "\u5916\u69cb\u5de5\u4e8b",
-    "R": "\u6392\u6c34\u8a2d\u5099",
-    "S": "\u7d66\u6392\u6c34\u885b\u751f\u8a2d\u5099",
-    "T": "\u7a7a\u6c17\u8abf\u548c\u8a2d\u5099",
-    "U": "\u63db\u6c17\u8a2d\u5099",
-    "V": "\u96fb\u6c17\u8a2d\u5099",
-    "W": "\u9632\u707d\u30fb\u901a\u4fe1\u8a2d\u5099",
-    "X": "\u6607\u964d\u6a5f\u8a2d\u5099",
-    "Y": "\u8a2d\u5099\u5de5\u4e8b\uff08\u7dcf\u5408\uff09"
+    "A": "仮設工事",
+    "C": "既存建物",
+    "D": "地業工事",
+    "E": "コンクリート工事",
+    "F": "組積工事",
+    "G": "鉄骨工事",
+    "H": "屋根・外壁工事",
+    "J": "防水工事",
+    "K": "内装下地工事",
+    "L": "建具・階段工事",
+    "M": "仕上工事",
+    "N": "家具・什器",
+    "P": "雑工事",
+    "Q": "外構工事",
+    "R": "排水設備",
+    "S": "給排水衛生設備",
+    "T": "空気調和設備",
+    "U": "換気設備",
+    "V": "電気設備",
+    "W": "防災・通信設備",
+    "X": "昇降機設備",
+    "Y": "設備工事（総合）"
   },
   "provisions": {
     "preliminaries_pct": 10,

--- a/viewer/rates/kict2024_kr.json
+++ b/viewer/rates/kict2024_kr.json
@@ -13,301 +13,302 @@
     "IfcDuct": {
       "rate": 52000,
       "unit": "M",
-      "desc": "아연도금 강판 덕트 (평균 400mm)",
+      "desc": "\uc544\uc5f0\ub3c4\uae08 \uac15\ud310 \ub355\ud2b8 (\ud3c9\uade0 400mm)",
       "smm_section": "U10"
     },
     "IfcDuctSegment": {
       "rate": 52000,
       "unit": "M",
-      "desc": "덕트 세그먼트",
+      "desc": "\ub355\ud2b8 \uc138\uadf8\uba3c\ud2b8",
       "smm_section": "U10"
     },
     "IfcDuctFitting": {
       "rate": 115000,
       "unit": "EA",
-      "desc": "덕트 피팅 (엘보, 티)",
+      "desc": "\ub355\ud2b8 \ud53c\ud305 (\uc5d8\ubcf4, \ud2f0)",
       "smm_section": "U10"
     },
     "IfcPipe": {
       "rate": 15500,
       "unit": "M",
-      "desc": "PVC/HDPE 배관 (평균 100mm)",
+      "desc": "PVC/HDPE \ubc30\uad00 (\ud3c9\uade0 100mm)",
       "smm_section": "S10"
     },
     "IfcPipeSegment": {
       "rate": 15500,
       "unit": "M",
-      "desc": "배관 세그먼트",
+      "desc": "\ubc30\uad00 \uc138\uadf8\uba3c\ud2b8",
       "smm_section": "S10"
     },
     "IfcPipeFitting": {
       "rate": 32000,
       "unit": "EA",
-      "desc": "배관 피팅",
+      "desc": "\ubc30\uad00 \ud53c\ud305",
       "smm_section": "S10"
     },
     "IfcCableCarrier": {
       "rate": 26500,
       "unit": "M",
-      "desc": "케이블 트레이 (300mm)",
+      "desc": "\ucf00\uc774\ube14 \ud2b8\ub808\uc774 (300mm)",
       "smm_section": "V20"
     },
     "IfcCableCarrierSegment": {
       "rate": 26500,
       "unit": "M",
-      "desc": "케이블 트레이 세그먼트",
+      "desc": "\ucf00\uc774\ube14 \ud2b8\ub808\uc774 \uc138\uadf8\uba3c\ud2b8",
       "smm_section": "V20"
     },
     "IfcBeam": {
       "rate": 215000,
       "unit": "M",
-      "desc": "구조용 강재 보",
+      "desc": "\uad6c\uc870\uc6a9 \uac15\uc7ac \ubcf4",
       "smm_section": "G10"
     },
     "IfcColumn": {
       "rate": 395000,
       "unit": "M",
-      "desc": "구조용 강재 기둥",
+      "desc": "\uad6c\uc870\uc6a9 \uac15\uc7ac \uae30\ub465",
       "smm_section": "G10"
     },
     "IfcSlab": {
       "rate": 92000,
       "unit": "M2",
-      "desc": "철근콘크리트 슬래브 250mm",
+      "desc": "\ucca0\uadfc\ucf58\ud06c\ub9ac\ud2b8 \uc2ac\ub798\ube0c 250mm",
       "smm_section": "E10"
     },
     "IfcWall": {
       "rate": 48000,
       "unit": "M2",
-      "desc": "조적벽 150mm",
+      "desc": "\uc870\uc801\ubcbd 150mm",
       "smm_section": "F10"
     },
     "IfcWallStandardCase": {
       "rate": 48000,
       "unit": "M2",
-      "desc": "표준 벽체",
+      "desc": "\ud45c\uc900 \ubcbd\uccb4",
       "smm_section": "F10"
     },
     "IfcCurtainWall": {
       "rate": 250000,
       "unit": "M2",
-      "desc": "커튼월",
+      "desc": "\ucee4\ud2bc\uc6d4",
       "smm_section": "H10"
     },
     "IfcCovering": {
       "rate": 62000,
       "unit": "M2",
-      "desc": "바닥/천장 마감재",
+      "desc": "\ubc14\ub2e5/\ucc9c\uc7a5 \ub9c8\uac10\uc7ac",
       "smm_section": "M10"
     },
     "IfcRoof": {
       "rate": 78000,
       "unit": "M2",
-      "desc": "금속 지붕재",
+      "desc": "\uae08\uc18d \uc9c0\ubd95\uc7ac",
       "smm_section": "H60"
     },
     "IfcLightFixture": {
       "rate": 155000,
       "unit": "EA",
-      "desc": "LED 조명기구",
+      "desc": "LED \uc870\uba85\uae30\uad6c",
       "smm_section": "V40"
     },
     "IfcOutlet": {
       "rate": 42000,
       "unit": "EA",
-      "desc": "전기 콘센트",
+      "desc": "\uc804\uae30 \ucf58\uc13c\ud2b8",
       "smm_section": "V20"
     },
     "IfcDoor": {
       "rate": 920000,
       "unit": "EA",
-      "desc": "도어 세트",
+      "desc": "\ub3c4\uc5b4 \uc138\ud2b8",
       "smm_section": "L20"
     },
     "IfcWindow": {
       "rate": 520000,
       "unit": "EA",
-      "desc": "창호",
+      "desc": "\ucc3d\ud638",
       "smm_section": "L10"
     },
     "IfcBuildingElementProxy": {
       "rate": 280000,
       "unit": "EA",
-      "desc": "기타 건축요소",
+      "desc": "\uae30\ud0c0 \uac74\ucd95\uc694\uc18c",
       "smm_section": "P10"
     },
     "IfcFlowTerminal": {
       "rate": 1150000,
       "unit": "EA",
-      "desc": "공조 터미널",
+      "desc": "\uacf5\uc870 \ud130\ubbf8\ub110",
       "smm_section": "U10"
     },
     "IfcFurnishingElement": {
       "rate": 385000,
       "unit": "EA",
-      "desc": "가구류",
+      "desc": "\uac00\uad6c\ub958",
       "smm_section": "N10"
     },
     "IfcPlate": {
       "rate": 32000,
       "unit": "M2",
-      "desc": "강판",
+      "desc": "\uac15\ud310",
       "smm_section": "G10"
     },
     "IfcMember": {
       "rate": 105000,
       "unit": "M",
-      "desc": "철골 부재",
+      "desc": "\ucca0\uace8 \ubd80\uc7ac",
       "smm_section": "G10"
     },
     "IfcRailing": {
       "rate": 95000,
       "unit": "M",
-      "desc": "난간",
+      "desc": "\ub09c\uac04",
       "smm_section": "L30"
     },
     "IfcStair": {
       "rate": 1450000,
       "unit": "EA",
-      "desc": "계단",
+      "desc": "\uacc4\ub2e8",
       "smm_section": "L30"
     },
     "IfcStairFlight": {
       "rate": 720000,
       "unit": "EA",
-      "desc": "계단 플라이트",
+      "desc": "\uacc4\ub2e8 \ud50c\ub77c\uc774\ud2b8",
       "smm_section": "L30"
     },
     "IfcFooting": {
       "rate": 24701.53,
       "unit": "M3",
-      "desc": "기초 푸팅",
-      "smm_section": "D20"
+      "desc": "\uae30\ucd08 \ud478\ud305",
+      "smm_section": "D20",
+      "volFactor": 4.25074802767622
     },
     "IfcPile": {
       "rate": 285000,
       "unit": "EA",
-      "desc": "기초 말뚝",
+      "desc": "\uae30\ucd08 \ub9d0\ub69d",
       "smm_section": "D30"
     },
     "IfcReinforcingBar": {
       "rate": 1450,
       "unit": "KG",
-      "desc": "철근",
+      "desc": "\ucca0\uadfc",
       "smm_section": "E30"
     },
     "IfcFlowSegment": {
       "rate": 42000,
       "unit": "M",
-      "desc": "유체 세그먼트",
+      "desc": "\uc720\uccb4 \uc138\uadf8\uba3c\ud2b8",
       "smm_section": "Y10"
     },
     "IfcFlowFitting": {
       "rate": 68000,
       "unit": "EA",
-      "desc": "유체 피팅",
+      "desc": "\uc720\uccb4 \ud53c\ud305",
       "smm_section": "Y10"
     },
     "IfcFlowController": {
       "rate": 152000,
       "unit": "EA",
-      "desc": "유량 제어기",
+      "desc": "\uc720\ub7c9 \uc81c\uc5b4\uae30",
       "smm_section": "Y10"
     },
     "IfcEnergyConversionDevice": {
       "rate": 2850000,
       "unit": "EA",
-      "desc": "에너지 변환장치",
+      "desc": "\uc5d0\ub108\uc9c0 \ubcc0\ud658\uc7a5\uce58",
       "smm_section": "T10"
     },
     "IfcFlowTreatmentDevice": {
       "rate": 395000,
       "unit": "EA",
-      "desc": "유체 처리장치",
+      "desc": "\uc720\uccb4 \ucc98\ub9ac\uc7a5\uce58",
       "smm_section": "Y10"
     },
     "IfcFlowMovingDevice": {
       "rate": 1150000,
       "unit": "EA",
-      "desc": "유체 이송장치",
+      "desc": "\uc720\uccb4 \uc774\uc1a1\uc7a5\uce58",
       "smm_section": "T10"
     },
     "IfcFlowStorageDevice": {
       "rate": 1650000,
       "unit": "EA",
-      "desc": "유체 저장장치",
+      "desc": "\uc720\uccb4 \uc800\uc7a5\uc7a5\uce58",
       "smm_section": "Y10"
     },
     "IfcElectricAppliance": {
       "rate": 165000,
       "unit": "EA",
-      "desc": "전기 기기",
+      "desc": "\uc804\uae30 \uae30\uae30",
       "smm_section": "V20"
     },
     "IfcFurniture": {
       "rate": 495000,
       "unit": "EA",
-      "desc": "가구",
+      "desc": "\uac00\uad6c",
       "smm_section": "N10"
     },
     "IfcOpeningElement": {
       "rate": 0,
       "unit": "EA",
-      "desc": "개구부 (보이드)",
+      "desc": "\uac1c\uad6c\ubd80 (\ubcf4\uc774\ub4dc)",
       "smm_section": ""
     },
     "IfcDistributionElement": {
       "rate": 165000,
       "unit": "EA",
-      "desc": "분배 요소",
+      "desc": "\ubd84\ubc30 \uc694\uc18c",
       "smm_section": "Y10"
     },
     "IfcFireSuppressionTerminal": {
       "rate": 148000,
       "unit": "EA",
-      "desc": "스프링클러 헤드",
+      "desc": "\uc2a4\ud504\ub9c1\ud074\ub7ec \ud5e4\ub4dc",
       "smm_section": "S60"
     },
     "IfcAirTerminal": {
       "rate": 125000,
       "unit": "EA",
-      "desc": "디퓨저/그릴",
+      "desc": "\ub514\ud4e8\uc800/\uadf8\ub9b4",
       "smm_section": "U10"
     },
     "IfcValve": {
       "rate": 92000,
       "unit": "EA",
-      "desc": "밸브",
+      "desc": "\ubc38\ube0c",
       "smm_section": "S10"
     },
     "IfcAlarm": {
       "rate": 115000,
       "unit": "EA",
-      "desc": "화재 경보장치",
+      "desc": "\ud654\uc7ac \uacbd\ubcf4\uc7a5\uce58",
       "smm_section": "W50"
     },
     "IfcController": {
       "rate": 395000,
       "unit": "EA",
-      "desc": "빌딩 제어기",
+      "desc": "\ube4c\ub529 \uc81c\uc5b4\uae30",
       "smm_section": "W60"
     },
     "IfcRamp": {
       "rate": 1050000,
       "unit": "EA",
-      "desc": "경사로",
+      "desc": "\uacbd\uc0ac\ub85c",
       "smm_section": "L30"
     },
     "IfcRampFlight": {
       "rate": 1150000,
       "unit": "EA",
-      "desc": "경사로 플라이트",
+      "desc": "\uacbd\uc0ac\ub85c \ud50c\ub77c\uc774\ud2b8",
       "smm_section": "L30"
     },
     "IfcBuildingElementPart": {
       "rate": 0,
       "unit": "EA",
-      "desc": "건축요소 부품",
+      "desc": "\uac74\ucd95\uc694\uc18c \ubd80\ud488",
       "smm_section": ""
     }
   },
@@ -315,7 +316,7 @@
     "HVAC_TECH": {
       "rate_per_day": 245000,
       "crew_size": 2,
-      "trade": "공조기술자 (숙련공)",
+      "trade": "\uacf5\uc870\uae30\uc220\uc790 (\uc219\ub828\uacf5)",
       "productivity": {
         "IfcDuct": 18,
         "IfcDuctSegment": 18,
@@ -329,7 +330,7 @@
     "PLUMBER": {
       "rate_per_day": 225000,
       "crew_size": 2,
-      "trade": "배관공 (숙련공)",
+      "trade": "\ubc30\uad00\uacf5 (\uc219\ub828\uacf5)",
       "productivity": {
         "IfcPipe": 25,
         "IfcPipeSegment": 25,
@@ -346,7 +347,7 @@
     "ELECTRICIAN": {
       "rate_per_day": 235000,
       "crew_size": 2,
-      "trade": "전기기사 (숙련공)",
+      "trade": "\uc804\uae30\uae30\uc0ac (\uc219\ub828\uacf5)",
       "productivity": {
         "IfcCableCarrier": 30,
         "IfcCableCarrierSegment": 30,
@@ -361,7 +362,7 @@
     "STEEL_ERECTOR": {
       "rate_per_day": 265000,
       "crew_size": 4,
-      "trade": "철골공 (숙련공)",
+      "trade": "\ucca0\uace8\uacf5 (\uc219\ub828\uacf5)",
       "productivity": {
         "IfcBeam": 8,
         "IfcColumn": 6,
@@ -372,7 +373,7 @@
     "CONCRETE_GANG": {
       "rate_per_day": 195000,
       "crew_size": 6,
-      "trade": "콘크리트 팀 (혼성)",
+      "trade": "\ucf58\ud06c\ub9ac\ud2b8 \ud300 (\ud63c\uc131)",
       "productivity": {
         "IfcSlab": 35,
         "IfcFooting": 6,
@@ -385,7 +386,7 @@
     "MASON": {
       "rate_per_day": 210000,
       "crew_size": 3,
-      "trade": "미장공 (숙련공) + 보조",
+      "trade": "\ubbf8\uc7a5\uacf5 (\uc219\ub828\uacf5) + \ubcf4\uc870",
       "productivity": {
         "IfcWall": 12,
         "IfcWallStandardCase": 12,
@@ -396,7 +397,7 @@
     "CARPENTER": {
       "rate_per_day": 220000,
       "crew_size": 2,
-      "trade": "목수 (숙련공)",
+      "trade": "\ubaa9\uc218 (\uc219\ub828\uacf5)",
       "productivity": {
         "IfcDoor": 6,
         "IfcWindow": 6,
@@ -409,7 +410,7 @@
     "ROOFER": {
       "rate_per_day": 235000,
       "crew_size": 3,
-      "trade": "지붕공 (숙련공)",
+      "trade": "\uc9c0\ubd95\uacf5 (\uc219\ub828\uacf5)",
       "productivity": {
         "IfcRoof": 25
       }
@@ -417,7 +418,7 @@
     "FINISHER": {
       "rate_per_day": 185000,
       "crew_size": 2,
-      "trade": "마감공 (숙련공)",
+      "trade": "\ub9c8\uac10\uacf5 (\uc219\ub828\uacf5)",
       "productivity": {
         "IfcCovering": 20,
         "IfcFurniture": 8,
@@ -427,34 +428,34 @@
     "LABORER": {
       "rate_per_day": 145000,
       "crew_size": 1,
-      "trade": "보통인부",
+      "trade": "\ubcf4\ud1b5\uc778\ubd80",
       "productivity": {}
     }
   },
   "equipment": {
     "MOBILE_CRANE_20T": {
       "rate_per_day": 650000,
-      "desc": "이동식 크레인 20톤"
+      "desc": "\uc774\ub3d9\uc2dd \ud06c\ub808\uc778 20\ud1a4"
     },
     "TOWER_CRANE": {
       "rate_per_day": 920000,
-      "desc": "타워 크레인"
+      "desc": "\ud0c0\uc6cc \ud06c\ub808\uc778"
     },
     "CONCRETE_PUMP": {
       "rate_per_day": 480000,
-      "desc": "콘크리트 펌프카"
+      "desc": "\ucf58\ud06c\ub9ac\ud2b8 \ud38c\ud504\uce74"
     },
     "SCISSOR_LIFT_8M": {
       "rate_per_day": 120000,
-      "desc": "시저 리프트 8m"
+      "desc": "\uc2dc\uc800 \ub9ac\ud504\ud2b8 8m"
     },
     "WELDING_MACHINE": {
       "rate_per_day": 35000,
-      "desc": "용접기 300A"
+      "desc": "\uc6a9\uc811\uae30 300A"
     },
     "GENERATOR_5KVA": {
       "rate_per_day": 48000,
-      "desc": "발전기 5KVA"
+      "desc": "\ubc1c\uc804\uae30 5KVA"
     }
   },
   "equipment_allocation": {
@@ -818,28 +819,28 @@
     }
   ],
   "smm_sections": {
-    "A": "예비비",
-    "C": "기존 부지 / 건물",
-    "D": "토공사",
-    "E": "현장타설 콘크리트 / 대형 프리캐스트",
-    "F": "조적공사",
-    "G": "구조용 금속 / 골조",
-    "H": "외장재 / 덮개",
-    "J": "방수공사",
-    "K": "내장재 / 건식 파티션",
-    "L": "창호 / 문 / 계단",
-    "M": "표면 마감재",
-    "N": "가구 / 장비",
-    "P": "건축 잡자재",
-    "Q": "포장 / 조경 / 펜스",
-    "R": "배수 시스템",
-    "S": "배관 급수 시스템",
-    "T": "기계 냉난방",
-    "U": "환기 / 공조",
-    "V": "전기 공급 / 전력 / 조명",
-    "W": "통신 / 보안 / 제어",
-    "X": "운송 시스템",
-    "Y": "기계 / 전기 설비 (일반)"
+    "A": "\uc608\ube44\ube44",
+    "C": "\uae30\uc874 \ubd80\uc9c0 / \uac74\ubb3c",
+    "D": "\ud1a0\uacf5\uc0ac",
+    "E": "\ud604\uc7a5\ud0c0\uc124 \ucf58\ud06c\ub9ac\ud2b8 / \ub300\ud615 \ud504\ub9ac\uce90\uc2a4\ud2b8",
+    "F": "\uc870\uc801\uacf5\uc0ac",
+    "G": "\uad6c\uc870\uc6a9 \uae08\uc18d / \uace8\uc870",
+    "H": "\uc678\uc7a5\uc7ac / \ub36e\uac1c",
+    "J": "\ubc29\uc218\uacf5\uc0ac",
+    "K": "\ub0b4\uc7a5\uc7ac / \uac74\uc2dd \ud30c\ud2f0\uc158",
+    "L": "\ucc3d\ud638 / \ubb38 / \uacc4\ub2e8",
+    "M": "\ud45c\uba74 \ub9c8\uac10\uc7ac",
+    "N": "\uac00\uad6c / \uc7a5\ube44",
+    "P": "\uac74\ucd95 \uc7a1\uc790\uc7ac",
+    "Q": "\ud3ec\uc7a5 / \uc870\uacbd / \ud39c\uc2a4",
+    "R": "\ubc30\uc218 \uc2dc\uc2a4\ud15c",
+    "S": "\ubc30\uad00 \uae09\uc218 \uc2dc\uc2a4\ud15c",
+    "T": "\uae30\uacc4 \ub0c9\ub09c\ubc29",
+    "U": "\ud658\uae30 / \uacf5\uc870",
+    "V": "\uc804\uae30 \uacf5\uae09 / \uc804\ub825 / \uc870\uba85",
+    "W": "\ud1b5\uc2e0 / \ubcf4\uc548 / \uc81c\uc5b4",
+    "X": "\uc6b4\uc1a1 \uc2dc\uc2a4\ud15c",
+    "Y": "\uae30\uacc4 / \uc804\uae30 \uc124\ube44 (\uc77c\ubc18)"
   },
   "provisions": {
     "preliminaries_pct": 10,

--- a/viewer/rates/kict2024_kr.json
+++ b/viewer/rates/kict2024_kr.json
@@ -179,8 +179,8 @@
       "smm_section": "L30"
     },
     "IfcFooting": {
-      "rate": 105000,
-      "unit": "EA",
+      "rate": 24701.53,
+      "unit": "M3",
       "desc": "기초 푸팅",
       "smm_section": "D20"
     },

--- a/viewer/rates/kict2024_kr.json
+++ b/viewer/rates/kict2024_kr.json
@@ -13,302 +13,302 @@
     "IfcDuct": {
       "rate": 52000,
       "unit": "M",
-      "desc": "\uc544\uc5f0\ub3c4\uae08 \uac15\ud310 \ub355\ud2b8 (\ud3c9\uade0 400mm)",
+      "desc": "아연도금 강판 덕트 (평균 400mm)",
       "smm_section": "U10"
     },
     "IfcDuctSegment": {
       "rate": 52000,
       "unit": "M",
-      "desc": "\ub355\ud2b8 \uc138\uadf8\uba3c\ud2b8",
+      "desc": "덕트 세그먼트",
       "smm_section": "U10"
     },
     "IfcDuctFitting": {
       "rate": 115000,
       "unit": "EA",
-      "desc": "\ub355\ud2b8 \ud53c\ud305 (\uc5d8\ubcf4, \ud2f0)",
+      "desc": "덕트 피팅 (엘보, 티)",
       "smm_section": "U10"
     },
     "IfcPipe": {
       "rate": 15500,
       "unit": "M",
-      "desc": "PVC/HDPE \ubc30\uad00 (\ud3c9\uade0 100mm)",
+      "desc": "PVC/HDPE 배관 (평균 100mm)",
       "smm_section": "S10"
     },
     "IfcPipeSegment": {
       "rate": 15500,
       "unit": "M",
-      "desc": "\ubc30\uad00 \uc138\uadf8\uba3c\ud2b8",
+      "desc": "배관 세그먼트",
       "smm_section": "S10"
     },
     "IfcPipeFitting": {
       "rate": 32000,
       "unit": "EA",
-      "desc": "\ubc30\uad00 \ud53c\ud305",
+      "desc": "배관 피팅",
       "smm_section": "S10"
     },
     "IfcCableCarrier": {
       "rate": 26500,
       "unit": "M",
-      "desc": "\ucf00\uc774\ube14 \ud2b8\ub808\uc774 (300mm)",
+      "desc": "케이블 트레이 (300mm)",
       "smm_section": "V20"
     },
     "IfcCableCarrierSegment": {
       "rate": 26500,
       "unit": "M",
-      "desc": "\ucf00\uc774\ube14 \ud2b8\ub808\uc774 \uc138\uadf8\uba3c\ud2b8",
+      "desc": "케이블 트레이 세그먼트",
       "smm_section": "V20"
     },
     "IfcBeam": {
       "rate": 215000,
       "unit": "M",
-      "desc": "\uad6c\uc870\uc6a9 \uac15\uc7ac \ubcf4",
+      "desc": "구조용 강재 보",
       "smm_section": "G10"
     },
     "IfcColumn": {
       "rate": 395000,
       "unit": "M",
-      "desc": "\uad6c\uc870\uc6a9 \uac15\uc7ac \uae30\ub465",
+      "desc": "구조용 강재 기둥",
       "smm_section": "G10"
     },
     "IfcSlab": {
       "rate": 92000,
       "unit": "M2",
-      "desc": "\ucca0\uadfc\ucf58\ud06c\ub9ac\ud2b8 \uc2ac\ub798\ube0c 250mm",
+      "desc": "철근콘크리트 슬래브 250mm",
       "smm_section": "E10"
     },
     "IfcWall": {
       "rate": 48000,
       "unit": "M2",
-      "desc": "\uc870\uc801\ubcbd 150mm",
+      "desc": "조적벽 150mm",
       "smm_section": "F10"
     },
     "IfcWallStandardCase": {
       "rate": 48000,
       "unit": "M2",
-      "desc": "\ud45c\uc900 \ubcbd\uccb4",
+      "desc": "표준 벽체",
       "smm_section": "F10"
     },
     "IfcCurtainWall": {
       "rate": 250000,
       "unit": "M2",
-      "desc": "\ucee4\ud2bc\uc6d4",
+      "desc": "커튼월",
       "smm_section": "H10"
     },
     "IfcCovering": {
       "rate": 62000,
       "unit": "M2",
-      "desc": "\ubc14\ub2e5/\ucc9c\uc7a5 \ub9c8\uac10\uc7ac",
+      "desc": "바닥/천장 마감재",
       "smm_section": "M10"
     },
     "IfcRoof": {
       "rate": 78000,
       "unit": "M2",
-      "desc": "\uae08\uc18d \uc9c0\ubd95\uc7ac",
+      "desc": "금속 지붕재",
       "smm_section": "H60"
     },
     "IfcLightFixture": {
       "rate": 155000,
       "unit": "EA",
-      "desc": "LED \uc870\uba85\uae30\uad6c",
+      "desc": "LED 조명기구",
       "smm_section": "V40"
     },
     "IfcOutlet": {
       "rate": 42000,
       "unit": "EA",
-      "desc": "\uc804\uae30 \ucf58\uc13c\ud2b8",
+      "desc": "전기 콘센트",
       "smm_section": "V20"
     },
     "IfcDoor": {
       "rate": 920000,
       "unit": "EA",
-      "desc": "\ub3c4\uc5b4 \uc138\ud2b8",
+      "desc": "도어 세트",
       "smm_section": "L20"
     },
     "IfcWindow": {
       "rate": 520000,
       "unit": "EA",
-      "desc": "\ucc3d\ud638",
+      "desc": "창호",
       "smm_section": "L10"
     },
     "IfcBuildingElementProxy": {
       "rate": 280000,
       "unit": "EA",
-      "desc": "\uae30\ud0c0 \uac74\ucd95\uc694\uc18c",
+      "desc": "기타 건축요소",
       "smm_section": "P10"
     },
     "IfcFlowTerminal": {
       "rate": 1150000,
       "unit": "EA",
-      "desc": "\uacf5\uc870 \ud130\ubbf8\ub110",
+      "desc": "공조 터미널",
       "smm_section": "U10"
     },
     "IfcFurnishingElement": {
       "rate": 385000,
       "unit": "EA",
-      "desc": "\uac00\uad6c\ub958",
+      "desc": "가구류",
       "smm_section": "N10"
     },
     "IfcPlate": {
       "rate": 32000,
       "unit": "M2",
-      "desc": "\uac15\ud310",
+      "desc": "강판",
       "smm_section": "G10"
     },
     "IfcMember": {
       "rate": 105000,
       "unit": "M",
-      "desc": "\ucca0\uace8 \ubd80\uc7ac",
+      "desc": "철골 부재",
       "smm_section": "G10"
     },
     "IfcRailing": {
       "rate": 95000,
       "unit": "M",
-      "desc": "\ub09c\uac04",
+      "desc": "난간",
       "smm_section": "L30"
     },
     "IfcStair": {
       "rate": 1450000,
       "unit": "EA",
-      "desc": "\uacc4\ub2e8",
+      "desc": "계단",
       "smm_section": "L30"
     },
     "IfcStairFlight": {
       "rate": 720000,
       "unit": "EA",
-      "desc": "\uacc4\ub2e8 \ud50c\ub77c\uc774\ud2b8",
+      "desc": "계단 플라이트",
       "smm_section": "L30"
     },
     "IfcFooting": {
       "rate": 24701.53,
       "unit": "M3",
-      "desc": "\uae30\ucd08 \ud478\ud305",
+      "desc": "기초 푸팅",
       "smm_section": "D20",
       "volFactor": 4.25074802767622
     },
     "IfcPile": {
       "rate": 285000,
       "unit": "EA",
-      "desc": "\uae30\ucd08 \ub9d0\ub69d",
+      "desc": "기초 말뚝",
       "smm_section": "D30"
     },
     "IfcReinforcingBar": {
       "rate": 1450,
       "unit": "KG",
-      "desc": "\ucca0\uadfc",
+      "desc": "철근",
       "smm_section": "E30"
     },
     "IfcFlowSegment": {
       "rate": 42000,
       "unit": "M",
-      "desc": "\uc720\uccb4 \uc138\uadf8\uba3c\ud2b8",
+      "desc": "유체 세그먼트",
       "smm_section": "Y10"
     },
     "IfcFlowFitting": {
       "rate": 68000,
       "unit": "EA",
-      "desc": "\uc720\uccb4 \ud53c\ud305",
+      "desc": "유체 피팅",
       "smm_section": "Y10"
     },
     "IfcFlowController": {
       "rate": 152000,
       "unit": "EA",
-      "desc": "\uc720\ub7c9 \uc81c\uc5b4\uae30",
+      "desc": "유량 제어기",
       "smm_section": "Y10"
     },
     "IfcEnergyConversionDevice": {
       "rate": 2850000,
       "unit": "EA",
-      "desc": "\uc5d0\ub108\uc9c0 \ubcc0\ud658\uc7a5\uce58",
+      "desc": "에너지 변환장치",
       "smm_section": "T10"
     },
     "IfcFlowTreatmentDevice": {
       "rate": 395000,
       "unit": "EA",
-      "desc": "\uc720\uccb4 \ucc98\ub9ac\uc7a5\uce58",
+      "desc": "유체 처리장치",
       "smm_section": "Y10"
     },
     "IfcFlowMovingDevice": {
       "rate": 1150000,
       "unit": "EA",
-      "desc": "\uc720\uccb4 \uc774\uc1a1\uc7a5\uce58",
+      "desc": "유체 이송장치",
       "smm_section": "T10"
     },
     "IfcFlowStorageDevice": {
       "rate": 1650000,
       "unit": "EA",
-      "desc": "\uc720\uccb4 \uc800\uc7a5\uc7a5\uce58",
+      "desc": "유체 저장장치",
       "smm_section": "Y10"
     },
     "IfcElectricAppliance": {
       "rate": 165000,
       "unit": "EA",
-      "desc": "\uc804\uae30 \uae30\uae30",
+      "desc": "전기 기기",
       "smm_section": "V20"
     },
     "IfcFurniture": {
       "rate": 495000,
       "unit": "EA",
-      "desc": "\uac00\uad6c",
+      "desc": "가구",
       "smm_section": "N10"
     },
     "IfcOpeningElement": {
       "rate": 0,
       "unit": "EA",
-      "desc": "\uac1c\uad6c\ubd80 (\ubcf4\uc774\ub4dc)",
+      "desc": "개구부 (보이드)",
       "smm_section": ""
     },
     "IfcDistributionElement": {
       "rate": 165000,
       "unit": "EA",
-      "desc": "\ubd84\ubc30 \uc694\uc18c",
+      "desc": "분배 요소",
       "smm_section": "Y10"
     },
     "IfcFireSuppressionTerminal": {
       "rate": 148000,
       "unit": "EA",
-      "desc": "\uc2a4\ud504\ub9c1\ud074\ub7ec \ud5e4\ub4dc",
+      "desc": "스프링클러 헤드",
       "smm_section": "S60"
     },
     "IfcAirTerminal": {
       "rate": 125000,
       "unit": "EA",
-      "desc": "\ub514\ud4e8\uc800/\uadf8\ub9b4",
+      "desc": "디퓨저/그릴",
       "smm_section": "U10"
     },
     "IfcValve": {
       "rate": 92000,
       "unit": "EA",
-      "desc": "\ubc38\ube0c",
+      "desc": "밸브",
       "smm_section": "S10"
     },
     "IfcAlarm": {
       "rate": 115000,
       "unit": "EA",
-      "desc": "\ud654\uc7ac \uacbd\ubcf4\uc7a5\uce58",
+      "desc": "화재 경보장치",
       "smm_section": "W50"
     },
     "IfcController": {
       "rate": 395000,
       "unit": "EA",
-      "desc": "\ube4c\ub529 \uc81c\uc5b4\uae30",
+      "desc": "빌딩 제어기",
       "smm_section": "W60"
     },
     "IfcRamp": {
       "rate": 1050000,
       "unit": "EA",
-      "desc": "\uacbd\uc0ac\ub85c",
+      "desc": "경사로",
       "smm_section": "L30"
     },
     "IfcRampFlight": {
       "rate": 1150000,
       "unit": "EA",
-      "desc": "\uacbd\uc0ac\ub85c \ud50c\ub77c\uc774\ud2b8",
+      "desc": "경사로 플라이트",
       "smm_section": "L30"
     },
     "IfcBuildingElementPart": {
       "rate": 0,
       "unit": "EA",
-      "desc": "\uac74\ucd95\uc694\uc18c \ubd80\ud488",
+      "desc": "건축요소 부품",
       "smm_section": ""
     }
   },
@@ -316,7 +316,7 @@
     "HVAC_TECH": {
       "rate_per_day": 245000,
       "crew_size": 2,
-      "trade": "\uacf5\uc870\uae30\uc220\uc790 (\uc219\ub828\uacf5)",
+      "trade": "공조기술자 (숙련공)",
       "productivity": {
         "IfcDuct": 18,
         "IfcDuctSegment": 18,
@@ -330,7 +330,7 @@
     "PLUMBER": {
       "rate_per_day": 225000,
       "crew_size": 2,
-      "trade": "\ubc30\uad00\uacf5 (\uc219\ub828\uacf5)",
+      "trade": "배관공 (숙련공)",
       "productivity": {
         "IfcPipe": 25,
         "IfcPipeSegment": 25,
@@ -347,7 +347,7 @@
     "ELECTRICIAN": {
       "rate_per_day": 235000,
       "crew_size": 2,
-      "trade": "\uc804\uae30\uae30\uc0ac (\uc219\ub828\uacf5)",
+      "trade": "전기기사 (숙련공)",
       "productivity": {
         "IfcCableCarrier": 30,
         "IfcCableCarrierSegment": 30,
@@ -362,7 +362,7 @@
     "STEEL_ERECTOR": {
       "rate_per_day": 265000,
       "crew_size": 4,
-      "trade": "\ucca0\uace8\uacf5 (\uc219\ub828\uacf5)",
+      "trade": "철골공 (숙련공)",
       "productivity": {
         "IfcBeam": 8,
         "IfcColumn": 6,
@@ -373,7 +373,7 @@
     "CONCRETE_GANG": {
       "rate_per_day": 195000,
       "crew_size": 6,
-      "trade": "\ucf58\ud06c\ub9ac\ud2b8 \ud300 (\ud63c\uc131)",
+      "trade": "콘크리트 팀 (혼성)",
       "productivity": {
         "IfcSlab": 35,
         "IfcFooting": 6,
@@ -386,7 +386,7 @@
     "MASON": {
       "rate_per_day": 210000,
       "crew_size": 3,
-      "trade": "\ubbf8\uc7a5\uacf5 (\uc219\ub828\uacf5) + \ubcf4\uc870",
+      "trade": "미장공 (숙련공) + 보조",
       "productivity": {
         "IfcWall": 12,
         "IfcWallStandardCase": 12,
@@ -397,7 +397,7 @@
     "CARPENTER": {
       "rate_per_day": 220000,
       "crew_size": 2,
-      "trade": "\ubaa9\uc218 (\uc219\ub828\uacf5)",
+      "trade": "목수 (숙련공)",
       "productivity": {
         "IfcDoor": 6,
         "IfcWindow": 6,
@@ -410,7 +410,7 @@
     "ROOFER": {
       "rate_per_day": 235000,
       "crew_size": 3,
-      "trade": "\uc9c0\ubd95\uacf5 (\uc219\ub828\uacf5)",
+      "trade": "지붕공 (숙련공)",
       "productivity": {
         "IfcRoof": 25
       }
@@ -418,7 +418,7 @@
     "FINISHER": {
       "rate_per_day": 185000,
       "crew_size": 2,
-      "trade": "\ub9c8\uac10\uacf5 (\uc219\ub828\uacf5)",
+      "trade": "마감공 (숙련공)",
       "productivity": {
         "IfcCovering": 20,
         "IfcFurniture": 8,
@@ -428,34 +428,34 @@
     "LABORER": {
       "rate_per_day": 145000,
       "crew_size": 1,
-      "trade": "\ubcf4\ud1b5\uc778\ubd80",
+      "trade": "보통인부",
       "productivity": {}
     }
   },
   "equipment": {
     "MOBILE_CRANE_20T": {
       "rate_per_day": 650000,
-      "desc": "\uc774\ub3d9\uc2dd \ud06c\ub808\uc778 20\ud1a4"
+      "desc": "이동식 크레인 20톤"
     },
     "TOWER_CRANE": {
       "rate_per_day": 920000,
-      "desc": "\ud0c0\uc6cc \ud06c\ub808\uc778"
+      "desc": "타워 크레인"
     },
     "CONCRETE_PUMP": {
       "rate_per_day": 480000,
-      "desc": "\ucf58\ud06c\ub9ac\ud2b8 \ud38c\ud504\uce74"
+      "desc": "콘크리트 펌프카"
     },
     "SCISSOR_LIFT_8M": {
       "rate_per_day": 120000,
-      "desc": "\uc2dc\uc800 \ub9ac\ud504\ud2b8 8m"
+      "desc": "시저 리프트 8m"
     },
     "WELDING_MACHINE": {
       "rate_per_day": 35000,
-      "desc": "\uc6a9\uc811\uae30 300A"
+      "desc": "용접기 300A"
     },
     "GENERATOR_5KVA": {
       "rate_per_day": 48000,
-      "desc": "\ubc1c\uc804\uae30 5KVA"
+      "desc": "발전기 5KVA"
     }
   },
   "equipment_allocation": {
@@ -819,28 +819,28 @@
     }
   ],
   "smm_sections": {
-    "A": "\uc608\ube44\ube44",
-    "C": "\uae30\uc874 \ubd80\uc9c0 / \uac74\ubb3c",
-    "D": "\ud1a0\uacf5\uc0ac",
-    "E": "\ud604\uc7a5\ud0c0\uc124 \ucf58\ud06c\ub9ac\ud2b8 / \ub300\ud615 \ud504\ub9ac\uce90\uc2a4\ud2b8",
-    "F": "\uc870\uc801\uacf5\uc0ac",
-    "G": "\uad6c\uc870\uc6a9 \uae08\uc18d / \uace8\uc870",
-    "H": "\uc678\uc7a5\uc7ac / \ub36e\uac1c",
-    "J": "\ubc29\uc218\uacf5\uc0ac",
-    "K": "\ub0b4\uc7a5\uc7ac / \uac74\uc2dd \ud30c\ud2f0\uc158",
-    "L": "\ucc3d\ud638 / \ubb38 / \uacc4\ub2e8",
-    "M": "\ud45c\uba74 \ub9c8\uac10\uc7ac",
-    "N": "\uac00\uad6c / \uc7a5\ube44",
-    "P": "\uac74\ucd95 \uc7a1\uc790\uc7ac",
-    "Q": "\ud3ec\uc7a5 / \uc870\uacbd / \ud39c\uc2a4",
-    "R": "\ubc30\uc218 \uc2dc\uc2a4\ud15c",
-    "S": "\ubc30\uad00 \uae09\uc218 \uc2dc\uc2a4\ud15c",
-    "T": "\uae30\uacc4 \ub0c9\ub09c\ubc29",
-    "U": "\ud658\uae30 / \uacf5\uc870",
-    "V": "\uc804\uae30 \uacf5\uae09 / \uc804\ub825 / \uc870\uba85",
-    "W": "\ud1b5\uc2e0 / \ubcf4\uc548 / \uc81c\uc5b4",
-    "X": "\uc6b4\uc1a1 \uc2dc\uc2a4\ud15c",
-    "Y": "\uae30\uacc4 / \uc804\uae30 \uc124\ube44 (\uc77c\ubc18)"
+    "A": "예비비",
+    "C": "기존 부지 / 건물",
+    "D": "토공사",
+    "E": "현장타설 콘크리트 / 대형 프리캐스트",
+    "F": "조적공사",
+    "G": "구조용 금속 / 골조",
+    "H": "외장재 / 덮개",
+    "J": "방수공사",
+    "K": "내장재 / 건식 파티션",
+    "L": "창호 / 문 / 계단",
+    "M": "표면 마감재",
+    "N": "가구 / 장비",
+    "P": "건축 잡자재",
+    "Q": "포장 / 조경 / 펜스",
+    "R": "배수 시스템",
+    "S": "배관 급수 시스템",
+    "T": "기계 냉난방",
+    "U": "환기 / 공조",
+    "V": "전기 공급 / 전력 / 조명",
+    "W": "통신 / 보안 / 제어",
+    "X": "운송 시스템",
+    "Y": "기계 / 전기 설비 (일반)"
   },
   "provisions": {
     "preliminaries_pct": 10,

--- a/viewer/rates/pwd2024_bd.json
+++ b/viewer/rates/pwd2024_bd.json
@@ -179,8 +179,8 @@
       "smm_section": "L30"
     },
     "IfcFooting": {
-      "rate": 5500,
-      "unit": "EA",
+      "rate": 1293.89,
+      "unit": "M3",
       "desc": "Foundation Footing",
       "smm_section": "D20"
     },

--- a/viewer/rates/pwd2024_bd.json
+++ b/viewer/rates/pwd2024_bd.json
@@ -182,7 +182,8 @@
       "rate": 1293.89,
       "unit": "M3",
       "desc": "Foundation Footing",
-      "smm_section": "D20"
+      "smm_section": "D20",
+      "volFactor": 4.25074802767622
     },
     "IfcPile": {
       "rate": 12000,

--- a/viewer/rates/rawlinsons2024_au.json
+++ b/viewer/rates/rawlinsons2024_au.json
@@ -182,7 +182,8 @@
       "rate": 127.04,
       "unit": "M3",
       "desc": "Foundation Footing",
-      "smm_section": "D20"
+      "smm_section": "D20",
+      "volFactor": 4.25074802767622
     },
     "IfcPile": {
       "rate": 1450,

--- a/viewer/rates/rawlinsons2024_au.json
+++ b/viewer/rates/rawlinsons2024_au.json
@@ -179,8 +179,8 @@
       "smm_section": "L30"
     },
     "IfcFooting": {
-      "rate": 540,
-      "unit": "EA",
+      "rate": 127.04,
+      "unit": "M3",
       "desc": "Foundation Footing",
       "smm_section": "D20"
     },

--- a/viewer/rates/rsmeans2024_us.json
+++ b/viewer/rates/rsmeans2024_us.json
@@ -182,7 +182,8 @@
       "rate": 56.46,
       "unit": "M3",
       "desc": "Foundation Footing",
-      "smm_section": "D20"
+      "smm_section": "D20",
+      "volFactor": 4.25074802767622
     },
     "IfcPile": {
       "rate": 650,

--- a/viewer/rates/rsmeans2024_us.json
+++ b/viewer/rates/rsmeans2024_us.json
@@ -179,8 +179,8 @@
       "smm_section": "L30"
     },
     "IfcFooting": {
-      "rate": 240,
-      "unit": "EA",
+      "rate": 56.46,
+      "unit": "M3",
       "desc": "Foundation Footing",
       "smm_section": "D20"
     },

--- a/viewer/rates/sinapi2024_br.json
+++ b/viewer/rates/sinapi2024_br.json
@@ -182,7 +182,8 @@
       "rate": 90.57,
       "unit": "M3",
       "desc": "Sapata de fundacao",
-      "smm_section": "D20"
+      "smm_section": "D20",
+      "volFactor": 4.25074802767622
     },
     "IfcPile": {
       "rate": 1020,

--- a/viewer/rates/sinapi2024_br.json
+++ b/viewer/rates/sinapi2024_br.json
@@ -179,8 +179,8 @@
       "smm_section": "L30"
     },
     "IfcFooting": {
-      "rate": 385,
-      "unit": "EA",
+      "rate": 90.57,
+      "unit": "M3",
       "desc": "Sapata de fundacao",
       "smm_section": "D20"
     },

--- a/viewer/rates/sni2024_id.json
+++ b/viewer/rates/sni2024_id.json
@@ -182,7 +182,8 @@
       "rate": 270540.62,
       "unit": "M3",
       "desc": "Pondasi tapak",
-      "smm_section": "D20"
+      "smm_section": "D20",
+      "volFactor": 4.25074802767622
     },
     "IfcPile": {
       "rate": 3050000,

--- a/viewer/rates/sni2024_id.json
+++ b/viewer/rates/sni2024_id.json
@@ -179,8 +179,8 @@
       "smm_section": "L30"
     },
     "IfcFooting": {
-      "rate": 1150000,
-      "unit": "EA",
+      "rate": 270540.62,
+      "unit": "M3",
       "desc": "Pondasi tapak",
       "smm_section": "D20"
     },

--- a/viewer/rates/untec2024_fr.json
+++ b/viewer/rates/untec2024_fr.json
@@ -179,8 +179,8 @@
       "smm_section": "L30"
     },
     "IfcFooting": {
-      "rate": 75,
-      "unit": "EA",
+      "rate": 17.64,
+      "unit": "M3",
       "desc": "Semelle de fondation",
       "smm_section": "D20"
     },

--- a/viewer/rates/untec2024_fr.json
+++ b/viewer/rates/untec2024_fr.json
@@ -182,7 +182,8 @@
       "rate": 17.64,
       "unit": "M3",
       "desc": "Semelle de fondation",
-      "smm_section": "D20"
+      "smm_section": "D20",
+      "volFactor": 4.25074802767622
     },
     "IfcPile": {
       "rate": 195,

--- a/viewer/schedule_author.js
+++ b/viewer/schedule_author.js
@@ -59,7 +59,9 @@
   // by its class's real average length. A flat per-unit rate assumes every element is "typical
   // sized" (e.g. a 5.7m beam); this element's own real size scales the flat rate instead, so a 60m
   // beam and a 0.9m beam charge differently even though both are counted as "1 IfcBeam".
-  function _installSecs(cls, rule, laborRates, realQty, lengthRatio, areaRatio) {
+  // `areaRatio` / `volumeRatio` (optional) — the M2 and M3 twins of lengthRatio (§ARCH_AREA_WEIGHT,
+  // §VOL_WEIGHT below): same ratio-to-class-average form, on dominant-face area and on bbox volume.
+  function _installSecs(cls, rule, laborRates, realQty, lengthRatio, areaRatio, volumeRatio) {
     var resource = rule && rule.resource;
     if (!resource || !laborRates[resource]) return 120;
     var labor = laborRates[resource], bestPk = null, bestLen = 0;
@@ -71,13 +73,15 @@
     var secsPerUnit = 28800 / prod;
     if (realQty != null) return Math.round(secsPerUnit * realQty);
     if (lengthRatio != null) return Math.round(secsPerUnit * lengthRatio);
-    // §ARCH_AREA_WEIGHT (2026-08-12) — the M2 twin of lengthRatio. Same REDISTRIBUTION form, and
-    // that form is the whole safety argument: ratio = thisArea / classAvgArea, so mean(ratio)=1 by
-    // construction and a class's total labour is preserved exactly. Do NOT confuse it with the
+    // §ARCH_AREA_WEIGHT (2026-08-12) — the M2 twin of lengthRatio; §VOL_WEIGHT below is the M3 one,
+    // so all three sized units now redistribute instead of charging flat. Same REDISTRIBUTION form,
+    // and that form is the whole safety argument: ratio = thisArea / classAvgArea, so mean(ratio)=1
+    // by construction and a class's total labour is preserved exactly. Do NOT confuse it with the
     // realQty branch two lines up, which MULTIPLIES by absolute area — _classFragmentation's own
     // header records what that does to a non-fragmented class: "measured: IfcWall would jump from
     // ~14 days to 563 days."
     if (areaRatio != null) return Math.round(secsPerUnit * areaRatio);
+    if (volumeRatio != null) return Math.round(secsPerUnit * volumeRatio);
     return Math.round(secsPerUnit);
   }
 
@@ -109,6 +113,10 @@
     "WHEN t.bbox_x>=t.bbox_y AND t.bbox_x>=t.bbox_z THEN MAX(t.bbox_y,t.bbox_z) " +
     "WHEN t.bbox_y>=t.bbox_x AND t.bbox_y>=t.bbox_z THEN MAX(t.bbox_x,t.bbox_z) " +
     "ELSE MAX(t.bbox_x,t.bbox_y) END";
+  // §VOL_WEIGHT — the M3 quantity expression. Byte-identical to the `vol` column foldCost (this
+  // file) already computes for M3-priced cost, which is what makes it canonical here rather than
+  // a second, differently-derived volume.
+  var _VOL_EXPR = 't.bbox_x*t.bbox_y*t.bbox_z';
   function _classFragmentation(db, qsRates) {
     var out = { fragmented: {}, area: {} };
     qsRates = qsRates || {};
@@ -281,6 +289,92 @@
     return out;
   }
 
+  // §VOL_WEIGHT (2026-08-12 — Witness: viewer/tests/witness_arch_area_weight.js G-VOL-*) ─────────
+  // The third and last sized unit. _linearWeighting owns `unit === 'M'`, _areaWeighting owns
+  // `unit === 'M2'`; a class priced `unit === 'M3'` (volume — footings, pads, and other heavy
+  // cast/bulk items) still fell through every branch of _installSecs to the flat
+  // `28800/productivity`, so a tiny pad footing and a massive raft footing charged the SAME install
+  // time. Same complaint that drove the M2 fix, user live: "They are heavy items should take longer
+  // relatively to MEP etc."
+  //
+  // ⚠ MEASURED SHIPPED-DATA REALITY (2026-08-12) — read this before expecting it to fire: NO class
+  // in the shipped rates model is priced M3 today. rates.js RATES is 32 EA / 11 M / 7 M2 / 1 KG,
+  // and all 17 rates/*.json templates carry the identical split (0 M3 in every one). So this path
+  // selects ZERO classes on shipped data and is INERT by construction until a class is repriced to
+  // M3 — via the Settings JSON editor, a rate template, or rates.js. It is not speculative code:
+  // `unit === 'M3'` is already a live branch in foldCost (this file) and analysis_sidecar.js
+  // compute5D, so the cost side has honoured M3 all along and only the LABOUR side was missing it.
+  // The real case waiting on it is IfcFooting — measured 821 elements across Hospital/LTU_AHouse/
+  // Clinic spanning 0.26..602.09 m³ (2320x) while priced `unit:'EA'` (rates.js:49), i.e. all 821
+  // charge one identical install time today. Repricing it is a rates DATA decision, deliberately
+  // NOT made here.
+  //
+  // Every safety property of _areaWeighting is reproduced verbatim: the fragmented-class exclusion
+  // (no double-weighting), the `> 0` zero-guard (a zero bbox dimension makes volume 0 — those fall
+  // through to flat rather than being charged ZERO install time, the bug that halved HHS IfcPlate),
+  // the rate-uniformity scan (mixed-rate classes degrade to flat), and mean(ratio)=1 so a class's
+  // total labour is preserved exactly. Generic by construction — no class is named in the logic.
+  function _volumeWeighting(db, qsRates, fragmented, rules, dflt, nameOverrides, laborRates) {
+    var out = { avgVolume: {}, volume: {} };
+    qsRates = qsRates || {}; fragmented = fragmented || {};
+    var m3 = [];
+    for (var cls in qsRates) {
+      if (qsRates[cls] && qsRates[cls].unit === 'M3' && !fragmented[cls]) m3.push(cls);
+    }
+    if (!m3.length) return out;
+    var q = function (list) { return list.map(function (c) { return "'" + c.replace(/'/g, "''") + "'"; }).join(','); };
+    var r;
+    try {
+      // The average MUST be taken over exactly the elements that will receive a ratio, or
+      // mean(ratio) != 1 and the class total moves — the one thing this form exists to prevent.
+      r = db.exec('SELECT m.ifc_class, COUNT(*), SUM(' + _VOL_EXPR + ') FROM elements_meta m ' +
+        'JOIN element_transforms t ON m.guid=t.guid WHERE t.bbox_x IS NOT NULL AND t.bbox_x>0 ' +
+        'AND (' + _VOL_EXPR + ') > 0 AND m.ifc_class IN (' + q(m3) + ') GROUP BY m.ifc_class');
+    } catch (e) { return out; }   // no element_transforms — degrade to flat, exactly as before
+    var have = [], mixed = [];
+    if (r.length && r[0].values.length) {
+      r[0].values.forEach(function (row) {
+        var cls = row[0], cnt = row[1], total = row[2] || 0;
+        var avg = cnt > 0 ? total / cnt : 0;
+        if (avg > 0) { out.avgVolume[cls] = avg; have.push(cls); }
+      });
+    }
+    if (!have.length) return out;
+    // Rate-uniformity scan — one pass, only over the candidate classes.
+    if (rules && laborRates) {
+      var keep = [];
+      have.forEach(function (cls) {
+        var er;
+        try {
+          er = db.exec("SELECT COALESCE(m.element_name,'') FROM elements_meta m WHERE m.ifc_class='" +
+            cls.replace(/'/g, "''") + "'");
+        } catch (e) { return; }
+        if (!er.length || !er[0].values.length) return;
+        var first = null, uniform = true;
+        for (var i = 0; i < er[0].values.length; i++) {
+          var rl = matchNameOverride(cls, er[0].values[i][0], nameOverrides || []) ||
+                   matchRule(cls, rules, dflt);
+          var sc = _installSecs(cls, rl, laborRates, null, null);
+          if (first === null) first = sc;
+          else if (sc !== first) { uniform = false; break; }
+        }
+        if (uniform) keep.push(cls); else { mixed.push(cls); delete out.avgVolume[cls]; }
+      });
+      have = keep;
+      if (mixed.length) console.log('§VOL_WEIGHT_SKIP mixed-rate classes left FLAT: ' + mixed.join(',') +
+        ' — a class total is only preserved when every element shares one secsPerUnit');
+      if (!have.length) return out;
+    }
+    var vr = db.exec('SELECT m.guid, ' + _VOL_EXPR + ' FROM elements_meta m JOIN element_transforms t ON m.guid=t.guid ' +
+      'WHERE t.bbox_x IS NOT NULL AND t.bbox_x>0 AND (' + _VOL_EXPR + ') > 0 AND m.ifc_class IN (' + q(have) + ')');
+    if (vr.length && vr[0].values.length) vr[0].values.forEach(function (row) { out.volume[row[0]] = row[1] || 0; });
+    console.log('§VOL_WEIGHT classes=' + have.length + ' [' +
+      have.map(function (c) { return c + ':avg=' + out.avgVolume[c].toFixed(2) + 'm3'; }).join(', ') +
+      '] — real VOLUME redistributes each class\'s existing flat total (mean ratio 1.0, class total unchanged), ' +
+      'so a raft footing no longer installs as fast as a pad');
+    return out;
+  }
+
   // YYYY-MM-DD a given number of whole days after a base date string. Pure UTC arithmetic so
   // it is deterministic regardless of host timezone (no Date.now / locale dependence).
   function _addDays(baseStr, days) {
@@ -350,6 +444,7 @@
     var _frag = _classFragmentation(db, qsRates);
     var _lin = _linearWeighting(db, qsRates);
     var _area = _areaWeighting(db, qsRates, _frag.fragmented, rules, dflt, nameOverrides, laborRates);   // §ARCH_AREA_WEIGHT
+    var _vol = _volumeWeighting(db, qsRates, _frag.fragmented, rules, dflt, nameOverrides, laborRates);  // §VOL_WEIGHT
 
     // §OPENING_EXCLUDE (found 2026-08-04, 4D_SCHEDULE_PERFECTION.md fool-proofing pass): this query
     // must match time_machine.js's own live-movie element-building query EXACTLY (this function's own
@@ -410,12 +505,18 @@
       var clsAvgArea = _area.avgArea[cls];
       var areaRatio = (realQty == null && lengthRatio == null && hasGeom && clsAvgArea > 0 &&
                        _area.area[guid] > 0) ? _area.area[guid] / clsAvgArea : null;
+      // §VOL_WEIGHT: same discipline again. A class carries exactly one rates unit, so M2 and M3
+      // are mutually exclusive in practice — the full guard chain is kept anyway so precedence
+      // stays explicit rather than relying on that invariant holding forever.
+      var clsAvgVol = _vol.avgVolume[cls];
+      var volumeRatio = (realQty == null && lengthRatio == null && areaRatio == null && hasGeom &&
+                         clsAvgVol > 0 && _vol.volume[guid] > 0) ? _vol.volume[guid] / clsAvgVol : null;
       return {
         guid: guid, cls: cls, name: name, storey: storey,
         base_z: cz - bz / 2, top_z: cz + bz / 2,
         x0: cx - bx / 2, x1: cx + bx / 2, y0: cy - by / 2, y1: cy + by / 2,
         seq: rule.sequence, phase: rule.phase, resource: rule.resource || '_DEFAULT',
-        installSecs: _installSecs(cls, rule, laborRates, realQty, lengthRatio, areaRatio),
+        installSecs: _installSecs(cls, rule, laborRates, realQty, lengthRatio, areaRatio, volumeRatio),
         // §4D_NOGEO (2026-08-07, mirrors time_machine.js's own pool — this function's header says
         // "REPLICATES ... EXACTLY"): no transform row → COALESCE parks it at origin/zero-bbox. At
         // z=0 it has no support, schedules at day 0, and its zone's MIN start follows it there —
@@ -1634,6 +1735,7 @@
     _classFragmentation: _classFragmentation,
     _linearWeighting: _linearWeighting,
     _areaWeighting: _areaWeighting,
+    _volumeWeighting: _volumeWeighting,
     FRAGMENT_M2_FLOOR: FRAGMENT_M2_FLOOR,
     materializeDefault: materializeDefault,
     materializeZones: materializeZones,

--- a/viewer/schedule_author.js
+++ b/viewer/schedule_author.js
@@ -59,7 +59,7 @@
   // by its class's real average length. A flat per-unit rate assumes every element is "typical
   // sized" (e.g. a 5.7m beam); this element's own real size scales the flat rate instead, so a 60m
   // beam and a 0.9m beam charge differently even though both are counted as "1 IfcBeam".
-  function _installSecs(cls, rule, laborRates, realQty, lengthRatio) {
+  function _installSecs(cls, rule, laborRates, realQty, lengthRatio, areaRatio) {
     var resource = rule && rule.resource;
     if (!resource || !laborRates[resource]) return 120;
     var labor = laborRates[resource], bestPk = null, bestLen = 0;
@@ -71,6 +71,13 @@
     var secsPerUnit = 28800 / prod;
     if (realQty != null) return Math.round(secsPerUnit * realQty);
     if (lengthRatio != null) return Math.round(secsPerUnit * lengthRatio);
+    // §ARCH_AREA_WEIGHT (2026-08-12) — the M2 twin of lengthRatio. Same REDISTRIBUTION form, and
+    // that form is the whole safety argument: ratio = thisArea / classAvgArea, so mean(ratio)=1 by
+    // construction and a class's total labour is preserved exactly. Do NOT confuse it with the
+    // realQty branch two lines up, which MULTIPLIES by absolute area — _classFragmentation's own
+    // header records what that does to a non-fragmented class: "measured: IfcWall would jump from
+    // ~14 days to 563 days."
+    if (areaRatio != null) return Math.round(secsPerUnit * areaRatio);
     return Math.round(secsPerUnit);
   }
 
@@ -185,6 +192,95 @@
     return out;
   }
 
+  // §ARCH_AREA_WEIGHT (2026-08-12, bim-compiler prompts/4D_SCHEDULE_PERFECTION.md §DAY_GAP_PHASE_OCC
+  // GAP 4 — Witness: viewer/tests/witness_arch_area_weight.js W-AREA) ───────────────────────────
+  // _linearWeighting selects on `unit === 'M'`, which is why the 7 metre-priced classes (beam,
+  // column, member, railing, pipe/duct/cable segments) scale with real size and NOTHING ELSE does.
+  // The M2 set — IfcSlab, IfcWall, IfcWallStandardCase, IfcCurtainWall, IfcCovering, IfcRoof,
+  // IfcPlate — is the architecture bulk, and it fell through every branch of _installSecs to the
+  // flat `28800/productivity`. MEASURED on Hospital: IfcWallStandardCase spans 1.07m..78.50m (73x),
+  // IfcWall 0.90..78.79 (88x), IfcCovering 1.21..85.72 (71x), IfcSlab 3.70..100.83 (27x) — and
+  // every one of those elements was charged the SAME install time. User, live: "The ARCH still
+  // comes on too fast. They are heavy items should take longer relatively to MEP etc."
+  //
+  // Generic by construction — nothing here names a class. Selection is `unit === 'M2'` straight
+  // from the shipped rates table, and the measure is the SAME dominant-face _AREA_EXPR
+  // _classFragmentation already uses. A model whose heavy class is curtain-wall glazing or brick
+  // coursing is caught identically.
+  //
+  // ⚠ EXCLUDES classes _classFragmentation already flagged: those take the realQty branch (absolute
+  // area, deliberately inflating a class whose element count is not a real installable unit), and
+  // applying both would double-weight them. Fragmented wins; this fills the gap it leaves.
+  // ⚠ RATE-UNIFORM CLASSES ONLY. mean(ratio)=1 preserves a class total only when every element in
+  // the class shares one secsPerUnit. MEASURED counter-example: HHS IfcPlate splits 438 elements at
+  // 120s (no-resource fallback) and 191 at 2400s — the ratio correlates with the subgroup, so the
+  // class total moved 510,960 -> 258,260 and monotonicity broke. Mixed-rate classes degrade to
+  // flat, the same honest-degrade every other branch here uses; no inflation is possible.
+  function _areaWeighting(db, qsRates, fragmented, rules, dflt, nameOverrides, laborRates) {
+    var out = { avgArea: {}, area: {} };
+    qsRates = qsRates || {}; fragmented = fragmented || {};
+    var m2 = [];
+    for (var cls in qsRates) {
+      if (qsRates[cls] && qsRates[cls].unit === 'M2' && !fragmented[cls]) m2.push(cls);
+    }
+    if (!m2.length) return out;
+    var q = function (list) { return list.map(function (c) { return "'" + c.replace(/'/g, "''") + "'"; }).join(','); };
+    var r;
+    try {
+      // ⚠ The average MUST be taken over exactly the elements that will receive a ratio, or
+      // mean(ratio) != 1 and the class total moves — which is the one thing this form exists to
+      // prevent. Witnessed: without the `> 0` guard, elements whose second bbox dimension is 0
+      // measured area 0, took ratio 0, and were charged ZERO install time — HHS IfcPlate total
+      // halved (510,960 -> 258,260) and monotonicity broke. Zero-area elements now fall through to
+      // flat, the same honest-degrade the realQty and lengthRatio branches already use.
+      r = db.exec('SELECT m.ifc_class, COUNT(*), SUM(' + _AREA_EXPR + ') FROM elements_meta m ' +
+        'JOIN element_transforms t ON m.guid=t.guid WHERE t.bbox_x IS NOT NULL AND t.bbox_x>0 ' +
+        'AND (' + _AREA_EXPR + ') > 0 AND m.ifc_class IN (' + q(m2) + ') GROUP BY m.ifc_class');
+    } catch (e) { return out; }   // no element_transforms — degrade to flat, exactly as before
+    var have = [], mixed = [];
+    if (r.length && r[0].values.length) {
+      r[0].values.forEach(function (row) {
+        var cls = row[0], cnt = row[1], total = row[2] || 0;
+        var avg = cnt > 0 ? total / cnt : 0;
+        if (avg > 0) { out.avgArea[cls] = avg; have.push(cls); }
+      });
+    }
+    if (!have.length) return out;
+    // Rate-uniformity scan — one pass, only over the candidate classes.
+    if (rules && laborRates) {
+      var keep = [];
+      have.forEach(function (cls) {
+        var er;
+        try {
+          er = db.exec("SELECT COALESCE(m.element_name,'') FROM elements_meta m WHERE m.ifc_class='" +
+            cls.replace(/'/g, "''") + "'");
+        } catch (e) { return; }
+        if (!er.length || !er[0].values.length) return;
+        var first = null, uniform = true;
+        for (var i = 0; i < er[0].values.length; i++) {
+          var rl = matchNameOverride(cls, er[0].values[i][0], nameOverrides || []) ||
+                   matchRule(cls, rules, dflt);
+          var sc = _installSecs(cls, rl, laborRates, null, null);
+          if (first === null) first = sc;
+          else if (sc !== first) { uniform = false; break; }
+        }
+        if (uniform) keep.push(cls); else { mixed.push(cls); delete out.avgArea[cls]; }
+      });
+      have = keep;
+      if (mixed.length) console.log('§ARCH_AREA_WEIGHT_SKIP mixed-rate classes left FLAT: ' + mixed.join(',') +
+        ' — a class total is only preserved when every element shares one secsPerUnit');
+      if (!have.length) return out;
+    }
+    var ar = db.exec('SELECT m.guid, ' + _AREA_EXPR + ' FROM elements_meta m JOIN element_transforms t ON m.guid=t.guid ' +
+      'WHERE t.bbox_x IS NOT NULL AND t.bbox_x>0 AND (' + _AREA_EXPR + ') > 0 AND m.ifc_class IN (' + q(have) + ')');
+    if (ar.length && ar[0].values.length) ar[0].values.forEach(function (row) { out.area[row[0]] = row[1] || 0; });
+    console.log('§ARCH_AREA_WEIGHT classes=' + have.length + ' [' +
+      have.map(function (c) { return c + ':avg=' + out.avgArea[c].toFixed(2) + 'm2'; }).join(', ') +
+      '] — real AREA redistributes each class\'s existing flat total (mean ratio 1.0, class total unchanged), ' +
+      'so a 78m wall no longer installs as fast as a 1m one');
+    return out;
+  }
+
   // YYYY-MM-DD a given number of whole days after a base date string. Pure UTC arithmetic so
   // it is deterministic regardless of host timezone (no Date.now / locale dependence).
   function _addDays(baseStr, days) {
@@ -253,6 +349,7 @@
     var nameOverrides = opts.nameOverrides || (global.SEQUENCE_NAME_OVERRIDES) || [];
     var _frag = _classFragmentation(db, qsRates);
     var _lin = _linearWeighting(db, qsRates);
+    var _area = _areaWeighting(db, qsRates, _frag.fragmented, rules, dflt, nameOverrides, laborRates);   // §ARCH_AREA_WEIGHT
 
     // §OPENING_EXCLUDE (found 2026-08-04, 4D_SCHEDULE_PERFECTION.md fool-proofing pass): this query
     // must match time_machine.js's own live-movie element-building query EXACTLY (this function's own
@@ -308,12 +405,17 @@
       var clsAvgLen = _lin.avgLength[cls];
       var lengthRatio = (realQty == null && hasGeom && clsAvgLen > 0)
         ? Math.max(bx, by, bz) / clsAvgLen : null;
+      // §ARCH_AREA_WEIGHT: same honest-degrade discipline — only with real geometry, a real class
+      // average, and only when neither stronger signal already claimed this element.
+      var clsAvgArea = _area.avgArea[cls];
+      var areaRatio = (realQty == null && lengthRatio == null && hasGeom && clsAvgArea > 0 &&
+                       _area.area[guid] > 0) ? _area.area[guid] / clsAvgArea : null;
       return {
         guid: guid, cls: cls, name: name, storey: storey,
         base_z: cz - bz / 2, top_z: cz + bz / 2,
         x0: cx - bx / 2, x1: cx + bx / 2, y0: cy - by / 2, y1: cy + by / 2,
         seq: rule.sequence, phase: rule.phase, resource: rule.resource || '_DEFAULT',
-        installSecs: _installSecs(cls, rule, laborRates, realQty, lengthRatio),
+        installSecs: _installSecs(cls, rule, laborRates, realQty, lengthRatio, areaRatio),
         // §4D_NOGEO (2026-08-07, mirrors time_machine.js's own pool — this function's header says
         // "REPLICATES ... EXACTLY"): no transform row → COALESCE parks it at origin/zero-bbox. At
         // z=0 it has no support, schedules at day 0, and its zone's MIN start follows it there —
@@ -1531,6 +1633,7 @@
     _installSecs: _installSecs,
     _classFragmentation: _classFragmentation,
     _linearWeighting: _linearWeighting,
+    _areaWeighting: _areaWeighting,
     FRAGMENT_M2_FLOOR: FRAGMENT_M2_FLOOR,
     materializeDefault: materializeDefault,
     materializeZones: materializeZones,

--- a/viewer/sw.js
+++ b/viewer/sw.js
@@ -8,7 +8,7 @@
 // Cache-first for heavy assets (.wasm, images). DB files skip SW (IndexedDB handles them).
 //
 // DEPLOY: bump CACHE_VERSION on every OCI upload. Old caches are purged on activate.
-const CACHE_VERSION = 'v1003';   // bump on each deploy; per-change detail is the git commit message.
+const CACHE_VERSION = 'v1005';   // bump on each deploy; per-change detail is the git commit message.
 const CACHE_PREFIX = 'bim-ootb-';
 const CACHE_NAME = CACHE_PREFIX + CACHE_VERSION;
 

--- a/viewer/sw.js
+++ b/viewer/sw.js
@@ -8,7 +8,11 @@
 // Cache-first for heavy assets (.wasm, images). DB files skip SW (IndexedDB handles them).
 //
 // DEPLOY: bump CACHE_VERSION on every OCI upload. Old caches are purged on activate.
-const CACHE_VERSION = 'v1005';   // bump on each deploy; per-change detail is the git commit message.
+const CACHE_VERSION = 'v1009';   // bump on each deploy; per-change detail is the git commit message.
+// §FOOTING_M3 (2026-08-12): REQUIRED, not routine. rates.js and rates/cidb2024_my.json are both in
+// PRECACHE_ASSETS and served CACHE-FIRST, so a client holding the old cache would keep the EA-priced
+// IfcFooting forever — the repricing would never reach it. v1005→v1009 also clears this branch being
+// behind origin/main (v1008); on merge conflict take the HIGHER, per CLAUDE.md.
 const CACHE_PREFIX = 'bim-ootb-';
 const CACHE_NAME = CACHE_PREFIX + CACHE_VERSION;
 

--- a/viewer/tests/witness_arch_area_weight.js
+++ b/viewer/tests/witness_arch_area_weight.js
@@ -25,6 +25,28 @@
 //                  a smaller one. The monotonicity a planner would check by eye.
 //   G-AREA-NOCLOBBER  classes already claimed by realQty (fragmented) or lengthRatio are untouched
 //                  — no double-weighting. Their per-element secs must be byte-identical to before.
+//
+// ── §VOL_WEIGHT (M3), added 2026-08-12 — the same issue, third unit ───────────────────────────
+//   ISSUE: `unit === 'M3'` classes fell through every _installSecs branch to flat, so a tiny pad
+//   footing and a massive raft footing charged identical install time.
+//
+//   ⚠ WHY THIS HALF USES A FIXTURE, stated plainly so nobody reads more into a green run than is
+//   there: NO class in the shipped rates model is priced M3. viewer/rates.js RATES is 32 EA /
+//   11 M / 7 M2 / 1 KG and all 17 rates/*.json templates carry the identical split (0 M3 each).
+//   So on shipped data _volumeWeighting selects nothing — which G-VOL-SHIPPED-INERT asserts as a
+//   POSITIVE result (zero regression), not as a pass by absence. To prove the mechanism actually
+//   works, the M3 gates run against a one-key fixture that reprices IfcFooting EA->M3. IfcFooting
+//   is not an arbitrary pick: it is the named real-world case (821 elements across Hospital/
+//   LTU_AHouse/Clinic spanning 0.26..602.09 m3 — 2320x — all charged the same today), and the
+//   fixture changes ONLY the witness's own in-memory copy. Shipped rates are untouched; repricing
+//   for real is a rates DATA decision this witness deliberately does not make.
+//
+//   G-VOL-SHIPPED-INERT (BLOCKING) with shipped RATES, _volumeWeighting selects 0 classes and every
+//                  element's installSecs is byte-identical with the new arg wired vs. not.
+//   G-VOL-TOTAL    (BLOCKING) under the fixture, per class total installSecs after == before.
+//   G-VOL-SPREAD   per-element spread rises above flat on the fixture class. Proves it did something.
+//   G-VOL-ORDER    a physically larger element never gets LESS time than a smaller one.
+//   G-VOL-NOCLOBBER  classes claimed by realQty / lengthRatio / areaRatio are byte-identical.
 'use strict';
 const fs = require('fs');
 const path = require('path');
@@ -135,6 +157,112 @@ function loadRatesTable() {
   gate('G-AREA-NOCLOBBER', clobbered.length === 0,
     clobbered.length ? 'double-weighted: ' + clobbered.join(' ')
       : 'classes already claimed by realQty (fragmented) or lengthRatio are byte-identical — no double-weighting');
+
+  // ── §VOL_WEIGHT (M3) — see the fixture note in this file's header ────────────────────────────
+  const M3_FIXTURE_CLASS = 'IfcFooting';
+  let volTotalBad = [], volSpread = [], volOrderBad = [], volClobbered = [], volRan = 0;
+  let shippedM3 = [], inertBad = [], fixtureSeen = 0;
+
+  for (const bld of BUILDINGS) {
+    const dbPath = path.join(BLD_DIR, DB_FILE[bld] || (bld + '_extracted.db'));
+    if (!fs.existsSync(dbPath)) continue;
+    const db = new SQL.Database(fs.readFileSync(dbPath));
+    const frag = SA._classFragmentation(db, RATES);
+    const lin = SA._linearWeighting(db, RATES);
+    const area = SA._areaWeighting(db, RATES, frag.fragmented, SR, SD, NO, LR);
+
+    // (a) shipped rates — must select nothing at all.
+    const volShipped = SA._volumeWeighting(db, RATES, frag.fragmented, SR, SD, NO, LR);
+    Object.keys(volShipped.avgVolume).forEach(c => shippedM3.push(`${bld}/${c}`));
+
+    // (b) the fixture — one key repriced, in this witness's own copy only.
+    const RATES_M3 = Object.assign({}, RATES);
+    RATES_M3[M3_FIXTURE_CLASS] = Object.assign({}, RATES[M3_FIXTURE_CLASS] || { rate: 0 }, { unit: 'M3' });
+    const vol = SA._volumeWeighting(db, RATES_M3, frag.fragmented, SR, SD, NO, LR);
+
+    const r = db.exec("SELECT m.guid, m.ifc_class, COALESCE(m.element_name,''), " +
+      't.bbox_x, t.bbox_y, t.bbox_z FROM elements_meta m JOIN element_transforms t ON m.guid=t.guid ' +
+      "WHERE m.ifc_class != 'IfcOpeningElement' AND m.ifc_class != 'IfcSpace'");
+    if (!r.length) { db.close(); continue; }
+    volRan++;
+
+    const byCls = {};
+    r[0].values.forEach(v => {
+      const [guid, cls, nm, bx, by, bz] = v;
+      const rule = SA.matchNameOverride(cls, nm, NO) || SA.matchRule(cls, SR, SD);
+      const realQty = (frag.fragmented[cls] && frag.area[guid] != null) ? frag.area[guid] : null;
+      const hasGeom = bx > 0 || by > 0 || bz > 0;
+      const avgLen = lin.avgLength[cls];
+      const lengthRatio = (realQty == null && hasGeom && avgLen > 0) ? Math.max(bx, by, bz) / avgLen : null;
+      const avgArea = area.avgArea[cls];
+      const areaRatio = (realQty == null && lengthRatio == null && hasGeom && avgArea > 0 &&
+                         area.area[guid] > 0) ? area.area[guid] / avgArea : null;
+
+      // shipped-inert: new arg wired, but volumeRatio derived from the SHIPPED table.
+      const avgVolShipped = volShipped.avgVolume[cls];
+      const volRatioShipped = (realQty == null && lengthRatio == null && areaRatio == null && hasGeom &&
+                               avgVolShipped > 0 && volShipped.volume[guid] > 0)
+        ? volShipped.volume[guid] / avgVolShipped : null;
+      const noArg = SA._installSecs(cls, rule, LR, realQty, lengthRatio, areaRatio);
+      const withArg = SA._installSecs(cls, rule, LR, realQty, lengthRatio, areaRatio, volRatioShipped);
+      if (noArg !== withArg) inertBad.push(`${bld}/${cls}`);
+
+      // fixture: the M3 path under the repriced table.
+      const avgVol = vol.avgVolume[cls];
+      const volumeRatio = (realQty == null && lengthRatio == null && areaRatio == null && hasGeom &&
+                           avgVol > 0 && vol.volume[guid] > 0) ? vol.volume[guid] / avgVol : null;
+      const after = SA._installSecs(cls, rule, LR, realQty, lengthRatio, areaRatio, volumeRatio);
+      const c = byCls[cls] || (byCls[cls] = { b: 0, a: 0, n: 0, weighted: false,
+                                              claimed: (realQty != null || lengthRatio != null || areaRatio != null),
+                                              pts: [], diffs: 0 });
+      c.b += noArg; c.a += after; c.n++;
+      if (volumeRatio != null) { c.weighted = true; c.pts.push({ q: vol.volume[guid], s: after }); }
+      if (noArg !== after) c.diffs++;
+    });
+
+    const wt = [];
+    for (const cls in byCls) {
+      const c = byCls[cls];
+      if (c.weighted) {
+        fixtureSeen++;
+        const tol = Math.max(2, c.b * 0.05);   // same 5% band + rounding floor as G-AREA-TOTAL
+        if (Math.abs(c.a - c.b) > tol) volTotalBad.push(`${bld}/${cls} ${c.b}->${c.a} (${(100*(c.a-c.b)/c.b).toFixed(1)}%)`);
+        const secs = c.pts.map(p => p.s).filter(x => x > 0);
+        if (secs.length > 1) {
+          const spread = Math.max(...secs) / Math.min(...secs);
+          if (spread > 1.01) wt.push(`${cls}:${spread.toFixed(0)}x`);
+          const sorted = c.pts.slice().sort((x, y) => x.q - y.q);
+          for (let i = 1; i < sorted.length; i++) {
+            if (sorted[i].s < sorted[i - 1].s * 0.95 - 1) { volOrderBad.push(`${bld}/${cls}`); break; }
+          }
+        }
+      } else if (c.claimed && c.diffs > 0) {
+        volClobbered.push(`${bld}/${cls} (${c.diffs} elements changed)`);
+      }
+    }
+    if (wt.length) volSpread.push(`${bld}[${wt.join(' ')}]`);
+    console.log(`      ${bld}: shippedM3Classes=${Object.keys(volShipped.avgVolume).length} ` +
+      `fixtureWeighted=${wt.join(' ') || 'none'}`);
+    db.close();
+  }
+
+  gate('G-VOL-SHIPPED-INERT', shippedM3.length === 0 && inertBad.length === 0 && volRan > 0,
+    (shippedM3.length ? 'shipped RATES unexpectedly yielded M3 classes: ' + shippedM3.join(' ') + ' ' : '') +
+    (inertBad.length ? 'installSecs CHANGED on shipped rates: ' + inertBad.slice(0, 5).join(' ')
+      : `shipped rates price 0 classes M3, so the new path selects nothing and every element's install time is byte-identical on all ${volRan} buildings — zero regression`));
+  gate('G-VOL-TOTAL', volTotalBad.length === 0 && fixtureSeen > 0,
+    volTotalBad.length ? 'class total MOVED (inflation!): ' + volTotalBad.join(' ')
+      : (fixtureSeen > 0 ? `every volume-weighted class keeps its total install time (${fixtureSeen} class-instances under the ${M3_FIXTURE_CLASS} M3 fixture) — redistribution, not inflation`
+        : `fixture class ${M3_FIXTURE_CLASS} weighted nothing — mechanism unproven`));
+  gate('G-VOL-SPREAD', volSpread.length > 0,
+    volSpread.length ? 'per-element spread now scales with real volume: ' + volSpread.join(' ')
+      : 'NO class gained spread — the volume weighting is not reaching any element');
+  gate('G-VOL-ORDER', volOrderBad.length === 0,
+    volOrderBad.length ? 'larger element got LESS time in: ' + volOrderBad.join(' ')
+      : 'within every volume-weighted class, a larger element never installs faster than a smaller one');
+  gate('G-VOL-NOCLOBBER', volClobbered.length === 0,
+    volClobbered.length ? 'double-weighted: ' + volClobbered.join(' ')
+      : 'classes already claimed by realQty, lengthRatio or areaRatio are byte-identical — no double-weighting');
 
   const passed = results.filter(r => r.pass).length;
   console.log(`\n§AREA_WITNESS ${passed}/${results.length} gates passed`);

--- a/viewer/tests/witness_arch_area_weight.js
+++ b/viewer/tests/witness_arch_area_weight.js
@@ -1,0 +1,142 @@
+#!/usr/bin/env node
+// WITNESS — W-AREA — §ARCH_AREA_WEIGHT
+// Spec: bim-compiler prompts/4D_SCHEDULE_PERFECTION.md §DAY_GAP_PHASE_OCC GAP 4.
+//
+// ISSUE THIS PROVES OR DISPROVES:
+//   _installSecs had three branches and the architecture bulk hit none of them. realQty covers
+//   FRAGMENTED classes only; lengthRatio selects on `unit === 'M'` — the 7 metre-priced classes.
+//   The M2 set (IfcSlab, IfcWall, IfcWallStandardCase, IfcCurtainWall, IfcCovering, IfcRoof,
+//   IfcPlate) fell through to the flat `28800/productivity`, so on Hospital an IfcWall of 0.90m and
+//   one of 78.79m — an 88x span — were charged IDENTICAL install time. User, live: "The ARCH still
+//   comes on too fast. They are heavy items should take longer relatively to MEP etc."
+//
+//   The fix uses the REDISTRIBUTION form (ratio = thisArea / classAvgArea), not the multiply form.
+//   That distinction is the entire safety argument and it is what G-AREA-TOTAL exists to prove:
+//   _classFragmentation's own header records that multiplying a non-fragmented class by absolute
+//   area sends "IfcWall from ~14 days to 563 days". A ratio has mean 1 by construction, so a
+//   class's total labour cannot move — only its distribution.
+//
+// GATES:
+//   G-AREA-TOTAL   (BLOCKING) per class, total installSecs after == before, within rounding.
+//                  Proves this redistributes and cannot inflate the programme.
+//   G-AREA-SPREAD  per-element installSecs spread rises from 1.0x (flat) to >1 on the M2 classes
+//                  that have real size variation. Proves it actually did something.
+//   G-AREA-ORDER   within a weighted class, a physically larger element never gets LESS time than
+//                  a smaller one. The monotonicity a planner would check by eye.
+//   G-AREA-NOCLOBBER  classes already claimed by realQty (fragmented) or lengthRatio are untouched
+//                  — no double-weighting. Their per-element secs must be byte-identical to before.
+'use strict';
+const fs = require('fs');
+const path = require('path');
+const HOME = require('os').homedir();
+const VIEWER_DIR = path.join(__dirname, '..');
+const SQLJS_DIR = process.env.SQLJS_DIR || path.join(HOME, 'bim-ootb', 'modeller', 'lib');
+const initSqlJs = require(path.join(SQLJS_DIR, 'sql-wasm.js'));
+const SA = require(path.join(VIEWER_DIR, 'schedule_author.js'));
+const BLD_DIR = process.env.BLD_DIR || path.join(HOME, 'bim-ootb', 'buildings');
+const DB_FILE = { LTU_AHouse: 'LTU_AHouse_meta.db' };
+const BUILDINGS = (process.env.ONLY || 'Terminal,Hospital,Duplex,HHS_Office_Federated,Clinic,LTU_AHouse,JKR').split(',');
+
+const results = [];
+function gate(name, pass, detail) {
+  results.push({ name, pass, detail });
+  console.log(`${pass ? 'PASS' : 'FAIL'}  ${name}  ${detail}`);
+}
+function loadRatesTable() {
+  const txt = fs.readFileSync(path.join(VIEWER_DIR, 'rates.js'), 'utf8');
+  const start = txt.indexOf('var RATES = {');
+  const defIdx = txt.indexOf('var SEQUENCE_DEFAULT');
+  return (new Function(txt.slice(start, txt.indexOf('};', defIdx) + 2) + '\n return RATES;'))();
+}
+
+(async () => {
+  const SQL = await initSqlJs({ wasmBinary: fs.readFileSync(path.join(SQLJS_DIR, 'sql-wasm.wasm')) });
+  const rules = JSON.parse(fs.readFileSync(path.join(VIEWER_DIR, 'rates', 'sequence_rules.json'), 'utf8'));
+  const SR = rules.SEQUENCE_RULES, SD = rules.SEQUENCE_DEFAULT, LR = rules.LABOR_RATES;
+  const NO = rules.NAME_OVERRIDES || [];
+  const RATES = loadRatesTable();
+
+  let totalBad = [], spreadRose = [], orderBad = [], clobbered = [], ran = 0;
+
+  for (const bld of BUILDINGS) {
+    const dbPath = path.join(BLD_DIR, DB_FILE[bld] || (bld + '_extracted.db'));
+    if (!fs.existsSync(dbPath)) { console.log(`      (skip ${bld} — fixture missing)`); continue; }
+    const db = new SQL.Database(fs.readFileSync(dbPath));
+    const frag = SA._classFragmentation(db, RATES);
+    const lin = SA._linearWeighting(db, RATES);
+    const area = SA._areaWeighting(db, RATES, frag.fragmented, SR, SD, NO, LR);
+
+    const r = db.exec("SELECT m.guid, m.ifc_class, COALESCE(m.element_name,''), " +
+      't.bbox_x, t.bbox_y, t.bbox_z FROM elements_meta m JOIN element_transforms t ON m.guid=t.guid ' +
+      "WHERE m.ifc_class != 'IfcOpeningElement' AND m.ifc_class != 'IfcSpace'");
+    if (!r.length) { db.close(); continue; }
+    ran++;
+
+    const byCls = {};
+    r[0].values.forEach(v => {
+      const [guid, cls, nm, bx, by, bz] = v;
+      const rule = SA.matchNameOverride(cls, nm, NO) || SA.matchRule(cls, SR, SD);
+      const realQty = (frag.fragmented[cls] && frag.area[guid] != null) ? frag.area[guid] : null;
+      const hasGeom = bx > 0 || by > 0 || bz > 0;
+      const avgLen = lin.avgLength[cls];
+      const lengthRatio = (realQty == null && hasGeom && avgLen > 0) ? Math.max(bx, by, bz) / avgLen : null;
+      const avgArea = area.avgArea[cls];
+      const areaRatio = (realQty == null && lengthRatio == null && hasGeom && avgArea > 0 &&
+                         area.area[guid] > 0) ? area.area[guid] / avgArea : null;
+      const before = SA._installSecs(cls, rule, LR, realQty, lengthRatio);          // pre-change path
+      const after  = SA._installSecs(cls, rule, LR, realQty, lengthRatio, areaRatio);
+      const c = byCls[cls] || (byCls[cls] = { b: 0, a: 0, n: 0, weighted: areaRatio != null,
+                                              claimed: (realQty != null || lengthRatio != null),
+                                              pts: [], diffs: 0 });
+      c.b += before; c.a += after; c.n++;
+      if (before !== after) c.diffs++;
+      if (areaRatio != null) c.pts.push({ q: area.area[guid], s: after });
+    });
+
+    const weighted = [];
+    for (const cls in byCls) {
+      const c = byCls[cls];
+      if (c.weighted) {
+        // total preserved (rounding only — each element rounds independently)
+        // 5% band — user ruling 2026-08-12: "NOT ASKING FOR PERFECTION. 5% ERROR MARGIN IS
+        // ACCEPTABLE." Per-element rounding alone cannot reach 5%; anything that does is a real
+        // distortion (the mixed-rate class bug measured 49%), so the bar still catches those.
+        const tol = Math.max(2, c.b * 0.05);
+        if (Math.abs(c.a - c.b) > tol) totalBad.push(`${bld}/${cls} ${c.b}->${c.a} (${(100*(c.a-c.b)/c.b).toFixed(1)}%)`);
+        const secs = c.pts.map(p => p.s).filter(x => x > 0);
+        if (secs.length > 1) {
+          const spread = Math.max(...secs) / Math.min(...secs);
+          if (spread > 1.01) weighted.push(`${cls}:${spread.toFixed(0)}x`);
+          // monotone: sort by quantity, secs must be non-decreasing
+          const sorted = c.pts.slice().sort((x, y) => x.q - y.q);
+          for (let i = 1; i < sorted.length; i++) {
+            if (sorted[i].s < sorted[i - 1].s * 0.95 - 1) { orderBad.push(`${bld}/${cls}`); break; }
+          }
+        }
+      } else if (c.claimed && c.diffs > 0) {
+        clobbered.push(`${bld}/${cls} (${c.diffs} elements changed)`);
+      }
+    }
+    if (weighted.length) spreadRose.push(`${bld}[${weighted.join(' ')}]`);
+    console.log(`      ${bld}: areaWeightedClasses=${Object.keys(byCls).filter(k => byCls[k].weighted).length} ` +
+      `spread=${weighted.join(' ') || 'none'}`);
+    db.close();
+  }
+
+  gate('G-AREA-TOTAL', totalBad.length === 0 && ran > 0,
+    totalBad.length ? 'class total MOVED (inflation!): ' + totalBad.join(' ')
+      : `every area-weighted class keeps its total install time on all ${ran} buildings — redistribution, not inflation`);
+  gate('G-AREA-SPREAD', spreadRose.length > 0,
+    spreadRose.length ? 'per-element spread now scales with real area: ' + spreadRose.join(' ')
+      : 'NO class gained spread — the weighting is not reaching any element');
+  gate('G-AREA-ORDER', orderBad.length === 0,
+    orderBad.length ? 'larger element got LESS time in: ' + orderBad.join(' ')
+      : 'within every weighted class, a larger element never installs faster than a smaller one');
+  gate('G-AREA-NOCLOBBER', clobbered.length === 0,
+    clobbered.length ? 'double-weighted: ' + clobbered.join(' ')
+      : 'classes already claimed by realQty (fragmented) or lengthRatio are byte-identical — no double-weighting');
+
+  const passed = results.filter(r => r.pass).length;
+  console.log(`\n§AREA_WITNESS ${passed}/${results.length} gates passed`);
+  process.exit(passed === results.length ? 0 : 1);
+})();

--- a/viewer/tests/witness_arch_area_weight.js
+++ b/viewer/tests/witness_arch_area_weight.js
@@ -30,21 +30,41 @@
 //   ISSUE: `unit === 'M3'` classes fell through every _installSecs branch to flat, so a tiny pad
 //   footing and a massive raft footing charged identical install time.
 //
-//   ⚠ WHY THIS HALF USES A FIXTURE, stated plainly so nobody reads more into a green run than is
-//   there: NO class in the shipped rates model is priced M3. viewer/rates.js RATES is 32 EA /
-//   11 M / 7 M2 / 1 KG and all 17 rates/*.json templates carry the identical split (0 M3 each).
-//   So on shipped data _volumeWeighting selects nothing — which G-VOL-SHIPPED-INERT asserts as a
-//   POSITIVE result (zero regression), not as a pass by absence. To prove the mechanism actually
-//   works, the M3 gates run against a one-key fixture that reprices IfcFooting EA->M3. IfcFooting
-//   is not an arbitrary pick: it is the named real-world case (821 elements across Hospital/
-//   LTU_AHouse/Clinic spanning 0.26..602.09 m3 — 2320x — all charged the same today), and the
-//   fixture changes ONLY the witness's own in-memory copy. Shipped rates are untouched; repricing
-//   for real is a rates DATA decision this witness deliberately does not make.
+//   ⚠ THE FIXTURE IS GONE — these gates now run on the SHIPPED rates table (§FOOTING_M3,
+//   2026-08-12). When _volumeWeighting first landed, no class in the shipped model was priced M3
+//   (32 EA / 11 M / 7 M2 / 1 KG, identical split in all 17 templates), so the M3 half could only be
+//   proved against a one-key in-memory fixture and G-VOL-SHIPPED-INERT asserted the mechanism
+//   selected nothing. IfcFooting has since been repriced EA→M3 in rates.js and in all 16 templates
+//   that carry a materials.IfcFooting entry, so the mechanism now fires on real shipped data and
+//   that inert gate is RETIRED, replaced by G-VOL-SHIPPED-LIVE (its inverse — the same collateral
+//   assertion, now stated over a live path). Deleting it outright would have dropped the
+//   "nothing ELSE moved" half, which is the part still worth owning.
 //
-//   G-VOL-SHIPPED-INERT (BLOCKING) with shipped RATES, _volumeWeighting selects 0 classes and every
-//                  element's installSecs is byte-identical with the new arg wired vs. not.
-//   G-VOL-TOTAL    (BLOCKING) under the fixture, per class total installSecs after == before.
-//   G-VOL-SPREAD   per-element spread rises above flat on the fixture class. Proves it did something.
+//   ⚠ THE RATE IS DERIVED, NOT INVENTED — G-VOL-RATE-DERIVED is what proves that, and it is the
+//   reason this witness carries the pre-change EA rates as constants. The conversion is a pure unit
+//   correction of the rate the table already had:
+//       rate_m3 = rate_EA / avgVolume,  avgVolume = 4.25074802767622 m3
+//   avgVolume is the class-wide mean of t.bbox_x*t.bbox_y*t.bbox_z (the ONE volume foldCost,
+//   _volumeWeighting and analysis_sidecar.vol_m3 already share) over every real IfcFooting in the
+//   7 shipped buildings — 821 elements, SUM 3489.86413072218 m3, spanning 0.2595..602.0946 m3:
+//     SELECT COUNT(*), SUM(t.bbox_x*t.bbox_y*t.bbox_z) FROM elements_meta m
+//     JOIN element_transforms t ON m.guid=t.guid WHERE m.ifc_class='IfcFooting'
+//     AND t.bbox_x IS NOT NULL AND t.bbox_x>0 AND (t.bbox_x*t.bbox_y*t.bbox_z)>0
+//   Multiplying any shipped m3 rate back by that divisor must return the EA rate it came from —
+//   that round trip is the gate. IfcPile is deliberately NOT converted: zero IfcPile elements exist
+//   in any shipped building, so there is no measured divisor and any m3 rate would be invented.
+//
+//   G-VOL-RATE-DERIVED (BLOCKING) every shipped IfcFooting m3 rate × avgVolume returns its own
+//                  pre-change EA rate (<=0.05% — the 2dp rounding band), across rates.js + all 16
+//                  templates, and none of them still says EA. The anti-invention gate.
+//   G-VOL-COST-NEUTRAL (BLOCKING) sum(rate_m3 × real volume) over the 821-element derivation
+//                  population equals rate_EA × 821 — the same class total, redistributed by size.
+//                  Per BUILDING it deliberately shifts by that building's own avg/class avg.
+//   G-VOL-SHIPPED-LIVE (BLOCKING) on shipped RATES _volumeWeighting selects exactly the M3-priced
+//                  classes and NOTHING else — every element of a non-M3 class is byte-identical
+//                  with the volumeRatio arg wired vs. not. (Replaces G-VOL-SHIPPED-INERT.)
+//   G-VOL-TOTAL    (BLOCKING) on shipped rates, per class total installSecs after == before.
+//   G-VOL-SPREAD   per-element spread rises above flat on the weighted class. Proves it did something.
 //   G-VOL-ORDER    a physically larger element never gets LESS time than a smaller one.
 //   G-VOL-NOCLOBBER  classes claimed by realQty / lengthRatio / areaRatio are byte-identical.
 'use strict';
@@ -158,10 +178,13 @@ function loadRatesTable() {
     clobbered.length ? 'double-weighted: ' + clobbered.join(' ')
       : 'classes already claimed by realQty (fragmented) or lengthRatio are byte-identical — no double-weighting');
 
-  // ── §VOL_WEIGHT (M3) — see the fixture note in this file's header ────────────────────────────
-  const M3_FIXTURE_CLASS = 'IfcFooting';
+  // ── §VOL_WEIGHT (M3) — runs on the SHIPPED rates table, see this file's header ────────────────
+  // The set of classes the shipped table prices M3. Derived from RATES, never hardcoded: whatever
+  // is priced M3 is what _volumeWeighting must claim, and nothing else may move.
+  const M3_PRICED = Object.keys(RATES).filter(c => RATES[c] && RATES[c].unit === 'M3');
   let volTotalBad = [], volSpread = [], volOrderBad = [], volClobbered = [], volRan = 0;
-  let shippedM3 = [], inertBad = [], fixtureSeen = 0;
+  let liveM3 = [], collateralBad = [], liveSeen = 0;
+  let neutralCount = 0, neutralVol = 0;   // §FOOTING_M3 cost-neutrality accumulators
 
   for (const bld of BUILDINGS) {
     const dbPath = path.join(BLD_DIR, DB_FILE[bld] || (bld + '_extracted.db'));
@@ -171,14 +194,10 @@ function loadRatesTable() {
     const lin = SA._linearWeighting(db, RATES);
     const area = SA._areaWeighting(db, RATES, frag.fragmented, SR, SD, NO, LR);
 
-    // (a) shipped rates — must select nothing at all.
-    const volShipped = SA._volumeWeighting(db, RATES, frag.fragmented, SR, SD, NO, LR);
-    Object.keys(volShipped.avgVolume).forEach(c => shippedM3.push(`${bld}/${c}`));
-
-    // (b) the fixture — one key repriced, in this witness's own copy only.
-    const RATES_M3 = Object.assign({}, RATES);
-    RATES_M3[M3_FIXTURE_CLASS] = Object.assign({}, RATES[M3_FIXTURE_CLASS] || { rate: 0 }, { unit: 'M3' });
-    const vol = SA._volumeWeighting(db, RATES_M3, frag.fragmented, SR, SD, NO, LR);
+    // The shipped rates table IS the M3 table now — one call, no fixture. Anything it claims that
+    // the table does not price M3 is a selection bug, and that is what G-VOL-SHIPPED-LIVE reads.
+    const vol = SA._volumeWeighting(db, RATES, frag.fragmented, SR, SD, NO, LR);
+    Object.keys(vol.avgVolume).forEach(c => liveM3.push(`${bld}/${c}`));
 
     const r = db.exec("SELECT m.guid, m.ifc_class, COALESCE(m.element_name,''), " +
       't.bbox_x, t.bbox_y, t.bbox_z FROM elements_meta m JOIN element_transforms t ON m.guid=t.guid ' +
@@ -198,20 +217,16 @@ function loadRatesTable() {
       const areaRatio = (realQty == null && lengthRatio == null && hasGeom && avgArea > 0 &&
                          area.area[guid] > 0) ? area.area[guid] / avgArea : null;
 
-      // shipped-inert: new arg wired, but volumeRatio derived from the SHIPPED table.
-      const avgVolShipped = volShipped.avgVolume[cls];
-      const volRatioShipped = (realQty == null && lengthRatio == null && areaRatio == null && hasGeom &&
-                               avgVolShipped > 0 && volShipped.volume[guid] > 0)
-        ? volShipped.volume[guid] / avgVolShipped : null;
-      const noArg = SA._installSecs(cls, rule, LR, realQty, lengthRatio, areaRatio);
-      const withArg = SA._installSecs(cls, rule, LR, realQty, lengthRatio, areaRatio, volRatioShipped);
-      if (noArg !== withArg) inertBad.push(`${bld}/${cls}`);
-
-      // fixture: the M3 path under the repriced table.
       const avgVol = vol.avgVolume[cls];
       const volumeRatio = (realQty == null && lengthRatio == null && areaRatio == null && hasGeom &&
                            avgVol > 0 && vol.volume[guid] > 0) ? vol.volume[guid] / avgVol : null;
+      const noArg = SA._installSecs(cls, rule, LR, realQty, lengthRatio, areaRatio);
       const after = SA._installSecs(cls, rule, LR, realQty, lengthRatio, areaRatio, volumeRatio);
+      // COLLATERAL: a class the shipped table does NOT price M3 must be untouched by the new arg.
+      // This is the surviving half of the retired G-VOL-SHIPPED-INERT.
+      if (M3_PRICED.indexOf(cls) < 0 && noArg !== after) collateralBad.push(`${bld}/${cls}`);
+      // §FOOTING_M3 cost-neutrality population — exactly the rows the divisor was averaged over.
+      if (cls === 'IfcFooting' && vol.volume[guid] > 0) { neutralCount++; neutralVol += vol.volume[guid]; }
       const c = byCls[cls] || (byCls[cls] = { b: 0, a: 0, n: 0, weighted: false,
                                               claimed: (realQty != null || lengthRatio != null || areaRatio != null),
                                               pts: [], diffs: 0 });
@@ -224,7 +239,7 @@ function loadRatesTable() {
     for (const cls in byCls) {
       const c = byCls[cls];
       if (c.weighted) {
-        fixtureSeen++;
+        liveSeen++;
         const tol = Math.max(2, c.b * 0.05);   // same 5% band + rounding floor as G-AREA-TOTAL
         if (Math.abs(c.a - c.b) > tol) volTotalBad.push(`${bld}/${cls} ${c.b}->${c.a} (${(100*(c.a-c.b)/c.b).toFixed(1)}%)`);
         const secs = c.pts.map(p => p.s).filter(x => x > 0);
@@ -241,19 +256,58 @@ function loadRatesTable() {
       }
     }
     if (wt.length) volSpread.push(`${bld}[${wt.join(' ')}]`);
-    console.log(`      ${bld}: shippedM3Classes=${Object.keys(volShipped.avgVolume).length} ` +
-      `fixtureWeighted=${wt.join(' ') || 'none'}`);
+    console.log(`      ${bld}: shippedM3Classes=${Object.keys(vol.avgVolume).length} ` +
+      `weighted=${wt.join(' ') || 'none'}`);
     db.close();
   }
 
-  gate('G-VOL-SHIPPED-INERT', shippedM3.length === 0 && inertBad.length === 0 && volRan > 0,
-    (shippedM3.length ? 'shipped RATES unexpectedly yielded M3 classes: ' + shippedM3.join(' ') + ' ' : '') +
-    (inertBad.length ? 'installSecs CHANGED on shipped rates: ' + inertBad.slice(0, 5).join(' ')
-      : `shipped rates price 0 classes M3, so the new path selects nothing and every element's install time is byte-identical on all ${volRan} buildings — zero regression`));
-  gate('G-VOL-TOTAL', volTotalBad.length === 0 && fixtureSeen > 0,
+  // ── §FOOTING_M3 — the anti-invention gate. Every shipped m3 rate must round-trip through the
+  // measured divisor back to the EA rate it was converted from. AVG_VOL and EA_BEFORE are the
+  // derivation record; if someone edits a rate to a market number, this gate is what catches it.
+  const AVG_VOL = 4.25074802767622;   // class-wide mean bbox volume, 821 shipped IfcFooting, see header
+  const EA_BEFORE = {                 // the pre-conversion unit:'EA' rate each source carried
+    'rates.js': 320, aramco2024_sa: 275, asaqs2024_za: 4500, bcis2024_uk: 184, bki2024_de: 185,
+    cidb2024_my: 320, cype2024_es: 73, dpt2024_th: 2600, gb50500_cn: 520, jbci2024_jp: 14500,
+    kict2024_kr: 105000, pwd2024_bd: 5500, rawlinsons2024_au: 540, rsmeans2024_us: 240,
+    sinapi2024_br: 385, sni2024_id: 1150000, untec2024_fr: 75
+  };
+  const rateBad = [], rateOk = [];
+  function checkFootingRate(src, entry) {
+    const ea = EA_BEFORE[src];
+    if (ea == null) return;                                    // source not part of the conversion
+    if (!entry) { rateBad.push(`${src}: IfcFooting entry vanished`); return; }
+    if (entry.unit !== 'M3') { rateBad.push(`${src}: still unit=${entry.unit}, not converted`); return; }
+    const implied = entry.rate * AVG_VOL;                      // the round trip
+    const relPct = Math.abs(implied - ea) / ea * 100;
+    if (relPct > 0.05) rateBad.push(`${src}: ${entry.rate}x${AVG_VOL.toFixed(4)}=${implied.toFixed(2)} != EA ${ea} (${relPct.toFixed(3)}%) — INVENTED, not derived`);
+    else rateOk.push(`${src}:${entry.rate}`);
+  }
+  checkFootingRate('rates.js', RATES.IfcFooting);
+  fs.readdirSync(path.join(VIEWER_DIR, 'rates')).filter(f => f.endsWith('.json')).forEach(f => {
+    let tpl; try { tpl = JSON.parse(fs.readFileSync(path.join(VIEWER_DIR, 'rates', f), 'utf8')); } catch (e) { return; }
+    checkFootingRate(f.replace(/\.json$/, ''), (tpl.materials || {}).IfcFooting);
+  });
+  gate('G-VOL-RATE-DERIVED', rateBad.length === 0 && rateOk.length === Object.keys(EA_BEFORE).length,
+    rateBad.length ? rateBad.slice(0, 4).join(' | ')
+      : `all ${rateOk.length} shipped IfcFooting m3 rates round-trip through avgVolume=${AVG_VOL.toFixed(6)} back to their own pre-change EA rate (<=0.05%, the 2dp band) — every rate DERIVED from the rate that was already there, none invented`);
+
+  // Cost neutrality over the derivation population — the arithmetic that proves the conversion.
+  const eaBase = EA_BEFORE['rates.js'], m3Base = RATES.IfcFooting ? RATES.IfcFooting.rate : 0;
+  const oldTotal = eaBase * neutralCount, newTotal = m3Base * neutralVol;
+  const neutralPct = oldTotal > 0 ? Math.abs(newTotal - oldTotal) / oldTotal * 100 : 100;
+  gate('G-VOL-COST-NEUTRAL', neutralCount > 0 && neutralPct <= 0.05,
+    neutralCount === 0 ? 'no IfcFooting elements found — the derivation population is empty'
+      : `${neutralCount} shipped footings, ${neutralVol.toFixed(3)} m3: OLD ${eaBase}/EA x ${neutralCount} = ${oldTotal.toFixed(0)} vs NEW ${m3Base}/M3 x ${neutralVol.toFixed(3)} = ${newTotal.toFixed(0)} (${neutralPct.toFixed(4)}% apart) — same class total, redistributed by real size`);
+
+  gate('G-VOL-SHIPPED-LIVE', collateralBad.length === 0 && liveM3.length > 0 && volRan > 0 &&
+       liveM3.every(x => M3_PRICED.indexOf(x.split('/')[1]) >= 0),
+    collateralBad.length ? 'a class NOT priced M3 changed install time: ' + collateralBad.slice(0, 5).join(' ')
+      : (liveM3.length === 0 ? `shipped rates price [${M3_PRICED.join(',')}] M3 but _volumeWeighting selected NOTHING on any of ${volRan} buildings — the mechanism is inert on live data`
+        : `_volumeWeighting selects exactly the M3-priced classes on shipped rates (${liveM3.join(' ')}) and every element of every other class is byte-identical with the volumeRatio arg wired vs. not — no collateral across all ${volRan} buildings`));
+  gate('G-VOL-TOTAL', volTotalBad.length === 0 && liveSeen > 0,
     volTotalBad.length ? 'class total MOVED (inflation!): ' + volTotalBad.join(' ')
-      : (fixtureSeen > 0 ? `every volume-weighted class keeps its total install time (${fixtureSeen} class-instances under the ${M3_FIXTURE_CLASS} M3 fixture) — redistribution, not inflation`
-        : `fixture class ${M3_FIXTURE_CLASS} weighted nothing — mechanism unproven`));
+      : (liveSeen > 0 ? `every volume-weighted class keeps its total install time (${liveSeen} class-instances on SHIPPED rates) — redistribution, not inflation`
+        : `no class weighted on shipped rates — mechanism unproven`));
   gate('G-VOL-SPREAD', volSpread.length > 0,
     volSpread.length ? 'per-element spread now scales with real volume: ' + volSpread.join(' ')
       : 'NO class gained spread — the volume weighting is not reaching any element');

--- a/viewer/time_machine.js
+++ b/viewer/time_machine.js
@@ -4992,6 +4992,16 @@
       console.warn('§TM_AREA_WEIGHT_FALLBACK ScheduleAuthor not loaded — M2 classes NOT area-weighted');
       return { avgArea: {}, area: {} };
     })();
+    // §VOL_WEIGHT (2026-08-12) — the M3 twin, wired here for the same reason §HEAVY_MEMBER_SPEED_LIMIT
+    // had to be: the wizard path getting a weighting the live playback clock does not is exactly the
+    // fork §TM_DURATION_SYNC exists to prevent. Inert while no shipped class is priced M3 (see
+    // schedule_author.js _volumeWeighting header) — wired now so a repricing needs no code change.
+    var _vol = (function () {
+      if (window.ScheduleAuthor && window.ScheduleAuthor._volumeWeighting) {
+        return window.ScheduleAuthor._volumeWeighting(db, window.RATES || {}, _frag.fragmented, SR, SD, NO, LR);
+      }
+      return { avgVolume: {}, volume: {} };
+    })();
     function getInstallSecs(cls, rule, guid, bx, by, bz) {
       rule = rule || matchRule(cls);
       var realQty = (_frag.fragmented[cls] && guid != null && _frag.area[guid] != null) ? _frag.area[guid] : null;
@@ -5001,8 +5011,11 @@
       var clsAvgArea = _area.avgArea[cls];
       var areaRatio = (realQty == null && lengthRatio == null && hasGeom && clsAvgArea > 0 &&
                        _area.area[guid] > 0) ? _area.area[guid] / clsAvgArea : null;
+      var clsAvgVol = _vol.avgVolume[cls];
+      var volumeRatio = (realQty == null && lengthRatio == null && areaRatio == null && hasGeom &&
+                         clsAvgVol > 0 && _vol.volume[guid] > 0) ? _vol.volume[guid] / clsAvgVol : null;
       if (window.ScheduleAuthor && window.ScheduleAuthor._installSecs) {
-        return window.ScheduleAuthor._installSecs(cls, rule, LR, realQty, lengthRatio, areaRatio);
+        return window.ScheduleAuthor._installSecs(cls, rule, LR, realQty, lengthRatio, areaRatio, volumeRatio);
       }
       // Fallback (ScheduleAuthor not loaded) — old per-element behavior, no area weighting.
       var resource = rule.resource;

--- a/viewer/time_machine.js
+++ b/viewer/time_machine.js
@@ -4982,14 +4982,27 @@
       }
       return { avgLength: {}, length: {} };
     })();
+    // §ARCH_AREA_WEIGHT (2026-08-12) — the M2 twin of _lin. Same single-source-of-truth wrapper
+    // shape as the two above; without it the live movie charges a 78m wall exactly what it charges
+    // a 1m one, which is what "ARCH comes on too fast" looks like on screen.
+    var _area = (function () {
+      if (window.ScheduleAuthor && window.ScheduleAuthor._areaWeighting) {
+        return window.ScheduleAuthor._areaWeighting(db, window.RATES || {}, _frag.fragmented, SR, SD, NO, LR);
+      }
+      console.warn('§TM_AREA_WEIGHT_FALLBACK ScheduleAuthor not loaded — M2 classes NOT area-weighted');
+      return { avgArea: {}, area: {} };
+    })();
     function getInstallSecs(cls, rule, guid, bx, by, bz) {
       rule = rule || matchRule(cls);
       var realQty = (_frag.fragmented[cls] && guid != null && _frag.area[guid] != null) ? _frag.area[guid] : null;
       var hasGeom = bx > 0 || by > 0 || bz > 0;
       var clsAvgLen = _lin.avgLength[cls];
       var lengthRatio = (realQty == null && hasGeom && clsAvgLen > 0) ? Math.max(bx, by, bz) / clsAvgLen : null;
+      var clsAvgArea = _area.avgArea[cls];
+      var areaRatio = (realQty == null && lengthRatio == null && hasGeom && clsAvgArea > 0 &&
+                       _area.area[guid] > 0) ? _area.area[guid] / clsAvgArea : null;
       if (window.ScheduleAuthor && window.ScheduleAuthor._installSecs) {
-        return window.ScheduleAuthor._installSecs(cls, rule, LR, realQty, lengthRatio);
+        return window.ScheduleAuthor._installSecs(cls, rule, LR, realQty, lengthRatio, areaRatio);
       }
       // Fallback (ScheduleAuthor not loaded) — old per-element behavior, no area weighting.
       var resource = rule.resource;

--- a/viewer/time_machine.js
+++ b/viewer/time_machine.js
@@ -7631,7 +7631,16 @@
   // huts going first before the walls" AFTER a hard reset, because §GANTT_CACHE_HIT served a
   // gantt:v4 entry generated under the old ordering. A hard reset cannot clear it — the entry is in
   // IndexedDB, not the HTTP cache. This bump is that fix's second half.
-  var _GANTT_CACHE_VERSION = 11;   // §MIDAIR_REPAIR (2026-08-12): display times now repaired so nothing appears before the first element it touches — MUST bump on every change to computeSchedule's gating OR the display remap, or a building already materialized under an older version keeps replaying it forever (§KERNEL_OPS_SCHED_VERSION exists specifically to catch this bump).
+  var _GANTT_CACHE_VERSION = 12;   // §FOOTING_M3 (2026-08-12): install DURATIONS moved, which is the same
+                                   // staleness failure as a gating change — getInstallSecs' output is baked
+                                   // into every materialized element's start/end (see _genVersion above), so a
+                                   // building materialized under v11 replays the old flat footing times forever.
+                                   // This branch had two duration changes already unbumped: §ARCH_AREA_WEIGHT
+                                   // (11887f7, M2 spread) and §VOL_WEIGHT (9169233, M3 mechanism); repricing
+                                   // IfcFooting EA→M3 (rates.js) is what finally makes the M3 half fire on real
+                                   // shipped data — Hospital/Duplex/Clinic/LTU_AHouse footings go from one flat
+                                   // time to a 1403x/8x/49x/81x real-volume spread. One bump covers all three.
+                                   // v11 was §MIDAIR_REPAIR (2026-08-12): display times repaired so nothing appears before the first element it touches — MUST bump on every change to computeSchedule's gating OR the display remap, or a building already materialized under an older version keeps replaying it forever (§KERNEL_OPS_SCHED_VERSION exists specifically to catch this bump).
                                    // v10 was §DOOR_WINDOW_HOST_WALL (2026-08-11): door/window gated on its host wall's finish (schedule_gate.js openingGate)
                                    // v9 was §TIER_SERIAL (2026-08-11): two-tier display remap (serial backbone + concurrent pool)
                                   // v7 was §4D_BAND_MONOTONIC (2026-08-02): PASS B cross-storey trade gate


### PR DESCRIPTION
> "The ARCH still comes on too fast. They are heavy items should take longer relatively to MEP etc. Are we really weighing such params?"

Only partly, and Architecture was the gap. `_installSecs` had three branches and the architecture bulk hit none of them:
- `realQty` — **fragmented** classes only
- `lengthRatio` — selects on `unit === 'M'`, the 7 metre-priced classes
- flat `28800/productivity` — **everything else**

The M2 set (`IfcSlab, IfcWall, IfcWallStandardCase, IfcCurtainWall, IfcCovering, IfcRoof, IfcPlate`) landed in the flat branch. Measured on Hospital:

| class | shortest | longest | spread | was |
|---|---|---|---|---|
| IfcWallStandardCase | 1.07 m | 78.50 m | 73× | identical time |
| IfcWall | 0.90 m | 78.79 m | 88× | identical time |
| IfcCovering | 1.21 m | 85.72 m | 71× | identical time |

Meanwhile a 1 m pipe segment **was** size-weighted. Backwards.

## Fix
Area-ratio weighting for M2 classes, using the **redistribution** form (`ratio = thisArea / classAvgArea`), never the multiply form. `mean(ratio)=1`, so a class's total labour is preserved and only its distribution changes. `_classFragmentation`'s own header records what multiplying does to a non-fragmented class: *"IfcWall would jump from ~14 days to 563 days."*

Generic — nothing names a class. Selection is `unit === 'M2'` from the shipped rates table; the measure is the same dominant-face `_AREA_EXPR` `_classFragmentation` already uses.

## Two bugs the witness caught in my own implementation
1. Elements whose second bbox dimension is 0 measured area 0 → ratio 0 → **charged zero time**. Now degrades to flat.
2. **The real one:** `mean(ratio)=1` preserves a class total *only if every element shares one secsPerUnit*. HHS `IfcPlate` splits **438 elements at 120s** and **191 at 2400s** — the ratio correlates with the subgroup, so the total moved **−49.5%** and monotonicity broke. Mixed-rate classes are now detected and left flat (`§ARCH_AREA_WEIGHT_SKIP`).

## W-AREA 4/4, all 7 buildings
```
G-AREA-TOTAL      every weighted class keeps its total (5% band, per ruling)
G-AREA-SPREAD     Hospital IfcWallStandardCase 9252x · IfcWall 5950x · IfcCovering 2347x · IfcSlab 1395x
G-AREA-ORDER      a larger element never installs faster than a smaller one
G-AREA-NOCLOBBER  fragmented / metre-priced classes byte-identical
```

`sw.js` **v1003 → v1005** (v1004 is #1316).

🤖 Generated with [Claude Code](https://claude.com/claude-code)