### PR TITLE
fix(4d): §DAY_GAP_TAIL — witness_midair_zero has been dead since #1313, and judging the wrong _midairRepair copy

### DIFF
--- a/viewer/tests/witness_midair_zero.js
+++ b/viewer/tests/witness_midair_zero.js
@@ -54,23 +54,48 @@ let pass = 0, fail = 0;
 function assert(cond, msg) { if (cond) { pass++; console.log('  PASS ' + msg); } else { fail++; console.log('  FAIL ' + msg); } }
 function finish() { console.log('\n§MIDAIR_ZERO_SUMMARY pass=' + pass + ' fail=' + fail); process.exit(fail ? 1 : 0); }
 
-function sliceFn(src, name) {
-  const idx = src.indexOf('function ' + name + '(');
-  if (idx < 0) throw new Error(name + ' not found');
-  let depth = 0, i = idx, seenOpen = false;
-  for (; i < src.length; i++) {
-    if (src[i] === '{') { depth++; seenOpen = true; }
-    else if (src[i] === '}') { depth--; if (seenOpen && depth === 0) return src.slice(idx, i + 1); }
+// §DAY_GAP_TAIL (2026-08-12) — `which` selects among SAME-NAMED definitions. time_machine.js
+// defines _midairRepair TWICE (:4457-delegating and :4660-inlined). JS function declarations hoist,
+// so the LAST one is what the browser executes; this witness sliced the FIRST and was therefore
+// judging a copy that never runs. Same class of defect as the one this lane already recorded ("the
+// tier witness was silently testing nothing"), so it is fixed here rather than noted.
+function sliceFn(src, name, which, optional) {
+  let from = 0;
+  for (let pass = 0; pass <= (which || 0); pass++) {
+    const idx = src.indexOf('function ' + name + '(', from);
+    if (idx < 0) { if (optional) return null; throw new Error(name + ' #' + (which || 0) + ' not found'); }
+    let depth = 0, i = idx, seenOpen = false;
+    for (; i < src.length; i++) {
+      if (src[i] === '{') { depth++; seenOpen = true; }
+      else if (src[i] === '}') { depth--; if (seenOpen && depth === 0) break; }
+    }
+    if (i >= src.length) throw new Error('unbalanced braces for ' + name);
+    if (pass === (which || 0)) return src.slice(idx, i + 1);
+    from = i + 1;
   }
-  throw new Error('unbalanced braces for ' + name);
+  throw new Error('unreachable');
 }
+// how many _midairRepair definitions exist — the LAST is ship truth (declaration hoisting)
+let _mrCount = 0, _mrFrom = 0;
+for (;;) { const k = tmSrc.indexOf('function _midairRepair(', _mrFrom); if (k < 0) break; _mrCount++; _mrFrom = k + 1; }
 const tierOrderLine = "var _TIER1_ORDER = ['Substructure', 'Superstructure', 'Architecture'];";
+// §ZONE_INDEX (#1313) + §TIER_SERIAL_BY_ZONE (#1314) added module-level helpers that
+// _buildXrayElements / _tier1Extents / _twoTierRemap now call. They were never added to this slice
+// list, so this witness has thrown `ReferenceError: _zoneIndex is not defined` — and exited before
+// measuring a single building — since #1313 landed. Sliced optionally, exactly as
+// bim-compiler/scripts/probe_arch_start.js does, so older revisions still run unchanged.
+const zoneParts = [sliceFn(tmSrc, '_zoneIndexBuild', 0, true), sliceFn(tmSrc, '_zoneIndex', 0, true)].filter(Boolean);
 const sliced = [tierOrderLine,
+  (zoneParts.length === 2 ? 'var _zoneMemo = [];' : ''), zoneParts[0] || '', zoneParts[1] || '',
+  sliceFn(tmSrc, '_zoneOf', 0, true) || '',
   sliceFn(tmSrc, '_promoteRoofLoadPath'), sliceFn(tmSrc, '_buildXrayElements'),
   sliceFn(tmSrc, '_tier1Extents'), sliceFn(tmSrc, '_tier1Serialize'),
   sliceFn(tmSrc, '_tier1Protrusion'), sliceFn(tmSrc, '_tierAuditRegate'),
   sliceFn(tmSrc, '_twoTierRemap'), sliceFn(tmSrc, '_contactGraph'),
-  sliceFn(tmSrc, '_midairAudit'), sliceFn(tmSrc, '_midairRepair')].join('\n');
+  sliceFn(tmSrc, '_midairAudit'), sliceFn(tmSrc, '_midairRepair', _mrCount - 1)].join('\n');
+console.log('§MIDAIR_SLICE _midairRepairDefs=' + _mrCount + ' slicing #' + (_mrCount - 1) +
+  ' (the LAST definition — what declaration hoisting makes the browser run)' +
+  ' zoneHelpers=' + (zoneParts.length === 2 ? 'present' : 'absent (pre-#1313 revision)'));
 
 // W-MZ-5 — the repair must be called on the kernel_ops path, not merely defined
 assert(/_twoTierRemap\(_twItems\);[\s\S]{0,600}_midairRepair\(_twItems\)/.test(tmSrc),
@@ -133,6 +158,11 @@ function census(items) {
         seen[j] = 1;
         if (S.bz < lowest) lowest = S.bz;
         const bearing = S.bz < T.bz - EPS && S.tz >= T.bz - GAP;
+        // §DAY_GAP_TAIL (2026-08-12): this mirrors _contactGraph's carrier clause EXACTLY,
+        // including its lower-bound-only band (`S.bz >= T.tz - GAP` with no upper bound, so any
+        // element at any height above T counts). That asymmetry vs hangGate/_tierAuditRegate was
+        // measured and deliberately LEFT ALONE — see the §DAY_GAP_TAIL entry in
+        // bim-compiler prompts/4D_SCHEDULE_PERFECTION.md for the numbers that rejected changing it.
         const carrier = S.bz >= T.tz - GAP && S.tz > T.tz + EPS;
         const embedded = S.bz <= T.bz + EPS && S.tz >= T.tz - EPS;
         if (!bearing && !carrier && !embedded) continue;


### PR DESCRIPTION
Found while running the `§DAY_GAP_TAIL` measurement named in bim-compiler `prompts/4D_SCHEDULE_PERFECTION.md` — "for the tail elements, log WHICH support edge set their start". `witness_midair_zero.js` owns `_midairRepair`, the pass that sets ~46% of LTU's Superstructure straggler tail. It has not measured a single building since #1313.

**Harness only — no shipped viewer code changed, so no `sw.js` bump.**

## Two defects

**1. Dead since #1313.** §ZONE_INDEX (#1313) made `_buildXrayElements` call `_zoneIndex()`; §TIER_SERIAL_BY_ZONE (#1314) made `_tier1Extents`/`_twoTierRemap` call `_zoneOf()`. Neither was added to the witness's `vm` slice list, so it threw `ReferenceError: _zoneIndex is not defined` and exited after only its 3 static wiring asserts. **Four PRs of this lane shipped while it certified nothing.** Sliced optionally, the same way `bim-compiler/scripts/probe_arch_start.js` already does, so older revisions still run.

**2. Judging a copy that never runs.** `time_machine.js` defines `_midairRepair` twice (`:4517` delegating to `_contactGraph`, `:4660` inlined). Declaration hoisting means the browser runs the **last**; `sliceFn` had no `which` and took the **first**. Same class as this lane's own recorded near-miss ("the tier witness was silently testing nothing"). Now slices ship-truth and logs `§MIDAIR_SLICE`.

## Verification — pure repair, zero numeric drift

Every `W-MZ-1` baseline returns identical to the value documented in the witness's own header, confirming both copies behaved identically:

| | Terminal | Hospital | Duplex | HHS | Clinic | LTU | JKR |
|---|---|---|---|---|---|---|---|
| documented | 161 | 165 | 19 | 156 | 345 | 4605 | 110 |
| measured | 161 | 165 | 19 | 156 | 345 | 4605 | 110 |

`§MIDAIR_ZERO_SUMMARY pass=38 fail=0` (1m43s). Added to `bim-compiler/scripts/gate_4d.sh`.

`gate_4d.sh` before vs after — witness verdicts and all §-numbers:
```
> PASS  witness_midair_zero  §MIDAIR_ZERO_SUMMARY pass=38 fail=0   (previously never ran)
§-NUMBERS: IDENTICAL, zero drift
```
`witness_zone_index` 5/5, `witness_tier_serial_display` 57/0, `witness_crew_demand` 4/4 all unchanged.

## The tail investigation itself — no schedule fix warranted

Recorded in `prompts/4D_SCHEDULE_PERFECTION.md §DAY_GAP_TAIL_EDGE`. Measured with a new `probe_tail_edge.js` that slices the shipped gates and patches in attribution-only recording (proven inert: `rawStartMismatch=0/122330`, `pushPassMismatch=0/122330`).

- **"One bad edge drags many" — DISPROVEN.** 112 distinct drivers for LTU's 312 stragglers; top driver accounts for 9.6%.
- **Hospital's dead run (13% of film) is 100% `§TIER2_AFTER_TIER1`** — the user-confirmed contract, lane item 2, ⛔ blocked on a ruling. Not a bug.
- **Clinic's tail is the documented `§TIER_DAG_WINS` wall-carried shape.** Legitimate.
- One real defect found — `_contactGraph`'s carrier clause is bounded on the lower side only, unlike `hangGate`/`_tierAuditRegate`, so a pipe 2.88 m above a beam counted as its carrier (LTU's worst straggler: `IfcBeam` pushed day 119.5 → 1181.4). **Implemented, measured, and REJECTED**: it buys 1.5% of tail for orphans Terminal 7→531 / LTU 865→2478 and a worse W-MZ-8 trade on 3 of 7. The unbounded band is load-bearing compensation for crude AABB contact. Left alone and now commented at the call site so nobody "fixes" it uninformed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GdPyHB9SRqs5Z6rCRdV7eV