### PR TITLE
fix(4d): §RULES_TABLE_SOURCE — the 4D harness was measuring a labour table the viewer never loads

### DIFF
--- a/viewer/rates.js
+++ b/viewer/rates.js
@@ -92,6 +92,19 @@ function getSMMSection(ifcClass) {
 // crew_size already here (CIDB 2024-derived, not extracted from IFC) — editable via the Settings
 // JSON editor / rates/sequence_rules.json the same way. Modest defaults for a large commercial
 // project; bump for a genuinely huge/fast-tracked site, lower for a small one.
+// ⚠ §RULES_TABLE_SOURCE (2026-08-13, bim-compiler prompts/4D_SCHEDULE_PERFECTION.md) — THIS TABLE,
+// NOT THE JSON, IS WHAT THE VIEWER RUNS. Same fact as the note at SEQUENCE_NAME_OVERRIDES below:
+// viewer.html never calls loadSequenceRules(), so rates/sequence_rules.json is a MIRROR (plus the
+// Settings-editor override surface) and this literal is the executed table. That is easy to forget
+// and it drifted: ELECTRICIAN.productivity here carried 15 class keys while the JSON carried 8
+// (IfcSwitchingDevice, IfcSensor, IfcActuator, IfcFlowInstrument, IfcDistributionControlElement,
+// IfcProtectiveDeviceTrippingUnit, IfcUnitaryControlElement were absent there). Because every Node
+// probe and every viewer/tests/witness_*.js reads the JSON, they were all measuring a labour table
+// the browser never used — Hospital programme 1889.4d measured vs 1926.4d shipped, and MEP Final
+// occupancy 14.1% vs 21.0%. Re-synced 2026-08-13. EDIT BOTH FILES IN THE SAME COMMIT.
+// (Separate, still true: panels.js's 5D rate-pack picker calls loadRateTemplate(), whose shallow
+// LABOR_RATES[k] = tpl.labor[k] REPLACES a whole trade — and no pack file carries max_crews, so
+// selecting one silently drops every crew cap to schedule_gate.js's MAX_CREWS_DEFAULT.)
 var LABOR_RATES = {
   HVAC_TECH: {
     rate_per_day: 185, crew_size: 2, max_crews: 2, trade: 'HVAC Technician (Skilled)',

--- a/viewer/rates/sequence_rules.json
+++ b/viewer/rates/sequence_rules.json
@@ -2,7 +2,7 @@
   "meta": {
     "name": "Default Sequence + Labour Rules",
     "version": "2024.2",
-    "note": "Timeline default steps (ifc_class -> phase/sequence/resource + labour productivity) used by Time Machine injectGantt and 4D/5D consumers. Values copied verbatim from rates.js (schedule_generator.py / boq_export.py origins). Editable via Settings JSON editor; rates.js keeps these as the in-file sync default."
+    "note": "Timeline default steps (ifc_class -> phase/sequence/resource + labour productivity). Values copied verbatim from rates.js (schedule_generator.py / boq_export.py origins). READ THIS BEFORE CITING A NUMBER FROM THIS FILE (corrected 2026-08-13, §RULES_TABLE_SOURCE): this file is NOT what Time Machine injectGantt runs on. viewer.html never calls loadSequenceRules() — only mep_report.html and boq_charts.html do — so rates.js's hardcoded SEQUENCE_RULES/LABOR_RATES/SEQUENCE_DEFAULT/SEQUENCE_NAME_OVERRIDES are what the viewer, Time Machine and the Author wizard actually execute, and this file is their MIRROR plus the Settings-JSON-editor override surface. The previous wording here claimed the opposite and is why every Node probe and viewer/tests/witness_*.js measured this file instead of ship: they had drifted (LABOR_RATES.ELECTRICIAN.productivity held 8 class keys here against rates.js's 15 — IfcSwitchingDevice/IfcSensor/IfcActuator/IfcFlowInstrument/IfcDistributionControlElement/IfcProtectiveDeviceTrippingUnit/IfcUnitaryControlElement were missing), worth 1889.4d vs 1926.4d of Hospital programme. Re-synced 2026-08-13. When you edit rates.js, edit this file in the same commit."
   },
   "NAME_OVERRIDES": [
     {
@@ -399,8 +399,15 @@
         "IfcOutlet": 25,
         "IfcElectricAppliance": 15,
         "IfcFlowController": 10,
+        "IfcSwitchingDevice": 10,
         "IfcAlarm": 25,
-        "IfcController": 10
+        "IfcController": 10,
+        "IfcDistributionControlElement": 10,
+        "IfcActuator": 10,
+        "IfcSensor": 10,
+        "IfcFlowInstrument": 10,
+        "IfcProtectiveDeviceTrippingUnit": 10,
+        "IfcUnitaryControlElement": 10
       }
     },
     "STEEL_ERECTOR": {

--- a/viewer/sw.js
+++ b/viewer/sw.js
@@ -8,7 +8,14 @@
 // Cache-first for heavy assets (.wasm, images). DB files skip SW (IndexedDB handles them).
 //
 // DEPLOY: bump CACHE_VERSION on every OCI upload. Old caches are purged on activate.
-const CACHE_VERSION = 'v1011';   // bump on each deploy; per-change detail is the git commit message.
+const CACHE_VERSION = 'v1012';   // bump on each deploy; per-change detail is the git commit message.
+// v1012 (2026-08-13) §RULES_TABLE_SOURCE: rates/sequence_rules.json is PRECACHED (line ~234) and its
+// content changed — LABOR_RATES.ELECTRICIAN.productivity re-synced to rates.js's 15 class keys. Its
+// only readers are mep_report.html and boq_charts.html (viewer.html never calls loadSequenceRules),
+// so without this bump those two pages keep costing 7 electrical classes off a stale 8-key table.
+// Deliberately NOT accompanied by a _GANTT_CACHE_VERSION bump: the viewer's generated schedule is
+// byte-unchanged by this commit (it never reads the JSON, and the rates.js edit is comment-only), so
+// forcing every materialized building to re-bake would be churn with no behavioural difference.
 const CACHE_PREFIX = 'bim-ootb-';
 const CACHE_NAME = CACHE_PREFIX + CACHE_VERSION;
 


### PR DESCRIPTION
## What this fixes

Chasing the user's report — *"the rush to build at onset leaving the rest idle is a bug"* — the first job was to trust the measurement. It could not be trusted. **Two systemic measurement bugs, both invalidating a day of `§`-numbers.** This PR fixes the one that lives in this repo; the probe-side fix is bim-compiler `b511fc084`.

### The bug

`viewer/rates.js:239` says, in shipped source:

> *"viewer.html does NOT call `initRateTemplate()`/`loadSequenceRules()` (only mep_report.html/boq_charts.html do), so this hardcoded copy, NOT the JSON, is what actually runs in the main viewer/Time Machine/Author wizard."*

Confirmed by grep — nothing on the viewer's load path calls it. But `rates/sequence_rules.json`'s own `meta.note` claimed the **opposite** ("used by Time Machine injectGantt"), and that false claim is why every Node probe and **every `viewer/tests/witness_*.js`** reads the JSON. The two had drifted:

```
LABOR_RATES.ELECTRICIAN.productivity — rates.js 15 class keys, JSON 8
missing from JSON: IfcSwitchingDevice, IfcSensor, IfcActuator, IfcFlowInstrument,
                   IfcDistributionControlElement, IfcProtectiveDeviceTrippingUnit,
                   IfcUnitaryControlElement   (all productivity 10)
```

Those seven classes fell through to `_installSecs`' no-match default in every Node run while carrying their real 2880 s in the browser. Everything else in the two files is identical: `SEQUENCE_DEFAULT` identical, `SEQUENCE_RULES` 58 keys with **zero** value differences, `NAME_OVERRIDES` differ only in a prose `reason` field. ELECTRICIAN is the whole drift.

### Measured effect (Hospital)

| | JSON table (what witnesses measured) | rates.js table (what ships) |
|---|---|---|
| programme | 1889.4 d | **1926.4 d** |
| MEP Final occupancy | 14.1% | **21.0%** |
| `§HOSTED_BEFORE_HOST hostFixed` | 80 | 80 |
| `§DOOR_WINDOW_HOST_WALL_DISPLAY openFixed` | 14 | 14 |

## Resolving the probe-vs-browser discrepancy

A live browser at `0b97891` printed `§TIER_SERIAL … totalDays=2019.6` while the probe said 1889.4 — a ~7% gap that was blocking this lane. Both causes are now measured:

1. the rules table above (+37 d), and
2. **`§SERVED_BYTES`** — `~/bim-ootb/buildings/Hospital_extracted.db` is a *newer re-extraction* than the OCI object the viewer fetches. Same model (identical class histogram, 63,182 scheduled elements, `totSecs=92,135,244`, **zero** numerically-differing `element_transforms` rows) but **21 storey names against the served copy's 9**, differing on 7,365 elements. `storey` IS the zone key, so `§TIER_SERIAL_BY_ZONE` re-serializes: 1926.4 → **2014.7 d** (+88 d).

```
live browser        2019.6   hostFixed=79  openFixed=13
corrected probe     2014.7   hostFixed=80  openFixed=13   <- residual 0.24%
old (wrong on both) 1889.4
```

Residual 0.24% is the browser's IndexedDB holding a slightly older vintage of the same object (raw server bytes are cached at first load, never content-revalidated). **1889.4 must not be cited again.**

Ruled out by measurement, each with its own run: the runtime SQL patch (`Hospital_extracted.db.sql` is 8 lines, `storey_walkable_raster` only), all 16 rate packs, element ordering (cross-swapped both ways), and code version.

> **Corollary worth more than this PR: re-extracting a building silently re-dates its whole schedule** — 4.6% on the storey taxonomy alone, geometry and labour seconds byte-identical.

## Scope

- **No `_GANTT_CACHE_VERSION` bump.** The viewer's generated schedule is byte-unchanged: it never reads this JSON, and the `rates.js` edit is comment-only. Forcing every materialized building to re-bake would be churn with no behavioural difference. `§CACHE_VERSION_GUARD` agrees — no diff in `time_machine.js`/`schedule_gate.js`.
- **`sw.js` v1011 → v1012 IS required.** `rates/sequence_rules.json` is precached (`sw.js:234`), so without it `mep_report.html` and `boq_charts.html` — its only two readers — keep costing seven electrical classes off the stale table.
- Values are **copied from rates.js**, nothing invented.
- Also recorded at `rates.js`: `panels.js`'s 5D rate-pack picker calls `loadRateTemplate()`, whose shallow `LABOR_RATES[k] = tpl.labor[k]` replaces a whole trade — and **no pack file carries `max_crews`**, so selecting a pack silently drops every crew cap to `MAX_CREWS_DEFAULT`. Measured across all 16 packs; reported, not changed here.

## The idle bug itself — located, not yet fixed

Now measurable, on served bytes with ship tables. New `§STAGE_OCC` / `§ZONE_BAR_TAIL` probe readouts (bim-compiler) attribute it to a **layer** and a **unit** instead of leaving it to inference. Hospital, `phase% / zone-mean%`:

| phase | RAW | REPAIR | owner |
|---|---|---|---|
| Superstructure | 39% / 16% | 40% / 16% | support gate |
| Architecture | 34% / **9%** | 23% / **6%** | support gate — already sparse before any remap |
| MEP Rough-in | 278% / 92% | 145% / 61% | — |
| MEP Final | **176%** / 55% | **27%** / 22% | `_twoTierRemap` — compact generatively (121 d), stretched 6.5x |
| Finishes | 49% / 28% | **8%** / **28%** | zone STAGGERING — the zone bars are dense (43–67%) |

**Three different shapes; no single fix covers them.** Trimming each bar to its own 95%-of-work point would take MEP Final 22.3% → **68.7%**, but Architecture only 6.1% → 10.9%, and it is the wrong instrument for Finishes entirely. And the elements past the 95% mark are *real* — Architecture `Level 5` has 750 of 3497 out there — so a blind display trim would exile hundreds of genuinely-scheduled elements from their own bar. `§ZONE_BAR_TAIL` reports `tailN` beside the trim gain and never trims anything.

⛔ **BLOCKED on one ruling**, deliberately not shipped here: `§TIER2_AFTER_TIER1` moves *every* Tier-2 element in a zone by `t1EndZ[z] - t2MinZ[z]` — the amount the **earliest** one needs — so already-compliant elements are pushed further for nothing, and since each zone's shift differs the phase gets **sheared**. A per-element clamp satisfies the barrier's own contract and moves strictly less, but it is not order-preserving within a zone (today's uniform shift is, *by construction*, deliberately), so `_midairRepair` would have to carry the ordering. Trading a by-construction guarantee for a repaired-after-the-fact one is a ruling, not a derivation. Full argument: bim-compiler `prompts/4D_SCHEDULE_PERFECTION.md` **§PHASE_WINDOW_IDLE**.

The authored Gantt stays untouched — `schedule_author.js`'s WBS/editing model is not modified by this PR, so the bars remain user-editable.

## Gate

`scripts/gate_4d.sh` before and after.

| | baseline | after |
|---|---|---|
| result | pass=7 fail=0 missing=1 | **pass=8 fail=0 missing=1** |
| `witness_zone_index` | 5/5 | 5/5 |
| `witness_tier_serial_display` | 57/0 | 57/0 |
| `witness_crew_demand` | 4/4 | 4/4 |
| `witness_midair_zero` | 38/0 | 38/0 |
| `witness_hosted_before_host` | 4/4 | 4/4 |
| `witness_kernel_ops_sched_version` | 12/0 | 12/0 |
| `witness_curtain_wall_opening` | 5/5 | 5/5 |
| `§CACHE_VERSION_GUARD` | SKIP (was origin/main) | **PASS** |

`witness_arch_area_weight` MISS in both — not in this revision, pre-existing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GdPyHB9SRqs5Z6rCRdV7eV