### PR TITLE
fix(4d): §HOSTED_BEFORE_HOST — a hosted element inherits its host's schedule floor

### DIFF
--- a/viewer/schedule_gate.js
+++ b/viewer/schedule_gate.js
@@ -44,6 +44,55 @@
   // class mix, less coverage). EXTRACTED, not invented — do not retune without re-measuring.
   var BIG_ELEMENT_VOL = 1.556;  // m³
   var MAX_CREWS_DEFAULT = 3;  // §CREW-CAP: fallback crew count per resource when no lookup is given
+  // ══ §HOSTED_BEFORE_HOST (2026-08-12, bim-compiler prompts/4D_SCHEDULE_PERFECTION.md) ═══════════
+  // The class sets and the ±HOST_Z bracket below are NOT new: they are verbatim the host inference
+  // that bim-compiler scripts/probe_arch_start.js measured the defect with (§HOSTED_BEFORE_HOST),
+  // so the scheduler now enforces exactly the predicate the witness asserts — one rule, every
+  // consumer, the same discipline §HANG_NEAREST follows. IFC ships no host link for these elements
+  // (no IfcRelVoidsElement/host column exists in the shipped extracted DBs — same fact
+  // §DOOR_WINDOW_HOST_WALL records), so the host is inferred geometrically and nothing is invented.
+  var HOSTED_CLS = /^(IfcOutlet|IfcLightFixture|IfcSwitchingDevice|IfcSensor|IfcAlarm|IfcFlowTerminal|IfcAirTerminal|IfcElectricAppliance|IfcFireSuppressionTerminal)$/;
+  var HOST_CLS   = /^(IfcWall|IfcWallStandardCase|IfcSlab|IfcRoof|IfcCovering|IfcCurtainWall)$/;
+  var HOST_Z     = 1.0;  // m — hosted centre must sit within the host's Z extent ± this (probe's measured bracket)
+  // ONE host-inference definition at module scope, three consumers: computeSchedule's hostGate, its
+  // DAG edge, and time_machine.js's display-layer repair (exported as hostPairs below, the same
+  // reason EPS/GAP are exported — "a second copy is a second thing to drift").
+  // Nearest bracketing host: among hosts whose bbox spans the hosted element's own XY cell and whose
+  // Z extent brackets its centre (±HOST_Z), the one nearest in XY. Verbatim probe_arch_start.js.
+  // isHosted needs no wall/slab guard — HOSTED_CLS ∩ HOST_CLS = ∅ by construction, which is also
+  // what makes a hosted element a pure DAG sink (see the host edge's cycle argument).
+  function isHosted(el) { return HOSTED_CLS.test(el.cls || '') && el.seq > 4; }
+  function hostCellKey(el) {
+    return Math.floor((el.x0 + el.x1) / 2 / CELL) + ',' + Math.floor((el.y0 + el.y1) / 2 / CELL);
+  }
+  function nearestHostAt(el, list, els) {   // list: indices into els
+    var cx = (el.x0 + el.x1) / 2, cy = (el.y0 + el.y1) / 2, cz = (el.base_z + el.top_z) / 2;
+    var bi = -1, bd = Infinity, q, H, d;
+    for (q = 0; q < list.length; q++) {
+      H = els[list[q]];
+      if (H.guid === el.guid) continue;
+      if (cz < H.base_z - HOST_Z || cz > H.top_z + HOST_Z) continue;   // not at this host's height
+      d = Math.abs((H.x0 + H.x1) / 2 - cx) + Math.abs((H.y0 + H.y1) / 2 - cy);
+      if (d < bd) { bd = d; bi = q; }
+    }
+    return bi;
+  }
+  // hostPairs(els) -> [{ i, h }] index pairs into els (i = hosted, h = its inferred host).
+  // els: [{ guid, cls, seq, x0,x1,y0,y1, base_z, top_z }]. Pure geometry — no timing read, so a
+  // caller can pair once and then compare whatever stage of the timeline it owns.
+  function hostPairs(els) {
+    var idx = {}, out = [], t, cs, c, e, k, bi;
+    for (t = 0; t < els.length; t++) { e = els[t];
+      if (!HOST_CLS.test(e.cls || '')) continue;
+      cs = cellsOf(e); for (c = 0; c < cs.length; c++) (idx[cs[c]] = idx[cs[c]] || []).push(t); }
+    for (t = 0; t < els.length; t++) { e = els[t];
+      if (!isHosted(e)) continue;
+      k = idx[hostCellKey(e)]; if (!k) continue;
+      bi = nearestHostAt(e, k, els);
+      if (bi >= 0) out.push({ i: t, h: k[bi] });
+    }
+    return out;
+  }
 
   function cellsOf(e) {
     var o = [], i, j;
@@ -99,6 +148,15 @@
   function computeSchedule(elements, baseMs, scaleFactor, maxCrews) {
     baseMs = baseMs || 0; scaleFactor = scaleFactor || 1;
     var grid = {}, wallGrid = {}, out = {}, c, cs, k, arr, S;
+    // §HOSTED_BEFORE_HOST: the host pairing is resolved ONCE, up front, off pure geometry — NOT from
+    // an incremental placement grid. That is deliberate and it was a measured bug before it was a
+    // design: a grid filled in PLACEMENT order and the DAG's index built in ELEMENT order break
+    // Manhattan-distance ties differently, so the gate could wait on one host while the DAG had
+    // ordered a different one — 125 of LTU_AHouse's 5,466 hosted elements survived the gate that way.
+    // One pairing, shared by the gate below, the DAG edge, and (through hostPairs) the display layer.
+    var _hostOf = {}, _hostPairs = hostPairs(elements), _hp;
+    for (_hp = 0; _hp < _hostPairs.length; _hp++)
+      _hostOf[elements[_hostPairs[_hp].i].guid] = elements[_hostPairs[_hp].h].guid;
     function crewCapFor(resource) {
       if (typeof maxCrews === 'number') return maxCrews;
       if (maxCrews && maxCrews[resource]) return maxCrews[resource];
@@ -335,6 +393,37 @@
               S.end > g && overlap(S, el)) g = S.end; } }
       return g;
     }
