### PR TITLE
fix(4d): §DOOR_WINDOW_HOST_WALL_DISPLAY — openingGate's display-layer twin (the movie undid the gate)

### DIFF
--- a/viewer/schedule_gate.js
+++ b/viewer/schedule_gate.js
@@ -169,6 +169,58 @@
     return o;
   }
   function overlap(a, b) { return a.x0 <= b.x1 && a.x1 >= b.x0 && a.y0 <= b.y1 && a.y1 >= b.y0; }
+  // ══ §DOOR_WINDOW_HOST_WALL_DISPLAY (2026-08-12, bim-compiler prompts/4D_SCHEDULE_PERFECTION.md) ══
+  // MEASURED (witness_curtain_wall_opening's own G-CWO-DISPLAY, left non-asserting on purpose so a
+  // fix could promote it): openingGate holds PERFECTLY on the generative timeline — rawEARLY 0.0% on
+  // all 7 shipped buildings — and the DISPLAY timeline the movie actually plays undoes it, LTU_AHouse
+  // 28.5%, Terminal 16.4%, JKR 10.1%, Hospital 2.5% of openings starting before their own host wall
+  // FINISHES. Identical shape to §HOSTED_BEFORE_HOST one layer over: a gate that is correct where it
+  // runs, re-broken by _twoTierRemap/_midairRepair rewriting the times afterwards. Same remedy, and
+  // deliberately the same SHAPE as hostPairs above rather than a second mechanism: one pairing at
+  // module scope, so the display-layer repair enforces the exact relation openingGate enforces.
+  //
+  // isOpening/openingBrackets are hoisted here so openingGate's openingScan and this twin test ONE
+  // predicate (the reason EPS/GAP are exported rather than re-typed — "a second copy is a second
+  // thing to drift"). Pool ORDER is openingGate's, verbatim: the IfcWall* pool when the opening has
+  // ANY wall host, else the §CURTAIN_WALL_OPENING fallback pool. Getting that order wrong would make
+  // the display layer enforce something the scheduler was never asked to.
+  function isOpening(e) { return e.cls === 'IfcDoor' || e.cls === 'IfcWindow'; }
+  function openingBrackets(S, el) {                 // openingScan's own bracket, one definition
+    return S.base_z <= el.top_z + EPS && S.top_z >= el.base_z - EPS && overlap(S, el);
+  }
+  // openingPairs(els) -> [{ i, h }] index pairs into els (i = opening, h = a host bracketing it).
+  // EVERY host of the chosen pool is returned, not the nearest — openingGate returns the MAX end
+  // over its whole pool, so a consumer that honours every pair reproduces the gate's exact bound.
+  // Pure geometry, no timing read: a caller pairs once and then compares whatever stage it owns.
+  function openingPairs(els) {
+    var wallIdx = {}, cwIdx = {}, out = [], t, e, cs, c, isW;
+    for (t = 0; t < els.length; t++) { e = els[t];
+      isW = !!(e.cls && e.cls.indexOf('IfcWall') === 0);
+      if (!isW && !CW_HOST_CLS.test(e.cls || '')) continue;
+      cs = cellsOf(e);
+      for (c = 0; c < cs.length; c++)
+        if (isW) (wallIdx[cs[c]] = wallIdx[cs[c]] || []).push(t);
+        else (cwIdx[cs[c]] = cwIdx[cs[c]] || []).push(t);
+    }
+    var seen = {}, gen = 0;
+    function scan(idx, el, into) {                  // dedup by index — an element spans many cells
+      var cs2 = cellsOf(el), c2, arr, k2, si;
+      into.length = 0; gen++;
+      for (c2 = 0; c2 < cs2.length; c2++) { arr = idx[cs2[c2]]; if (!arr) continue;
+        for (k2 = 0; k2 < arr.length; k2++) { si = arr[k2]; if (seen[si] === gen) continue;
+          seen[si] = gen;
+          if (openingBrackets(els[si], el)) into.push(si); } }
+      return into;
+    }
+    var wall = [], cw = [], pool, q;
+    for (t = 0; t < els.length; t++) { e = els[t];
+      if (!isOpening(e)) continue;
+      pool = scan(wallIdx, e, wall);
+      if (!pool.length) pool = scan(cwIdx, e, cw);
+      for (q = 0; q < pool.length; q++) out.push({ i: t, h: pool[q] });
+    }
+    return out;
+  }
   // bbox volume — the same m³ the BIG_ELEMENT_VOL p95 was measured in (§SUPPORT_UNCHECKED 1a and
   // the §HANG_NEAREST fallback below share this one definition so their populations can never drift)
   function bboxVol(e) { return (e.x1 - e.x0) * (e.y1 - e.y0) * (e.top_z - e.base_z); }
