### PR TITLE
fix(4d): §ARCH_START_TEMPO/M1 — the 8-hour crew day (the movie clock was running crews 24/7)

### DIFF
--- a/viewer/schedule_gate.js
+++ b/viewer/schedule_gate.js
@@ -44,6 +44,46 @@
   // class mix, less coverage). EXTRACTED, not invented — do not retune without re-measuring.
   var BIG_ELEMENT_VOL = 1.556;  // m³
   var MAX_CREWS_DEFAULT = 3;  // §CREW-CAP: fallback crew count per resource when no lookup is given
+  // ══ §ARCH_START_TEMPO / M1 — THE 8-HOUR CREW DAY (2026-08-12) ═══════════════════════════════
+  // `el.installSecs` is 28800/productivity — 28800 s IS one 8-hour crew-day (schedule_author.js
+  // _installSecs line 71, and its own phase widths already divide by `28800 * maxCrews`). But
+  // place() below spent those seconds as PURE CONTINUOUS WALL-CLOCK ms: nothing capped how many of
+  // them could land inside one calendar day, so a crew that ran out of one day's quota simply
+  // started the next day's work in the same day's hour 9. Effective model: every crew works 24 real
+  // hours, non-stop, forever — 3x the shift the productivity table is quoted in.
+  // MEASURED (Terminal Substructure): 236 IfcSlab x 822.9 s / 3 CONCRETE_GANG crews = 64,732 s =
+  // 0.75 wall-clock days, and the probe reported Substructure=[0.0..0.8]d. On a real 8-h shift the
+  // same labour is 2.25 days — exactly 24/8, structural, not a coincidence.
+  //
+  // THE FIX, at the ONE layer every gate and every crew slot already funnels through: a crew's clock
+  // is kept in PRODUCTIVE ms and mapped to wall-clock ms for storage. Each calendar day donates
+  // SHIFT_MS productive ms; the remaining 16 h are idle for that crew and the work rolls over to the
+  // START of the next day's window — never lost, never double-counted, and a `dur` longer than one
+  // window consumes as many following windows as it needs (toWall's floor/mod does that by
+  // construction, no per-day loop).
+  //
+  // WHAT DOES NOT CHANGE, deliberately: the calendar stays 24/7 — no weekend, no holiday, work may
+  // start or continue on ANY day. That settled ruling is about not SKIPPING days; this is about the
+  // length of a day's shift, which it never spoke to.
+  // Because toWall is strictly increasing and toProductive is its exact left inverse on every time
+  // this module produces, the whole generative schedule is toWall(old schedule): every gate max,
+  // every ordering and every start<end comparison is preserved element-for-element. Only the
+  // wall-clock SPAN grows (~3x on crew-bound phases) — which is the fix.
+  var SHIFT_MS = 8 * 3600 * 1000;    // productive ms one crew can spend in one calendar day
+  var DAY_MS   = 24 * 3600 * 1000;   // the calendar day the film advances through (24/7, unchanged)
+  // toProductive(t, base): wall-clock ms -> productive ms elapsed for a crew since `base`.
+  // toWall(p, base): the inverse. toProductive(toWall(p)) === p for every p >= 0, so a duration can
+  // be recovered from a stored [start,end] pair without carrying it alongside (the repair loop).
+  function toProductive(t, base) {
+    var off = t - base; if (off <= 0) return 0;
+    var d = Math.floor(off / DAY_MS), r = off - d * DAY_MS;
+    return d * SHIFT_MS + (r < SHIFT_MS ? r : SHIFT_MS);
+  }
+  function toWall(p, base) {
+    if (p <= 0) return base;
+    var d = Math.floor(p / SHIFT_MS), r = p - d * SHIFT_MS;
+    return base + d * DAY_MS + r;
+  }
   // ══ §HOSTED_BEFORE_HOST (2026-08-12, bim-compiler prompts/4D_SCHEDULE_PERFECTION.md) ═══════════
   // The class sets and the ±HOST_Z bracket below are NOT new: they are verbatim the host inference
   // that bim-compiler scripts/probe_arch_start.js measured the defect with (§HOSTED_BEFORE_HOST),