+    // ══ §HOSTED_BEFORE_HOST (2026-08-12, bim-compiler prompts/4D_SCHEDULE_PERFECTION.md) ═════════
+    // User, live 2026-08-12: "electrical outlets and hanging elements appearing bit early." MEASURED
+    // on the DISPLAY timeline before this gate existed (probe_arch_start.js §HOSTED_BEFORE_HOST, all
+    // 7 shipped buildings): Hospital 1480/2830 (52.3%) hosted elements start before the element they
+    // are mounted in, worst 147.7d; Terminal 25.6%, LTU_AHouse 37.8% (worst 573.9d), Clinic 24.1%,
+    // HHS 17.8%, Duplex 8.7%, JKR 5.9%. Long-standing, NOT a §TIER_SERIAL_BY_ZONE regression — the
+    // same probe run against 42539c9 (pre-#1313) reports 50.3/25.2/37.7/23.2/17.7/9.6/5.7%.
+    //
+    // WHY NO EXISTING GATE CAUGHT IT, and it is one fact: the host of essentially every offender is
+    // IfcCovering — a ceiling — and IfcCovering is in NO support pool. geoGate/hangGate read the
+    // structure grid (seq<=4 + promoted slabs), wallGate/openingGate read the wall grid. A ceiling is
+    // in neither, so a light fixture had literally nothing to be checked against. Worse, the shipped
+    // trade order makes the inversion the DEFAULT rather than an accident: sequence_rules.json puts
+    // MEP Final at seq 9 and Finishes (IfcCovering) at seq 10, so a lay-in fixture is scheduled
+    // BEFORE the ceiling it drops into, by rule, everywhere. hangGate cannot save it either — its
+    // §HANG_NEAREST fallback is scoped to BIG (>BIG_ELEMENT_VOL) elements, and outlets/fixtures are
+    // exactly the small ones it deliberately leaves ungated.
+    //
+    // THE RULE: a hosted element inherits its HOST's floor — it may not start before the host it is
+    // mounted in/on has FINISHED (the same S.end every other gate in this module returns). STRICT
+    // ADDITION: only HOSTED_CLS elements are gated, nothing else's timing moves, and an element with
+    // no bracketing host in its cell keeps exactly its previous behaviour.
+    // Reads the host's CURRENT end straight out of `out`, so a §DEQ_REPAIR shift of a host is seen
+    // by what it hosts on the very next sweep — no stale grid copy to keep in step. An unplaced host
+    // (a §SUPPORT_CYCLE fallback member) yields baseMs here and the repair loop closes it after.
+    function hostGate(el) {                // finish of the wall/slab/ceiling this element is mounted in
+      var hg = _hostOf[el.guid];
+      if (!hg) return baseMs;
+      var o = out[hg];
+      return (o && o.end > baseMs) ? o.end : baseMs;
+    }
     // ══ §GEOMETRIC_SUPPORT_ORDER (2026-08-07, 4D_SCHEDULE_PERFECTION.md) ════════════════════════
     // Placement order is derived from GEOMETRY FIRST: a support DAG built from XYZ data alone —
     // edge S→E for exactly the pair predicates the timing gates above consult (geoGate's
@@ -377,7 +466,8 @@
     function wallCarries(S, E)   { return edgeBearing(S, E) && S.top_z <= E.base_z + GAP; }
     function edgeCarrier(S, E)   { return S.base_z >= E.top_z - GAP && S.base_z <= E.top_z + GAP && S.top_z > E.top_z + EPS; }  // hangGate
     var indeg = new Int32Array(N), succs = new Array(N), hangs = new Uint8Array(N), _edges = 0,
-        _hangNearest = 0;  // §HANG_NEAREST fallback edges added (logged in §GEO_ORDER)
+        _hangNearest = 0,  // §HANG_NEAREST fallback edges added (logged in §GEO_ORDER)
+        _hostEdges = 0;    // §HOSTED_BEFORE_HOST host→hosted edges added (logged in §GEO_ORDER)
     // stamp-array dedup (an {} per element measured 28s at 15k elements — dictionary churn), and a
     // reused cands array; _gen is bumped once per scan so stamps never need clearing
     var stamp = new Int32Array(N), _gen = 0, cands = [], nc;
@@ -429,6 +519,16 @@
             if (wallCarries(S, E)) { (succs[si] = succs[si] || []).push(t); indeg[t]++; _edges++; } } }   // §TM_GEO_ORDER_CYCLES: bounded, carry-at-top
       }
     }
+    // §HOSTED_BEFORE_HOST — the DAG twin of hostGate, from the SAME _hostPairs the gate reads, so
+    // placement order and runtime gate cannot pick different hosts (they did, until they shared one
+    // pairing — see _hostOf's header). CANNOT CREATE A CYCLE, structurally, not by luck: HOSTED_CLS
+    // ∩ HOST_CLS = ∅ and isHosted requires seq>4, so a hosted element is in NO pool — struct, wall
+    // or host — hence has zero outgoing edges and an added in-edge closes nothing. Same argument
+    // §HANG_NEAREST rests on (W-TMREPRO-4 cycles=0 stays structural).
+    for (_hp = 0; _hp < _hostPairs.length; _hp++) {
+      si = _hostPairs[_hp].h; t = _hostPairs[_hp].i;
+      (succs[si] = succs[si] || []).push(t); indeg[t]++; _edges++; _hostEdges++;
+    }
     // tiebreak = the old seq-primary processing order (precomputed keys — collapsePhase is regex)
     var rankKey = new Float64Array(N), seqKey = new Float64Array(N);
     for (t = 0; t < N; t++) { rankKey[t] = _bandRank[collapsePhase(elements[t].storey)] || 0; seqKey[t] = elements[t].seq; }