@@ -486,7 +538,9 @@
       var g = -1, cs2 = cellsOf(el), c2, k2, arr2, S2;
       for (c2 = 0; c2 < cs2.length; c2++) { arr2 = gr[cs2[c2]]; if (!arr2) continue;
         for (k2 = 0; k2 < arr2.length; k2++) { S2 = arr2[k2];
-          if (S2.base_z <= el.top_z + EPS && S2.top_z >= el.base_z - EPS && overlap(S2, el) && S2.end > g) g = S2.end; } }
+          // §DOOR_WINDOW_HOST_WALL_DISPLAY: the bracket now lives at module scope (openingBrackets)
+          // so this gate and its display-layer twin can never test different geometry.
+          if (openingBrackets(S2, el) && S2.end > g) g = S2.end; } }
       return g;
     }
     // §CURTAIN_WALL_OPENING: STRICT ADDITION, and the fallback ordering is what makes it strict —
@@ -497,7 +551,7 @@
     // so the §DEQ_REPAIR loop (which shifts seq>4 only) never moves them, and the one seq>4 member
     // of the pool, IfcCurtainWall, is not an opening so nothing ever gates it back.
     function openingGate(el) {
-      if (el.cls !== 'IfcDoor' && el.cls !== 'IfcWindow') return baseMs;
+      if (!isOpening(el)) return baseMs;
       var g = openingScan(wallGrid, el);
       if (g < 0) {
         g = openingScan(cwGrid, el);
@@ -1003,7 +1057,7 @@
   // SHIFT_MS/DAY_MS + the two mappers are exported for the same reason EPS/GAP/CELL are: the live
   // movie clock (time_machine.js injectGantt's scaleFactor/projectDays) must size a day with THIS
   // module's shift, not a second hand-typed 8h constant to drift (§TM_DURATION_SYNC's lesson).
-  var API = { computeSchedule: computeSchedule, collapsePhase: collapsePhase, elementsInPhase: elementsInPhase, auditFloating: auditFloating, deriveBandRanks: deriveBandRanks, deriveZones: deriveZones, hostPairs: hostPairs, CELL: CELL, EPS: EPS, GAP: GAP, BIG_ELEMENT_VOL: BIG_ELEMENT_VOL, SHIFT_MS: SHIFT_MS, DAY_MS: DAY_MS, toProductive: toProductive, toWall: toWall };
+  var API = { computeSchedule: computeSchedule, collapsePhase: collapsePhase, elementsInPhase: elementsInPhase, auditFloating: auditFloating, deriveBandRanks: deriveBandRanks, deriveZones: deriveZones, hostPairs: hostPairs, openingPairs: openingPairs, CELL: CELL, EPS: EPS, GAP: GAP, BIG_ELEMENT_VOL: BIG_ELEMENT_VOL, SHIFT_MS: SHIFT_MS, DAY_MS: DAY_MS, toProductive: toProductive, toWall: toWall };
   global.ScheduleGate = API;
   if (typeof module !== 'undefined' && module.exports) module.exports = API;
 })(typeof window !== 'undefined' ? window : (typeof globalThis !== 'undefined' ? globalThis : this));

--- a/viewer/sw.js
+++ b/viewer/sw.js
@@ -8,7 +8,7 @@
 // Cache-first for heavy assets (.wasm, images). DB files skip SW (IndexedDB handles them).
 //
 // DEPLOY: bump CACHE_VERSION on every OCI upload. Old caches are purged on activate.
