### PR TITLE
chore(sw): CACHE_VERSION v1005 → v1007 — restore the bump #1319's squash orphaned

### DIFF
--- a/viewer/sw.js
+++ b/viewer/sw.js
@@ -8,7 +8,7 @@
 // Cache-first for heavy assets (.wasm, images). DB files skip SW (IndexedDB handles them).
 //
 // DEPLOY: bump CACHE_VERSION on every OCI upload. Old caches are purged on activate.
-const CACHE_VERSION = 'v1005';   // bump on each deploy; per-change detail is the git commit message.
+const CACHE_VERSION = 'v1007';   // bump on each deploy; per-change detail is the git commit message.
 const CACHE_PREFIX = 'bim-ootb-';
 const CACHE_NAME = CACHE_PREFIX + CACHE_VERSION;
 


### PR DESCRIPTION
`#1319` was squash-merged while a follow-up commit was still in flight, so its `CACHE_VERSION` bump landed as **v1005** instead of v1007 — the squash-merge + late-push orphaning that `CLAUDE.md` calls out (first observed on #138). The code fix itself landed complete; only the version is short.

That matters because **#1317 is still open and also claims v1005**: merging it would ship new schedule JS behind a cache key users already hold, so the deploy would not bust anything. v1007 clears both #1317 (v1005) and #1318 (v1006).

One line, no code change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GdPyHB9SRqs5Z6rCRdV7eV