@@ -269,9 +309,18 @@
     // joins the same support grid as PASS-A structure. As a support it sits ABOVE what it carries, so
     // the bearing-below predicate almost never matches it; only hangGate reads it upward.
     function isPromotedSlab(e) { return e.cls === 'IfcSlab' && e.seq > 4; }
+    // §ARCH_START_TEMPO / M1 — the crew day, bound to this run's epoch (see the module header).
+    // Every crew slot, every gate and the repair loop below read/write wall-clock ms exactly as
+    // before; only the ADVANCE of the clock by a duration goes through the shift window.
+    function prodAt(t) { return toProductive(t, baseMs); }
+    function wallAt(p) { return toWall(p, baseMs); }
+    var _prodMsTot = 0;   // §CREW_DAY audit: productive ms actually committed
     function place(el, start) {
       var dur = Math.round((el.installSecs || 120) * scaleFactor * 1000);
-      var end = start + dur; out[el.guid] = { start: start, end: end };
+      // 8 productive h per calendar day: the remainder rolls to the next day's window start, and a
+      // multi-window `dur` consumes as many following windows as it needs.
+      var end = wallAt(prodAt(start) + dur); _prodMsTot += dur;
+      out[el.guid] = { start: start, end: end };
       if (el.seq <= 4 || isPromotedSlab(el)) {
         var rec = { x0: el.x0, x1: el.x1, y0: el.y0, y1: el.y1, base_z: el.base_z, top_z: el.top_z, end: end, guid: el.guid,
                     promoted: isPromotedSlab(el) };
@@ -621,7 +670,12 @@
         var need = Math.max(geoGate(el), wallGate(el), hangGate(el), openingGate(el), hostGate(el));
         var o = out[el.guid];
         if (o.start < need) {
-          var dur = o.end - o.start; o.start = need; o.end = need + dur;
+          // §ARCH_START_TEMPO / M1: a shift preserves the element's PRODUCTIVE duration, not its
+          // wall-clock width — moving it across a different number of idle windows would otherwise
+          // silently invent or destroy crew hours. toProductive is toWall's exact inverse on both
+          // stored times, so the duration is recovered, never carried.
+          var dur = prodAt(o.end) - prodAt(o.start);
+          o.start = need; o.end = wallAt(prodAt(need) + dur);
           var rl = recsByGuid[el.guid];
           if (rl) for (var q = 0; q < rl.length; q++) rl[q].end = o.end;
           _moved++;
@@ -632,6 +686,20 @@
     }
     if (typeof console !== 'undefined' && console.log)
       console.log('§DEQ_REPAIR sweeps=' + _rIter + ' shifted=' + _rMovedTot + ' (0=order already dependency-consistent)');
+    // §CREW_DAY (§ARCH_START_TEMPO / M1) — the whitebox proof that the shift cap is live and that it
+    // neither lost nor invented labour. spanD = wall-clock days the programme now occupies;
+    // serialProdD = the same labour on ONE crew at 8 h/day (Σ installSecs*scale / SHIFT_MS) — the
+    // number materializeDefault's phase widths have always been quoted in. spanD24 is what the same
+    // schedule would have spanned on the old 24-h clock, printed so the 3x is measured, not claimed.
+    if (typeof console !== 'undefined' && console.log) {
+      var _cdEnd = baseMs, _cdG;
+      for (_cdG in out) if (out[_cdG].end > _cdEnd) _cdEnd = out[_cdG].end;
+      console.log('§CREW_DAY shift=' + (SHIFT_MS / 3600000) + 'h/' + (DAY_MS / 3600000) + 'h n=' + N +
+        ' spanD=' + ((_cdEnd - baseMs) / DAY_MS).toFixed(1) +
+        ' spanD24=' + (toProductive(_cdEnd, baseMs) / DAY_MS).toFixed(1) +
+        ' serialProdD=' + (_prodMsTot / SHIFT_MS).toFixed(1) +
+        ' (a crew works ' + (SHIFT_MS / 3600000) + 'h of every calendar day — 24/7 calendar unchanged)');
+    }
     // The ladder this rule is standing on, printed so it can be audited rather than trusted — see
     // the §GANTT_STOREY_Z reassignment warning in the header comment above.
     if (typeof console !== 'undefined' && console.log) {
@@ -853,7 +921,10 @@
   // EPS/GAP exported alongside CELL so a consumer of the same geometry (time_machine.js
   // §MIDAIR_REPAIR) can test contact with THIS module's measured constants instead of re-typing
   // them — a second copy is a second thing to drift.
-  var API = { computeSchedule: computeSchedule, collapsePhase: collapsePhase, elementsInPhase: elementsInPhase, auditFloating: auditFloating, deriveBandRanks: deriveBandRanks, deriveZones: deriveZones, hostPairs: hostPairs, CELL: CELL, EPS: EPS, GAP: GAP, BIG_ELEMENT_VOL: BIG_ELEMENT_VOL };
+  // SHIFT_MS/DAY_MS + the two mappers are exported for the same reason EPS/GAP/CELL are: the live
+  // movie clock (time_machine.js injectGantt's scaleFactor/projectDays) must size a day with THIS
+  // module's shift, not a second hand-typed 8h constant to drift (§TM_DURATION_SYNC's lesson).
+  var API = { computeSchedule: computeSchedule, collapsePhase: collapsePhase, elementsInPhase: elementsInPhase, auditFloating: auditFloating, deriveBandRanks: deriveBandRanks, deriveZones: deriveZones, hostPairs: hostPairs, CELL: CELL, EPS: EPS, GAP: GAP, BIG_ELEMENT_VOL: BIG_ELEMENT_VOL, SHIFT_MS: SHIFT_MS, DAY_MS: DAY_MS, toProductive: toProductive, toWall: toWall };
   global.ScheduleGate = API;
   if (typeof module !== 'undefined' && module.exports) module.exports = API;
 })(typeof window !== 'undefined' ? window : (typeof globalThis !== 'undefined' ? globalThis : this));

--- a/viewer/sw.js
+++ b/viewer/sw.js
@@ -8,7 +8,7 @@
 // Cache-first for heavy assets (.wasm, images). DB files skip SW (IndexedDB handles them).
 //
 // DEPLOY: bump CACHE_VERSION on every OCI upload. Old caches are purged on activate.
-const CACHE_VERSION = 'v1008';   // bump on each deploy; per-change detail is the git commit message.
+const CACHE_VERSION = 'v1009';   // bump on each deploy; per-change detail is the git commit message.
 const CACHE_PREFIX = 'bim-ootb-';
 const CACHE_NAME = CACHE_PREFIX + CACHE_VERSION;
 

--- a/viewer/tests/witness_crew_demand.js
+++ b/viewer/tests/witness_crew_demand.js
@@ -36,6 +36,7 @@ const VIEWER_DIR = path.join(__dirname, '..');
 const SQLJS_DIR = process.env.SQLJS_DIR || path.join(HOME, 'bim-ootb', 'modeller', 'lib');
 const initSqlJs = require(path.join(SQLJS_DIR, 'sql-wasm.js'));
 const ScheduleAuthor = require(path.join(VIEWER_DIR, 'schedule_author.js'));
+const ScheduleGate = require(path.join(VIEWER_DIR, 'schedule_gate.js'));   // §ARCH_START_TEMPO / M1: SHIFT_MS, one owner
 const BLD_DIR = process.env.BLD_DIR || path.join(HOME, 'bim-ootb', 'buildings');
 const DB_FILE = { LTU_AHouse: 'LTU_AHouse_meta.db' };
 const BUILDINGS = (process.env.ONLY || 'Terminal,Hospital,Duplex,HHS_Office_Federated,Clinic,LTU_AHouse,JKR').split(',');
@@ -105,7 +106,12 @@ function computeFor(els, LR, projectDays, crewMul) {
                installSecs: ScheduleAuthor._installSecs(cls, rule, LR, realQty, null) };
     });
     let tot = 0; els.forEach(e => { tot += e.installSecs; });
