### PR TITLE
fix(viewer): N8AO screen-space radius — fixes far-bright/up-close-dark

### DIFF
--- a/viewer/effects.js
+++ b/viewer/effects.js
@@ -3441,12 +3441,20 @@ async function setupEffects(A, renderer, scene, camera) {
   // never against the darkness the user is now flagging directly, nor against §SUN_ARC's dusk
   // sweep (shipped 2026-08-11, after this constant was set) which compounds AO darkening on the
   // dim half of every Alt+C film. A live user verdict on "look" supersedes an old A/B per this
-  // project's standing rule (the look is the user's call) — radius 8→4, intensity 6→2, matching
-  // the same retune applied to the standalone Alt+G preview (effects_gi_poc.js). Denoise raised
-  // toward n8ao's own library defaults (aoSamples 8/16, denoiseSamples 4/12→8, denoiseRadius
-  // 6→12 below) to cut residual noise too — free here, this is an offline accumulate, not a
-  // real-time cost. Verify live on the next round trip, not with a synthetic re-A/B.
-  var STILL_AO_RADIUS = 4;
+  // project's standing rule (the look is the user's call) — first pass: radius 8→4, intensity 6→2.
+  // §PHOTO_AO_SCALE (2026-08-13, same-day follow-up, user: "far off well lighted, up close dark"):
+  // the flat retune above didn't fix this — it's a distance-scale problem, not overall strength. A
+  // FIXED WORLD-SPACE radius (metres) spans the whole visible wall up close but is a barely-visible
+  // contact band far away; no single metre value is right at both distances. Switched to n8ao's
+  // `screenSpaceRadius` mode (their README: aoRadius becomes SCREEN PIXELS, recommended 16-64, and
+  // the effective world radius self-scales with camera distance so the AO reads a consistent size
+  // on screen) — same change applied to the standalone Alt+G preview (effects_gi_poc.js).
+  // `distanceFalloff` (never set before — was n8ao's own default of 1) set to their documented 0.2
+  // for this mode. Denoise raised toward n8ao's own library defaults (aoSamples 8/16, denoiseSamples
+  // 4/12→8, denoiseRadius 6→12 below) to cut residual noise too — free here, this is an offline
+  // accumulate, not a real-time cost. First-pass pixel radius, like every other value here — verify
+  // live on the next round trip, not with a synthetic re-A/B.
+  var STILL_AO_RADIUS = 32;       // pixels (screenSpaceRadius mode), not metres
   var STILL_AO_INTENSITY = 2;
   var _stillAOPromise = null, _stillAORAF = null, _stillAODepthDirty = true;
   function _buildStillAO() {
@@ -3465,7 +3473,9 @@ async function setupEffects(A, renderer, scene, camera) {
                                                   // compositer the first frame a transparent material streams in
       n8.configuration.gammaCorrection = false;   // OutputPass tone-maps after this pass — stay linear
       n8.configuration.accumulate = true;         // camera is frozen during the AO phase — refine, don't flicker
+      n8.configuration.screenSpaceRadius = true;  // §PHOTO_AO_SCALE: radius scales with camera distance
       n8.configuration.aoRadius = STILL_AO_RADIUS;
+      n8.configuration.distanceFalloff = 0.2;     // n8ao's documented value for screenSpaceRadius mode
       n8.configuration.intensity = STILL_AO_INTENSITY;
       n8.configuration.aoSamples = 8;
       n8.configuration.denoiseSamples = 8;        // §PHOTO_AO_DARK: 4→8, toward n8ao's own library

--- a/viewer/effects_gi_poc.js
+++ b/viewer/effects_gi_poc.js
@@ -31,18 +31,24 @@ async function setupGIPoc(A, renderer, scene, camera) {
       composer.addPass(new _pp.RenderPass(scene, camera));
 
       var n8aoPass = new _pp.N8AOPostPass(scene, camera, window.innerWidth, window.innerHeight);
-      n8aoPass.configuration.aoRadius = 4;         // §GI_POC_RADIUS_TEST: bumped from 1.5 — at a whole-
-      // building establishing-shot distance (envelope ~68m on Terminal), a 1.5m radius produces a
-      // sub-pixel contact band, invisible in practice (confirmed: no visible difference vs staging-
-      // only in a direct A/B test). Testing a building-scale radius instead — architectural AO
-      // radii for exterior shots commonly run several meters, not sub-2m interior-detail scale.
+      // §GI_POC_RADIUS_TEST (2026-07-16): a FIXED WORLD-SPACE radius (was 1.5m, bumped to 8m so it
+      // read at whole-building establishing-shot distance) is the actual reason for the
+      // §PHOTO_AO_SCALE symptom below — the same radius, in metres, spans the whole visible
+      // surface up close (over-darkens) but is barely a contact band far away (needs bumping). A
+      // single world-space number cannot be correct at both distances at once.
       // §PHOTO_AO_DARK (2026-08-13, user live verdict: "Alt-G too dark... affecting Alt-S and
-      // movie" — supersedes the still-quality-only 2026-07-16 A/B kept in effects.js's own
-      // STILL_AO_RADIUS/INTENSITY comment; see prompts/PHOTOREAL_STILL_RENDER.md §PHOTO_AO_TUNING
-      // for the full trace). radius 8→4, intensity 6→2 — this app's own §GI_CINEMA_PRESET comment
-      // already frames radius=8/intensity=6 as a still/converged-only choice, never validated as a
-      // general "always this dark" default; the look is the user's call per this project's
-      // standing rule, verify live on the next round trip rather than re-run a synthetic A/B here.
+      // movie") first-pass fix (radius 8→4, intensity 6→2) only lowered the SAME flat-radius curve
+      // — it helped everywhere but didn't fix the underlying scale mismatch.
+      // §PHOTO_AO_SCALE (2026-08-13, same-day follow-up, user: "far off well lighted, up close
+      // dark"): confirms it's a distance-scale problem, not just overall strength. n8ao's own
+      // `screenSpaceRadius` mode exists exactly for this — per its README, when true, `aoRadius`
+      // means SCREEN PIXELS (recommended 16-64), not metres, and the effective world radius scales
+      // itself down automatically for near geometry / up for far geometry so the AO reads a
+      // consistent size on screen regardless of camera distance. `distanceFalloff` docs recommend
+      // 0.2 in this mode (was left at n8ao's own default 1 — never set here before).
+      n8aoPass.configuration.screenSpaceRadius = true;
+      n8aoPass.configuration.aoRadius = 32;       // pixels (16-64 recommended range), not metres
+      n8aoPass.configuration.distanceFalloff = 0.2;
       n8aoPass.configuration.intensity = 2;
       n8aoPass.configuration.aoSamples = 8;       // still-preview budget, not tuned for real-time nav
       // §GI_POC_GHOST_FIX: N8AO's accumulationRenderTarget is ONLY cleared on camera movement when

--- a/viewer/sw.js
+++ b/viewer/sw.js
@@ -8,7 +8,7 @@
 // Cache-first for heavy assets (.wasm, images). DB files skip SW (IndexedDB handles them).
 //
 // DEPLOY: bump CACHE_VERSION on every OCI upload. Old caches are purged on activate.
-const CACHE_VERSION = 'v1015';   // bump on each deploy; per-change detail is the git commit message.
+const CACHE_VERSION = 'v1016';   // bump on each deploy; per-change detail is the git commit message.
 // v1013 (2026-08-13) §17.17.4 (W-OCC3-ARM): occlStructEnabled armed default-true in dlod_nav.js —
 // bump so returning browsers actually get the new default instead of a cached copy.
 // v1012 (2026-08-13) §RULES_TABLE_SOURCE: rates/sequence_rules.json is PRECACHED (line ~234) and its


### PR DESCRIPTION
## Summary
Follow-up to #1331. User report after that shipped: "has always been from outside building the insides are well lighted. Far off well lighted. Up close dark." That's a distance-scale problem, not overall strength — a fixed world-space `aoRadius` (metres) spans the whole visible wall up close but is barely visible far away, so no single metre value works at both distances.

Switches both N8AO integrations to n8ao's `screenSpaceRadius` mode (per their docs: `aoRadius` becomes screen pixels, recommended 16-64, using 32; `distanceFalloff` recommended at 0.2 in this mode, was left at the library default of 1 before). The effective world-space radius now self-scales with camera distance.

- `effects_gi_poc.js` (Alt+G): `screenSpaceRadius=true`, `aoRadius` 4→32px, `distanceFalloff=0.2`.
- `effects.js` §PHOTO_AO (Alt+S/Alt+C fold): same three additions.
- `sw.js` `CACHE_VERSION` v1015→v1016.

## Test plan
- [x] `node -c` on all three files
- [x] Live real-GPU witness confirms both passes run the new config end-to-end (`screenSpaceRadius=true`, `distanceFalloff=0.2`, `aoRadius=32`, converges 24/24 frames, no errors)
- [ ] User visual confirmation, specifically checking the far-vs-close symptom this targets

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>