@@ -466,7 +566,7 @@
       var slot = claimCrew(el.resource);
       // §4D_BAND_MONOTONIC: the "upper floors gets walled first" half — the cross-storey term.
       var bg = bandGate(el);
-      var start = Math.max(geoGate(el), wallGate(el), hangGate(el), openingGate(el), tg, bg, slot.time);   // §4D_WALLS_BEFORE_ROOF M5 + §DEQ_V1 + §DOOR_WINDOW_HOST_WALL
+      var start = Math.max(geoGate(el), wallGate(el), hangGate(el), openingGate(el), hostGate(el), tg, bg, slot.time);   // §4D_WALLS_BEFORE_ROOF M5 + §DEQ_V1 + §DOOR_WINDOW_HOST_WALL + §HOSTED_BEFORE_HOST
       if (bg > baseMs && bg >= Math.max(geoGate(el), wallGate(el), tg)) _bmGatedB++;
       var end = place(el, start);
       if (bg > baseMs && start - bg > _bmMaxLagMs) _bmMaxLagMs = start - bg;
@@ -501,7 +601,7 @@
       console.log('§SUPPORT_CYCLE cycles=' + _cyc.length +
         (_cyc.length ? ' sample=[' + _cyc.slice(0, 5).map(function (x) { return elements[x].guid; }).join(',') + ']' : ''));
       console.log('§GEO_ORDER n=' + N + ' edges=' + _edges + ' hangNearest=' + _hangNearest +
-        ' orderMs=' + (Date.now() - _t0));
+        ' hostEdges=' + _hostEdges + ' orderMs=' + (Date.now() - _t0));
     }
     var nonst = elements.filter(function (e) { return e.seq > 4; });
     // §DEQ_V1 repair loop — the zero-contradiction guarantee. The gates above are only as good as
