### PR TITLE
fix(viewer): retune N8AO radius/intensity — Alt+G/Alt+S/Alt+C read too dark and noisy

### DIFF
--- a/viewer/effects.js
+++ b/viewer/effects.js
@@ -3430,16 +3430,24 @@ async function setupEffects(A, renderer, scene, camera) {
   var STILL_AO_ENABLED = true;
   var STILL_AO_FRAMES = 24;       // n8ao accumulates 1 AO sample-set per still frame; 24 ≈ converged
   // §PHOTO_AO_TUNE (2026-07-16, real-GPU A/B at STILL quality — PHOTO_AO_TUNE_r{8_i6,5_i4,3_i4,
-  // 1p5_i3}_2026-07-16.png, identical frozen pose/beauty, only AO varied): radius=8/intensity=6
-  // KEPT. The review's earlier "broad mottle / reads busy" verdict was measured over LIVE
-  // navigation, where every frame resets the AO accumulation (markDirty→firstFrame) and shows raw
-  // single-frame noise — at still quality the accumulation fully converges (24+ frames, frozen
-  // camera) and the same radius reads as clean depth: courtyard corners, roof openings, skyline
-  // masses, base contact. Smaller radii (3/1.5) are near-invisible at whole-building establishing
-  // distance — consistent with §GI_POC_RADIUS_TEST's original sub-pixel finding. Perf at still:
-  // r8 ≈ 30ms/frame, r3 ≈ 6.5ms/frame (RTX 4060, 1280x800) — both trivial for a one-shot still.
-  var STILL_AO_RADIUS = 8;
-  var STILL_AO_INTENSITY = 6;
+  // 1p5_i3}_2026-07-16.png, identical frozen pose/beauty, only AO varied): radius=8/intensity=6 was
+  // kept THEN — the earlier "broad mottle / reads busy" verdict it was compared against was
+  // measured over LIVE navigation (raw, unconverged single-frame AO), and at still quality the same
+  // radius read as clean contact shadow instead. Smaller radii (3/1.5) were near-invisible at
+  // whole-building establishing distance in that same test.
+  // §PHOTO_AO_DARK (2026-08-13, user live verdict: "Alt-G too dark... affecting Alt-S and movie" —
+  // full trace in prompts/PHOTOREAL_STILL_RENDER.md §PHOTO_AO_TUNING): the 2026-07-16 test compared
+  // this radius/intensity against a WORSE (raw-noise) baseline, at ONE lighting condition, and
+  // never against the darkness the user is now flagging directly, nor against §SUN_ARC's dusk
+  // sweep (shipped 2026-08-11, after this constant was set) which compounds AO darkening on the
+  // dim half of every Alt+C film. A live user verdict on "look" supersedes an old A/B per this
+  // project's standing rule (the look is the user's call) — radius 8→4, intensity 6→2, matching
+  // the same retune applied to the standalone Alt+G preview (effects_gi_poc.js). Denoise raised
+  // toward n8ao's own library defaults (aoSamples 8/16, denoiseSamples 4/12→8, denoiseRadius
+  // 6→12 below) to cut residual noise too — free here, this is an offline accumulate, not a
+  // real-time cost. Verify live on the next round trip, not with a synthetic re-A/B.
+  var STILL_AO_RADIUS = 4;
+  var STILL_AO_INTENSITY = 2;
   var _stillAOPromise = null, _stillAORAF = null, _stillAODepthDirty = true;
   function _buildStillAO() {
     return Promise.all([
@@ -3460,8 +3468,9 @@ async function setupEffects(A, renderer, scene, camera) {
       n8.configuration.aoRadius = STILL_AO_RADIUS;
       n8.configuration.intensity = STILL_AO_INTENSITY;
       n8.configuration.aoSamples = 8;
-      n8.configuration.denoiseSamples = 4;
-      n8.configuration.denoiseRadius = 6;
+      n8.configuration.denoiseSamples = 8;        // §PHOTO_AO_DARK: 4→8, toward n8ao's own library
+      n8.configuration.denoiseRadius = 12;        // default (8/12) — cuts residual noise, free at
+                                                   // still/bake (offline accumulate, not real-time)
       n8.configuration.halfRes = false;           // still-frame quality
       n8.renderToScreen = false;
       var copyMat = new THREE.ShaderMaterial({

--- a/viewer/effects_gi_poc.js
+++ b/viewer/effects_gi_poc.js
@@ -31,12 +31,19 @@ async function setupGIPoc(A, renderer, scene, camera) {
       composer.addPass(new _pp.RenderPass(scene, camera));
 
       var n8aoPass = new _pp.N8AOPostPass(scene, camera, window.innerWidth, window.innerHeight);
-      n8aoPass.configuration.aoRadius = 8;         // §GI_POC_RADIUS_TEST: bumped from 1.5 — at a whole-
+      n8aoPass.configuration.aoRadius = 4;         // §GI_POC_RADIUS_TEST: bumped from 1.5 — at a whole-
       // building establishing-shot distance (envelope ~68m on Terminal), a 1.5m radius produces a
       // sub-pixel contact band, invisible in practice (confirmed: no visible difference vs staging-
       // only in a direct A/B test). Testing a building-scale radius instead — architectural AO
       // radii for exterior shots commonly run several meters, not sub-2m interior-detail scale.
-      n8aoPass.configuration.intensity = 6;
+      // §PHOTO_AO_DARK (2026-08-13, user live verdict: "Alt-G too dark... affecting Alt-S and
+      // movie" — supersedes the still-quality-only 2026-07-16 A/B kept in effects.js's own
+      // STILL_AO_RADIUS/INTENSITY comment; see prompts/PHOTOREAL_STILL_RENDER.md §PHOTO_AO_TUNING
+      // for the full trace). radius 8→4, intensity 6→2 — this app's own §GI_CINEMA_PRESET comment
+      // already frames radius=8/intensity=6 as a still/converged-only choice, never validated as a
+      // general "always this dark" default; the look is the user's call per this project's
+      // standing rule, verify live on the next round trip rather than re-run a synthetic A/B here.
+      n8aoPass.configuration.intensity = 2;
       n8aoPass.configuration.aoSamples = 8;       // still-preview budget, not tuned for real-time nav
       // §GI_POC_GHOST_FIX: N8AO's accumulationRenderTarget is ONLY cleared on camera movement when
       // configuration.accumulate=true (read from n8ao's own source — the `else` branch that calls

--- a/viewer/sw.js
+++ b/viewer/sw.js
@@ -8,7 +8,7 @@
 // Cache-first for heavy assets (.wasm, images). DB files skip SW (IndexedDB handles them).
 //
 // DEPLOY: bump CACHE_VERSION on every OCI upload. Old caches are purged on activate.
-const CACHE_VERSION = 'v1013';   // bump on each deploy; per-change detail is the git commit message.
+const CACHE_VERSION = 'v1014';   // bump on each deploy; per-change detail is the git commit message.
 // v1013 (2026-08-13) §17.17.4 (W-OCC3-ARM): occlStructEnabled armed default-true in dlod_nav.js —
 // bump so returning browsers actually get the new default instead of a cached copy.
 // v1012 (2026-08-13) §RULES_TABLE_SOURCE: rates/sequence_rules.json is PRECACHED (line ~234) and its


### PR DESCRIPTION
## Summary
- User live verdict: "Alt-G too dark... affecting Alt-S and movie" — the 2026-07-16 A/B that kept `radius=8/intensity=6` only compared it against a worse raw-noise baseline at one lighting condition, never against this darkness directly, and never against §SUN_ARC's dusk sweep (shipped later, compounds AO darkening on the dim half of every Alt+C film).
- `effects_gi_poc.js` (standalone Alt+G): `aoRadius` 8→4, `intensity` 6→2.
- `effects.js` §PHOTO_AO (the fold Alt+S uses, and which MaxQ/Alt+C bakes run on every captured frame): `STILL_AO_RADIUS` 8→4, `STILL_AO_INTENSITY` 6→2, `denoiseSamples` 4→8, `denoiseRadius` 6→12 (toward n8ao's own library defaults — free at bake/still quality, this is an offline accumulate not real-time).
- `sw.js` `CACHE_VERSION` v1013→v1014 (`effects.js` is in `PRECACHE_ASSETS`).

Full trace in `bim-compiler` `prompts/PHOTOREAL_STILL_RENDER.md` §PHOTO_AO_TUNING, including a retracted first-pass fix attempt and why it was wrong.

## Test plan
- [x] `node -c` on all three changed files
- [x] Live real-GPU witness (headless Chrome, RTX 4060, `Duplex_extracted.db`): confirms both passes actually run the new config — `§WITNESS_GI_CFG {"aoRadius":4,"intensity":2}`, `§PHOTO_AO start frames=24 radius=4 intensity=2`, converges cleanly (24/24, 396ms, no timeout/no page errors). This proves the wiring, not the look.
- [ ] User visual confirmation on a real building (Alt+G, Alt+S, and an Alt+C bake) — the look is the user's call per this project's standing rule; merge after that round trip.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>