### PR TITLE
feat(cpe): §CPE_DISCIPLINE_REVEAL panel wiring — Reveal checkbox beside room titles

### DIFF
--- a/viewer/cinema_maxq.js
+++ b/viewer/cinema_maxq.js
@@ -934,7 +934,7 @@
     // Set from the editor's override below. `poseAt` is the ONE place the window is applied, so
     // every consumer — the preview, the bake loop, and anything added later — flies the clip through
     // the same function, and there is no second notion of "which part of the film this is".
-    var _clip = null, _buildup = false, _bkState = null, _roomTitle = false, _titleSegs = null;
+    var _clip = null, _buildup = false, _bkState = null, _roomTitle = false, _titleSegs = null, _reveal = false;
     var _dayPos = 'tr';
     function _tFilm(tNorm) { return _clip ? _clip.in + tNorm * (_clip.out - _clip.in) : tNorm; }
     function poseAt(tNorm) {
@@ -1070,6 +1070,12 @@
         }
         _buildup = !!_ov.buildup;
         _roomTitle = !!_ov.roomTitle; // §CPE_ROOM_TITLE — off unless the editor's checkbox set it
+        // §CPE_DISCIPLINE_REVEAL — captured for future Mechanism A/B render logic
+        // (prompts/CINEMA_DISCIPLINE_REVEAL.md), not yet acted on: no ghost/pacing code exists yet
+        // (spec Open Question 1 unresolved). Logged so an ON flag is never silently swallowed.
+        _reveal = !!_ov.reveal;
+        if (_reveal) console.log('§CPE_REVEAL flag=on — no render mechanism built yet ' +
+          '(spec: prompts/CINEMA_DISCIPLINE_REVEAL.md), bake proceeds unaffected');
         // §CPE_DAY_COUNTER_POS — the editor's corner choice. Absent (an older saved plan, or a bake
         // that never opened the editor) means TOP RIGHT, which is what shipped, so nothing re-bakes
         // differently by accident.

--- a/viewer/cinema_path_editor.js
+++ b/viewer/cinema_path_editor.js
@@ -673,6 +673,7 @@
       clip: (s.clipIn > 0 || s.clipOut < 1) ? { in: s.clipIn, out: s.clipOut } : null,
       buildup: !!s.buildup,
       roomTitle: !!s.roomTitle,
+      reveal: !!s.reveal,
       dayCounter: s.dayCounter || 'tr',
       diveSec: s.baseSec.dive * scale, spinSec: s.baseSec.spin * scale,
       // §CPE_STICK_HOLD: the TRAVEL part of the walk scales with the user's total, the authored hold
@@ -723,6 +724,8 @@
     if (_state.buildup !== _state.origBuildup) return true;
     if (_state.roomTitle) return true;
     if (_state.roomTitle !== _state.origRoomTitle) return true;
+    if (_state.reveal) return true;
+    if (_state.reveal !== _state.origReveal) return true;
     if (_state.userTotal != null && Math.abs(_state.userTotal - _naturalDuration().total) > 0.05) return true;
     // §CPE_STICK: the band COUNT is now a thing that can change, and it must count as an edit before
     // the per-band comparison below (which indexes both arrays in lockstep and would otherwise miss
@@ -830,7 +833,13 @@
         '<div style="margin-top:4px"><label style="cursor:pointer"><input id="cpe-buildup" type="checkbox" checked> ' +
           'build the model as the film plays</label> <span style="color:#666">(follows the Time Machine, not a programme)</span></div>' +
         '<div style="margin-top:4px"><label style="cursor:pointer"><input id="cpe-room-title" type="checkbox"> ' +
-          'room titles</label> <span style="color:#666">(name card as the camera enters each room)</span></div>' +
+          'room titles</label> <span style="color:#666">(name card as the camera enters each room)</span> ' +
+          // §CPE_DISCIPLINE_REVEAL (prompts/CINEMA_DISCIPLINE_REVEAL.md) — panel wiring only so far.
+          // Checkbox + state round-trip through save/restore, same as every sibling here; the actual
+          // ghost/pacing render mechanism is NOT built (spec Open Question 1, render approach, still
+          // unresolved) — the hint says so, so checking it does not silently do nothing unexplained.
+          '<label style="cursor:pointer;margin-left:10px"><input id="cpe-reveal" type="checkbox"> ' +
+          'Reveal</label> <span style="color:#666">(discipline ghost-parade — spec only, not yet live)</span></div>' +
         // §CPE_DAY_COUNTER_POS — user 2026-08-02: "the movie maker panel puts the Day # counter top
         // right display option". Top right is the DEFAULT so an existing plan re-bakes identically.
         // Only meaningful with the buildup on (there is no day to show without one), which the hint