-const CACHE_VERSION = 'v1010';   // bump on each deploy; per-change detail is the git commit message.
+const CACHE_VERSION = 'v1011';   // bump on each deploy; per-change detail is the git commit message.
 const CACHE_PREFIX = 'bim-ootb-';
 const CACHE_NAME = CACHE_PREFIX + CACHE_VERSION;
 

--- a/viewer/tests/witness_curtain_wall_opening.js
+++ b/viewer/tests/witness_curtain_wall_opening.js
@@ -37,13 +37,28 @@
 //                  fails it 34 times. It asserts COVERAGE, which no prior witness did.
 //   G-CWO-FALLBACK reported — how many openings the curtain-wall pool actually caught per building,
 //                  and how many have no host of any kind (a real data limit, never invented away).
-//   G-CWO-DISPLAY  reported, NOT blocking, and deliberately so: it surfaces
-//                  §DOOR_WINDOW_HOST_WALL_DISPLAY — a SEPARATE, pre-existing, still-OPEN defect
-//                  where _twoTierRemap + _midairRepair rewrite the display timeline and undo
-//                  openingGate's guarantee (measured LTU 28.6% worst 974.0d, Terminal 16.4%, JKR
-//                  10.1%, Hospital 2.5% worst 172.5d — HHS/Clinic/Duplex 0). Failing on it here
-//                  would red-flag every run for something this fix does not claim to solve; printing
-//                  it every run is what stops it being forgotten the way this one was.
+//   G-CWO-DISPLAY  (BLOCKING since 2026-08-12) EARLY <= 5% of hostMatched on the DISPLAY timeline
+//                  the movie actually plays (post _twoTierRemap + _midairRepair). It shipped
+//                  REPORT-ONLY for one day, deliberately, so the defect it surfaced —
+//                  §DOOR_WINDOW_HOST_WALL_DISPLAY, openingGate correct at the generative layer and
+//                  undone by the display rewrite — could be fixed and this gate promoted rather than
+//                  red-flagging every run for something unowned. That fix landed: _twoTierRemap now
+//                  carries openingGate's twin (ScheduleGate.openingPairs), the same shape
+//                  §HOSTED_BEFORE_HOST's own display twin uses.
+//                  MEASURED display EARLY%, before the twin → after it:
+//                    LTU_AHouse 28.5 → 2.0 (25/1280) | Terminal 16.4 → 0.0 | JKR 10.1 → 0.0
+//                    Hospital    2.5 → 0.2 (1/570)   | HHS/Clinic/Duplex 0.0 → 0.0
+//                  Not 0, for the same measured reason G-HOST-DISPLAY is not: _midairRepair runs
+//                  AFTER the remap and may move a host wall later than what it hosts (LTU 25 doors,
+//                  Hospital 1 — every residual is remap=0 → display=N, i.e. attributable to that one
+//                  pass, which is what G-CWO-STAGE below prints). Chasing it to 0 means alternating
+//                  the two rules to a joint fixpoint, which _midairRepair's own header records as
+//                  BUILT, MEASURED and REJECTED (4 rounds, 7,650 pushes, no convergence, 0.8s→14.8s)
+//                  — one is keyed on a contact's START, the other on a host's END. 5% is this lane's
+//                  standing error margin.
+//   G-CWO-STAGE    attribution, reported per building — EARLY after generation vs after the remap
+//                  (where the twin runs) vs after the midair repair. This is what names WHICH layer
+//                  any residual came from instead of leaving it an unexplained number.
 //
 // Command (from the worktree root):
 //   BLD_DIR=~/bim-ootb/buildings node viewer/tests/witness_curtain_wall_opening.js
@@ -62,6 +77,8 @@ const BLD_DIR = process.env.BLD_DIR || path.join(HOME, 'bim-ootb', 'buildings');
 const DB_FILE = { LTU_AHouse: 'LTU_AHouse_meta.db' };
 const BUILDINGS = (process.env.ONLY || 'Terminal,Hospital,Duplex,HHS_Office_Federated,Clinic,LTU_AHouse,JKR').split(',');
 const D = 86400000;