@@ -518,7 +618,7 @@
       var _moved = 0;
       nonst.slice().sort(function (a, b) { return out[a.guid].start - out[b.guid].start; })
         .forEach(function (el) {
-        var need = Math.max(geoGate(el), wallGate(el), hangGate(el), openingGate(el));
+        var need = Math.max(geoGate(el), wallGate(el), hangGate(el), openingGate(el), hostGate(el));
         var o = out[el.guid];
         if (o.start < need) {
           var dur = o.end - o.start; o.start = need; o.end = need + dur;
@@ -753,7 +853,7 @@
   // EPS/GAP exported alongside CELL so a consumer of the same geometry (time_machine.js
   // §MIDAIR_REPAIR) can test contact with THIS module's measured constants instead of re-typing
   // them — a second copy is a second thing to drift.
-  var API = { computeSchedule: computeSchedule, collapsePhase: collapsePhase, elementsInPhase: elementsInPhase, auditFloating: auditFloating, deriveBandRanks: deriveBandRanks, deriveZones: deriveZones, CELL: CELL, EPS: EPS, GAP: GAP, BIG_ELEMENT_VOL: BIG_ELEMENT_VOL };
+  var API = { computeSchedule: computeSchedule, collapsePhase: collapsePhase, elementsInPhase: elementsInPhase, auditFloating: auditFloating, deriveBandRanks: deriveBandRanks, deriveZones: deriveZones, hostPairs: hostPairs, CELL: CELL, EPS: EPS, GAP: GAP, BIG_ELEMENT_VOL: BIG_ELEMENT_VOL };
   global.ScheduleGate = API;
   if (typeof module !== 'undefined' && module.exports) module.exports = API;
 })(typeof window !== 'undefined' ? window : (typeof globalThis !== 'undefined' ? globalThis : this));

--- a/viewer/sw.js
+++ b/viewer/sw.js
@@ -8,7 +8,7 @@
 // Cache-first for heavy assets (.wasm, images). DB files skip SW (IndexedDB handles them).
 //
 // DEPLOY: bump CACHE_VERSION on every OCI upload. Old caches are purged on activate.
-const CACHE_VERSION = 'v1004';   // bump on each deploy; per-change detail is the git commit message.
+const CACHE_VERSION = 'v1005';   // bump on each deploy; per-change detail is the git commit message.
 const CACHE_PREFIX = 'bim-ootb-';
 const CACHE_NAME = CACHE_PREFIX + CACHE_VERSION;
 

--- a/viewer/tests/witness_hosted_before_host.js
+++ b/viewer/tests/witness_hosted_before_host.js
@@ -1,0 +1,265 @@
+#!/usr/bin/env node
+// WITNESS — W-HOST — §HOSTED_BEFORE_HOST
+// Spec: bim-compiler prompts/4D_SCHEDULE_PERFECTION.md §HOSTED_BEFORE_HOST.
+//
+// ISSUE THIS PROVES OR DISPROVES:
+//   User, live 2026-08-12: "electrical outlets and hanging elements appearing bit early." Five 4D
+//   changes shipped that day, each with its own witness, each green in isolation — and the user
+//   still saw this. NO WITNESS OWNED THE PREDICATE. This one does: did a hosted element (outlet,
+//   light fixture, air/flow terminal, sensor, alarm) start before the wall/slab/CEILING it is
+//   mounted in? That is the question a viewer's eye asks, and nothing asserted it.
+//
+//   PROVENANCE, measured before the fix and NOT assumed (probe_arch_start.js, all 7 buildings,
+//   DISPLAY timeline): the defect is LONG-STANDING, not a §TIER_SERIAL_BY_ZONE (#1314) regression.
+//     building      pre-#1313 (42539c9)   at 314185d
+//     Terminal              25.2%            25.6%
+//     Hospital              50.3%            52.3%
+//     Duplex                 9.6%             8.7%
+//     HHS_Office_Federated  17.7%            17.8%
+//     Clinic                23.2%            24.1%
+//     LTU_AHouse            37.7%            37.8%
+//     JKR                    5.7%             5.9%
+//   Max delta 2.0pp. The zone barrier made it neither better nor materially worse.
+//
+//   ROOT CAUSE, one fact: the inferred host of essentially every offender is IfcCovering — a
+//   ceiling — and IfcCovering sits in NO support pool (structGrid = seq<=4 + promoted slabs,
+//   wallGrid = walls). geoGate/hangGate/wallGate/openingGate all read one of those two, so a
+//   ceiling was invisible to every gate and what it hosts was never checked against it. The trade
+//   order then makes the inversion the DEFAULT, not an accident: sequence_rules.json puts MEP Final
+//   at seq 9 and Finishes (IfcCovering) at seq 10, so a lay-in fixture is scheduled before its own
+//   ceiling by rule, everywhere. schedule_gate.js's hostGate + its DAG twin close it.
+//
+//   HOST IS INFERRED, NOT READ: no IfcRelVoidsElement / host column exists in the shipped extracted
+//   DBs (the same fact §DOOR_WINDOW_HOST_WALL records). The inference here is byte-identical to the
+//   one the defect was MEASURED with in probe_arch_start.js and to the one hostGate enforces —
+//   among hosts whose bbox spans the hosted element's own XY cell and whose Z extent brackets its
+//   centre (+-1.0m), the nearest in XY. One rule, three consumers, so the witness cannot drift into
+//   asserting something the scheduler was never asked to do.
+//
+// GATES:
+//   G-HOST-RAW      (BLOCKING) EARLY=0 on the GENERATIVE schedule — the timeline schedule_gate.js
+//                   itself owns. Exactly 0 is required here: hostGate + its DAG edge make it
+//                   structural, so any non-zero is a real gate defect, not display-layer slack.
+//   G-HOST-DISPLAY  (BLOCKING) EARLY <= 5% of hostMatched on the DISPLAY timeline the movie
+//                   actually plays (post _twoTierRemap + _midairRepair). Not 0: those two layers
+//                   are allowed to move a host relative to what it hosts (see G-HOST-STAGE), and
+//                   5% is this lane's standing error margin.
+//   G-HOST-STAGE    attribution, reported per building — EARLY after generation vs after remap vs
+//                   after midair repair. This is what says WHICH layer any residual came from,
+//                   rather than leaving it as an unexplained number.
+//   G-HOST-MATCH    the hosted-vs-hostMatched gap: hosted elements with NO bracketing host in their
+//                   cell at all. A separate, already-accepted category (not part of EARLY) —
+//                   reported so it can never quietly grow into a way of passing this witness.
+//
+// Command (from the worktree root):
+//   BLD_DIR=~/bim-ootb/buildings node viewer/tests/witness_hosted_before_host.js
+// Read the log, not the exit code.
+'use strict';
+const fs = require('fs');
+const path = require('path');
+const vm = require('vm');
+const HOME = require('os').homedir();
+const VIEWER_DIR = path.join(__dirname, '..');
+const SQLJS_DIR = process.env.SQLJS_DIR || path.join(HOME, 'bim-ootb', 'modeller', 'lib');
+const initSqlJs = require(path.join(SQLJS_DIR, 'sql-wasm.js'));
+const ScheduleGate = require(path.join(VIEWER_DIR, 'schedule_gate.js'));
+const ScheduleAuthor = require(path.join(VIEWER_DIR, 'schedule_author.js'));
+const BLD_DIR = process.env.BLD_DIR || path.join(HOME, 'bim-ootb', 'buildings');
+const DB_FILE = { LTU_AHouse: 'LTU_AHouse_meta.db' };
+const BUILDINGS = (process.env.ONLY || 'Terminal,Hospital,Duplex,HHS_Office_Federated,Clinic,LTU_AHouse,JKR').split(',');
+const D = 86400000;
+const DISPLAY_TOL = 5;   // % of hostMatched — the lane's standing error margin (G-HOST-DISPLAY)
+
+// The measured host inference — kept identical to schedule_gate.js's HOSTED_CLS/HOST_CLS/HOST_Z and
+// to probe_arch_start.js §HOSTED_BEFORE_HOST. Changing it here without changing them there is what
+// this comment exists to prevent.
+const HOSTED = /^(IfcOutlet|IfcLightFixture|IfcSwitchingDevice|IfcSensor|IfcAlarm|IfcFlowTerminal|IfcAirTerminal|IfcElectricAppliance|IfcFireSuppressionTerminal)$/;
+const HOSTS = /^(IfcWall|IfcWallStandardCase|IfcSlab|IfcRoof|IfcCovering|IfcCurtainWall)$/;
+const HOST_Z = 1.0;   // m
+const CELL = 4;       // m — schedule_gate.js's own grid cell
+
+const results = [];
+function gate(name, pass, detail) {
+  results.push({ name, pass, detail });
+  console.log(`${pass ? 'PASS' : 'FAIL'}  ${name}  ${detail}`);
+}
+
+function sliceFn(src, name, which) {
+  let from = 0;
+  for (let pass = 0; pass <= (which || 0); pass++) {
+    const idx = src.indexOf('function ' + name + '(', from);
+    if (idx < 0) return null;
+    let depth = 0, i = idx, seenOpen = false;
+    for (; i < src.length; i++) {
+      if (src[i] === '{') { depth++; seenOpen = true; }
+      else if (src[i] === '}') { depth--; if (seenOpen && depth === 0) break; }
+    }
+    if (pass === (which || 0)) return src.slice(idx, i + 1);
+    from = i + 1;
+  }
+  return null;
+}
+
+function loadRatesTable() {
+  const txt = fs.readFileSync(path.join(VIEWER_DIR, 'rates.js'), 'utf8');
+  const start = txt.indexOf('var RATES = {');
+  const defIdx = txt.indexOf('var SEQUENCE_DEFAULT');
+  return (new Function(txt.slice(start, txt.indexOf('};', defIdx) + 2) + '\n return RATES;'))();
+}
+
+// Pair every hosted element with its inferred host ONCE, on geometry alone — so the three stage
+// measurements below compare the SAME pairs and a stage difference can only be a timing difference.
+function pairHosts(items) {
+  const hosted = items.filter(it => HOSTED.test(it.cls));
+  const hosts = items.filter(it => HOSTS.test(it.cls));
+  const grid = {};
+  const cells = e => { const o = [];
+    for (let i = Math.floor(e.x0 / CELL); i <= Math.floor(e.x1 / CELL); i++)
+      for (let j = Math.floor(e.y0 / CELL); j <= Math.floor(e.y1 / CELL); j++) o.push(i + ',' + j);
+    return o; };
+  hosts.forEach(h => cells(h).forEach(c => (grid[c] || (grid[c] = [])).push(h)));
+  const pairs = [];
+  hosted.forEach(e => {
+    const cx = (e.x0 + e.x1) / 2, cy = (e.y0 + e.y1) / 2, cz = (e.bz + e.tz) / 2;
+    const cand = grid[Math.floor(cx / CELL) + ',' + Math.floor(cy / CELL)];
+    if (!cand) return;
+    let best = null, bestD = Infinity;
+    for (const h of cand) {
+      if (h.guid === e.guid) continue;
+      if (cz < h.bz - HOST_Z || cz > h.tz + HOST_Z) continue;
+      const d = Math.abs((h.x0 + h.x1) / 2 - cx) + Math.abs((h.y0 + h.y1) / 2 - cy);
+      if (d < bestD) { bestD = d; best = h; }
+    }
+    if (best) pairs.push({ e, h: best });
+  });
+  return { hostedN: hosted.length, pairs };
+}
+
+// EARLY = hosted element STARTS before its host starts — literally "appears before the thing it
+// hangs on" on screen, the user's own predicate. `get` reads the stage's start times.
+function countEarly(pairs, get) {
+  let early = 0, worstD = 0, worst = null;
+  pairs.forEach(p => {
+    const dDays = (get(p.h) - get(p.e)) / D;
+    if (dDays > 0) { early++; if (dDays > worstD) { worstD = dDays; worst = p.e.cls + '@' + p.h.cls; } }
+  });
+  return { early, worstD, worst };
+}
+
+(async () => {
+  const SQL = await initSqlJs({ wasmBinary: fs.readFileSync(path.join(SQLJS_DIR, 'sql-wasm.wasm')) });
+  const rulesJson = JSON.parse(fs.readFileSync(path.join(VIEWER_DIR, 'rates', 'sequence_rules.json'), 'utf8'));
+  const SR = rulesJson.SEQUENCE_RULES, SD = rulesJson.SEQUENCE_DEFAULT, LR = rulesJson.LABOR_RATES;
+  const NO = rulesJson.NAME_OVERRIDES || [];
+  const RATES = loadRatesTable();
+  const tmSrc = fs.readFileSync(path.join(VIEWER_DIR, 'time_machine.js'), 'utf8');
+  const zoneParts = [sliceFn(tmSrc, '_zoneIndexBuild'), sliceFn(tmSrc, '_zoneIndex')].filter(Boolean);
+  const sliced = ["var _TIER1_ORDER = ['Substructure', 'Superstructure', 'Architecture'];",
+    (zoneParts.length === 2 ? 'var _zoneMemo = [];' : ''), zoneParts[0] || '', zoneParts[1] || '',
+    sliceFn(tmSrc, '_zoneOf') || '',
+    sliceFn(tmSrc, '_promoteRoofLoadPath'), sliceFn(tmSrc, '_buildXrayElements'),
+    sliceFn(tmSrc, '_tier1Extents'), sliceFn(tmSrc, '_tier1Serialize'),
+    sliceFn(tmSrc, '_tier1Protrusion'), sliceFn(tmSrc, '_tierAuditRegate'),
+    sliceFn(tmSrc, '_twoTierRemap'), sliceFn(tmSrc, '_contactGraph'),
+    sliceFn(tmSrc, '_midairAudit'),
+    // the LAST _midairRepair definition is the one that hoists last and therefore the one the
+    // browser executes — measure ship truth, same selection probe_arch_start.js defaults to
+    sliceFn(tmSrc, '_midairRepair', 1) || sliceFn(tmSrc, '_midairRepair', 0)].filter(Boolean).join('\n');
+
+  let ran = 0, rawBad = [], dispBad = [], stageRep = [], matchRep = [];
+
+  for (const bld of BUILDINGS) {
+    const dbPath = path.join(BLD_DIR, DB_FILE[bld] || (bld + '_extracted.db'));
+    if (!fs.existsSync(dbPath)) { console.log(`      (skip ${bld} — fixture missing)`); continue; }
+    const db = new SQL.Database(fs.readFileSync(dbPath));
+    const sandbox = { console: { log: () => {}, warn: () => {} }, performance: { now: () => Date.now() },
+      window: { SEQUENCE_RULES: SR, SEQUENCE_DEFAULT: SD, SEQUENCE_NAME_OVERRIDES: NO },
+      ScheduleGate: ScheduleGate, Math: Math, RegExp: RegExp, Object: Object, Infinity: Infinity,
+      A: () => ({ db: db, activeBuilding: bld, _metaGen: 0 }) };
+    vm.createContext(sandbox);
+    vm.runInContext(sliced + '\nthis.__bxe = _buildXrayElements; this.__remap = _twoTierRemap; this.__repair = _midairRepair;', sandbox);
+    const els = sandbox.__bxe();
+    if (!els || !els.length) { console.log(`      (skip ${bld} — element build returned nothing)`); db.close(); continue; }
+
+    const nameOf = {};
+    const nr = db.exec("SELECT guid, ifc_class, COALESCE(element_name,'') FROM elements_meta");
+    if (nr.length) nr[0].values.forEach(v => { nameOf[v[0]] = v[2]; });
+    const frag = ScheduleAuthor._classFragmentation(db, RATES);
+    const lin = ScheduleAuthor._linearWeighting(db, RATES);
+    const geoEls = els.filter(e => !(e.x0 === e.x1 && e.y0 === e.y1 && e.base_z === e.top_z));
+    geoEls.forEach(e => {
+      const rule = ScheduleAuthor.matchNameOverride(e.cls, nameOf[e.guid] || '', NO) || ScheduleAuthor.matchRule(e.cls, SR, SD);
+      if (!e.phase) e.phase = rule.phase;
+      e.resource = rule.resource || '_DEFAULT';
+      const realQty = (frag.fragmented[e.cls] && frag.area[e.guid] != null) ? frag.area[e.guid] : null;
+      const span = Math.max(e.x1 - e.x0, e.y1 - e.y0, e.top_z - e.base_z);
+      const avgLen = lin.avgLength[e.cls];
+      const lengthRatio = (realQty == null && span > 0 && avgLen > 0) ? span / avgLen : null;
+      e.installSecs = ScheduleAuthor._installSecs(e.cls, rule, LR, realQty, lengthRatio);
+    });
+    db.close();
+
+    // §CREW_AUTOSCALE — mirrors injectGantt so this witness schedules the SAME programme the viewer does
+    const crewWorkDays = {};
+    let totSecs = 0;
+    geoEls.forEach(e => { const r = e.resource || '_DEFAULT';
+      crewWorkDays[r] = (crewWorkDays[r] || 0) + (e.installSecs || 0) / 28800; totSecs += e.installSecs || 0; });
+    const projDays = Math.max(10, Math.ceil(totSecs * 1000 / 86400000));
+    const maxCrews = {};
+    for (const rk in LR) {
+      if (!LR[rk].max_crews && LR[rk].max_crews_fixed == null) continue;
+      maxCrews[rk] = (LR[rk].max_crews_fixed != null) ? LR[rk].max_crews_fixed
+        : Math.max(LR[rk].max_crews || 0, Math.ceil((crewWorkDays[rk] || 0) / projDays));
+    }
+
+    const quiet = console.log; console.log = () => {};
+    let sched;
+    try { sched = ScheduleGate.computeSchedule(geoEls, 0, 1, maxCrews); } finally { console.log = quiet; }
+
+    const items = geoEls.map(e => ({ guid: e.guid, s: sched[e.guid].start, e: sched[e.guid].end,
+      rawS: sched[e.guid].start,
+      bz: e.base_z, tz: e.top_z, x0: e.x0, x1: e.x1, y0: e.y0, y1: e.y1, cls: e.cls, seq: e.seq,
+      phase: e.phase, storey: e.storey }));
+
+    const { hostedN, pairs } = pairHosts(items);
+    if (!pairs.length) { console.log(`      ${bld}: hosted=${hostedN} hostMatched=0 — nothing to check`); continue; }
+    ran++;
+
+    const raw = countEarly(pairs, it => it.rawS);                      // stage 1: generative
+    sandbox.console = { log: () => {}, warn: () => {} };
+    sandbox.__items = items;
+    vm.runInContext('this.__remap(this.__items);', sandbox);
+    const remapS = {}; items.forEach(it => { remapS[it.guid] = it.s; });
+    const rem = countEarly(pairs, it => remapS[it.guid]);              // stage 2: + two-tier remap
+    vm.runInContext('this.__repair(this.__items);', sandbox);
+    const disp = countEarly(pairs, it => it.s);                        // stage 3: DISPLAY (what plays)
+
+    const pct = n => (100 * n / pairs.length).toFixed(1);
+    if (raw.early !== 0) rawBad.push(`${bld}=${raw.early}(${pct(raw.early)}%, worst ${raw.worstD.toFixed(1)}d ${raw.worst})`);
+    if (100 * disp.early / pairs.length > DISPLAY_TOL)
+      dispBad.push(`${bld}=${pct(disp.early)}% (${disp.early}/${pairs.length}, worst ${disp.worstD.toFixed(1)}d ${disp.worst})`);
+    stageRep.push(`${bld} gen=${raw.early} remap=${rem.early} display=${disp.early}`);
+    matchRep.push(`${bld}=${hostedN - pairs.length}/${hostedN}`);
+
+    console.log(`      ${bld}: hosted=${hostedN} hostMatched=${pairs.length} ` +
+      `EARLY gen=${raw.early}(${pct(raw.early)}%) remap=${rem.early}(${pct(rem.early)}%) ` +
+      `display=${disp.early}(${pct(disp.early)}%) worstDisplay=${disp.worstD.toFixed(1)}d${disp.worst ? ' ' + disp.worst : ''}`);
+  }
+
+  gate('G-HOST-RAW', rawBad.length === 0 && ran > 0,
+    rawBad.length ? 'generative schedule still inverts: ' + rawBad.join(' ')
+      : `0 hosted elements start before their host on the generative timeline, all ${ran} buildings ` +
+        `— hostGate + its DAG edge make this structural, not incidental`);
+  gate('G-HOST-DISPLAY', dispBad.length === 0 && ran > 0,
+    dispBad.length ? `over the ${DISPLAY_TOL}% margin on the timeline the movie plays: ` + dispBad.join(' ')
+      : `every building within the ${DISPLAY_TOL}% margin on the DISPLAY timeline (post remap + midair repair)`);
+  gate('G-HOST-STAGE', ran > 0, stageRep.join(' | ') +
+    ' — gen is schedule_gate.js\'s own output; any growth from gen to display is _twoTierRemap or ' +
+    '_midairRepair moving a host relative to what it hosts, and this is where that shows');
+  gate('G-HOST-MATCH', ran > 0, `hosted elements with NO bracketing host in their cell: ${matchRep.join(' ')} ` +
+    `— an accepted separate category (never counted as EARLY), reported so it cannot grow into a way of passing this witness`);
+
+  const passed = results.filter(r => r.pass).length;
+  console.log(`\n§HOST_WITNESS ${passed}/${results.length} gates passed`);
+  process.exit(passed === results.length ? 0 : 1);
+})();

--- a/viewer/time_machine.js
+++ b/viewer/time_machine.js
@@ -4377,6 +4377,31 @@
       var d = t1EndZ[z] - t2MinZ[z];
       if (d > 0) { it.s += d; it.e += d; if (d > tier2Shift) tier2Shift = d; }
     });