@@ -2114,7 +2123,7 @@
     var tm = null;
     try { tm = (typeof window.tmGetState === 'function') ? window.tmGetState() : null; } catch (e) {}
     return {
-      checkboxes: { buildup: !!ov.buildup, roomTitle: !!ov.roomTitle },
+      checkboxes: { buildup: !!ov.buildup, roomTitle: !!ov.roomTitle, reveal: !!ov.reveal },
       dayCounter: ov.dayCounter || 'tr',
       tmActive: tm ? !!tm.active : false,
       tmCursor: tm ? tm.cursor : null,
@@ -2144,7 +2153,8 @@
         ' buildup=' + (rec.meta.buildup ? 1 : 0) + ' total=' + rec.meta.totalSec.toFixed(1) + 's' +
         ' — IndexedDB working store; cinema_path TABLE written separately so it travels with the .db');
       console.log('§CPE_PANEL_STATE saved buildup=' + (ps.checkboxes.buildup ? 1 : 0) +
-        ' roomTitle=' + (ps.checkboxes.roomTitle ? 1 : 0) + ' dayCounter=' + ps.dayCounter +
+        ' roomTitle=' + (ps.checkboxes.roomTitle ? 1 : 0) + ' reveal=' + (ps.checkboxes.reveal ? 1 : 0) +
+        ' dayCounter=' + ps.dayCounter +
         ' tmActive=' + (ps.tmActive ? 1 : 0) +
         ' tmCursor=' + (ps.tmCursor != null ? ps.tmCursor : 'n/a') +
         ' tmSpanMs=' + (ps.tmSpanMs != null ? ps.tmSpanMs : 'n/a'));
@@ -2161,7 +2171,8 @@
   // bare DOM mutation the rest of the app cannot see. The dayEl seeding at wiring time already did
   // this for the select; the sibling checkboxes never got it — this closes that gap.
   function _syncPanelControls() {
-    [['cpe-buildup', !!_state.buildup], ['cpe-room-title', !!_state.roomTitle]].forEach(function(p) {
+    [['cpe-buildup', !!_state.buildup], ['cpe-room-title', !!_state.roomTitle],
+     ['cpe-reveal', !!_state.reveal]].forEach(function(p) {
       var el = document.getElementById(p[0]);
       if (el && el.checked !== p[1]) { el.checked = p[1]; el.dispatchEvent(new Event('change')); }
     });
@@ -2177,10 +2188,12 @@
     if (ps.checkboxes) {
       _state.buildup = !!ps.checkboxes.buildup;
       _state.roomTitle = !!ps.checkboxes.roomTitle;
+      _state.reveal = !!ps.checkboxes.reveal;
       // §CPE_EDIT_BASELINE: a restored plan's own checkbox values are the new "unedited" baseline —
       // reopening a saved buildup=on plan and touching nothing else must not read as edited.
       _state.origBuildup = _state.buildup;
       _state.origRoomTitle = _state.roomTitle;
+      _state.origReveal = _state.reveal;
     }
     if (ps.dayCounter) _state.dayCounter = ps.dayCounter;
     _syncPanelControls();
@@ -2202,7 +2215,8 @@
       }
     }
     console.log('§CPE_PANEL_STATE restored buildup=' + (_state.buildup ? 1 : 0) +
-      ' roomTitle=' + (_state.roomTitle ? 1 : 0) + ' dayCounter=' + (_state.dayCounter || 'tr') +
+      ' roomTitle=' + (_state.roomTitle ? 1 : 0) + ' reveal=' + (_state.reveal ? 1 : 0) +
+      ' dayCounter=' + (_state.dayCounter || 'tr') +
       ' tmCursor=' + cursorNote + ' tmSpanMs=' + (ps.tmSpanMs != null ? ps.tmSpanMs : 'n/a'));
   }
   // Loading REPLACES the authored state, and only when asked — never on open. The spec left that as
@@ -2230,6 +2244,7 @@
     _state.clipOut = ov.clip ? ov.clip.out : 1;
     _state.buildup = !!ov.buildup;
     _state.roomTitle = !!ov.roomTitle;
+    _state.reveal = !!ov.reveal;
     _state.dayCounter = ov.dayCounter || 'tr';   // older saved plans predate the choice — top right
     _state.userTotal = ov._total;
     _state.held = null;
