### PR TITLE
fix(viewer): §17.17.4 arm occlStructEnabled default-true (W-OCC3-ARM)

### DIFF
--- a/viewer/dlod_nav.js
+++ b/viewer/dlod_nav.js
@@ -277,8 +277,13 @@
     // doesn't re-walk this exact fix shape without knowing it was already tried and falsified.
     occlDepthDecoupleEnabled: false,
     // §17.16 step: same console-only convention (window.__dlodNav.occlStructEnabled = true),
-    // independent of occlBvhEnabled — false ⇒ identical to shipped §13+§16 behavior. Once witnessed
-    // (W-OCC2-*), this flips to default true and occlBvhEnabled's whole §17.2-17.4 machinery retires.
+    // independent of occlBvhEnabled — false ⇒ identical to shipped §13+§16 behavior.
+    // §17.17.4 (W-OCC3-ARM): the squash-merge that landed §17.17.1-3 (PR #1328) dropped this
+    // declaration entirely (_stats.occlStructEnabled read as undefined, not false — harmless since
+    // undefined===true is still false, but not the intended explicit default). Restored here,
+    // armed true: false-hide dropped 26.9%→2.3-4.1% (real RTX 4060, LTU_AHouse), W-OCC3-EQUIV
+    // passed lever-off first. See prompts/OCCL_STRUCT_SESSION_HANDOFF.md.
+    occlStructEnabled: true, occlStructReady: false, occlStructCount: 0, occlStructRootDiag: 0,
     occlStructCandidates: 0, occlStructHidden: 0, occlStructQueriesIssued: 0, occlStructResultsRead: 0,
     // §17.17.2/§17.17.3 sub-levers — all three only ever read while occlStructEnabled is true, so
     // the off-path stays byte-identical regardless of their values (W-OCC3-EQUIV).

--- a/viewer/sw.js
+++ b/viewer/sw.js
@@ -8,7 +8,9 @@
 // Cache-first for heavy assets (.wasm, images). DB files skip SW (IndexedDB handles them).
 //
 // DEPLOY: bump CACHE_VERSION on every OCI upload. Old caches are purged on activate.
-const CACHE_VERSION = 'v1012';   // bump on each deploy; per-change detail is the git commit message.
+const CACHE_VERSION = 'v1013';   // bump on each deploy; per-change detail is the git commit message.
+// v1013 (2026-08-13) §17.17.4 (W-OCC3-ARM): occlStructEnabled armed default-true in dlod_nav.js —
+// bump so returning browsers actually get the new default instead of a cached copy.
 // v1012 (2026-08-13) §RULES_TABLE_SOURCE: rates/sequence_rules.json is PRECACHED (line ~234) and its
 // content changed — LABOR_RATES.ELECTRICIAN.productivity re-synced to rates.js's 15 class keys. Its
 // only readers are mep_report.html and boq_charts.html (viewer.html never calls loadSequenceRules),


### PR DESCRIPTION
Arms the false-hide fix from PR #1328 by default. Real RTX 4060 testing on LTU_AHouse: false-hide
26.9% -> 2.3-4.1%. Also restores an init-line declaration PR #1328's squash-merge silently dropped
(harmless in practice, now explicit). Still gated behind DLOD-nav's own pill — no visible change
until a user engages it. sw.js CACHE_VERSION bumped v1012->v1013.