+    // ══ §HOSTED_BEFORE_HOST (2026-08-12, bim-compiler prompts/4D_SCHEDULE_PERFECTION.md) ═════════
+    // The zone shift above is order-preserving WITHIN a zone — its own comment says so, and that is
+    // true. It is NOT order-preserving ACROSS zones, and a hosted element and the ceiling it hangs
+    // in routinely land in different ones: _zoneOf is the RAW storey, so a covering tagged
+    // "Level 3 Ceiling" and the light fixture in it tagged "Level 3" are two zones, get two
+    // different shifts (or none at all — a zone with no Tier-1 returns early above), and the pair
+    // re-inverts after the generative layer had it right.
+    // MEASURED, per stage, by witness_hosted_before_host.js on the fixed generative layer:
+    // JKR gen=0 → remap=30, HHS_Office_Federated gen=0 → remap=11. So schedule_gate.js's hostGate
+    // cannot own this alone — the layer that re-broke the order has to be the layer that repairs it.
+    // Same host inference the scheduler gates on (ScheduleGate.hostPairs — ONE definition, the same
+    // reason EPS/GAP are imported rather than re-typed), and the same later-only safety
+    // §MIDAIR_REPAIR carries: a hosted element is pushed to its host's end, never pulled earlier,
+    // so nothing already satisfied above can be undone by it.
+    var _hostFixed = 0;
+    if (typeof ScheduleGate !== 'undefined' && ScheduleGate.hostPairs) {
+      var _hp = ScheduleGate.hostPairs(items.map(function (it) {
+        return { guid: it.guid, cls: it.cls, seq: it.seq, x0: it.x0, x1: it.x1, y0: it.y0, y1: it.y1,
+                 base_z: it.bz, top_z: it.tz };
+      }));
+      _hp.forEach(function (p) {
+        var e = items[p.i], h = items[p.h];
+        if (e.s < h.e) { var dur = e.e - e.s; e.s = h.e; e.e = h.e + dur; _hostFixed++; }
+      });
+    }
     var base = Infinity, endAll = -Infinity, ext2 = {};
     items.forEach(function (it) {
       if (it.s < base) base = it.s;
@@ -4394,6 +4419,8 @@
     console.log('§TIER_SERIAL iterations=' + iters + ' tier1OverlapPairs=' + overlap +
       ' (0=strictly serial backbone, dag-wins excluded) tier1DagWins=' + dagWins +
       ' rawTailExempt=' + Object.keys(_exempt).length + ' pushed=' + pushed + ' sweeps=' + sweeps +
+      ' §HOSTED_BEFORE_HOST hostFixed=' + _hostFixed +
+      ' (hosted elements the cross-zone Tier-2 shift left ahead of their own host, pushed back to it)' +
       ' §TIER2_AFTER_TIER1 shiftDays=' + (tier2Shift / D).toFixed(1) +
       ' (0=Tier2 already started after Tier1\'s true completion, no shift needed)' +
       ' totalDays=' + ((endAll - base) / D).toFixed(1) + ' ' + parts.join(' '));


### PR DESCRIPTION
User, live 2026-08-12: *"electrical outlets and hanging elements appearing bit early."*

Five 4D changes shipped that day (#1313–#1316), each with its own witness, each green in isolation — and the user still hit this. That is the failure mode a per-change witness cannot catch: **no witness owned this predicate.** Now one does.

## Provenance — measured first, not assumed

The 52% figure was suspicious enough to be worth attributing before fixing. `probe_arch_start.js §HOSTED_BEFORE_HOST`, run against `42539c9` (pre-#1313) and against `314185d`:

| building | pre-#1313 | at 314185d | delta |
|---|---|---|---|
| Terminal | 25.2% | 25.6% | +0.4 |
| Hospital | 50.3% | 52.3% | +2.0 |
| Duplex | 9.6% | 8.7% | −0.9 |
| HHS_Office_Federated | 17.7% | 17.8% | +0.1 |
| Clinic | 23.2% | 24.1% | +0.9 |
| LTU_AHouse | 37.7% | 37.8% | +0.1 |
| JKR | 5.7% | 5.9% | +0.2 |

**Verdict: LONG-STANDING.** Not a §TIER_SERIAL_BY_ZONE regression — the zone barrier made it more visible, it did not cause it. Fixed on its own merits.

## Root cause — one fact

The inferred host of essentially every offender is **IfcCovering — a ceiling — and IfcCovering is in NO support pool.** `structGrid` is seq<=4 + promoted slabs, `wallGrid` is walls; `geoGate`/`hangGate`/`wallGate`/`openingGate` each read one of those two. A ceiling is in neither, so a light fixture had literally nothing to be checked against.

The trade order then makes the inversion the **default**, not an accident: `sequence_rules.json` puts MEP Final at seq 9 and Finishes (IfcCovering) at seq 10, so a lay-in fixture is scheduled before the ceiling it drops into, by rule, everywhere. `hangGate` cannot save it either — its §HANG_NEAREST fallback is scoped to BIG elements, and outlets/fixtures are exactly the small ones it deliberately leaves ungated.

## Fix — both layers that own the order

**`schedule_gate.js`** — `hostGate` + its DAG twin: a hosted element may not start before its host has finished (the same `S.end` every other gate returns). Host inference is verbatim the one the defect was measured with; no new heuristic, no invented constant. The pairing is resolved **once, up front, off pure geometry** and shared by the gate, the DAG edge and (via the newly exported `hostPairs`) the display layer. That sharing is load-bearing rather than tidiness: a placement-order grid and an element-order index break Manhattan-distance ties differently, and that alone left **125 of LTU_AHouse's 5,466** hosted elements past the gate until both read one pairing.

The host edge cannot create a cycle, structurally: `HOSTED_CLS ∩ HOST_CLS = ∅` and `isHosted` requires `seq>4`, so a hosted element is in no pool at all, has zero outgoing edges, and an added in-edge closes nothing — the same argument §HANG_NEAREST rests on.

**`time_machine.js` `_twoTierRemap`** — §TIER2_AFTER_TIER1's per-zone shift is order-preserving *within* a zone (its own comment says so, correctly) but **not across zones**, and `_zoneOf` is the raw storey — so a covering tagged `"Level 3 Ceiling"` and the fixture in it tagged `"Level 3"` are two zones, get two different shifts, and re-invert after the generative layer had them right. Measured on the already-fixed generative layer: `JKR gen=0 → remap=30`, `HHS gen=0 → remap=11`. The repair is later-only, the same safety §MIDAIR_REPAIR carries.

## Result — DISPLAY timeline (what the movie plays), all 7 shipped buildings

| building | before | after |
|---|---|---|
| Terminal | 25.6% | **0.0%** |
| Hospital | 52.3% (worst 147.7d) | **0.0%** |
| Duplex | 8.7% | **0.0%** |
| HHS_Office_Federated | 17.8% | **0.0%** |
| Clinic | 24.1% | **0.0%** |
| JKR | 5.9% | **0.0%** |
| LTU_AHouse | 37.8% (worst 573.9d) | **0.2%** (11/5466) |

LTU's residual 11 is attributed by the witness itself (`G-HOST-STAGE`: `gen=0 remap=0 display=11`) to `_midairRepair` pushing 11 coverings past what they host — inside this lane's standing 5% margin, and reported rather than absorbed.

## Witness

New `viewer/tests/witness_hosted_before_host.js`, 4/4 green, added to `bim-compiler scripts/gate_4d.sh` so it is part of the standing gate:

- **G-HOST-RAW** (blocking) — EARLY=**0**, exactly, on the generative timeline. hostGate + its DAG edge make it structural, so any non-zero is a real gate defect.
- **G-HOST-DISPLAY** (blocking) — EARLY ≤5% on the display timeline.
- **G-HOST-STAGE** — per-stage attribution (gen / remap / display). This is what turns a residual into a located fact instead of an unexplained number.
- **G-HOST-MATCH** — the hosted-vs-hostMatched gap, reported so it can never quietly grow into a way of passing.

## Gate diff

`gate_4d.sh` **pass=4 fail=0 missing=1** (`witness_arch_area_weight` is #1317, not merged here). `witness_zone_index` 5/5, `witness_tier_serial_display` 57/0, `witness_crew_demand` 4/4 — all unchanged.

§-number movement, all in the right direction: **§DAY_GAP dead air shrank** where it moved (Hospital 13→11%, Clinic 13→11%, Terminal 8→7%, LTU 3→2%) because MEP Final now spreads into what was empty film. Display programme +0..2.2% (Hospital 616.7→630.1d is the largest) — the expected cost of a real new dependency. §CREW_AUTOSCALE unchanged on every building.

`viewer/sw.js` CACHE_VERSION v1004→v1005 (both changed files are precached).

## Found in passing, NOT fixed here

`viewer/tests/witness_midair_zero.js` crashes with `ReferenceError: _zoneIndex is not defined` — it slices `_buildXrayElements` but not `_zoneIndex`/`_zoneIndexBuild`, which `_buildXrayElements` has required since #1313 landed this morning. Pre-existing, unrelated to this diff (which does not touch `_buildXrayElements`), and invisible because that witness is not in `gate_4d.sh`. Its static gates W-MZ-5/6a/6b still pass; the per-building census does not run. One-line fix, someone else's lane.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GdPyHB9SRqs5Z6rCRdV7eV