### PR TITLE
fix(bake): §BAKE_INTERIOR_LIGHTS — the movie bake had no fixture lighting at all

### DIFF
--- a/tests/witness_bake_interior_lights.js
+++ b/tests/witness_bake_interior_lights.js
@@ -1,0 +1,200 @@
+#!/usr/bin/env node
+/**
+ * W-BAKE-INTERIOR-LIGHTS — §BAKE_INTERIOR_LIGHTS / §BAKE_LIGHTS / §BAKE_LIGHT_BUILDUP_GATE.
+ *
+ * ISSUE THIS TEST EXPOSES: interior shots of a MaxQ (Alt+M/Alt+C) construction-movie bake render
+ * with NO fixture point lighting, while the same building explored at night via Fly/handsfree is
+ * well lit. User, verbatim: "Night mode usually solves this PL well, when Fly or handsfree...
+ * during baking, there are no PLs shining at the lighting."
+ *
+ * ROOT CAUSE (measured on this same harness against unpatched code, BASE=1 below):
+ *   (a) the still/bake light selection (tools.js _nightUpdateLights, §NIGHT_STILL_FRUSTUM branch)
+ *       selected ONLY fixtures whose centre falls inside the view frustum, with no floor — a frame
+ *       that looks where no fixture centre lands selects ZERO and every point light is disposed;
+ *   (b) both callers that can re-select (effects.js §NIGHT_STILL_LIGHTS and _teardownStillRefine)
+ *       gated on A._nightLights.length — the OUTPUT of that selection — so once (a) produced 0,
+ *       nothing ever called the selector again: a self-latching zero that darkens the whole
+ *       remainder of the film, including every later interior beat.
+ *   Baseline numbers from the pre-fix run: 18 lights at frame 0, 0 lights from frame 2 to frame 27,
+ *   scene point-light intensity sum 127.39 -> 82.39 (difference 45.00 = 18 x NIGHT_LIGHT_INTENSITY
+ *   2.5 — every fixture light, exactly).
+ *
+ * NOT A SCREENSHOT TEST (CLAUDE.md FUNDAMENTAL LAW). Every gate below is a NUMBER read either from
+ * the shipped §-log or from live scene state via page.evaluate: active THREE.PointLight count and
+ * summed intensity, against the placed-fixture count Time Machine itself reports.
+ *
+ * GATES
+ *   G-BL-LATCH   the bake never latches dark: on the LAST logged frame, activePL > 0 while
+ *                placedFixtures > 0. (RED on baseline: 0 for the whole tail of the bake.)
+ *   G-BL-TRACK   every §BAKE_LIGHTS frame with placedFixtures > 0 has activePL > 0, and no frame
+ *                ever has activePL > placedFixtures — light count tracks placed-fixture count and
+ *                can never exceed it.
+ *   G-BL-GATE    §BAKE_LIGHT_BUILDUP_GATE is real: at least one logged frame has
+ *                placedFixtures < fixtures (the schedule is withholding luminaires), which on
+ *                unpatched code was impossible — lights ignored placement entirely.
+ *   G-BL-LIVE    live scene state agrees with the log: sampled during the bake, scene point-light
+ *                intensity sum stays above the no-fixture-light floor once fixtures are placed.
+ *   G-BL-NAV     navigation is UNCHANGED: with night mode toggled on and no bake, the selection
+ *                mode is the nav rule ('all' / 'nearest-to-aim'), never the still frustum branch.
+ *
+ * Run:  node tests/witness_bake_interior_lights.js 2>&1 | tee /tmp/W_BAKE_LIGHTS.log
+ *       BASE=1 PORT=8399 node tests/witness_bake_interior_lights.js   # RED side, origin/main
+ *       (then READ THE LOG — exit code is not evidence.)
+ */
+'use strict';
+const puppeteer = require('/home/red1/bim-compiler/node_modules/puppeteer');
+const BLD = process.env.BLD || 'Duplex';
+const PORT = process.env.PORT || 8531;
+const BASE = process.env.BASE === '1';   // baseline build has no §BAKE_LIGHTS — live sampling only
+const sleep = ms => new Promise(r => setTimeout(r, ms));
+
+let pass = 0, fail = 0;
+function gate(id, claim, ok, detail) {
+  (ok ? pass++ : fail++);
+  console.log((ok ? 'PASS ' : 'FAIL ') + id + ' — ' + claim + '\n     ' + detail);
+}
+
+// Live scene truth, independent of any § line: what is actually lighting the scene right now.
+const SAMPLE = () => {
+  const A = window.APP;
+  let pl = 0, plI = 0;
+  A.scene.traverse(o => { if (o.isPointLight && o.visible) { pl++; plI += o.intensity; } });
+  return { night: !!A._nightMode, nightLights: (A._nightLights || []).length,
+    scenePL: pl, scenePLI: +plI.toFixed(2), sel: A._nightLightSelectInfo || null,
+    fixtures: (A._nightFixtures || []).length };
+};
+
+(async () => {
+  const logs = [], samples = [];
+  const browser = await puppeteer.launch({
+    headless: 'new', protocolTimeout: 1200000,
+    args: ['--no-sandbox', '--disable-dev-shm-usage', '--use-gl=angle', '--use-angle=swiftshader',
+      '--enable-unsafe-swiftshader']
+  });
+  try {
+    const page = await browser.newPage();
+    await page.setViewport({ width: 960, height: 600 });
+    page.on('console', m => logs.push(m.text()));
+    page.on('pageerror', e => logs.push('PAGEERROR ' + e.message));
+    await page.goto(`http://localhost:${PORT}/viewer/viewer.html?db=/buildings/${BLD}_extracted.db`,
+      { waitUntil: 'domcontentloaded', timeout: 60000 });
+    await page.waitForFunction(
+      () => window.APP && window.APP.cinemaPathPlan && window.APP.startMaxQualityOrbit && window.APP._composer,
+      { timeout: 180000 });
+    await sleep(9000);
+    await page.waitForFunction(() => {
+      try { const r = window.APP.dbQuery('SELECT COUNT(*) FROM element_transforms'); return r && r[0][0] > 0; }
+      catch (e) { return false; }
+    }, { timeout: 120000, polling: 2000 });
+
+    // ── G-BL-NAV: plain night mode, no bake. This is the path the user says already works; it must
+    //    keep using the navigation selection rule and must not be dragged onto the frustum branch.
+    await page.evaluate(() => { if (window.toggleNightMode) window.toggleNightMode(); });
+    await sleep(3000);
+    const nav = await page.evaluate(SAMPLE);
+    await page.evaluate(() => { if (window.toggleNightMode) window.toggleNightMode(); });
+    await sleep(1500);
+
+    // ── the bake, driven exactly as a user does it (editor → OK) ──
+    await page.evaluate(() => { window.APP.startMaxQualityOrbit({ preview: false, fps: 1, editor: true, forceWebm: true }); });
+    await page.waitForSelector('#cpe-ok', { timeout: 300000 });
+    await sleep(1500);
+    await page.evaluate(() => { document.getElementById('cpe-ok').click(); });
+    // A swiftshader bake of even a small building runs ~12 s/frame — budget for the whole film
+    // plus the stitch, or the run ends mid-bake and the gates grade a truncated film.
+    for (let s = 0; s < 400; s++) {
+      await sleep(3000);
+      samples.push(await page.evaluate(SAMPLE));
+      if (logs.some(l => /§MAXQ_(DONE|WEBM|MP4)\b/.test(l))) break;
+    }
+    const done = logs.some(l => /§MAXQ_(DONE|WEBM|MP4)\b/.test(l));
+    await page.close();
+    if (process.env.CONSOLE_LOG) {
+      require('fs').writeFileSync(process.env.CONSOLE_LOG, logs.join('\n'));
+      console.log('console log written to ' + process.env.CONSOLE_LOG + ' lines=' + logs.length);
+    }
+
+    // ── parse both §BAKE_LIGHTS forms: the per-frame bake line (cinema_maxq.js, first/last/every
+    //    60th frame) and the change-driven selector line (tools.js, emitted whenever the selection
+    //    answer changes). A short test bake produces few of the former and many of the latter.
+    const bl = logs.filter(l => /§BAKE_LIGHTS frame=/.test(l)).map(l => ({
+      raw: l,
+      frame: +(l.match(/frame=(\d+)/) || [])[1],
+      placed: +(l.match(/placedFixtures=(\d+)/) || [])[1],
+      fixtures: +(l.match(/placedFixtures=\d+\/(\d+)/) || [])[1],
+      active: +(l.match(/activePL=(\d+)/) || [])[1]
+    }));
+    const sel = logs.filter(l => /§BAKE_LIGHTS select /.test(l)).map(l => ({
+      raw: l,
+      mode: (l.match(/mode=(\S+)/) || [])[1],
+      placed: +(l.match(/placedFixtures=(\d+)/) || [])[1],
+      fixtures: +(l.match(/placedFixtures=\d+\/(\d+)/) || [])[1],
+      active: +(l.match(/activePL=(\d+)/) || [])[1]
+    }));
+    const all = bl.concat(sel);
+
+    gate('G-BL-INFRA', 'the bake ran to completion with no page errors',
+      done && !logs.some(l => /^PAGEERROR/.test(l)),
+      `done=${done} pageErrors=${logs.filter(l => /^PAGEERROR/.test(l)).length} bakeLightsLines=${bl.length}`);
+
+    if (BASE) {
+      // Baseline build predates §BAKE_LIGHTS: the RED evidence is the live sample series alone.
+      const dark = samples.filter(s => s.nightLights === 0 && s.night).length;
+      gate('G-BL-BASELINE-RED', 'baseline goes dark mid-bake and never recovers (the defect)',
+        dark > 0,
+        `samples=${samples.length} withNightModeOnButZeroLights=${dark} ` +
+        `series=${samples.map(s => s.nightLights).join(',')}`);
+    } else {
+      const last = bl[bl.length - 1];
+      gate('G-BL-LATCH', 'the last logged bake frame still has fixture lighting (no self-latching zero)',
+        !!last && last.placed > 0 && last.active > 0,
+        last ? `lastFrame=${last.frame} placedFixtures=${last.placed}/${last.fixtures} activePL=${last.active}`
+             : 'no §BAKE_LIGHTS lines at all');
+
+      const noLight = all.filter(r => r.placed > 0 && r.active === 0);
+      const overLight = all.filter(r => r.active > r.placed);
+      gate('G-BL-TRACK', 'light count tracks placed-fixture count on every logged selection',
+        all.length > 0 && noLight.length === 0 && overLight.length === 0,
+        `selections=${all.length} (perFrame=${bl.length} onChange=${sel.length}) ` +
+        `placedButDark=${noLight.length} litMoreThanPlaced=${overLight.length}` +
+        (noLight[0] ? ' firstDark=' + noLight[0].raw : '') +
+        (overLight[0] ? ' firstOver=' + overLight[0].raw : ''));
+
+      const withheld = all.filter(r => r.placed < r.fixtures);
+      gate('G-BL-GATE', 'the buildup gate is live — some frames legitimately have fewer placed luminaires than the building holds',
+        withheld.length > 0,
+        `selectionsWithLuminairesStillUnplaced=${withheld.length}/${all.length}` +
+        (withheld[0] ? ' e.g. ' + withheld[0].raw : ''));
+
+      // The whole point of the gate: as the schedule installs luminaires, the light count RISES.
+      // A constant count would pass the two gates above while proving nothing about the tracking.
+      const placedSeries = sel.map(r => r.placed);
+      const rose = placedSeries.length > 1 && Math.max(...placedSeries) > Math.min(...placedSeries);
+      const lastSel = sel[sel.length - 1];
+      gate('G-BL-RISE', 'lighting follows installation — the placed-luminaire count changes over the bake and the light count moves with it',
+        rose && !!lastSel && lastSel.active > 0,
+        `placedSeries=${placedSeries.join(',')} activeSeries=${sel.map(r => r.active).join(',')}`);
+
+      // Night mode is legitimately OFF between the warm-up fold and frame 0 (staging is torn down
+      // there) — a zero light count while night is off is correct, not the defect. Only samples
+      // taken with night mode ON can testify.
+      const lit = samples.filter(s => s.night && s.sel && s.sel.placed > 0);
+      const litDark = lit.filter(s => s.nightLights === 0);
+      gate('G-BL-LIVE', 'live scene state agrees: point lights exist whenever night mode is on and the schedule has placed luminaires',
+        lit.length > 0 && litDark.length === 0,
+        `samplesNightOnWithPlacedFixtures=${lit.length} ofWhichZeroPointLights=${litDark.length} ` +
+        `nightLightSeries=${samples.map(s => (s.night ? '' : 'n') + s.nightLights).join(',')}`);
+
+      gate('G-BL-NAV', 'plain night navigation still uses the navigation selection rule, not the still frustum branch',
+        !!nav.sel && nav.night && (nav.sel.mode === 'all' || nav.sel.mode === 'nearest-to-aim') && nav.nightLights > 0,
+        `mode=${nav.sel ? nav.sel.mode : 'none'} nightLights=${nav.nightLights} fixtures=${nav.fixtures} ` +
+        `budget=${nav.sel ? nav.sel.budget : '?'} floor=${nav.sel ? nav.sel.floor : '?'}`);
+    }
+  } catch (e) {
+    gate('G-BL-INFRA', 'harness ran', false, e.message);
+  } finally {
+    console.log(`\n§BAKE_INTERIOR_LIGHTS WITNESS ${pass}/${pass + fail} PASS`);
+    await browser.close();
+    process.exit(fail === 0 ? 0 : 1);
+  }
+})();