@@ -2249,7 +2264,7 @@
     console.log('§CPE_PATH_LOADED name="' + rec.name + '" bands=' + _state.bands.length +
       ' hoseOps=' + _state.hose.length + ' clip=' + _state.clipIn.toFixed(2) + '→' + _state.clipOut.toFixed(2) +
       ' buildup=' + (_state.buildup ? 1 : 0) + ' roomTitle=' + (_state.roomTitle ? 1 : 0) +
-      ' dayCounter=' + (_state.dayCounter || 'tr') +
+      ' reveal=' + (_state.reveal ? 1 : 0) + ' dayCounter=' + (_state.dayCounter || 'tr') +
       ' savedAt=' + new Date(rec.savedAt).toISOString().slice(0, 16) +
       ' — re-staged (§CPE_PATH_NOT_PORTABLE): Ctrl+S now writes this path; Ctrl+Z restores what you had before loading');
     _markPreviewStale();
@@ -3105,6 +3120,10 @@
         // (RESUME_CPE_ROOM_TITLE.md).
         roomTitle: false,
         origRoomTitle: false,
+        // §CPE_DISCIPLINE_REVEAL: off by default, same reasoning as roomTitle — a deliberate choice,
+        // not a default-on behavior. Mechanism not built yet (see checkbox hint + spec file).
+        reveal: false,
+        origReveal: false,
         dayCounter: 'tr',        // §CPE_DAY_COUNTER_POS — the shipped position, unchanged by default
         // §CPE_PREVIEW_BUTTON: edits counts every landed change; previewedAt is the edit the user
         // has actually seen. Equal = "you have seen this version".
@@ -3228,6 +3247,18 @@
         var _a = A();
         if (_state.roomTitle && typeof _a.friendlyName !== 'function' && typeof _a.loadNavigate === 'function') _a.loadNavigate();
         if (!_state.roomTitle && _a.roomTitleLiveStop) _a.roomTitleLiveStop();
+        _renderWhole(); _syncButtons();
+      });
+      // §CPE_DISCIPLINE_REVEAL (prompts/CINEMA_DISCIPLINE_REVEAL.md) — panel-side wiring only. The
+      // flag round-trips through _buildOverride/_pathsSave/_pathsApply exactly like roomTitle, and
+      // cinema_maxq.js captures it at bake time, but NO render/pacing behavior is built yet — Open
+      // Question 1 (render approach for the ARCH/STR ghost) is still unresolved. Checking this box
+      // today changes nothing visible in the bake; the hint text next to it says so.
+      document.getElementById('cpe-reveal').addEventListener('change', function(e) {
+        _state.reveal = !!e.target.checked;
+        _markPreviewStale();
+        console.log('§CPE_REVEAL ' + (_state.reveal ? 'ON' : 'off') +
+          ' — panel flag only, no render mechanism built yet (spec: prompts/CINEMA_DISCIPLINE_REVEAL.md)');
         _renderWhole(); _syncButtons();
       });
       // Seeded from state, not left on the markup's first <option>: a plan re-opened from