+const DISPLAY_TOL = 5;   // % of hostMatched — the lane's standing error margin (G-CWO-DISPLAY),
+                         // the same one witness_hosted_before_host's G-HOST-DISPLAY carries
 
 // Kept identical to schedule_gate.js's own openingGate/CW_HOST_CLS and to probe_door_wall.js.
 // Changing it here without changing them there is what this comment exists to prevent.
@@ -164,7 +181,7 @@ function countEarly(pairs, getS, getE) {
     sliceFn(tmSrc, '_midairRepair', 1) || sliceFn(tmSrc, '_midairRepair', 0)].filter(Boolean).join('\n');
 
   let ran = 0;
-  const rawBad = [], coverBad = [], fallbackRep = [], dispRep = [];
+  const rawBad = [], coverBad = [], fallbackRep = [], dispBad = [], stageRep = [];
 
   for (const bld of BUILDINGS) {
     const dbPath = path.join(BLD_DIR, DB_FILE[bld] || (bld + '_extracted.db'));
@@ -235,6 +252,11 @@ function countEarly(pairs, getS, getE) {
     sandbox.console = { log: () => {}, warn: () => {} };
     sandbox.__items = items;
     vm.runInContext('this.__remap(this.__items);', sandbox);
+    // stage 2: + two-tier remap (where §DOOR_WINDOW_HOST_WALL_DISPLAY's twin runs). Frozen here so
+    // G-CWO-STAGE can attribute any residual to a NAMED layer instead of leaving it unexplained.
+    const remS = {}, remE = {};
+    items.forEach(it => { remS[it.guid] = it.s; remE[it.guid] = it.e; });
+    const rem = countEarly(pairs, it => remS[it.guid], it => remE[it.guid]);
     vm.runInContext('this.__repair(this.__items);', sandbox);
     const disp = countEarly(pairs, it => it.s, it => it.e);             // stage 3: DISPLAY (what plays)
 
@@ -249,10 +271,13 @@ function countEarly(pairs, getS, getE) {
     else if (engCw !== viaCw || engUn !== noHost)
       coverBad.push(`${bld}=engine(cwGated=${engCw},stillUngated=${engUn}) vs witness(viaCw=${viaCw},noHost=${noHost})`);
     fallbackRep.push(`${bld} viaCurtainWall=${viaCw} noHostAtAll=${noHost}/${openN}`);
-    dispRep.push(`${bld} gen=${raw.early} display=${disp.early}(${pct(disp.early)}%, worst ${disp.worstD.toFixed(1)}d)`);
+    if (100 * disp.early / pairs.length > DISPLAY_TOL)
+      dispBad.push(`${bld}=${pct(disp.early)}% (${disp.early}/${pairs.length}, worst ${disp.worstD.toFixed(1)}d ${disp.worst})`);
+    stageRep.push(`${bld} gen=${raw.early} remap=${rem.early} display=${disp.early}`);
 
     console.log(`      ${bld}: openings=${openN} hostMatched=${pairs.length} viaCurtainWall=${viaCw} ` +
-      `noHostAtAll=${noHost} EARLY gen=${raw.early}(${pct(raw.early)}%) display=${disp.early}(${pct(disp.early)}%) ` +
+      `noHostAtAll=${noHost} EARLY gen=${raw.early}(${pct(raw.early)}%) remap=${rem.early}(${pct(rem.early)}%) ` +
+      `display=${disp.early}(${pct(disp.early)}%) ` +
       `worstDisplay=${disp.worstD.toFixed(1)}d${disp.worst ? ' ' + disp.worst : ''}`);
   }
 
@@ -270,11 +295,15 @@ function countEarly(pairs, getS, getE) {
     ' — viaCurtainWall is what the IfcCurtainWall/IfcPlate/IfcMember pool caught that the IfcWall* ' +
     'pool could not see; noHostAtAll is a real data limit (an opening in no modelled envelope), ' +
     'reported rather than invented away');
-  gate('G-CWO-DISPLAY', ran > 0, dispRep.join(' | ') +
-    ' — REPORT ONLY. Any gen→display growth is §DOOR_WINDOW_HOST_WALL_DISPLAY, a separate ' +
-    'pre-existing OPEN defect: _twoTierRemap/_midairRepair rewrite the played timeline and undo ' +
-    'openingGate, which has no display-layer twin the way §HOSTED_BEFORE_HOST does. Not failed ' +
-    'here because this fix does not claim to solve it; printed every run so it is not forgotten.');
+  gate('G-CWO-DISPLAY', dispBad.length === 0 && ran > 0,
+    dispBad.length ? `over the ${DISPLAY_TOL}% margin on the timeline the movie plays: ` + dispBad.join(' ')
+      : `every building within the ${DISPLAY_TOL}% margin on the DISPLAY timeline (post remap + ` +
+        `midair repair) — §DOOR_WINDOW_HOST_WALL_DISPLAY's twin in _twoTierRemap holds`);
+  gate('G-CWO-STAGE', ran > 0, stageRep.join(' | ') +
+    ' — gen is schedule_gate.js\'s own output (openingGate); remap is after _twoTierRemap, where ' +
+    '§DOOR_WINDOW_HOST_WALL_DISPLAY\'s twin runs; any growth from remap to display is _midairRepair ' +
+    'moving a host wall later than what it hosts, and this is where that shows rather than being an ' +
+    'unexplained number');
 
   const passed = results.filter(r => r.pass).length;
   console.log(`\n§CWO_WITNESS ${passed}/${results.length} gates passed`);

--- a/viewer/time_machine.js
+++ b/viewer/time_machine.js
@@ -4391,16 +4391,43 @@
     // reason EPS/GAP are imported rather than re-typed), and the same later-only safety
     // §MIDAIR_REPAIR carries: a hosted element is pushed to its host's end, never pulled earlier,
     // so nothing already satisfied above can be undone by it.
-    var _hostFixed = 0;
-    if (typeof ScheduleGate !== 'undefined' && ScheduleGate.hostPairs) {
-      var _hp = ScheduleGate.hostPairs(items.map(function (it) {
-        return { guid: it.guid, cls: it.cls, seq: it.seq, x0: it.x0, x1: it.x1, y0: it.y0, y1: it.y1,
-                 base_z: it.bz, top_z: it.tz };
-      }));
+    var _hostFixed = 0, _openFixed = 0;
+    var _gateEls = (typeof ScheduleGate !== 'undefined' && (ScheduleGate.hostPairs || ScheduleGate.openingPairs))
+      ? items.map(function (it) {
+          return { guid: it.guid, cls: it.cls, seq: it.seq, x0: it.x0, x1: it.x1, y0: it.y0, y1: it.y1,
+                   base_z: it.bz, top_z: it.tz };
+        })
+      : null;
+    if (_gateEls && ScheduleGate.hostPairs) {
+      var _hp = ScheduleGate.hostPairs(_gateEls);
       _hp.forEach(function (p) {
         var e = items[p.i], h = items[p.h];
         if (e.s < h.e) { var dur = e.e - e.s; e.s = h.e; e.e = h.e + dur; _hostFixed++; }
       });
+    }
+    // ══ §DOOR_WINDOW_HOST_WALL_DISPLAY (2026-08-12, bim-compiler prompts/4D_SCHEDULE_PERFECTION.md)
+    // The §HOSTED_BEFORE_HOST argument above, one layer over and with the same remedy — deliberately
+    // not a second mechanism. openingGate (schedule_gate.js) gates a door/window on its host wall's
+    // FINISH and holds perfectly where it runs: rawEARLY 0.0% on all 7 shipped buildings
+    // (witness_curtain_wall_opening G-CWO-RAW). The DISPLAY timeline then undid it — MEASURED by that
+    // witness's own G-CWO-DISPLAY, which was shipped non-asserting for exactly this fix to promote:
+    // LTU_AHouse 28.5%, Terminal 16.4%, JKR 10.1%, Hospital 2.5% of openings started before their
+    // host finished on the timeline the movie plays. Same cause as the host case: the passes that
+    // rewrite times afterwards (the Tier-1 straggler/zone work above, _tierAuditRegate, and
+    // _midairRepair after) are order-preserving only within a zone, and a door and the wall it is cut
+    // into are routinely in different ones.
+    // SAME PAIRING THE GATE USES (ScheduleGate.openingPairs — one definition, same reason hostPairs
+    // is imported rather than re-derived), same later-only safety: an opening is pushed to its host's
+    // end, never pulled earlier, so nothing already satisfied above can be undone by it. Every host
+    // of the pool is honoured, which is openingGate's own MAX-over-pool bound; hosts are walls and
+    // curtain-wall parts and openings are never hosts, so one pass reaches that maximum exactly.
+    if (_gateEls && ScheduleGate.openingPairs) {
+      var _opMoved = {};
+      ScheduleGate.openingPairs(_gateEls).forEach(function (p) {
+        var e = items[p.i], h = items[p.h];
+        if (e.s < h.e) { var dur = e.e - e.s; e.s = h.e; e.e = h.e + dur; _opMoved[p.i] = 1; }
+      });
+      _openFixed = Object.keys(_opMoved).length;
     }
     var base = Infinity, endAll = -Infinity, ext2 = {};
     items.forEach(function (it) {
@@ -4421,6 +4448,8 @@
       ' rawTailExempt=' + Object.keys(_exempt).length + ' pushed=' + pushed + ' sweeps=' + sweeps +
       ' §HOSTED_BEFORE_HOST hostFixed=' + _hostFixed +
       ' (hosted elements the cross-zone Tier-2 shift left ahead of their own host, pushed back to it)' +
+      ' §DOOR_WINDOW_HOST_WALL_DISPLAY openFixed=' + _openFixed +
+      ' (doors/windows this remap left starting before their own host wall finished, pushed to its end)' +
       ' §TIER2_AFTER_TIER1 shiftDays=' + (tier2Shift / D).toFixed(1) +
       ' (0=Tier2 already started after Tier1\'s true completion, no shift needed)' +
       ' totalDays=' + ((endAll - base) / D).toFixed(1) + ' ' + parts.join(' '));
@@ -7654,7 +7683,8 @@
   // huts going first before the walls" AFTER a hard reset, because §GANTT_CACHE_HIT served a
   // gantt:v4 entry generated under the old ordering. A hard reset cannot clear it — the entry is in
   // IndexedDB, not the HTTP cache. This bump is that fix's second half.
-  var _GANTT_CACHE_VERSION = 14;   // §CURTAIN_WALL_OPENING (2026-08-12): openingGate gained a curtain-wall fallback pool (IfcCurtainWall/IfcPlate/IfcMember) for openings with no IfcWall* host — HHS_Office_Federated had 34 of 133 openings ungated, Level 3's glass doors starting up to 9.5d before the façade they sit in. computeSchedule's gating changed ⇒ this constant MUST move with it, or a building already materialized under v13 replays the ungated order forever. NOTE this landed as v13 on its own branch and became v14 on merge: §ARCH_START_TEMPO/M1 (#1323) took v13 concurrently. Two independent gating changes on the same day = two bumps, never a shared one — the whole point of the constant is that a cache entry maps to exactly one algorithm.
+  var _GANTT_CACHE_VERSION = 15;   // §DOOR_WINDOW_HOST_WALL_DISPLAY (2026-08-12): _twoTierRemap gained openingGate's display-layer twin (ScheduleGate.openingPairs) — a door/window the remap left starting before its own host wall FINISHED is pushed to that wall's end. MEASURED display EARLY% before→after: LTU_AHouse 28.5→2.0, Terminal 16.4→0.0, JKR 10.1→0.0, Hospital 2.5→0.2, HHS/Clinic/Duplex 0.0→0.0 (every residual is _midairRepair moving a host wall later AFTER the twin ran — witness_curtain_wall_opening G-CWO-STAGE attributes it). The DISPLAY timeline is what kernel_ops is written from, so a building materialized under v14 replays the un-repaired order forever regardless of deployed code — the same second-half miss this constant's own v12/v13 notes record.
+                                   // v14 was §CURTAIN_WALL_OPENING (2026-08-12): openingGate gained a curtain-wall fallback pool (IfcCurtainWall/IfcPlate/IfcMember) for openings with no IfcWall* host — HHS_Office_Federated had 34 of 133 openings ungated, Level 3's glass doors starting up to 9.5d before the façade they sit in. computeSchedule's gating changed ⇒ this constant MUST move with it, or a building already materialized under v13 replays the ungated order forever. NOTE this landed as v13 on its own branch and became v14 on merge: §ARCH_START_TEMPO/M1 (#1323) took v13 concurrently. Two independent gating changes on the same day = two bumps, never a shared one — the whole point of the constant is that a cache entry maps to exactly one algorithm.
                                    // v13 was §ARCH_START_TEMPO / M1 (2026-08-12): the 8-hour crew day. schedule_gate.js place() no longer spends installSecs as continuous 24-h wall clock — a crew gets 8 productive hours per calendar day (24/7 calendar unchanged) and the rest rolls over — so EVERY generated start/end moves and the programme is ~3x longer. A building materialized under v12 replays the old 24-h-shift timeline forever, no matter what code is deployed.
                                    // v12 was §HOSTED_BEFORE_HOST (2026-08-12, #1319): hostGate added to computeSchedule — a hosted element now waits for its host's finish. Missed on first landing (this constant's own v11 comment says "MUST bump on every change to computeSchedule's gating", and #1319 changed exactly that, same day, without bumping it) — a building materialized under v11 kept replaying the pre-fix order regardless of deployed code. This bump is that fix's second half.
                                    // v11 was §MIDAIR_REPAIR (2026-08-12): display times repaired so nothing appears before the first element it touches


### PR DESCRIPTION
## §DOOR_WINDOW_HOST_WALL_DISPLAY — the display timeline undid a gate that was already correct

`openingGate` (`viewer/schedule_gate.js`) gates a door/window on its host wall's **finish**, and it
holds perfectly where it runs: **rawEARLY 0.0% on all 7 shipped buildings** (`G-CWO-RAW`, shipped
yesterday with #1325). The **DISPLAY** timeline the movie actually plays then undid it —
`_twoTierRemap` / `_midairRepair` rewrite the times afterwards and are order-preserving only *within*
a zone, and a door and the wall it is cut into are routinely in different ones.

This is the identical shape `§HOSTED_BEFORE_HOST` hit one layer over, so it takes the **identical
remedy, not a second mechanism**.

### The mechanism
`ScheduleGate.openingPairs(els)` — one pairing at module scope, exported exactly like `hostPairs`:

* `openingGate`'s own pools and **fallback ORDER** (the `IfcWall*` pool when the opening has any wall
  host, else the `§CURTAIN_WALL_OPENING` `IfcCurtainWall|IfcPlate|IfcMember` pool);
* `openingGate`'s own bracket predicate, hoisted out of `openingScan` as `openingBrackets()` so the
  gate and its twin **cannot test different geometry**;
* every host of the chosen pool is returned, which reproduces `openingGate`'s MAX-over-pool bound
  exactly. Openings are never hosts, so one pass reaches that maximum.

`_twoTierRemap` honours every pair right beside the existing `hostPairs` repair, **later-only** (an
opening is pushed to its host's end, never pulled earlier), and logs
`§DOOR_WINDOW_HOST_WALL_DISPLAY openFixed=N`. No new threshold, no new class list.

### Measured, before → after (display EARLY%, the acceptance number this thread was tracked by)

| building | before | after |
|---|---|---|
| LTU_AHouse | 366/1280 (**28.5%**) | 25/1280 (**2.0%**) |
| Terminal | 61/371 (**16.4%**) | **0 (0.0%)** |
| JKR | 15/148 (**10.1%**) | **0 (0.0%)** |
| Hospital | 14/570 (**2.5%**) | 1/570 (**0.2%**) |
| HHS_Office_Federated / Clinic / Duplex | 0 (0.0%) | **0 (0.0%)** — unchanged |

Percentages, not days: the worst-day figures are inflated ~3x by #1323's 8-hour crew day and are not
a measure of this defect.

**Every residual is `gen=0 remap=0 → display=N`** — `_midairRepair`, which runs *after* the twin,
moving a host wall later than what it hosts. That is not inferred; the new **`G-CWO-STAGE`** gate
prints gen/remap/display per building every run. Driving it to 0 means alternating the two rules to a
joint fixpoint, which `_midairRepair`'s own header records as **built, measured and REJECTED** (4
rounds, 7,650 pushes, no convergence, 0.8s → 14.8s — one rule is keyed on a contact's START, the
other on a host's END). Accepted at this lane's standing 5% margin, the same one `G-HOST-DISPLAY`
carries for the same reason.

### Witness — promoted, not forked
`witness_curtain_wall_opening.js`'s `G-CWO-DISPLAY` shipped **report-only for exactly one day** so a
fix could promote it. It is now **BLOCKING** at `<= 5%` of `hostMatched`, and `G-CWO-STAGE` was added
so any residual names its layer instead of being an unexplained number. **§CWO_WITNESS 5/5** (was
4/4).

### Cache version
`_GANTT_CACHE_VERSION` **14 → 15**, `sw.js` **v1010 → v1011**. `kernel_ops` is written from the
DISPLAY timeline, so a building materialized under v14 replays the un-repaired order forever
regardless of deployed code — the same second-half miss this constant's v12/v13 notes record.

### Gate diff — `scripts/gate_4d.sh` before vs after (bim-compiler)

Baseline was run against a **pristine export of `main`** (not this tree), so the two logs are a real
A/B and not a self-comparison.

```
BEFORE  §GATE_4D_RESULT pass=7 fail=0 missing=1     AFTER  §GATE_4D_RESULT pass=8 fail=0 missing=1
  witness_zone_index               5/5      →  5/5
  witness_tier_serial_display    57/0       → 57/0     (W-TS-1 tier-1 serial, W-TS-2 no new floating,
                                                        W-TS-3 monotone — all hold with the twin)
  witness_crew_demand              4/4      →  4/4
  witness_midair_zero            38/0       → 38/0     (no midair regression from moving openings)
  witness_hosted_before_host       4/4      →  4/4     (the DAG-twin machinery this extends: untouched)
  witness_kernel_ops_sched_version 12/0     → 12/0
  witness_curtain_wall_opening     4/4      →  5/5     (G-CWO-DISPLAY promoted + G-CWO-STAGE added)
  §CACHE_VERSION_GUARD    SKIP (plain export) →  PASS  gating_changed=36 version_bumped=1
  missing=1 = witness_arch_area_weight, absent from this revision — pre-existing, not this change.
```

Independent confirmation from `scripts/probe_door_wall.js` (`§DW_COVER`, `wallGrid` pool) — the same
numbers the witness reports, derived separately: Terminal `61(16.4%) → 0(0.0%)`, Hospital
`14(2.5%) → 1(0.2%)`, LTU_AHouse `365(28.5%) → 25(2.0%)`, JKR `15(10.1%) → 0(0.0%)`; HHS / Clinic /
Duplex byte-identical at 0. The unfiltered `any` pool (every bracketing element, coincidental
neighbours included — the upper bound, never a target) improves as a side effect rather than
regressing: Terminal 42.3→34.0%, LTU 65.4→50.4%, JKR 64.2→58.1%, Hospital 30.1→27.8%.

**Zero §-number drift anywhere else**: `§TIER_SERIAL_BY_ZONE`, `§DAY_GAP`, `§DAY_GAP_PHASE_OCC`,
`§CREW_AUTOSCALE` and `§HOSTED_BEFORE_HOST` are byte-identical between the two logs on all 7
buildings. The change moves openings and nothing else.

Spec: bim-compiler `prompts/4D_SCHEDULE_PERFECTION.md` §DOOR_WINDOW_HOST_WALL_DISPLAY (updated to
✅ FIXED with the table above).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GdPyHB9SRqs5Z6rCRdV7eV