-    const projectDays = Math.max(10, Math.ceil(tot * 1000 / 86400000));
+    // §ARCH_START_TEMPO / M1 (2026-08-12): mirrors injectGantt's projectDays, which now sizes a
+    // calendar day by the crew's 8-hour SHIFT (ScheduleGate.SHIFT_MS) instead of 24 h — installSecs
+    // is 28800/productivity, so demand (crew-days) and capacity (crews x projectDays) are finally in
+    // the same unit here. Same formula as the shipped line, taken from the same owner.
+    const SHIFT_MS = ScheduleGate.SHIFT_MS;
+    const projectDays = Math.max(10, Math.ceil(tot * 1000 / SHIFT_MS));
 
     const a = computeFor(els, LR, projectDays, 1);
     const b = computeFor(els, LR, projectDays, 2);   // double every crew — cost must not move

--- a/viewer/tests/witness_hosted_before_host.js
+++ b/viewer/tests/witness_hosted_before_host.js
@@ -204,7 +204,10 @@ function countEarly(pairs, get) {
     let totSecs = 0;
     geoEls.forEach(e => { const r = e.resource || '_DEFAULT';
       crewWorkDays[r] = (crewWorkDays[r] || 0) + (e.installSecs || 0) / 28800; totSecs += e.installSecs || 0; });
-    const projDays = Math.max(10, Math.ceil(totSecs * 1000 / 86400000));
+    // §ARCH_START_TEMPO / M1 (2026-08-12): injectGantt sizes a day by the 8-h crew SHIFT now — same
+    // owner, same formula. (This value only feeds the autoscale `need` below, which measures as a
+    // no-op on all 7 shipped buildings either way; kept in step so the mirror stays a real mirror.)
+    const projDays = Math.max(10, Math.ceil(totSecs * 1000 / ScheduleGate.SHIFT_MS));
     const maxCrews = {};
     for (const rk in LR) {
       if (!LR[rk].max_crews && LR[rk].max_crews_fixed == null) continue;

--- a/viewer/tests/witness_midair_zero.js
+++ b/viewer/tests/witness_midair_zero.js
@@ -128,8 +128,20 @@ const BUILDINGS = (process.env.ONLY || 'Terminal,Hospital,Duplex,HHS_Office_Fede
 // on display times. Movement either way is a real change to examine — a drop means the trade shrank,
 // a rise means it grew. Pre-repair values for reference: Terminal 8, Hospital 0, Duplex 0, HHS 0,
 // Clinic 1, LTU_AHouse 334, JKR 81.
+// ⚠ RE-LOCKED 2026-08-12 for §ARCH_START_TEMPO / M1 (the 8-hour crew day): Clinic 356 → 367,
+// LTU_AHouse 1100 → 1101, JKR 158 → 151 (Terminal/Hospital/Duplex/HHS unmoved). Note the movement
+// is in BOTH directions — JKR's trade got 7 SMALLER — which is what says this is a re-measure, not
+// a regression: a regression from a 3x-longer programme would push one way.
+// The PRE-repair column above is the proof of where the movement is not: it is unchanged on all 7
+// (8/0/0/0/1/334/81), and computeSchedule's raw output is exactly toWall(the old output) —
+// verified element-for-element over all 265,954 elements of the 7 buildings, 0 mismatches, with
+// auditFloating over the raw schedule identical on every one. So the generative layer contributes
+// zero of this delta. What moved is display-layer only: _twoTierRemap/_midairRepair shift items by
+// WALL-CLOCK deltas, and on a shift clock an element's wall-clock width depends on whether its
+// install straddles a day's 8-h productive window — so the ±1ms-tolerance audit comparisons at the
+// margin land differently. 11/367 on Clinic, 1/1101 on LTU, -7/151 on JKR.
 const FLOAT_AFTER_BASELINE = { Terminal: 102, Hospital: 135, Duplex: 9, HHS_Office_Federated: 11,
-  Clinic: 356, LTU_AHouse: 1100, JKR: 158 };
+  Clinic: 367, LTU_AHouse: 1101, JKR: 151 };
 const ORPHAN_BASELINE = { Terminal: 7, Hospital: 35, Duplex: 1, HHS_Office_Federated: 36, Clinic: 27,
   LTU_AHouse: 865, JKR: 1 };
 const CELL = ScheduleGate.CELL, EPS = ScheduleGate.EPS, GAP = ScheduleGate.GAP;

--- a/viewer/tests/witness_tier_serial_display.js
+++ b/viewer/tests/witness_tier_serial_display.js
@@ -254,8 +254,22 @@ const D = 86400000;
     // Terminal 24007→4003 and JKR 398→205 (far fewer elements forced out of their phase), but
     // Hospital 9→256 and LTU 882→1017 (more, because a zone's window is tighter than the model's).
     // Movement from HERE is still a real data/rules change to examine, same contract as before.
+    // ⚠ RE-LOCKED 2026-08-12 for §ARCH_START_TEMPO / M1 (the 8-hour crew day). ONE number moved:
+    // LTU_AHouse 1017 → 1019 (+2 of 122,330 elements, 0.2% of its own straggler set). Everything
+    // else is byte-identical, and that asymmetry is the evidence, not an anomaly:
+    //   • The GENERATIVE layer provably did not move. computeSchedule's new output is EXACTLY
+    //     toWall(old output) — verified element-for-element on all 265,954 elements of the 7 shipped
+    //     buildings, 0 mismatches, and auditFloating over the raw schedule is identical on every one
+    //     (8/0/0/0/1/334/81, unchanged). toWall is strictly increasing, so every gate max and every
+    //     start<end comparison in the scheduler is preserved.
+    //   • dagWins is measured on the DISPLAY timeline, AFTER _tier1Serialize, and that pass adds a
+    //     wall-clock delta (it.s += d). A wall-clock shift is NOT invariant under the shift clock:
+    //     an element whose install straddles a day's 8-h window boundary has a longer wall-clock
+    //     width than one that fits inside it, so `it.e > nextMinS` can flip for elements sitting
+    //     within one window of the boundary. LTU is the only building with a straggler population
+    //     dense enough at that margin (18 zones, 122k elements) for 2 to cross it.
     const DAGWINS_BASELINE = { Terminal: 4003, Hospital: 256, Duplex: 0, HHS_Office_Federated: 420, Clinic: 5,
-      LTU_AHouse: 1017, JKR: 205 };
+      LTU_AHouse: 1019, JKR: 205 };
     assert(stats && stats.dagWins === DAGWINS_BASELINE[bld],
       'W-TS-1b ' + bld + ' DAG-forced cross-phase population locked at ' + DAGWINS_BASELINE[bld] +
       ' (got ' + (stats ? stats.dagWins : '?') + ') — support order wins for these, counted never hidden');

--- a/viewer/time_machine.js
+++ b/viewer/time_machine.js
@@ -5164,12 +5164,29 @@
     var totalSecs = 0;
     elements.forEach(function(el) { totalSecs += el.installSecs; });
     var rawMs = totalSecs * 1000;
-    // Round the clock — 24/7, no weekends
+    // Round the clock — 24/7 CALENDAR, no weekends, no holidays (unchanged ruling).
+    // §ARCH_START_TEMPO / M1 (2026-08-12, bim-compiler prompts/4D_SCHEDULE_PERFECTION.md): the
+    // 24/7 calendar never meant a 24-HOUR SHIFT, but this line assumed one — `rawDays` divided the
+    // labour by a 24 h day while every second of it came from `28800/productivity`, i.e. an 8 h
+    // crew-day (schedule_author.js _installSecs; its phase widths already divide by 28800*crews).
+    // So the movie clock and the authored Gantt disagreed by exactly 24/8 on the same work.
+    // schedule_gate.js now spends a crew's seconds inside an 8 h window per calendar day, so the
+    // wall-clock day this project really needs is rawMs/SHIFT_MS — take the shift length FROM that
+    // module (one owner, no second constant to drift).
+    // COMPOSITION WITH scaleFactor, deliberately not compounding: scaleFactor exists only to inflate
+    // a DEGENERATELY tiny project (<10 days) up to a watchable 10. Measuring rawDays on the capped
+    // clock FIRST means the 3x the crew day already bought is counted before the <10 test — a
+    // project that reaches 10 real days once its crews work 8 h/day gets scaleFactor 1, not a second
+    // stretch on top. The 10-day floor is then in the same wall-clock unit as everything downstream.
     var fullDayMs = 24 * 3600000;
-    var rawDays = rawMs / fullDayMs;
-    var scaleFactor = rawDays < 10 ? (10 * fullDayMs) / rawMs : 1;
+    var shiftMs = (typeof ScheduleGate !== 'undefined' && ScheduleGate.SHIFT_MS) || 8 * 3600000;
+    var rawDays = rawMs / shiftMs;
+    var scaleFactor = rawDays < 10 ? (10 * shiftMs) / rawMs : 1;
 
     var projectDays = Math.max(10, Math.ceil(rawDays * scaleFactor));
+    console.log('§CREW_DAY_CLOCK totalSecs=' + Math.round(totalSecs) + ' shiftH=' + (shiftMs / 3600000) +
+      ' rawDays=' + rawDays.toFixed(1) + ' scale=' + scaleFactor.toFixed(2) + ' projectDays=' + projectDays +
+      ' (was rawDays=' + (rawMs / fullDayMs).toFixed(1) + ' on the pre-M1 24h-shift clock)');
     var startDate = new Date();
     startDate.setDate(startDate.getDate() - projectDays);
     startDate.setHours(0, 0, 0, 0);
@@ -5222,6 +5239,11 @@
     // §CREW_DEMAND — "the max resource needed", reported per trade so a user can see what to edit.
     // capacity = crews x projectDays crew-days; utilisation = demand / capacity. A trade over 100%
     // genuinely cannot fit and wants more crews; everything under is headroom.
+    // §ARCH_START_TEMPO / M1: this ratio is only now dimensionally honest. demand is crew-days
+    // (installSecs/28800 = 8 h each) while projectDays used to be counted on a 24-h clock, so ONE
+    // calendar day was silently worth THREE crew-days of capacity and every utilisation printed here
+    // was overstated ~3x. Same formula, same inputs — projectDays is now wall-clock days at the same
+    // 8 h shift the demand is quoted in, so a trade's % is comparable to its real crew count.
     var _cdLog = [];
     for (var _cd in _crewWorkDays) {
       var _cdr = LR[_cd]; if (!_cdr) continue;
@@ -7632,7 +7654,8 @@
   // huts going first before the walls" AFTER a hard reset, because §GANTT_CACHE_HIT served a
   // gantt:v4 entry generated under the old ordering. A hard reset cannot clear it — the entry is in
   // IndexedDB, not the HTTP cache. This bump is that fix's second half.
-  var _GANTT_CACHE_VERSION = 12;   // §HOSTED_BEFORE_HOST (2026-08-12, #1319): hostGate added to computeSchedule — a hosted element now waits for its host's finish. Missed on first landing (this constant's own v11 comment says "MUST bump on every change to computeSchedule's gating", and #1319 changed exactly that, same day, without bumping it) — a building materialized under v11 kept replaying the pre-fix order regardless of deployed code. This bump is that fix's second half.
+  var _GANTT_CACHE_VERSION = 13;   // §ARCH_START_TEMPO / M1 (2026-08-12): the 8-hour crew day. schedule_gate.js place() no longer spends installSecs as continuous 24-h wall clock — a crew gets 8 productive hours per calendar day (24/7 calendar unchanged) and the rest rolls over — so EVERY generated start/end moves and the programme is ~3x longer. A building materialized under v12 replays the old 24-h-shift timeline forever, no matter what code is deployed.
+                                   // v12 was §HOSTED_BEFORE_HOST (2026-08-12, #1319): hostGate added to computeSchedule — a hosted element now waits for its host's finish. Missed on first landing (this constant's own v11 comment says "MUST bump on every change to computeSchedule's gating", and #1319 changed exactly that, same day, without bumping it) — a building materialized under v11 kept replaying the pre-fix order regardless of deployed code. This bump is that fix's second half.
                                    // v11 was §MIDAIR_REPAIR (2026-08-12): display times repaired so nothing appears before the first element it touches
                                    // v10 was §DOOR_WINDOW_HOST_WALL (2026-08-11): door/window gated on its host wall's finish (schedule_gate.js openingGate)
                                    // v9 was §TIER_SERIAL (2026-08-11): two-tier display remap (serial backbone + concurrent pool)


### PR DESCRIPTION
## §ARCH_START_TEMPO / M1 — the 8-hour crew day

**The bug, in one line:** `el.installSecs` is `28800 / productivity` — and 28800 s *is* one 8-hour
crew-day — but `schedule_gate.js` `place()` spent those seconds as **pure continuous wall-clock ms**.
Nothing capped how many of them could land inside one calendar day, so a crew that used up a day's
quota simply started the next day's work in the same day's hour 9. The effective model was **every
crew working 24 real hours, non-stop, forever** — exactly 3x the shift the productivity table is
quoted in.

The planner-facing artefact never had this bug: `schedule_author.js` has always divided by
`28800 * maxCrews` for its phase widths. So the **movie clock and the authored Gantt disagreed by
24/8 on the same work**. This closes that fork.

### Measured, not asserted — Terminal Substructure
| step | value | source |
|---|---|---|
| elements | 236 IfcSlab (the 30 m precast piles, `foundation_pile_misclassified_slab` override) | extracted DB |
| per element | 822.99 s | `28800 / 35` — CONCRETE_GANG productivity, `rates/sequence_rules.json` |
| crews | 3 | `max_crews`, same file |
| busiest crew | ceil(236/3) = 79 elements = 65,016 s = **2.2575 crew-days** | arithmetic |
| expected wall-clock | 2 full days + 0.2575 x 8 h = **2.0858 d** | the 8-h shift |
| **measured after** | **2.09 d** | `probe_arch_start.js` §ARCH_PHASE RAW |
| measured before | 0.8 d | pre-fix gate log |

### What changed
- **`schedule_gate.js`** — a crew's clock is kept in **productive ms** and mapped to wall-clock for
  storage (`toProductive`/`toWall`, exported). Each calendar day donates 8 h; the remainder rolls to
  the **start of the next day's window** — never lost, never double-counted — and a duration longer
  than one window consumes as many following windows as it needs (no per-day loop, floor/mod does it).
  The `§DEQ_REPAIR` loop now preserves an element's **productive** duration when it shifts it, not its
  wall width. New `§CREW_DAY` log line reports spanD / spanD24 / serialProdD.
- **`time_machine.js`** (the live movie clock — `§TM_DURATION_SYNC` discipline, both places or
  neither) — `projectDays`/`scaleFactor` size a day by `ScheduleGate.SHIFT_MS`. **`scaleFactor`
  cannot compound with the day cap**: `rawDays` is measured on the *capped* clock first, so the 3x is
  counted **before** the `<10 day` degenerate test — a project that reaches 10 real days once its
  crews work 8 h/day gets `scaleFactor 1`, not a second stretch. New `§CREW_DAY_CLOCK` log line.
- `_GANTT_CACHE_VERSION` **12 -> 13** (every generated start/end moves; a v12-materialized building
  would replay the 24-h-shift timeline forever, deploy or no deploy) and `sw.js` **v1008 -> v1009**.

**The 24/7 calendar is untouched** — no weekends, no holidays, work may start or continue on any day.
That ruling was about not *skipping* days; it never spoke to the length of a shift. A crew now works
8 h somewhere in every calendar day and idles the other 16.

### Programme length, per building (all 7)
`RAW` = `computeSchedule`'s generative span. `display` = what the movie actually plays
(`_twoTierRemap` + `_midairRepair`), from `gate_4d.sh`'s `§TIER_SERIAL_BY_ZONE`.

| building | RAW before | RAW after | x | display before | display after | x |
|---|---|---|---|---|---|---|
| Terminal | 115.2 d | 345.2 d | 3.00 | 236.0 d | **711.9 d** | 3.02 |
| Hospital | 328.3 d | 984.3 d | 3.00 | 630.1 d | **1889.4 d** | 3.00 |
| Duplex | 10.6 d | 31.3 d | 2.95 | 13.3 d | **40.0 d** | 3.01 |
| HHS_Office_Federated | 48.5 d | 145.2 d | 2.99 | 83.4 d | **251.4 d** | 3.01 |
| Clinic | 148.3 d | 444.3 d | 3.00 | 278.5 d | **833.8 d** | 2.99 |
| LTU_AHouse | 824.1 d | 2472.1 d | 3.00 | 1322.4 d | **3967.1 d** | 3.00 |
| JKR | 36.4 d | 109.0 d | 3.00 | 74.4 d | **223.7 d** | 3.01 |

Ratios below 3.00 are the partial last day (a fraction of a crew-day costs a fraction of a *shift*,
not of a calendar day) — Duplex is the smallest project, so it shows it most.

### Proof the generative order did not silently change
`computeSchedule`'s new output is **exactly `toWall(old output)`** — verified element-for-element
against `origin/main`'s `schedule_gate.js` on **all 265,954 elements of the 7 shipped buildings,
0 mismatches** — and `auditFloating` over the raw schedule is **identical on every building**
(8 / 0 / 0 / 0 / 1 / 334 / 81, unchanged). `toWall` is strictly increasing, so every gate `max` and
every `start < end` comparison in the scheduler is preserved by construction, not by luck.

### gate_4d.sh — before vs after
```
witness_zone_index            PASS -> PASS  (5/5)
witness_tier_serial_display   PASS -> PASS  (57/57, 1 baseline re-locked)
witness_crew_demand           PASS -> PASS  (4/4)
witness_midair_zero           PASS -> PASS  (38/38, 3 baselines re-locked)
witness_hosted_before_host    PASS -> PASS  (4/4)
§CACHE_VERSION_GUARD          SKIP -> PASS  (version_bumped=1)
§GATE_4D_RESULT               pass=5 fail=0 -> pass=6 fail=0
```
Every other number that moved, and why:
- **`§HOSTED_BEFORE_HOST`** — EARLY counts **unchanged** (0 on six buildings, 11 on LTU_AHouse). Only
  `worst` scaled, 137.3 d -> 412.6 d (x3.005): the same inversion measured on a 3x-longer clock.
- **`§DAY_GAP`** — `longestEmptyRun` unchanged (6/11/9/11/11/2/6 %). The dead-air *fraction* of the
  film is the same; only the axis is longer. (LTU's window moved 94-99% -> 95-99%.)
- **`§DAY_GAP_PHASE_OCC`** — occupancy `work/window` drops ~3x wherever the window is span-driven
  (Duplex Superstructure 197.7% -> 61.2%: `work` 0.6 d unchanged, `win` 0.3 -> 1.0 d) and holds where
  the phase is packed back-to-back (Terminal Substructure 298.7% -> 299.5%: `work` 2.2 -> 6.2 d, `win`
  0.8 -> 2.1 d). The `work` rise is arithmetic, not labour: 3 crews x 2 shift boundaries x 16 h idle =
  4.0 d, and 2.2 + 4.0 = 6.2. **Reading note:** an element whose install straddles the end of a shift
  carries the overnight idle inside its own bar — same as any real 4D task spanning a night.
- **`§CREW_DEMAND`** is dimensionally honest for the first time: demand was crew-days (8 h each)
  against a capacity counted in 24-h days, overstating every trade's utilisation ~3x.

### Baselines RE-LOCKED (display-layer only, and in **both** directions)
| witness | building | was | now |
|---|---|---|---|
| `witness_tier_serial_display` W-TS-1b `dagWins` | LTU_AHouse | 1017 | **1019** |
| `witness_midair_zero` W-MZ-8 float-after-repair | Clinic | 356 | **367** |
| | LTU_AHouse | 1100 | **1101** |
| | JKR | 158 | **151** |

None of this comes from the generative layer (proved identical above). `_tier1Serialize` and
`_midairRepair` shift items by **wall-clock** deltas, and on a shift clock an element's wall width
depends on whether its install straddles a day's 8-h window — so borderline `it.e > nextMinS` and
`start < end - 1` comparisons land differently. JKR's trade got 7 **smaller**; a regression from a
3x-longer programme would push one way. Derivations are written into both witness files.
`witness_crew_demand` / `witness_hosted_before_host` `projectDays` mirrors follow the shipped formula
(`ScheduleGate.SHIFT_MS`, one owner).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GdPyHB9SRqs5Z6rCRdV7eV