--- a/viewer/cinema_maxq.js
+++ b/viewer/cinema_maxq.js
@@ -1293,6 +1293,32 @@
         // ever the ORIGINAL fixed 6°. Moving the call to AFTER startStillRefine() re-asserts the
         // correct per-frame elevation once the staging reset has already happened.
         if (A._sunArcStep) A._sunArcStep(_tn);
+        // §BAKE_LIGHTS (2026-08-12, user: "during baking, there are no PLs shining at the lighting"
+        // — while the same building explored at night via Fly/handsfree is well lit). The per-frame
+        // NUMERIC record of what is actually lighting this frame, so the claim "the film's fixture
+        // lighting tracks the 4D schedule" is grep-checkable from a bake log instead of watched.
+        // Nothing is computed here: A._nightUpdateLights (tools.js §BAKE_LIGHTS) has just re-selected
+        // for THIS pose and THIS cursor inside the startStillRefine above, and publishes its own
+        // counts — placedFixtures comes from Time Machine's predicate, not from a second derivation.
+        // Read at the SAME cadence as §CPE_BUILDUP (first, last, every 60th) because a 2500ms/frame
+        // bake does not need a line per frame, and because the two lines are then directly
+        // comparable: `placed=` elements against `placedFixtures=` luminaires against `activePL=`.
+        // WHY INTERIOR AND EXTERIOR DIFFER, measured, not assumed: photo staging enables sun shadow
+        // casting (§PHOTO_SHADOW) and logs §MOVIE_SHADOW_TM sun=4.400 fill=2.042. Outdoors a surface
+        // gets sun + fill = 6.44; indoors the roof shadows the sun out and the ONLY light left is the
+        // 2.042 uniform fill plus these point lights. So the missing point lights are near-invisible
+        // outside and total inside — the user's "outside at the end looks fine, inside is dark" is a
+        // real, structural difference, not two separate faults.
+        if (i === 0 || i === nFrames - 1 || i % 60 === 0) {
+          var _bl = A._nightLightSelectInfo;
+          console.log('§BAKE_LIGHTS frame=' + i + '/' + nFrames + ' nightMode=' + !!A._nightMode +
+            (_bl ? ' placedFixtures=' + _bl.placed + '/' + _bl.fixtures + ' inFrustum=' + _bl.inView +
+                   ' activePL=' + _bl.active + ' mode=' + _bl.mode + ' budget=' + _bl.budget +
+                   ' nearFadeFloor=' + _bl.floor + ' plIntensitySum=' + _bl.intensitySum
+                 : ' (no fixture selection has run — A._nightLightSelectInfo unset)') +
+            ' sun=' + (A.sun ? A.sun.intensity.toFixed(3) : '?') +
+            ' fill=' + ((A.ambient ? A.ambient.intensity : 0) + (A.hemi ? A.hemi.intensity : 0)).toFixed(3));
+        }
         var ok = await _waitFoldDone(30000, 'cook of frame ' + i + '/' + nFrames);
         await _raf2('frame ' + i + ' capture');
         // §SHADOW_FRONTIER_AT_CAPTURE (2026-08-12) — the real answer, checked at the real moment:

