### PR TITLE
fix(4d): revive witness_kernel_ops_sched_version — dead since #1313, and it guards M1's version bump

### DIFF
--- a/viewer/tests/witness_kernel_ops_sched_version.js
+++ b/viewer/tests/witness_kernel_ops_sched_version.js
@@ -45,9 +45,12 @@ const ScheduleGate = require(path.join(__dirname, '..', 'schedule_gate.js'));
 const ScheduleAuthor = require(path.join(__dirname, '..', 'schedule_author.js'));
 const tmSrc = fs.readFileSync(path.join(__dirname, '..', 'time_machine.js'), 'utf8');
 
-function sliceFn(src, name) {
+// §DAY_GAP_TAIL discipline, applied here 2026-08-12 (§ARCH_START_TEMPO / M1): `optional` lets a
+// helper that a newer time_machine.js introduced be sliced without breaking on a revision that
+// predates it — same shape witness_midair_zero.js and bim-compiler/scripts/probe_arch_start.js use.
+function sliceFn(src, name, optional) {
   const idx = src.indexOf('function ' + name + '(');
-  if (idx < 0) throw new Error(name + ' not found');
+  if (idx < 0) { if (optional) return null; throw new Error(name + ' not found'); }
   let depth = 0, i = idx, seenOpen = false;
   for (; i < src.length; i++) {
     if (src[i] === '{') { depth++; seenOpen = true; }
@@ -71,8 +74,17 @@ if (tmSrc.indexOf(genVersionLine) < 0) {
 const tierOrderLine = "var _TIER1_ORDER = ['Substructure', 'Superstructure', 'Architecture'];";
 if (tmSrc.indexOf(tierOrderLine) < 0) { assert(false, 'W-KOS-0c _TIER1_ORDER constant found in time_machine.js'); finish(); }
 
+// ⚠ #1313 (§ZONE_INDEX) moved _buildXrayElements' storey banding into the shared _zoneIndex, and
+// this slice list was never updated — so from W-KOS-4 onward this witness has thrown
+// `ReferenceError: _zoneIndex is not defined` and certified NOTHING about the live materialize path
+// since. Exactly the dead-witness failure §DAY_GAP_TAIL found in witness_midair_zero.js the same
+// day. Found 2026-08-12 while landing §ARCH_START_TEMPO / M1 — which bumps the very constant this
+// witness guards, so a dead one here is not something to leave for later.
+const zoneParts = [sliceFn(tmSrc, '_zoneIndexBuild', true), sliceFn(tmSrc, '_zoneIndex', true)].filter(Boolean);
 const sliced = [
   tierOrderLine,
+  (zoneParts.length === 2 ? 'var _zoneMemo = [];' : ''), zoneParts[0] || '', zoneParts[1] || '',
+  sliceFn(tmSrc, '_zoneOf', true) || '',
   sliceFn(tmSrc, '_kernelOpsSchedStale'),
   sliceFn(tmSrc, '_promoteRoofLoadPath'),
   sliceFn(tmSrc, '_buildXrayElements'),


### PR DESCRIPTION
Follow-on to #1323 (§ARCH_START_TEMPO/M1). **This change was part of #1323 and got orphaned by its
squash-merge landing while the commit was in flight** — the landmine `CLAUDE.md` documents (PR #138).
Re-cut off fresh `origin/main` and re-verified there.

### The finding
`witness_kernel_ops_sched_version.js` has been **dead since #1313**. §ZONE_INDEX moved
`_buildXrayElements`' storey banding into the shared `_zoneIndex`; this witness's slice list was
never updated, so from **W-KOS-4 onward** it threw `ReferenceError: _zoneIndex is not defined` and
certified nothing about the live materialize path. Its first four gates still passed, so nothing
looked wrong. Exactly the dead-witness shape §DAY_GAP_TAIL found in `witness_midair_zero.js` the
same day — and this one owns the **runtime half** of the `_GANTT_CACHE_VERSION` contract that #1323
depends on (`_kernelOpsSchedStale` wired into `_activateAsync`, plus the `_genVersion` stamp on
every `ELEMENT_PLACE` op). `§CACHE_VERSION_GUARD` only checks the constant statically.

### The fix
Slice `_zoneIndexBuild`/`_zoneIndex`/`_zoneOf` optionally — the same pattern
`witness_midair_zero.js` and `bim-compiler/scripts/probe_arch_start.js` use — so older revisions
still run unchanged.

### Verified
**12/12 green** on all 7 shipped buildings. W-KOS-5 now reports the magnitude the version bump
avoids — days of Architecture/MEP overlap a stale `kernel_ops` table would replay on the actual 3D
reveal: **LTU_AHouse 2816.1 d · Clinic 588.7 d · HHS_Office_Federated 158.1 d · JKR 157.0 d**.
Added to `bim-compiler/scripts/gate_4d.sh` (`45232d8d`) so the static bump check and the runtime
wiring check run in one command: full gate **pass=7 fail=0 missing=1**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GdPyHB9SRqs5Z6rCRdV7eV
