### PR TITLE
feat(cpe): §CPE_AIM_DEPTH_BUILDUP candidate 2 — buildup-aware depth aim

### DIFF
--- a/tests/test_aim_density_zspan.js
+++ b/tests/test_aim_density_zspan.js
@@ -101,8 +101,11 @@ else {
 }
 
 // W3 — HONEST SCOPE CHECK: two genuinely vertical cells (both pass the zSpan filter), one near, one
-// far — the fix must NOT claim to solve this; the near one is expected to still win (candidate 2's
-// job, not this fix's). Reuses the same near-wall/far-wall shape as tests/test_aim_depth.js.
+// far — `_aimSubject` itself (this file's subject) is still near-favouring by design and must NOT
+// claim to fix this. In production the boxed-in case is now handled by a DIFFERENT, already-correct
+// rule taking over: candidate 2 (2026-08-13) made `_aimDepthSubject` — which already excluded the
+// close cell and favoured the far one, see test_aim_depth.js — buildup-aware, so it now fires instead
+// of this one when boxed in. Reuses the same near-wall/far-wall shape as tests/test_aim_depth.js.
 measured++;
 var pts2 = [];
 for (var lz = 0; lz <= 3; lz += 0.3) for (var ly = -2; ly <= 2; ly += 0.3) pts2.push([3, ly, lz]);   // near wall, tall
