### PR TITLE
fix(viewer): night PointLight near-field blowout — decay 1.5->1.0

### DIFF
--- a/viewer/sw.js
+++ b/viewer/sw.js
@@ -8,7 +8,10 @@
 // Cache-first for heavy assets (.wasm, images). DB files skip SW (IndexedDB handles them).
 //
 // DEPLOY: bump CACHE_VERSION on every OCI upload. Old caches are purged on activate.
-const CACHE_VERSION = 'v1018';   // bump on each deploy; per-change detail is the git commit message.
+const CACHE_VERSION = 'v1019';   // bump on each deploy; per-change detail is the git commit message.
+// v1019 (2026-08-13) §NIGHT_LIGHT_NEARFIELD: tools.js NIGHT_LIGHT_DECAY 1.5->1.0 — real
+// PointLights were blowing out to a flat highlight right up close under ACES tonemapping (bright
+// from afar, "not evident" close up) — bump so returning browsers get the retuned falloff.
 // v1018 (2026-08-13) §PHOTO_AO_EDGE: N8AO intensity 2->4 in effects.js/effects_gi_poc.js (corner/
 // edge contact shadow had gone invisible after the v1016 screenSpaceRadius fix) — bump so
 // returning browsers get the new intensity instead of a cached pre-fix pass. This PR's own v1017

--- a/viewer/tools.js
+++ b/viewer/tools.js
@@ -949,7 +949,18 @@ function setupTools(A) {
   };
   var NIGHT_LIGHT_RANGE = 0; // §S277d: 0 = infinite range — no artificial cutoff, inverse-square does the physics (restores overhang/doorway/corridor spillover when outside)
   var NIGHT_LIGHT_INTENSITY = 2.5; // §S277d, reduced 8.0->6.5->4.5->2.5 2026-08-08 (user: still too bright to make out individual PLs)
-  var NIGHT_LIGHT_DECAY = 1.5; // §S277d: between linear (1) and quadratic (2) — reaches further than physics
+  // §NIGHT_LIGHT_NEARFIELD (2026-08-13, user: "bright lighting up surrounding when afar, but when
+  // near not evident"). Confirmed against three.module.min.js's own shader (not guessed):
+  // `getDistanceAttenuation` = 1 / max(pow(lightDistance, decayExponent), 0.01) — no lower
+  // distance clamp beyond that 0.01 floor (~4.6cm). At decay=1.5, falloff hits ~11.2x base
+  // intensity at 0.2m and ~2.8x at 0.5m; under ACESFilmic tonemapping (exposure=0.45) that's
+  // enough to clip a close surface to a flat/blown highlight instead of a readable graded glow —
+  // reading as "nothing visible" up close for the opposite reason of being too dim. Lowered
+  // 1.5->1.0 (linear): same maths at 0.2m/0.5m falls to ~5x/2x instead of ~11.2x/2.8x, AND at long
+  // range decay=1.0 falls off SLOWER than 1.5 (reaches further, not less), so the "bright from
+  // afar" character this is deliberately NOT trading away. First-pass value, like every other
+  // constant in this file — verify live, no pixel-level A/B run (would need a real close-up bake).
+  var NIGHT_LIGHT_DECAY = 1.0; // was 1.5 — between linear (1) and quadratic (2), reaches further than physics
 
   // §NIGHT_GLOW_REASSERT: extracted from toggleNightMode() so it can be re-called every frame
   // while night mode / photo-staging is active — see the comment at its call site below for why.


### PR DESCRIPTION
## Summary
User: real fixture PointLights read "bright lighting up surrounding when afar, but when near not evident." Confirmed against `three.module.min.js`'s own shader (not guessed): `getDistanceAttenuation = 1 / max(pow(dist, decay), 0.01)` — no lower clamp beyond that 0.01 floor (~4.6cm). At `decay=1.5`, falloff hits ~11.2x base intensity at 0.2m and ~2.8x at 0.5m; under ACESFilmic tonemapping (exposure=0.45) that's enough to clip a close surface to a flat/blown highlight instead of a readable graded glow — reading as "nothing visible" up close for the opposite reason of being too dim.

Lowered `decay` 1.5→1.0 (linear). At long range, decay=1.0 falls off *slower* than 1.5, so the "bright from afar" character isn't traded away.

Ruled out first: near-fade-floor ordering — confirmed correct in code (floor set to 1.0 for stills before `_nightUpdateLights()` recomputes), not the cause.

## Test plan
- [x] `node -c` on both files
- [x] Live real-GPU witness: `A._nightLights[*].decay` reads `1` on real PointLight instances after toggling night mode
- [ ] User visual confirmation on a real close-up shot — no pixel-level A/B was feasible without a real bake

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>