### PR TITLE
fix(viewer): N8AO intensity 2->4 — edge/corner contact shadow was invisible

### DIFF
--- a/viewer/effects.js
+++ b/viewer/effects.js
@@ -3454,8 +3454,13 @@ async function setupEffects(A, renderer, scene, camera) {
   // 4/12→8, denoiseRadius 6→12 below) to cut residual noise too — free here, this is an offline
   // accumulate, not a real-time cost. First-pass pixel radius, like every other value here — verify
   // live on the next round trip, not with a synthetic re-A/B.
+  // §PHOTO_AO_EDGE (2026-08-13, same-day 3rd round: user, after §PHOTO_AO_SCALE cleared the
+  // darkness, "completely no edge corner shadow"): intensity had been sitting at 2 (down from the
+  // original 6) since the first retune and was never revisited when the radius mechanism changed —
+  // too weak to read at all once the broad-area darkening was gone. One controlled step up, not
+  // back to 6. STILL_AO_RADIUS left unchanged — single-variable change, easy to read next round.
   var STILL_AO_RADIUS = 32;       // pixels (screenSpaceRadius mode), not metres
-  var STILL_AO_INTENSITY = 2;
+  var STILL_AO_INTENSITY = 4;
   var _stillAOPromise = null, _stillAORAF = null, _stillAODepthDirty = true;
   function _buildStillAO() {
     return Promise.all([

--- a/viewer/effects_gi_poc.js
+++ b/viewer/effects_gi_poc.js
@@ -49,7 +49,13 @@ async function setupGIPoc(A, renderer, scene, camera) {
       n8aoPass.configuration.screenSpaceRadius = true;
       n8aoPass.configuration.aoRadius = 32;       // pixels (16-64 recommended range), not metres
       n8aoPass.configuration.distanceFalloff = 0.2;
-      n8aoPass.configuration.intensity = 2;
+      // §PHOTO_AO_EDGE (2026-08-13, same-day 3rd round: user, after §PHOTO_AO_SCALE cleared the
+      // darkness, "completely no edge corner shadow"): intensity had been sitting at 2 (down from
+      // the original 6) since the very first retune and was never revisited when the radius
+      // mechanism changed to screenSpaceRadius — too weak to read at all once the broad-area
+      // darkening was gone. One controlled step up, not back to 6. aoRadius (32px) left unchanged
+      // — this is a single-variable change so the next round trip is easy to read.
+      n8aoPass.configuration.intensity = 4;
       n8aoPass.configuration.aoSamples = 8;       // still-preview budget, not tuned for real-time nav
       // §GI_POC_GHOST_FIX: N8AO's accumulationRenderTarget is ONLY cleared on camera movement when
       // configuration.accumulate=true (read from n8ao's own source — the `else` branch that calls

--- a/viewer/sw.js
+++ b/viewer/sw.js
@@ -8,7 +8,7 @@
 // Cache-first for heavy assets (.wasm, images). DB files skip SW (IndexedDB handles them).
 //
 // DEPLOY: bump CACHE_VERSION on every OCI upload. Old caches are purged on activate.
-const CACHE_VERSION = 'v1016';   // bump on each deploy; per-change detail is the git commit message.
+const CACHE_VERSION = 'v1017';   // bump on each deploy; per-change detail is the git commit message.
 // v1013 (2026-08-13) §17.17.4 (W-OCC3-ARM): occlStructEnabled armed default-true in dlod_nav.js —
 // bump so returning browsers actually get the new default instead of a cached copy.
 // v1012 (2026-08-13) §RULES_TABLE_SOURCE: rates/sequence_rules.json is PRECACHED (line ~234) and its


### PR DESCRIPTION
## Summary
Follow-up to #1331/#1334. User, same day: after #1334's `screenSpaceRadius` fix cleared the darkness, "completely no edge corner shadow." `intensity` had been at 2 (down from the original 6) since #1331's first retune and was never revisited when the radius mechanism changed in #1334 — too weak to read once the broad-area darkening was gone.

One controlled step (2→4, not back to the original 6). `aoRadius` (32px) left unchanged — single-variable change, easy to read on the next round trip.

- `effects_gi_poc.js` (Alt+G): `intensity` 2→4.
- `effects.js` §PHOTO_AO (Alt+S/Alt+C fold): `STILL_AO_INTENSITY` 2→4.
- `sw.js` `CACHE_VERSION` v1016→v1017.

## Test plan
- [x] `node -c` on all three files
- [x] Live real-GPU witness confirms both passes run `intensity=4`, `screenSpaceRadius=true`, `aoRadius=32`, converges cleanly (24/24, no errors)
- [ ] User visual confirmation — corner/edge contact shadow should now be visible without returning to the original over-dark look

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>