--- a/witness_cpe_reveal_panel.js
+++ b/witness_cpe_reveal_panel.js
@@ -1,0 +1,80 @@
+#!/usr/bin/env node
+/**
+ * §CPE_DISCIPLINE_REVEAL panel wiring — prompts/CINEMA_DISCIPLINE_REVEAL.md.
+ * Checks the 'Reveal' checkbox exists beside 'room titles', is OFF by default, toggling it fires
+ * §CPE_REVEAL and round-trips through _buildOverride (Guardrail-2 style: an OK with ONLY this box
+ * checked must still hand back override.reveal=true), same pattern as witness_cpe_room_title.js.
+ * RUN: node witness_cpe_reveal_panel.js
+ */
+'use strict';
+const http = require('http'), fs = require('fs'), path = require('path');
+const puppeteer = require('/home/red1/bim-compiler/node_modules/puppeteer');
+const ROOT = __dirname;
+const MIME = { '.html': 'text/html', '.js': 'text/javascript', '.wasm': 'application/wasm', '.db': 'application/octet-stream' };
+function makeServer(root) {
+  return http.createServer((q, r) => {
+    let p = decodeURIComponent(q.url.split('?')[0]);
+    fs.readFile(path.join(root, p), (e, b) => {
+      if (e) { r.writeHead(404); r.end('404'); return; }
+      r.writeHead(200, { 'Content-Type': MIME[path.extname(p)] || 'application/octet-stream' });
+      r.end(b);
+    });
+  });
+}
+let pass = 0, fail = 0;
+const chk = (n, c, x) => { if (c) { pass++; console.log('  ✅ ' + n + (x ? '  ' + x : '')); } else { fail++; console.log('  ❌ ' + n + (x ? '  ' + x : '')); } };
+const _watchdog = setTimeout(() => { console.log('\n§W-CPE-REVEAL-PANEL TIMEOUT — killed after 180s'); process.exit(3); }, 180000);
+
+(async () => {
+  const server = makeServer(ROOT);
+  await new Promise(r => server.listen(0, r));
+  const port = server.address().port;
+  const br = await puppeteer.launch({ headless: 'new', args: ['--no-sandbox', '--disable-setuid-sandbox'] });
+  const pg = await br.newPage();
+  await pg.setViewport({ width: 1400, height: 900 });
+  const errs = [], logs = [];
+  pg.on('pageerror', e => errs.push(String(e)));
+  pg.on('console', m => logs.push(m.text()));
+  const url = `http://localhost:${port}/viewer/viewer.html?db=buildings/Duplex_extracted.db`;
+  await pg.goto(url, { waitUntil: 'load', timeout: 60000 });
+  await pg.waitForFunction('!!window.APP && !!window.APP.camera && !!window.APP.db', { timeout: 45000 });
+  await new Promise(r => setTimeout(r, 2000));
+
+  const cbTest = await pg.evaluate(async () => {
+    const A = window.APP;
+    let plan; try { plan = A.cinemaPathPlan(15); } catch (e) { return { ok: false, reason: 'cinemaPathPlan failed: ' + e.message }; }
+    const openPromise = A.cinemaPathEditor.open({ plan: plan, durationSec: 15, fps: 15 });
+    await new Promise(function(r) { setTimeout(r, 400); });
+    const rt = document.getElementById('cpe-room-title');
+    const cb = document.getElementById('cpe-reveal');
+    if (!rt || !cb) { document.getElementById('cpe-cancel') && document.getElementById('cpe-cancel').click(); return { ok: false, reason: 'missing: ' + (!rt ? 'cpe-room-title ' : '') + (!cb ? 'cpe-reveal' : '') }; }
+    // "just beside" — same parent row as the room-title checkbox, not a new row below it.
+    const sameRow = rt.closest('div') === cb.closest('div');
+    const startChecked = cb.checked;
+    cb.click(); // native click toggles .checked AND fires 'change'
+    await new Promise(function(r) { setTimeout(r, 50); });
+    const afterChecked = cb.checked;
+    document.getElementById('cpe-ok').click();
+    const res = await openPromise;
+    return { ok: true, sameRow: sameRow, startChecked: startChecked, afterChecked: afterChecked,
+      overrideReveal: res.override ? res.override.reveal : 'NO-OVERRIDE(' + JSON.stringify(res) + ')' };
+  });
+  chk('checkbox exists in the Film-Maker panel', cbTest.ok, cbTest.reason || '');
+  if (cbTest.ok) {
+    chk('Reveal sits in the SAME row as room titles ("just beside")', cbTest.sameRow === true);
+    chk('checkbox starts unchecked (OFF by default)', cbTest.startChecked === false);
+    chk('checkbox click sets checked=true', cbTest.afterChecked === true);
+    chk('OK with ONLY the checkbox toggled still returns override.reveal=true (Guardrail 2)',
+      cbTest.overrideReveal === true, 'got=' + cbTest.overrideReveal);
+  }
+  chk('§CPE_REVEAL logged on toggle', logs.some(l => l.indexOf('§CPE_REVEAL ON') !== -1),
+    logs.filter(l => l.indexOf('§CPE_REVEAL') !== -1).join(' | '));
+
+  chk('zero pageerrors through the whole run', errs.length === 0, errs.join(' | '));
+
+  await br.close();
+  await server.close();
+  clearTimeout(_watchdog);
+  console.log('\n§W-CPE-REVEAL-PANEL DONE pass=' + pass + ' fail=' + fail);
+  process.exit(fail ? 1 : 0);
+})().catch(e => { console.log('\n§W-CPE-REVEAL-PANEL CRASHED ' + (e && e.stack || e)); process.exit(2); });


### PR DESCRIPTION
## Summary
- Adds a 'Reveal' checkbox in the Alt+C panel, same row as 'room titles' (prompts/CINEMA_DISCIPLINE_REVEAL.md)
- Panel-side scaffolding only: state/_buildOverride/save-restore round-trip + bake-time capture in cinema_maxq.js — mirrors the roomTitle checkbox's wiring exactly
- No ghost/pacing render logic — spec's Open Question 1 (render approach) is still unresolved; checkbox hint says "spec only, not yet live" and the bake log makes clear an ON flag changes nothing yet

## Test plan
- [x] `node witness_cpe_reveal_panel.js` — 7/7 pass (checkbox exists in same row as room titles, off by default, click toggles + fires §CPE_REVEAL, OK-with-only-this-box returns override.reveal=true, zero pageerrors)
- [x] `node witness_cpe_room_title.js` regression check — 11/11 still pass (shared functions touched: _buildOverride, _isEdited, _capturePanelState, _syncPanelControls, _applyPanelState, _pathsApply, default _state init)

🤖 Generated with [Claude Code](https://claude.com/claude-code)