--- a/viewer/effects.js
+++ b/viewer/effects.js
@@ -3593,10 +3593,23 @@ async function setupEffects(A, renderer, scene, camera) {
     // user into their next orbit and the frame rate goes with it. Compares against the CURRENT nav
     // default (A._nightMaxLightsNav), not a stale literal, so §NIGHT_LIGHT_BUDGET_UP-style tuning
     // never silently breaks this reset.
-    if (A._nightMaxLights !== A._nightMaxLightsNav && typeof A._nightUpdateLights === 'function') {
+    // §BAKE_INTERIOR_LIGHTS — two changes, same reasoning as §MAXQ_STAGE_KEEP:
+    // (1) during a MaxQ bake with staging KEPT, the still budget is per-BAKE state, not per-frame.
+    //     Handing it back here and re-raising it in the next startStillRefine rebuilt the whole
+    //     light set TWICE per captured frame (up to 200 -> nav -> up to 200), and a change in the
+    //     point-light COUNT is exactly what forces three.js's per-material shader recompile that
+    //     §NIGHT_LIGHT_CHURN measured as the expensive part. The bake is offline and has no 60fps
+    //     budget to protect, and the end-of-bake stop (keepStaging falsy) still hands it back, so
+    //     an interrupted or finished bake can never leak the still budget into navigation.
+    // (2) the re-select is gated on the INPUT (night mode + this building's fixtures), not on
+    //     A._nightLights.length — see the §NIGHT_STILL_LIGHTS gate below for the self-latching
+    //     zero that reading the previous output produced.
+    if (keepStaging && A._maxqActive) {
+      // bake keeps the still budget across frames — nothing to hand back until the bake ends
+    } else if (A._nightMaxLights !== A._nightMaxLightsNav && typeof A._nightUpdateLights === 'function') {
       A._nightMaxLights = A._nightMaxLightsNav;
       A._nightNearFadeFloor = 0.3;
-      if (A._nightLights && A._nightLights.length) A._nightUpdateLights();
+      if (A._nightMode && A._nightFixtures && A._nightFixtures.length) A._nightUpdateLights();
     }
     // §PHOTO_SSGI: same rule — a fold-engaged SSGI must not outlive the still (a pre-existing
     // Alt+J preview survives, only dropped back to nav-quality knobs; see effects_gi_poc.js).
@@ -4046,6 +4059,42 @@ async function setupEffects(A, renderer, scene, camera) {
     _glowLensMesh = null;
   }
 
+  // §NIGHT_STILL_LIGHTS: if night mode is on, the still gets the raised point-light set. The nav
+  // number is a 60fps budget (every light costs per-pixel work on every lit material every frame);
+  // a frozen still renders once and then sits there, so that budget does not apply to it. The
+  // user's report was that the night lights "have been weak" — part of that was simply that an
+  // 841-fixture building was being lit by the navigation count.
+  // §NIGHT_STILL_LIGHTS_REGATE (2026-07-27, found answering "how many POL did we employ?"): this
+  // was gated on A._emberEnabled, which §PHOTO_EMBER_DISARMED set to false — so the raised still
+  // budget had been DEAD CODE ever since, and every Alt+S still was lit by the NAVIGATION budget.
+  // Re-arming it made Alt+S measurably heavier (user: "alt-s also getting heavy"; §STILL_REFINE
+  // elapsedMs 4496 -> 6560 on Hospital), which is exactly what 4x the point lights costs:
+  // per-fragment lighting on every lit material, plus a shader recompile when the count changes.
+  // It shipped OFF by default for that reason.
+  // §NIGHT_LIGHT_BUDGET_UP (2026-08-07): RE-ARMED — user directive explicitly accepts this cost
+  // ("we got speed... throw all in, up to 50 as it is baking"), see tools.js A._nightStillBoost.
+  // §BAKE_INTERIOR_LIGHTS defect (b) (2026-08-12, tools.js carries the full measurement): this gate
+  // used to read `A._nightLights.length` — the OUTPUT of the LAST selection. A bake frame whose
+  // frustum happened to hold no fixture drove that output to 0, and from then on the gate was false
+  // forever, so _nightUpdateLights() was never called again and the rest of the film baked with
+  // ZERO fixture lighting (measured on a real headless Duplex bake: 18 lights at frame 0, 0 from
+  // frame 2 to the end of 28). The question this gate should ask is whether the BUILDING has
+  // fixtures to light and night mode is on — inputs, which cannot be zeroed by their own previous
+  // answer. Extracted into a function at the same time, so it can be called AFTER staging (which
+  // is what turns night mode on) instead of before it.
+  function _stillNightLightBoost() {
+    if (!(A._nightStillBoost && A._nightMode && A._nightFixtures && A._nightFixtures.length &&
+          typeof A._nightUpdateLights === 'function')) return;
+    A._nightMaxLights = A._nightMaxLightsStill;
+    A._nightNearFadeFloor = A._nightNearFadeFloorStill;   // §NIGHT_NEAR_FADE — no proximity penalty
+    A._nightUpdateLights();
+    var _sel = A._nightLightSelectInfo || {};
+    console.log('§NIGHT_STILL_LIGHTS raised to ' + A._nightLights.length +
+      ' lights, near-fade floor ' + A._nightNearFadeFloorStill + ' (was 0.3) for the still' +
+      ' (placedFixtures=' + (_sel.placed == null ? '?' : _sel.placed + '/' + _sel.fixtures) +
+      ' inFrustum=' + (_sel.inView == null ? '?' : _sel.inView) + ')');
+  }
+
   A.startStillRefine = function() {
     if (!A._composer || !A._taaPass || A._stillRefineActive) return;
     // §GI_EXCLUSION (review finding 5): the GI preview composer and this TAA composer both render
@@ -4086,28 +4135,12 @@ async function setupEffects(A, renderer, scene, camera) {
     _glowOff();
     _glowOn(function(p) { return p.__exit; });
     _glowLensOn();
-    // §NIGHT_STILL_LIGHTS: if night mode is on, the still gets 4x the point lights. 12 is a 60fps
-    // navigation budget (every light costs per-pixel work on every lit material every frame); a
-    // frozen still renders once and then sits there, so that budget does not apply to it. The
-    // user's report is that the night lights "have been weak" — part of that is simply that a
-    // 841-fixture building was being lit by 12 of them.
-    // §NIGHT_STILL_LIGHTS_REGATE (2026-07-27, found answering "how many POL did we employ?"): this
-    // was gated on A._emberEnabled, which §PHOTO_EMBER_DISARMED set to false — so the 48-light still
-    // budget had been DEAD CODE ever since, and every Alt+S still was lit by the 12-light NAVIGATION
-    // budget. Re-arming it made Alt+S measurably heavier (user: "alt-s also getting heavy";
-    // §STILL_REFINE elapsedMs 4496 -> 6560 on Hospital), which is exactly what 4x the point lights
-    // costs: per-fragment lighting on every lit material, plus a shader recompile when the count
-    // changes. It shipped OFF by default for that reason.
-    // §NIGHT_LIGHT_BUDGET_UP (2026-08-07): RE-ARMED — user directive explicitly accepts this cost
-    // ("we got speed... throw all in, up to 50 as it is baking"), see tools.js A._nightStillBoost.
-    if (A._nightStillBoost &&
-        A._nightLights && A._nightLights.length && typeof A._nightUpdateLights === 'function') {
-      A._nightMaxLights = A._nightMaxLightsStill;
-      A._nightNearFadeFloor = A._nightNearFadeFloorStill;   // §NIGHT_NEAR_FADE — no proximity penalty
-      A._nightUpdateLights();
-      console.log('§NIGHT_STILL_LIGHTS raised to ' + A._nightLights.length +
-        ' lights, near-fade floor ' + A._nightNearFadeFloorStill + ' (was 0.3) for the still');
-    }
+    // §BAKE_INTERIOR_LIGHTS ordering: the raise itself now runs AFTER _applyPhotoStaging() below —
+    // staging is what turns night mode ON in the first place (its amber-glow mechanism), so on the
+    // FIRST fold of a session this block ran before there was any night mode to boost and the frame
+    // was lit at the NAVIGATION budget with the 0.3 near-fade penalty still applied. That is a
+    // MaxQ frame-0 defect and an Alt+S first-press defect in one; both are fixed by ordering, not
+    // by a new mechanism. See _stillNightLightBoost() below.
     A._composerEnabled = true;   // teardown RECOMPUTES from SSAO/Outline state (§GI_HANDOFF_GHOST_FIX) — no save needed
     A._taaPass.accumulate = true;
     A._taaPass.accumulateIndex = -1;
@@ -4122,6 +4155,7 @@ async function setupEffects(A, renderer, scene, camera) {
     _stillRestartLogged = false;
     var _triCount = _setTriplanarActive(true);
     _applyPhotoStaging();
+    _stillNightLightBoost();   // §BAKE_INTERIOR_LIGHTS — after staging, which is what turns night on
     console.log('§STILL_REFINE start samples=16 triplanarMaterials=' + _triCount);
     // §PHOTO_ENVMAP_STALE safety net: the fresh dusk env map is 2s-throttled (scene.js
     // A.updateSky), but a fast/cached accumulate can finish (and stop calling _reassertPhotoEnvMap

--- a/viewer/sw.js
+++ b/viewer/sw.js
@@ -8,7 +8,7 @@
 // Cache-first for heavy assets (.wasm, images). DB files skip SW (IndexedDB handles them).
 //
 // DEPLOY: bump CACHE_VERSION on every OCI upload. Old caches are purged on activate.
-const CACHE_VERSION = 'v1009';   // bump on each deploy; per-change detail is the git commit message.
+const CACHE_VERSION = 'v1010';   // bump on each deploy; per-change detail is the git commit message.
 const CACHE_PREFIX = 'bim-ootb-';
 const CACHE_NAME = CACHE_PREFIX + CACHE_VERSION;
 

--- a/viewer/tools.js
+++ b/viewer/tools.js
@@ -1286,8 +1286,33 @@ function setupTools(A) {
       A._applyNightGlowToMatCache();
       console.log('§NIGHT_MODE on fixtures=' + A._nightFixtures.length + ' source=' + source +
         ' glowMats=' + A._nightGlowMats.length);
+      // §BAKE_LIGHT_BUILDUP_GATE — make sure the Time Machine predicate slot EXISTS before the
+      // first selection: window.__tmOverlaySync is what TM calls each tick to hand over its
+      // placed/frontier/recent answer, and effects.js only registers it from the glow-sprite path
+      // (_glowOn), which returns early when sprites are disabled. Registering here (idempotent)
+      // means the point lights read the schedule whether or not the sprites are staged.
+      if (typeof A._tmOverlayRegister === 'function') A._tmOverlayRegister();
       // §S277d: 4 POL follow camera — subtle ambient on nearby walls/floor
       A._nightUpdateLights();
+      // §BAKE_LIGHT_BUILDUP_GATE restage — the same count-changed rule §GLOW_BUILDUP_GATE uses for
+      // the sprite cloud: while a buildup is running, the set of PLACED fixtures grows tick by
+      // tick, so re-select when that count actually changes (not every tick). Skipped while a
+      // still/bake fold is active — that path already re-selects once per frame from
+      // startStillRefine, and a second selection per frame is pure light churn (§NIGHT_LIGHT_CHURN).
+      if (typeof A._tmVisSubscribe === 'function' && !A._nightTmVisSubscribed) {
+        A._nightTmVisSubscribed = true;
+        A._tmVisSubscribe(function(isVisible) {
+          if (!A._nightMode || A._stillRefineActive) return;
+          var all = A._nightFixtureWorldPositions ? A._nightFixtureWorldPositions() : [];
+          var n = 0;
+          for (var _ti = 0; _ti < all.length; _ti++) {
+            if (all[_ti].__guid == null || !isVisible || isVisible(all[_ti].__guid)) n++;
+          }
+          if (n === A._nightPlacedLast) return;
+          A._nightPlacedLast = n;
+          A._nightUpdateLights();
+        });
+      }
       // §NIGHT_MEM_WITNESS (2026-08-08, moved AFTER _nightUpdateLights() — placing it before, as
       // the first version did, made nightLights read 0 on every toggle-on since the light Map
       // hadn't been populated yet. Real numbers now.
@@ -1439,11 +1464,86 @@ function setupTools(A) {
     return A._nightFixturePositions;
   };
 
+  // §NIGHT_PICK_NEAREST (extracted 2026-08-12 by §BAKE_INTERIOR_LIGHTS) — the navigation selection
+  // rule, moved out of _nightUpdateLights's third branch VERBATIM so a second caller can reuse it:
+  // score every candidate by distance to a point HALFWAY between the eye and the look-at (§S277d),
+  // take them nearest-first while skipping anything within NIGHT_SPREAD_MIN_M of one already
+  // picked (§NIGHT_SPREAD), then fill any remainder ignoring spacing so the budget is always fully
+  // used. `already` is the set the caller has ALREADY placed (the still/bake in-frustum set) — its
+  // members are excluded from the pick, counted against `limit`, and honoured by the spread test,
+  // so a top-up lands AWAY from the lights that are already there. Nav passes `already` empty and
+  // therefore gets byte-identical behaviour to before the extraction.
+  var NIGHT_SPREAD_MIN_M = 4;
+  function _nightPickNearest(pool, limit, already) {
+    var picked = already ? already.slice() : [];
+    if (picked.length >= limit) return picked;
+    var camPos = A.camera.position;
+    var _tgt = A.controls ? A.controls.target : camPos;
+    var _aim = {
+      x: camPos.x + (_tgt.x - camPos.x) * 0.5,
+      y: camPos.y + (_tgt.y - camPos.y) * 0.5,
+      z: camPos.z + (_tgt.z - camPos.z) * 0.5
+    };
+    var have = new Set(picked);
+    var sorted = [];
+    for (var pi = 0; pi < pool.length; pi++) {
+      var p = pool[pi];
+      if (have.has(p)) continue;
+      var dx = p.x - _aim.x, dy = p.y - _aim.y, dz = p.z - _aim.z;
+      sorted.push({ pos: p, dist2: dx * dx + dy * dy + dz * dz });
+    }
+    sorted.sort(function(a, b) { return a.dist2 - b.dist2; });
+    for (var si = 0; si < sorted.length && picked.length < limit; si++) {
+      var cand = sorted[si].pos;
+      var tooClose = picked.some(function(pk) {
+        var ddx = pk.x - cand.x, ddy = pk.y - cand.y, ddz = pk.z - cand.z;
+        return (ddx * ddx + ddy * ddy + ddz * ddz) < NIGHT_SPREAD_MIN_M * NIGHT_SPREAD_MIN_M;
+      });
+      if (!tooClose) { picked.push(cand); have.add(cand); }
+    }
+    for (var si2 = 0; si2 < sorted.length && picked.length < limit; si2++) {
+      if (!have.has(sorted[si2].pos)) { picked.push(sorted[si2].pos); have.add(sorted[si2].pos); }
+    }
+    return picked;
+  }
+
+  // §BAKE_INTERIOR_LIGHTS (2026-08-12, user: "Night mode usually solves this PL well, when Fly or
+  // handsfree... during baking, there are no PLs shining at the lighting"). MEASURED on a real
+  // headless Duplex MaxQ bake before any change (probe_bake_lighting.log, 28 frames):
+  //     frame 0  §NIGHT_STILL_LIGHTS raised to 18 lights   scenePointLightIntensitySum 127.39
+  //     frame 1  §NIGHT_STILL_LIGHTS raised to 0  lights   scenePointLightIntensitySum  82.39
+  //     frames 2..27  A._nightLights.length = 0 for the ENTIRE rest of the bake
+  // 127.39 - 82.39 = 45.00 = 18 x NIGHT_LIGHT_INTENSITY(2.5) — every fixture light gone, exactly.
+  // TWO defects, and it is the pair that makes it permanent:
+  //   (a) the still/bake branch below selects ONLY what the frustum contains. A frame that happens
+  //       to look where no fixture centre falls (a wide establishing beat, or an interior where the
+  //       fittings lighting the room you stand in are overhead/behind) selects ZERO, and every
+  //       light is disposed.
+  //   (b) the callers' re-arm gate (effects.js §NIGHT_STILL_LIGHTS and _teardownStillRefine) read
+  //       A._nightLights.length — the OUTPUT of the last selection — to decide whether to call this
+  //       function at all. Once (a) drove that output to 0, nothing could ever call it again: a
+  //       self-latching zero. That is why the whole remaining film is dark, not just the one frame
+  //       that emptied the frustum, and why the fixtures being installed later never turns anything
+  //       back on. Nav is unaffected because it never takes the frustum branch (§NIGHT_STILL_BOOST_
+  //       GATE_FIX) — which is exactly the user's "Fly or handsfree is well lit" vs "bake is dark".
+  // The fix here is (a) plus the buildup gate below; (b) is fixed at both call sites in effects.js.
   A._nightUpdateLights = function() {
     if (!A._nightMode || !A._nightFixtures.length) return;
     var allPos = A._nightFixtureWorldPositions();
+    // §BAKE_LIGHT_BUILDUP_GATE — the IDENTICAL one-line filter effects.js _glowOn (§GLOW_BUILDUP_
+    // GATE) and _glowLensOn (§GLOW_LENS_BUILDUP_GATE) already apply to the glow sprite and the lens
+    // quad, now applied to the ILLUMINATION as well: the two systems disagreed, and the point light
+    // was the one that ignored the schedule. Measured in the same baseline run — the Duplex bake
+    // logged `§PHOTO_GLOW_SPRITE_GATE 0/18 fixtures placed yet — nothing to light` while 18 point
+    // lights were shining from those same unplaced fittings. A fixture with no guid (the synthetic
+    // per-storey / room-fallback tiers) has no real element to gate against and always lights, same
+    // rule as the sprite. A._tmIsVisible defaults to true whenever Time Machine is not driving the
+    // scene, so plain Night Mode navigation is completely unchanged.
+    var pos = allPos.filter(function(p) {
+      return p.__guid == null || typeof A._tmIsVisible !== 'function' || A._tmIsVisible(p.__guid);
+    });
     var camPos = A.camera.position;
-    var needed;
+    var needed, _selMode, _inViewN = 0;
     // §NIGHT_STILL_BOOST_GATE_FIX (2026-08-08): A._nightStillBoost is set true ONCE at init and
     // never reset — it's a static "is the still-boost feature enabled" flag (effects.js reads it
     // the same way, correctly, to decide whether Alt+S is ALLOWED to raise the cap). Reading it
@@ -1458,54 +1558,51 @@ function setupTools(A) {
       // rather than a flat count cap; a still pays this cost once, not every frame. 200 is a
       // sanity ceiling against a pathological wide aerial shot with hundreds in frame at once —
       // not a deliberate creative limit.
+      // §BAKE_FRUSTUM_STALE — the frustum must be built from THIS pose, not the last rendered one.
+      // three.js only refreshes camera.matrixWorldInverse inside renderer.render(), and the MaxQ
+      // bake calls startStillRefine() (→ here) immediately after moving the camera and BEFORE any
+      // render of that pose, so the cull ran against the PREVIOUS frame's view. Same two lines the
+      // renderer itself runs — not a new mechanism.
+      A.camera.updateMatrixWorld();
+      A.camera.matrixWorldInverse.copy(A.camera.matrixWorld).invert();
       var frustum = new THREE.Frustum();
       var vpMatrix = new THREE.Matrix4().multiplyMatrices(A.camera.projectionMatrix, A.camera.matrixWorldInverse);
       frustum.setFromProjectionMatrix(vpMatrix);
-      var inView = allPos.filter(function(p) {
+      var inView = pos.filter(function(p) {
         return frustum.containsPoint(new THREE.Vector3(p.x, p.y, p.z));
       });
-      needed = inView.slice(0, 200).map(function(p) { return { pos: p }; });
-    } else if (allPos.length <= A._nightMaxLights) {
+      _inViewN = inView.length;
+      var picked = inView.slice(0, 200);
+      // §BAKE_INTERIOR_LIGHTS defect (a): frustum-only was a HARD floor of zero. A point light
+      // behind or above the eye still lights the wall in front of it — containsPoint tests the
+      // fitting's own centre, so an interior lit by the troffers over your head selected nothing.
+      // Top the set up to the still budget (A._nightMaxLightsStill = 50, already the sanctioned
+      // still count) with the SAME nearest-to-aim + §NIGHT_SPREAD rule navigation uses — no new
+      // constant, no second selection mechanism, and never more than the 200 the frustum branch
+      // already allowed. Fixtures in frame keep priority; the top-up only fills what is left.
+      if (picked.length < A._nightMaxLights) picked = _nightPickNearest(pos, A._nightMaxLights, picked);
+      needed = picked.map(function(p) { return { pos: p }; });
+      _selMode = 'still-frustum';
+    } else if (pos.length <= A._nightMaxLights) {
       // Small building — place ALL fixtures, no culling
-      needed = allPos.map(function(p) { return { pos: p }; });
+      needed = pos.map(function(p) { return { pos: p }; });
+      _selMode = 'all';
     } else {
       // §S277d: MIXED selection — score by a point BETWEEN the eye and the look-at, so the
       // active lights sit near you AND extend down the hall you're flying toward (they
       // transfer ahead as you move). Pure camera-nearest clustered them all at the eye; pure
       // orbit-target clustered them at building centre. Debounced by the controls 'change'
       // listener (>5m move) so small orbits don't thrash the set.
-      var _tgt = A.controls ? A.controls.target : camPos;
-      var _aim = {
-        x: camPos.x + (_tgt.x - camPos.x) * 0.5,
-        y: camPos.y + (_tgt.y - camPos.y) * 0.5,
-        z: camPos.z + (_tgt.z - camPos.z) * 0.5
-      };
-      var sorted = allPos.map(function(p) {
-        var dx = p.x - _aim.x, dy = p.y - _aim.y, dz = p.z - _aim.z;
-        return { pos: p, dist2: dx*dx + dy*dy + dz*dz };
-      }).sort(function(a, b) { return a.dist2 - b.dist2; });
       // §NIGHT_SPREAD (2026-08-07, user: "not in dense area, if two sources nearby spread out to
       // cover further line of sight") — greedy nearest-first, but skip a candidate within
-      // NIGHT_SPREAD_MIN_M of one already picked, so the 24-light budget reaches further down a
-      // corridor instead of bunching on one dense cluster right at the camera. If spacing can't
-      // fill the budget (not enough distant candidates), a second pass fills the rest ignoring
-      // spacing — the budget is always fully used, spacing is a preference, not a hard cutoff.
-      var NIGHT_SPREAD_MIN_M = 4;
-      var picked = [];
-      for (var si = 0; si < sorted.length && picked.length < A._nightMaxLights; si++) {
-        var cand = sorted[si].pos;
-        var tooClose = picked.some(function(pk) {
-          var ddx = pk.x - cand.x, ddy = pk.y - cand.y, ddz = pk.z - cand.z;
-          return (ddx * ddx + ddy * ddy + ddz * ddz) < NIGHT_SPREAD_MIN_M * NIGHT_SPREAD_MIN_M;
-        });
-        if (!tooClose) picked.push(cand);
-      }
-      if (picked.length < A._nightMaxLights) {
-        for (var si2 = 0; si2 < sorted.length && picked.length < A._nightMaxLights; si2++) {
-          if (picked.indexOf(sorted[si2].pos) === -1) picked.push(sorted[si2].pos);
-        }
-      }
-      needed = picked.map(function(p) { return { pos: p }; });
+      // NIGHT_SPREAD_MIN_M of one already picked, so the budget reaches further down a corridor
+      // instead of bunching on one dense cluster right at the camera. If spacing can't fill the
+      // budget (not enough distant candidates), a second pass fills the rest ignoring spacing —
+      // the budget is always fully used, spacing is a preference, not a hard cutoff.
+      // Both rules now live in _nightPickNearest above (§NIGHT_PICK_NEAREST), unchanged — the
+      // still/bake branch tops up with the same rule instead of going dark.
+      needed = _nightPickNearest(pos, A._nightMaxLights, null).map(function(p) { return { pos: p }; });
+      _selMode = 'nearest-to-aim';
     }
     // §NIGHT_LIGHT_CHURN_FIX (2026-08-08): this used to dispose EVERY light and rebuild the whole
     // set from scratch on every call — called on every 5m of camera travel while night mode is on,
@@ -1552,6 +1649,27 @@ function setupTools(A) {
       A._nightLightByPos.delete(pos);
     });
     A._nightLights = Array.from(A._nightLightByPos.values());
+    // §BAKE_LIGHTS — the numeric truth this feature is verified by (FUNDAMENTAL LAW: code and maths,
+    // never a screenshot of the film). Published for the bake's own per-frame line (cinema_maxq.js)
+    // and logged HERE whenever the answer changes, so a live session's console shows the point at
+    // which lighting appears/disappears and against what placed-fixture count. `placed` is the
+    // schedule's own answer via A._tmIsVisible — the bake does not re-derive placement.
+    var _intensitySum = 0;
+    for (var _li = 0; _li < A._nightLights.length; _li++) _intensitySum += A._nightLights[_li].intensity;
+    A._nightLightSelectInfo = {
+      fixtures: allPos.length, placed: pos.length, inView: _inViewN,
+      active: A._nightLights.length, mode: _selMode,
+      budget: A._nightMaxLights, floor: A._nightNearFadeFloor,
+      intensitySum: +_intensitySum.toFixed(2)
+    };
+    var _sig = _selMode + '|' + pos.length + '|' + A._nightLights.length;
+    if (_sig !== A._nightLightSelectSig) {
+      A._nightLightSelectSig = _sig;
+      console.log('§BAKE_LIGHTS select mode=' + _selMode + ' placedFixtures=' + pos.length + '/' + allPos.length +
+        ' inFrustum=' + _inViewN + ' activePL=' + A._nightLights.length +
+        ' budget=' + A._nightMaxLights + ' nearFadeFloor=' + A._nightNearFadeFloor +
+        ' intensitySum=' + _intensitySum.toFixed(2));
+    }
     if (A.markDirty) A.markDirty();
   };
 

--- a/viewer/viewer.html
+++ b/viewer/viewer.html
@@ -822,13 +822,13 @@ html.bim-embedded, html.bim-embedded body { background: #0b0b0b; }
 <script src="qrcode.min.js?v=1" onerror="console.warn('§LOAD_FAIL qrcode.min.js — QR sharing disabled')"></script>
 <script src="config.js?v=4" onerror="console.warn('§LOAD_FAIL config.js')"></script>
 <script src="db_resolve.js?v=2" onerror="console.warn('§LOAD_FAIL db_resolve.js')"></script>
-<script src="effects.js?v=17" onerror="console.warn('§LOAD_FAIL effects.js')"></script>
+<script src="effects.js?v=18" onerror="console.warn('§LOAD_FAIL effects.js')"></script>
 <script src="effects_gi_poc.js?v=3" onerror="console.warn('§LOAD_FAIL effects_gi_poc.js')"></script>
 <script src="lib/mp4_mux.js?v=1" onerror="console.warn('§LOAD_FAIL mp4_mux.js — MaxQ falls back to webm')"></script>
 <script src="cinema_path_editor.js?v=14" onerror="console.warn('§LOAD_FAIL cinema_path_editor.js — Alt+C path editing disabled')"></script>
 <script src="cpe_walk.js?v=6" onerror="console.warn('§LOAD_FAIL cpe_walk.js — CPE walk-mode disabled')"></script>
 <script src="cpe_xr.js?v=1" onerror="console.warn('§LOAD_FAIL cpe_xr.js — VR entry disabled')"></script>
-<script src="cinema_maxq.js?v=5" onerror="console.warn('§LOAD_FAIL cinema_maxq.js — Alt+M MaxQ export disabled')"></script>
+<script src="cinema_maxq.js?v=6" onerror="console.warn('§LOAD_FAIL cinema_maxq.js — Alt+M MaxQ export disabled')"></script>
 <script src="input_registry.js?v=1" onerror="console.warn('§LOAD_FAIL input_registry.js')"></script>
 <script src="../common/pill_builder.js?v=1" onerror="console.warn('§LOAD_FAIL pill_builder.js')"></script>
 <script src="list_builder.js?v=1" onerror="console.warn('§LOAD_FAIL list_builder.js')"></script>
@@ -840,7 +840,7 @@ html.bim-embedded, html.bim-embedded body { background: #0b0b0b; }
 <script src="streaming.js?v=59" onerror="console.warn('§LOAD_FAIL streaming.js')"></script>
 <script src="dlod.js?v=8" onerror="console.warn('§LOAD_FAIL dlod.js')"></script>
 <script src="panels.js?v=43" onerror="console.warn('§LOAD_FAIL panels.js')"></script>
-<script src="tools.js?v=39" onerror="console.warn('§LOAD_FAIL tools.js')"></script>
+<script src="tools.js?v=40" onerror="console.warn('§LOAD_FAIL tools.js')"></script>
 <script src="picking.js?v=30" onerror="console.warn('§LOAD_FAIL picking.js')"></script>
 <script src="hover_name.js?v=1" onerror="console.warn('§LOAD_FAIL hover_name.js — hover-name disabled')"></script>
 <script src="cpe_room_title.js?v=1" onerror="console.warn('§LOAD_FAIL cpe_room_title.js — room titles disabled')"></script>


### PR DESCRIPTION
## §BAKE_INTERIOR_LIGHTS — the movie bake had no fixture lighting at all

User: *"Night mode usually solves this PL well, when Fly or handsfree… during baking, there are no
PLs shining at the lighting."* Interiors dark for the whole film; the exterior beat at the end reads
fine.

### Measured first, on a real headless Duplex bake of unpatched `main` (28 frames, swiftshader)

| frame | `§NIGHT_STILL_LIGHTS` | `A._nightLights.length` | scene point-light intensity sum |
|---|---|---|---|
| 0 | raised to **18** lights | 18 | 127.39 |
| 1 | raised to **0** lights | 0 | 82.39 |
| 2 … 27 | never logged again | **0** | 82.39 |

`127.39 − 82.39 = 45.00 = 18 × NIGHT_LIGHT_INTENSITY (2.5)` — every fixture light, exactly, gone for
the entire remainder of the bake.

### Two defects, and it is the PAIR that made it permanent

**(a) frustum-only selection with a hard floor of zero.** `tools.js _nightUpdateLights`'s still/bake
branch (`§NIGHT_STILL_FRUSTUM`) selected only fixtures whose *centre* falls inside the view frustum.
A wide establishing beat — or an interior lit by the troffers directly overhead/behind the eye —
selects zero and every point light is disposed.

**(b) the re-arm gates read the OUTPUT of that selection.** `effects.js §NIGHT_STILL_LIGHTS` and
`_teardownStillRefine` both asked `A._nightLights.length` before calling the selector. Once (a) drove
that to 0, nothing could ever call it again — a **self-latching zero**. That is why one bad frame
darkens the rest of the film, and why fixtures installed later never light up.

Navigation never takes the frustum branch (`§NIGHT_STILL_BOOST_GATE_FIX`), which is exactly why
Fly/handsfree looked right while the bake did not — one mechanism explains both halves of the report.

### Interior vs exterior is a real structural difference, not coincidence

Same run, `§MOVIE_SHADOW_TM sun=4.400 ambient=0.785 hemi=1.257 fill=2.042`. Photo staging enables sun
shadow casting (`§PHOTO_SHADOW`), so an interior surface is shadow-occluded from the sun and is lit by
the 2.042 uniform fill **plus these point lights**; an exterior surface gets 4.400 + 2.042 = 6.44.
Losing the point lights costs an exterior almost nothing and an interior everything that is not flat
fill. Nothing else differs between the two cases.

### The fix — reuse, not reinvention

1. **`tools.js`** — the frustum set is **topped up** to the still budget (`A._nightMaxLightsStill`,
   already 50) using the *same* nearest-to-aim + `§NIGHT_SPREAD` rule navigation uses, extracted
   verbatim as `_nightPickNearest` (`§NIGHT_PICK_NEAREST`). Nav passes an empty `already` set and is
   behaviourally identical. **No new constant, no second selection mechanism.**
2. **`tools.js` `§BAKE_FRUSTUM_STALE`** — refresh `camera.matrixWorld`/`matrixWorldInverse` before
   building the frustum. The bake moves the camera and calls `startStillRefine()` *before* any render
   of that pose, so the cull was running against the previous frame's view.
3. **`tools.js` `§BAKE_LIGHT_BUILDUP_GATE`** — the identical
   `p.__guid == null || A._tmIsVisible(p.__guid)` line the glow sprite (#1235/#1260) and the lens quad
   already use, now applied to the **illumination**. The baseline run logged
   `§PHOTO_GLOW_SPRITE_GATE 0/18 fixtures placed yet` while 18 point lights shone from those same
   unplaced fittings — the two systems disagreed and the light was the one ignoring the schedule.
   Placement state comes from Time Machine's own predicate; nothing is re-derived.
4. **`effects.js`** — both re-arm gates now read INPUTS (`A._nightMode` + `A._nightFixtures.length`),
   which cannot be zeroed by their own previous answer. The boost moved into `_stillNightLightBoost()`
   and now runs **after** `_applyPhotoStaging()` — staging is what turns night mode on, so frame 0 of
   every bake (and the first Alt+S press of a session) used to run at the nav budget with the 0.3
   near-fade penalty still applied.
5. **`effects.js` (perf)** — during a MaxQ bake with staging kept (`keepStaging && A._maxqActive`) the
   still budget is no longer handed back per frame. The light set was being rebuilt **twice per
   captured frame** (still → nav → still), and a change in point-light *count* is exactly the
   three.js per-material shader recompile `§NIGHT_LIGHT_CHURN` measured as the expensive part. Same
   reasoning as `§MAXQ_STAGE_KEEP`; the end-of-bake stop still hands the budget back, so nothing can
   leak into navigation.

### Verification — numbers, not a screenshot

Per `CLAUDE.md`'s FUNDAMENTAL LAW this is verified by `§`-tagged numeric log lines and live scene
state, never by watching the film.

- New `§BAKE_LIGHTS` line, published by the selector and logged per bake frame at the existing
  `§CPE_BUILDUP` cadence:
  `§BAKE_LIGHTS frame=i/N nightMode=true placedFixtures=P/F inFrustum=V activePL=L mode=… budget=… nearFadeFloor=… plIntensitySum=… sun=… fill=…`
  so "light count tracks placed-fixture count" is grep-checkable from any bake log.
- New witness `tests/witness_bake_interior_lights.js` — drives a **real headless bake** (editor → OK,
  buildup on) and gates on numbers only:
  `G-BL-LATCH` (last frame still lit), `G-BL-TRACK` (no frame with placed fixtures and zero lights;
  never more lights than placed fixtures), `G-BL-GATE` (the buildup gate genuinely withholds),
  `G-BL-LIVE` (live `THREE.PointLight` census agrees with the log), `G-BL-NAV` (plain night navigation
  still takes the nav selection rule). `BASE=1` runs the same harness against unpatched code for the
  RED side.

**Result, this branch, real headless Duplex bake (28 frames, buildup on, swiftshader): 7/7 PASS.**

```
PASS G-BL-LATCH   lastFrame=27 placedFixtures=18/18 activePL=18      (baseline: 0)
PASS G-BL-TRACK   selections=47 placedButDark=0 litMoreThanPlaced=0
PASS G-BL-GATE    selectionsWithLuminairesStillUnplaced=22/47
PASS G-BL-RISE    placed 14,18,18,4,…,12,…,18   active 14,18,18,4,…,12,…,18   (identical series)
PASS G-BL-LIVE    263 samples with night on + placed fixtures, 0 with zero point lights
PASS G-BL-NAV     mode=all nightLights=14 fixtures=14 budget=30 floor=0.3   (nav rule intact)
```

The two per-frame lines from that run, first and last:

```
§BAKE_LIGHTS frame=0/28  placedFixtures=4/18  inFrustum=4  activePL=4  mode=still-frustum budget=50 nearFadeFloor=1 plIntensitySum=10 sun=4.400 fill=2.042
§BAKE_LIGHTS frame=27/28 placedFixtures=18/18 inFrustum=18 activePL=18 mode=still-frustum budget=50 nearFadeFloor=1 plIntensitySum=45 sun=4.400 fill=2.042
```

`plIntensitySum=45` on the final frame is the same 45.00 the baseline LOST at frame 1 — the film now
ends with exactly the fixture lighting the old bake threw away, and the active count equals the placed
count on all 47 logged selections.

Perf: the change removes one of the two per-frame light-set rebuilds (structural — see item 5); no
wall-clock claim is made from these runs, since swiftshader timings on this machine varied with
concurrent load (baseline probe ~12 s/frame, witness run ~25 s/frame with other work running).

`gate_4d.sh` was **not** run: this change touches no scheduling code (`time_machine.js` /
`schedule_gate.js` are untouched, so its `§CACHE_VERSION_GUARD` and the 4D witnesses cannot exercise
it). `sw.js` `CACHE_VERSION` v1009→v1010; `viewer.html` `tools.js?v=39→40`, `effects.js?v=17→18`,
`cinema_maxq.js?v=5→6`.