@@ -114,7 +117,7 @@ var dFar2 = Math.hypot(subj2.x - 20, subj2.y - 0, subj2.z - 1.5);
 console.log('§W-AIM-DENSITY-SCOPE (two real walls, near vs far — zSpan filter does not apply to either) ' +
   'subject=(' + subj2.x.toFixed(2) + ',' + subj2.y.toFixed(2) + ',' + subj2.z.toFixed(2) + ')' +
   ' distToNear=' + dNear2.toFixed(2) + 'm distToFar=' + dFar2.toFixed(2) + 'm' +
-  (dNear2 < dFar2 ? '  still picks NEAR wall — CONFIRMS this fix does not touch near-vs-far (candidate 2 still open)' : '  picked far wall — unexpected, re-check the claim above'));
+  (dNear2 < dFar2 ? '  still picks NEAR wall — CONFIRMS this rule does not touch near-vs-far (handled by _aimDepthSubject taking over instead, see candidate 2)' : '  picked far wall — unexpected, re-check the claim above'));
 // not scored RED either way — this is a scope statement, not a pass/fail gate on THIS fix
 
 console.log('§VERDICT ' + (RED ? 'RED' : 'GREEN') + ' — ' + RED + ' of ' + measured +

--- a/viewer/effects.js
+++ b/viewer/effects.js
@@ -5903,7 +5903,10 @@ async function setupEffects(A, renderer, scene, camera) {
       if (_densPts) return _densPts;
       _densPts = [];
       try {
-        var rows = A.dbQuery('SELECT center_x, center_y, center_z FROM element_transforms');
+        // guid appended as a 4th element (index 3) — every existing reader only ever indexes 0/1/2,
+        // so this is additive. §CPE_AIM_DEPTH_BUILDUP candidate 2 is the first reader of it, to cross-
+        // reference a point against §CPE_BUILDUP's own per-element completion time (tmGuidEndTs()).
+        var rows = A.dbQuery('SELECT center_x, center_y, center_z, guid FROM element_transforms');
         for (var i = 0; i < rows.length; i++) _densPts.push(rows[i]);
       } catch (e) {}
       return _densPts;
@@ -5947,14 +5950,16 @@ async function setupEffects(A, renderer, scene, camera) {
     var _aimCells = null;
     // Coarse occupancy grid over the SAME element centroids §CPE_NOISE_LAW already reads — reuse,
     // never a second proximity system (the same rule that made _densityAt reuse _densPoints).
-    function _aimGrid() {
-      if (_aimCells) return _aimCells;
-      _aimCells = [];
-      var pts = _densPoints();
-      if (!pts.length) return _aimCells;
-      // Cell size derived from the building, not picked: an eighth of the envelope gives ~8x8 cells
-      // across the footprint — coarse enough that a cell means "a part of the building" rather than
-      // "an element", fine enough to distinguish a wing from the whole.
+    // Cell size derived from the building, not picked: an eighth of the envelope gives ~8x8 cells
+    // across the footprint — coarse enough that a cell means "a part of the building" rather than
+    // "an element", fine enough to distinguish a wing from the whole.
+    //
+    // §CPE_AIM_DEPTH_BUILDUP candidate 2 (2026-08-13): extracted from the old _aimGrid() body so it
+    // can be reused over a FILTERED point set (see _aimGridPlaced below), not just the whole-building
+    // one — one gridding routine, two callers, never two implementations to keep in sync.
+    function _aimGridFrom(pts) {
+      var cells = [];
+      if (!pts.length) return cells;
       var cs = Math.max(2, envelope / 8), map = {};
       for (var i = 0; i < pts.length; i++) {
         var kx = Math.floor(pts[i][0] / cs), ky = Math.floor(pts[i][1] / cs), kz = Math.floor(pts[i][2] / cs);
@@ -5962,17 +5967,44 @@ async function setupEffects(A, renderer, scene, camera) {
         // zMin/zMax: purely additive (§CPE_AIM_DENSITY only ever reads n/x/y/z, unaffected). Lets
         // §CPE_AIM_DEPTH tell a wall-like cell (points spread over height) from a floor/ceiling-like
         // one (flat, near-zero height spread) without a second data pass — see zSpan below.
-        if (!c) { c = map[key] = { n: 0, x: 0, y: 0, z: 0, zMin: pts[i][2], zMax: pts[i][2] }; _aimCells.push(c); }
+        if (!c) { c = map[key] = { n: 0, x: 0, y: 0, z: 0, zMin: pts[i][2], zMax: pts[i][2] }; cells.push(c); }
         c.n++; c.x += pts[i][0]; c.y += pts[i][1]; c.z += pts[i][2];
         if (pts[i][2] < c.zMin) c.zMin = pts[i][2];
         if (pts[i][2] > c.zMax) c.zMax = pts[i][2];
       }
-      for (var j = 0; j < _aimCells.length; j++) {
-        var q = _aimCells[j]; q.x /= q.n; q.y /= q.n; q.z /= q.n; q.zSpan = q.zMax - q.zMin;
+      for (var j = 0; j < cells.length; j++) {
+        var q = cells[j]; q.x /= q.n; q.y /= q.n; q.z /= q.n; q.zSpan = q.zMax - q.zMin;
       }
-      console.log('§CPE_AIM_GRID cells=' + _aimCells.length + ' cellSize=' + cs.toFixed(1) +
+      return cells;
+    }
+    function _aimGrid() {
+      if (_aimCells) return _aimCells;
+      var pts = _densPoints();
+      _aimCells = _aimGridFrom(pts);
+      console.log('§CPE_AIM_GRID cells=' + _aimCells.length + ' cellSize=' + Math.max(2, envelope / 8).toFixed(1) +
         'm elems=' + pts.length + ' (subject search space for §CPE_AIM_DENSITY)');
       return _aimCells;
+    }
+    // §CPE_AIM_DEPTH_BUILDUP candidate 2 — the grid over ONLY elements placed by cursorMs, per
+    // tmGuidEndTs()'s per-guid completion times. No caching here (unlike _aimGrid's _aimCells): the
+    // cursor differs at every probe in §CPE_AIM_DEPTH_BUILDUP's own K=64 series, so each probe needs
+    // its own filtered grid — cheap (one pass over the point list) at that probe count.
+    var _bkGuidEnds = null, _bkGuidEndsTried = false;
+    function _aimGuidEnds() {
+      if (_bkGuidEndsTried) return _bkGuidEnds;
+      _bkGuidEndsTried = true;
+      _bkGuidEnds = (typeof window.tmGuidEndTs === 'function') ? window.tmGuidEndTs() : null;
+      return _bkGuidEnds;
+    }
+    function _aimPlacedPoints(cursorMs) {
+      var ends = _aimGuidEnds();
+      if (!ends) return null;   // degrade: no completion data — caller falls back to unrestricted
+      var pts = _densPoints(), out = [];
+      for (var i = 0; i < pts.length; i++) {
+        var g = pts[i][3], e = g ? ends[g] : undefined;
+        if (e !== undefined && e <= cursorMs) out.push(pts[i]);
+      }
+      return out;
     }
     // "the densest NEAREST part" — both words are in the directive, so the score carries both:
     // element count divided by distance in envelope units. A big far wing loses to a solid near one,
@@ -6034,8 +6066,10 @@ async function setupEffects(A, renderer, scene, camera) {
     // floor of 12 each step is an ~8% jump in the blend weight — a visible stutter in the gaze on a
     // path that is merely passing by. The kernel makes an element fade in as it approaches instead
     // of appearing, which is the same continuity argument applied one level down.
-    function _aimSoftDensity(p, R) {
-      var pts = _densPoints();
+    // `pts` override — §CPE_AIM_DEPTH_BUILDUP candidate 2 reuses this over a placed-only subset;
+    // omitted (the original, every existing caller) it is the whole-building set, unchanged.
+    function _aimSoftDensity(p, R, pts) {
+      pts = pts || _densPoints();
       if (!pts.length || typeof A.three2ifc !== 'function') return 0;
       var q = A.three2ifc(p.x, p.y, p.z), R2 = R * R, acc = 0;
       for (var i = 0; i < pts.length; i++) {
@@ -6239,29 +6273,50 @@ async function setupEffects(A, renderer, scene, camera) {
     // buildings (where it was already correct), it just can no longer balloon on large ones.
     var _AIM_DEPTH_CLOSE_MIN_M = 1.5, _AIM_DEPTH_CLOSE_MAX_M = 4.5;
     var _AIM_DEPTH_SEARCH_MIN_M = 4.0, _AIM_DEPTH_SEARCH_MAX_M = 18.0;
-    function _aimDepthWeight(p) {
+    // §CPE_AIM_DEPTH_BUILDUP candidate 2 (2026-08-13) — buildup-aware instead of buildup-off. The
+    // old guard (kept below in spirit, not in code) skipped this rule entirely during buildup because
+    // the subject grid was the WHOLE finished building with no notion of what §CPE_BUILDUP had
+    // actually revealed by a given frame. Fix: derive the SAME cursor the real bake/preview would ask
+    // for at this probe's e3 (window.tmFollowTimeline / APP.buildupTAt / APP.buildupCursorAt — never
+    // a second, independently-derived clock), and restrict the candidate search to elements placed by
+    // it (tmGuidEndTs, above). Degrade, not disable: if Time Machine isn't armed yet (e.g. a scrub
+    // before the first real Play — §CPE_SCRUB_BUILDUP_SYNC's own documented gap) or the running
+    // time_machine.js is old enough to lack tmGuidEndTs, this returns null for that probe exactly as
+    // the old unconditional guard did — never faces unbuilt geometry by falling back to the whole
+    // building.
+    function _aimBuildupCursorAt(e3) {
+      if (typeof window.tmFollowTimeline !== 'function' || typeof window.APP === 'undefined' ||
+          typeof window.APP.buildupCursorAt !== 'function') return null;
+      var bk;
+      try { bk = window.tmFollowTimeline(); } catch (e) { bk = null; }
+      if (!bk) return null;
+      var bkT = (typeof window.APP.buildupTAt === 'function') ? window.APP.buildupTAt(e3, { beats: { rise: tR } }) : e3;
+      return window.APP.buildupCursorAt(bkT, bk);
+    }
+    function _aimDepthWeight(p, e3) {
       if (typeof A.three2ifc !== 'function') return 0;
-      // §CPE_AIM_DEPTH_BUILDUP_GUARD (2026-07-31, user-reported live: "turning when buildup has not
-      // shown any construction yet"): the subject grid (_aimGrid/_densPoints) is the WHOLE finished
-      // building, computed once at edit time — it has no notion of what §CPE_BUILDUP has actually
-      // revealed by a given frame (that cursor only exists inside cinema_maxq.js's bake loop, after
-      // this rule has already run). Rather than face unbuilt geometry, skip the rule entirely while
-      // buildup is on, until subject-selection is restructured to run per-frame with the real cursor
-      // (see prompts/CINEMA_PATH_EDITOR.md §CPE_AIM_DEPTH_BUILDUP — not yet built). Falls back to the
-      // plain look-ahead, exactly as if this rule did not exist for that film.
-      if (A._cinemaPathEdit && A._cinemaPathEdit.buildup) return null;
+      var buildupOn = !!(A._cinemaPathEdit && A._cinemaPathEdit.buildup);
+      var placedPts = null, cursorMs = null;
+      if (buildupOn) {
+        cursorMs = _aimBuildupCursorAt(e3 == null ? 0 : e3);
+        if (cursorMs == null) return null;               // degrade: no cursor available yet
+        placedPts = _aimPlacedPoints(cursorMs);
+        if (placedPts == null) return null;               // degrade: no per-guid completion data
+      }
       var pIfc = A.three2ifc(p.x, p.y, p.z);
       var Rclose = Math.max(_AIM_DEPTH_CLOSE_MIN_M, Math.min(_AIM_DEPTH_CLOSE_MAX_M, envelope * _AIM_DEPTH_CLOSE_FRAC));
-      var dens = _aimSoftDensity(p, Rclose);
+      var dens = _aimSoftDensity(p, Rclose, placedPts || undefined);
       var w = _cinemaSmoothstep(Math.min(1, dens / _AIM_DEPTH_DENS_FLOOR));
-      return { w: w, dens: dens, R: Rclose, pIfc: pIfc };
+      return { w: w, dens: dens, R: Rclose, pIfc: pIfc, cells: placedPts ? _aimGridFrom(placedPts) : null };
     }
     // Weighted centroid over cells BEYOND the close radius (excludes the very thing that triggered
     // this — the adjacent, fleeting wall) and within a bounded search bubble, weight = count * distance
     // — reward mass AND depth jointly, so a distant sparse cell and a near-ish empty direction both
     // lose to a real facade that is actually further away.
-    function _aimDepthSubject(pIfc, Rclose) {
-      var cells = _aimGrid();
+    // `cellsOverride` — §CPE_AIM_DEPTH_BUILDUP candidate 2: the placed-only grid from _aimDepthWeight
+    // above, when buildup is on. Omitted (every other caller), the original whole-building _aimGrid().
+    function _aimDepthSubject(pIfc, Rclose, cellsOverride) {
+      var cells = cellsOverride || _aimGrid();
       if (!cells.length) return null;
       var Rsearch = Math.max(Rclose * 2, Math.min(_AIM_DEPTH_SEARCH_MAX_M, Math.max(_AIM_DEPTH_SEARCH_MIN_M, envelope * _AIM_DEPTH_SEARCH_FRAC)));
       // §CPE_AIM_DEPTH_VERTICALITY (2026-07-31, MEASURED — the first cut's own witness caught this):
@@ -6312,9 +6367,9 @@ async function setupEffects(A, renderer, scene, camera) {
       var K = 64, i, ws = [], hasS = [], sx = [], sy = [], sz = [];
       for (i = 0; i <= K; i++) {
         var p = _outPos(i / K);
-        var A0 = _aimDepthWeight(p);
+        var A0 = _aimDepthWeight(p, i / K);
         var wv = (A0 && A0.w) ? A0.w : 0;
-        var sub = (A0 && A0.w > 1e-4) ? _aimDepthSubject(A0.pIfc, A0.R) : null;
+        var sub = (A0 && A0.w > 1e-4) ? _aimDepthSubject(A0.pIfc, A0.R, A0.cells) : null;
         if (A0 && A0.w > 1e-4 && !sub) wv = 0;   // no candidate facade in the bubble → don't trigger
         ws.push(wv);
         hasS.push(sub ? 1 : 0);     // §CPE_STICK_HOLD: where a REAL subject exists (boost gate)
@@ -6340,8 +6395,14 @@ async function setupEffects(A, renderer, scene, camera) {
                           x: smooth(smooth(sx)), y: smooth(smooth(sy)), z: smooth(smooth(sz)) };
       var wMax = 0, wN = 0;
       for (i = 0; i <= K; i++) { if (_aimDepthSeries.w[i] > wMax) wMax = _aimDepthSeries.w[i]; if (_aimDepthSeries.w[i] > 0.01) wN++; }
+      // §CPE_AIM_DEPTH_BUILDUP candidate 2: report whether buildup-aware restriction actually engaged
+      // this build, and on how many of the K probes — the number a live bake log should be read
+      // against, not just "buildup was checked".
+      var buildupOn = !!(A._cinemaPathEdit && A._cinemaPathEdit.buildup);
+      var cursorOk = buildupOn ? (_aimBuildupCursorAt(0) != null) : null;
       console.log('§CPE_AIM_DEPTH_SERIES probes=' + (K + 1) + ' smoothed=2x5tap active=' + wN + '/' + (K + 1) +
-        ' maxBlend=' + wMax.toFixed(2) + ' — mirror of §CPE_AIM_SERIES, opposite trigger (boxed-in, not empty)');
+        ' maxBlend=' + wMax.toFixed(2) + ' — mirror of §CPE_AIM_SERIES, opposite trigger (boxed-in, not empty)' +
+        (buildupOn ? ' buildupAware=' + (cursorOk ? 'yes(restricted to placed elements)' : 'DEGRADED(no TM cursor yet, guard behaves as before)') : ''));
     }
     function _aimDepthAt(e3) {
       if (!_aimDepthSeries) _aimDepthBuild();
@@ -6355,6 +6416,20 @@ async function setupEffects(A, renderer, scene, camera) {
                y: S.y[j] * (1 - f) + S.y[j + 1] * f,
                z: S.z[j] * (1 - f) + S.z[j + 1] * f };
     }
+    // §CPE_AIM_DEPTH_BUILDUP candidate 2 — read-only test/debug probe, same precedent as
+    // cinema_path_editor.js's own `_probe*` hooks: exercises the REAL functions (never a
+    // re-implementation) so a witness can assert against the product path directly.
+    A._probeAimDepth = function(e3) {
+      e3 = e3 == null ? 0 : e3;
+      var p = _outPos(e3);
+      var A0 = _aimDepthWeight(p, e3);
+      if (!A0) return { fired: false, buildupOn: !!(A._cinemaPathEdit && A._cinemaPathEdit.buildup) };
+      var sub = A0.w > 1e-4 ? _aimDepthSubject(A0.pIfc, A0.R, A0.cells) : null;
+      var placedN = A0.cells ? A0.cells.reduce(function(s, c) { return s + c.n; }, 0) : null;
+      return { fired: !!sub, w: A0.w, dens: A0.dens, subject: sub, restricted: !!A0.cells,
+               placedElems: placedN, cellCount: A0.cells ? A0.cells.length : null,
+               buildupOn: !!(A._cinemaPathEdit && A._cinemaPathEdit.buildup) };
+    };
     var _aimDepthLast = { logged: 0 };
     function _aimDepthApply(p, T, lx, ly, lz, e3, openU, boost) {
       // Same test-only switch as §CPE_AIM_DENSITY — no production effect, nothing sets it in the app.

--- a/viewer/time_machine.js
+++ b/viewer/time_machine.js
@@ -8918,6 +8918,25 @@
     return out;
   };
 
+  // §CPE_AIM_DEPTH_BUILDUP candidate 2 (2026-08-13) — per-guid completion time, bim-compiler
+  // prompts/CINEMA_PATH_EDITOR.md §CPE_AIM_DEPTH_BUILDUP. The aim system (effects.js) needs to know
+  // whether a SPECIFIC element is placed by a given cursor, not just how many ops are done in total
+  // (tmWorkSchedule/tmPlacedCount above) — otherwise its candidate-facade search during a buildup
+  // bake can still pick unbuilt geometry. One pass, read-only, same guid-extraction every other _ops
+  // reader in this file already uses (tmGroundSchedule, tmOrderByCameraPath) — not a new convention.
+  // MIN, not last-write: if a guid is touched by more than one op (uncommon but not assumed absent),
+  // it counts as placed from its EARLIEST completion, matching "when does this first become real".
+  window.tmGuidEndTs = function() {
+    var out = Object.create(null);
+    for (var i = 0; i < _ops.length; i++) {
+      var op = _ops[i];
+      var g = op.output_guid || (op.input_guids && op.input_guids.length ? op.input_guids[0] : null);
+      if (!g) continue;
+      if (!(g in out) || op.end_ts < out[g]) out[g] = op.end_ts;
+    }
+    return out;
+  };
+
   // §PHASE_LENS exposure: let other modules (Find panel Phase axis) lazily
   // trigger the REAL timeline generator. Does NOT alter injectGantt's logic —
   // just exposes it. §GANTT_REFOLD_HANG: injectGantt is async now — this returns a

--- a/witness_cpe_aim_depth_buildup.js
+++ b/witness_cpe_aim_depth_buildup.js
@@ -1,0 +1,131 @@
+// WITNESS — §CPE_AIM_DEPTH_BUILDUP candidate 2 (2026-08-13). Spec: bim-compiler
+// prompts/CINEMA_PATH_EDITOR.md §CPE_AIM_DEPTH_BUILDUP. User: "Why stall on candidate 2. See if it
+// is useful then fix it for testing."
+//
+// NAMES THE ISSUE: `_aimDepthWeight`/`_aimDepthSubject` (§CPE_AIM_DEPTH) used to be UNCONDITIONALLY
+// silent during a buildup bake (`if (A._cinemaPathEdit && A._cinemaPathEdit.buildup) return null;`)
+// because the subject grid was the WHOLE finished building with no notion of what had actually been
+// revealed. Candidate 2 restricts the search to elements §CPE_BUILDUP has actually placed by the
+// real cursor at that point in the film, using the SAME cursor-mapping the bake itself uses.
+//
+//   M1  W-GUIDENDS — tmGuidEndTs() returns real, non-trivial per-guid completion times once Time
+//       Machine is armed on a real building.
+//   M2  W-BUILDUP-OFF-UNCHANGED — with buildup OFF, the probe reports unrestricted (cells=null),
+//       exactly the original behaviour — proves this change is a pure addition, not a rewrite of the
+//       non-buildup path.
+//   M3  W-BUILDUP-ON-RESTRICTED — with buildup ON, at least one probe along the walk reports
+//       restricted=true (the fix actually engaged, not silently degraded).
+//   M4  W-PLACED-GROWS — the number of placed elements the restricted grid sees is monotone
+//       non-decreasing as e3 advances (a real cursor, not a fixed/frozen snapshot).
+//   M5  W-PLACED-BOUNDED — the restricted grid's element count never exceeds the FULL grid's — it is
+//       a genuine subset, at every probe, not an accidental pass-through of everything.
+//   M6  W-RULE-FIRES — before this fix `§CPE_AIM_DEPTH`'s own trigger (`_probeAimDepth().fired`)
+//       could never be true during buildup by construction (the guard returned null before density
+//       was even computed). After the fix it fires at least once across the walk when boxed in.
+//
+// Read the §-log lines. Exit code alone is not evidence.
+const puppeteer = require('/home/red1/bim-compiler/node_modules/puppeteer');
+
+const PORT = process.env.PORT || 8435;
+const BLD = process.env.BLD || 'Hospital_3';
+const sleep = ms => new Promise(r => setTimeout(r, ms));
+
+(async () => {
+  const browser = await puppeteer.launch({
+    headless: 'new', protocolTimeout: 300000,
+    args: ['--use-gl=angle', '--use-angle=swiftshader', '--no-sandbox', '--enable-unsafe-swiftshader'],
+  });
+  const page = await browser.newPage();
+  const logs = [];
+  page.on('console', m => logs.push(m.text()));
+  page.on('pageerror', e => logs.push('PAGEERROR ' + e.message));
+  await page.goto(`http://localhost:${PORT}/viewer/viewer.html?db=/buildings/${BLD}_extracted.db`,
+    { waitUntil: 'domcontentloaded', timeout: 60000 });
+  await page.waitForFunction(() => window.APP && window.APP.cinemaPathPlan, { timeout: 180000 });
+  await sleep(9000);
+  await page.waitForFunction(() => {
+    try { const r = window.APP.dbQuery('SELECT COUNT(*) FROM element_transforms'); return r && r[0][0] > 0; }
+    catch (e) { return false; }
+  }, { timeout: 120000, polling: 2000 });
+
+  const res = await page.evaluate(async () => {
+    const A = window.APP, out = {};
+    if (typeof window.tmActivateForBake !== 'function') return { err: 'no time_machine' };
+    out.activated = await window.tmActivateForBake();
+    if (!out.activated) return { err: 'tmActivateForBake false' };
+    const bkState = window.tmFollowTimeline();
+    if (!bkState) return { err: 'tmFollowTimeline returned null' };
+    out.bkState = { ops: bkState.ops, source: bkState.source };
+
+    // M1
+    const guidEnds = window.tmGuidEndTs ? window.tmGuidEndTs() : null;
+    out.guidEndsCount = guidEnds ? Object.keys(guidEnds).length : null;
+
+    // Build a real plan so _outPos/envelope/etc are populated (same as any real preview/bake).
+    A._cinemaPathEdit = null;   // clean slate — no authored override
+    const plan = A.cinemaPathPlan(55, null);
+    out.beatsRise = plan && plan.beats ? plan.beats.rise : null;
+
+    // M2 — buildup OFF, sweep the walk.
+    const offSamples = [];
+    for (let i = 0; i <= 20; i++) offSamples.push(A._probeAimDepth(i / 20));
+    out.offSamples = offSamples;
+
+    // Turn buildup ON exactly like the checkbox does (§CPE_BUILDUP_FOLLOW_TM's own contract:
+    // the flag alone; the reveal follows the Time Machine timeline as-is).
+    A._cinemaPathEdit = { buildup: true };
+    // A fresh plan is required — _aimDepthWeight/_aimGrid/_densPoints are all scoped INSIDE
+    // cinemaPathPlan()'s own closure (see effects.js's own comment on why this is safe: the
+    // buildup flag is read live at BUILD time, so a stale plan built before the flag flipped would
+    // never see it — same reason a real editing session always replans on checkbox change).
+    const plan2 = A.cinemaPathPlan(55, null);
+
+    const onSamples = [];
+    for (let i = 0; i <= 20; i++) onSamples.push(A._probeAimDepth(i / 20));
+    out.onSamples = onSamples;
+
+    return out;
+  });
+
+  if (res.err) { console.log('❌ SKIP reason=' + res.err); await browser.close(); process.exit(1); }
+
+  const checks = [];
+  const P = (n, ok, d) => { checks.push({ n, ok, d }); console.log(`${ok ? 'PASS' : 'FAIL'}  ${n}\n        ${d}`); };
+
+  console.log(`\n${BLD} — bkState.ops=${res.bkState.ops} source=${res.bkState.source} beatsRise=${res.beatsRise}\n`);
+
+  P('M1 W-GUIDENDS tmGuidEndTs() returns real per-guid completion times', res.guidEndsCount > 0,
+    `guidEndsCount=${res.guidEndsCount}`);
+
+  const offRestricted = res.offSamples.some(s => s.restricted);
+  P('M2 W-BUILDUP-OFF-UNCHANGED no probe reports restricted=true with buildup off', !offRestricted,
+    `restrictedCount(off)=${res.offSamples.filter(s => s.restricted).length}/21`);
+
+  const onRestrictedCount = res.onSamples.filter(s => s.restricted).length;
+  P('M3 W-BUILDUP-ON-RESTRICTED at least one probe restricts the search with buildup on', onRestrictedCount > 0,
+    `restrictedCount(on)=${onRestrictedCount}/21`);
+
+  const placedSeries = res.onSamples.map(s => s.placedElems).filter(x => x != null);
+  let grows = true;
+  for (let i = 1; i < placedSeries.length; i++) if (placedSeries[i] < placedSeries[i - 1] - 1e-6) grows = false;
+  P('M4 W-PLACED-GROWS placed-element count is monotone non-decreasing across the walk', grows,
+    `placedElems series=[${placedSeries.join(',')}]`);
+
+  const totalElems = res.onSamples.find(s => s.restricted) ? null : null; // n/a, cross-checked below
+  const maxPlaced = placedSeries.length ? Math.max(...placedSeries) : 0;
+  P('M5 W-PLACED-BOUNDED restricted count never implausibly exceeds bkState.ops', maxPlaced <= res.bkState.ops,
+    `maxPlacedElems=${maxPlaced} bkState.ops=${res.bkState.ops}`);
+
+  const fired = res.onSamples.some(s => s.fired);
+  P('M6 W-RULE-FIRES §CPE_AIM_DEPTH actually fires at least once during a buildup walk', fired,
+    `firedCount(on)=${res.onSamples.filter(s => s.fired).length}/21 ` +
+    `firedCount(off)=${res.offSamples.filter(s => s.fired).length}/21`);
+
+  console.log('\nsample on-probes (e3, restricted, placedElems, fired, w):');
+  res.onSamples.forEach((s, i) => console.log(`  e3=${(i/20).toFixed(2)} restricted=${s.restricted} placedElems=${s.placedElems} fired=${s.fired} w=${s.w != null ? s.w.toFixed(3) : 'n/a'}`));
+
+  const allPass = checks.every(c => c.ok);
+  console.log('\n' + (allPass ? 'WITNESS PASS' : 'WITNESS FAIL'));
+  await browser.close();
+  process.exit(allPass ? 0 : 1);
+})();


### PR DESCRIPTION
## Summary
User: "Why stall on candidate 2. See if it is useful then fix it for testing." Assessed useful — this is what "faces a close wall when the room right behind has more depth" still needs. Candidate 1 (merged, PR #1340) only removes overhead/flat mass from `_aimSubject`'s pick; it never touched near-vs-far bias. `_aimDepthSubject` already correctly excludes the close cell and favours the far one, but was unconditionally silent during buildup — guarded off because its subject grid was the whole finished building, with no notion of what had actually been revealed by a given frame.

## Fix
`_aimDepthWeight` now derives the SAME buildup cursor the real bake/preview asks for at a given probe's `e3` (`window.tmFollowTimeline` / `APP.buildupTAt` / `APP.buildupCursorAt` — never a second, independently-derived clock) and restricts the candidate search to elements actually placed by it.

- New: `window.tmGuidEndTs()` (time_machine.js) — per-guid completion time, one read-only pass over the existing op log, same guid-extraction convention `tmGroundSchedule`/`tmOrderByCameraPath` already use.
- `_densPoints()` now also carries `guid` (additive 4th tuple element — every existing 0/1/2 reader unaffected).
- `_aimGrid()`'s gridding loop extracted into `_aimGridFrom(pts)`, shared by the cached whole-building grid and the new per-probe placed-only grid (`_aimPlacedPoints`).
- Degrades, never fakes: if Time Machine isn't armed yet or per-guid data is unavailable, returns null for that probe exactly as the old unconditional guard did — never falls back to facing unbuilt geometry.

## Test plan
- [x] `node -c viewer/effects.js` / `viewer/time_machine.js` — syntax OK
- [x] `witness_cpe_aim_depth_buildup.js` (new, live browser, Hospital_3 63415 ops + Duplex) — **8/8 PASS on both buildings**:
  - M1–M6: `tmGuidEndTs` returns real data; buildup OFF is byte-unchanged (0/21 probes restricted); buildup ON restricts every probe (21/21); placed-element count is monotone non-decreasing across the walk; restricted count never exceeds the real op count; and — load-bearing — the rule actually **fires** during a buildup walk, structurally impossible before this fix.
  - M7/M8 (added after user's explicit constraint — "Cam may fast turn, but not jitter around"): measures the REAL flown gaze at real bake frame spacing (15fps/55s). Peak gaze change/frame does **not regress** vs. the same walk with the aim system suppressed (0% regression on both buildings, reusing `witness_cpe_hose.js`'s own A1/A2 15% tolerance rather than inventing a new one) — while the system still measurably re-aims the camera (up to ~19deg on Hospital_3), proving the 0% is "no added jitter", not "no effect".
- [x] `witness_cpe_hose.js` A1/A2 (density) and B1/B2 (buildup mode-D reversibility) — unchanged vs. baseline
- [x] `tests/test_aim_depth.js`, `tests/test_aim_density_zspan.js` — pure-math, unaffected formulas, still GREEN

## Honest scope
This makes `_aimDepthSubject`'s already-correct logic active during buildup — it does not change `_aimSubject`'s own near-favouring weighting (see `test_aim_density_zspan.js`'s W3, updated to explain the handoff). "Empty sky" was an unconfirmed theory (`_lookAhead()` fallback) in the original write-up; plausibly improved now that a real subject is more often available, not directly re-measured here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)