### PR TITLE
fix(4d): §GANTT_CACHE_VERSION — bump for #1319's hostGate, missed on first landing

### DIFF
--- a/viewer/sw.js
+++ b/viewer/sw.js
@@ -8,7 +8,7 @@
 // Cache-first for heavy assets (.wasm, images). DB files skip SW (IndexedDB handles them).
 //
 // DEPLOY: bump CACHE_VERSION on every OCI upload. Old caches are purged on activate.
-const CACHE_VERSION = 'v1007';   // bump on each deploy; per-change detail is the git commit message.
+const CACHE_VERSION = 'v1008';   // bump on each deploy; per-change detail is the git commit message.
 const CACHE_PREFIX = 'bim-ootb-';
 const CACHE_NAME = CACHE_PREFIX + CACHE_VERSION;
 

--- a/viewer/time_machine.js
+++ b/viewer/time_machine.js
@@ -7632,7 +7632,8 @@
   // huts going first before the walls" AFTER a hard reset, because §GANTT_CACHE_HIT served a
   // gantt:v4 entry generated under the old ordering. A hard reset cannot clear it — the entry is in
   // IndexedDB, not the HTTP cache. This bump is that fix's second half.
-  var _GANTT_CACHE_VERSION = 11;   // §MIDAIR_REPAIR (2026-08-12): display times now repaired so nothing appears before the first element it touches — MUST bump on every change to computeSchedule's gating OR the display remap, or a building already materialized under an older version keeps replaying it forever (§KERNEL_OPS_SCHED_VERSION exists specifically to catch this bump).
+  var _GANTT_CACHE_VERSION = 12;   // §HOSTED_BEFORE_HOST (2026-08-12, #1319): hostGate added to computeSchedule — a hosted element now waits for its host's finish. Missed on first landing (this constant's own v11 comment says "MUST bump on every change to computeSchedule's gating", and #1319 changed exactly that, same day, without bumping it) — a building materialized under v11 kept replaying the pre-fix order regardless of deployed code. This bump is that fix's second half.
+                                   // v11 was §MIDAIR_REPAIR (2026-08-12): display times repaired so nothing appears before the first element it touches
                                    // v10 was §DOOR_WINDOW_HOST_WALL (2026-08-11): door/window gated on its host wall's finish (schedule_gate.js openingGate)
                                    // v9 was §TIER_SERIAL (2026-08-11): two-tier display remap (serial backbone + concurrent pool)
                                   // v7 was §4D_BAND_MONOTONIC (2026-08-02): PASS B cross-storey trade gate


### PR DESCRIPTION
#1319 (§HOSTED_BEFORE_HOST) added a `hostGate` to `computeSchedule` but never bumped `_GANTT_CACHE_VERSION`. The constant's own v11 comment says this MUST bump on every change to `computeSchedule`'s gating — #1319 changed exactly that, same day, and missed it.

Any building already materialized (kernel_ops in IndexedDB) under v11 kept replaying the pre-fix schedule regardless of deployed code — which is why the fix looked live (v1007 confirmed in browser console) but hanging fixtures were still visible in a live test.

v11 → v12. `sw.js` `CACHE_VERSION` v1007 → v1008 to match.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GdPyHB9SRqs5Z6rCRdV7eV