### PR TITLE
feat(cpe): §CPE_DISCIPLINE_REVEAL Mechanism C — retrace reveal round (geometry/timeline stage)

### DIFF
--- a/viewer/cinema_maxq.js
+++ b/viewer/cinema_maxq.js
@@ -1070,12 +1070,15 @@
         }
         _buildup = !!_ov.buildup;
         _roomTitle = !!_ov.roomTitle; // §CPE_ROOM_TITLE — off unless the editor's checkbox set it
-        // §CPE_DISCIPLINE_REVEAL — captured for future Mechanism A/B render logic
-        // (prompts/CINEMA_DISCIPLINE_REVEAL.md), not yet acted on: no ghost/pacing code exists yet
-        // (spec Open Question 1 unresolved). Logged so an ON flag is never silently swallowed.
+        // §CPE_DISCIPLINE_REVEAL Mechanism C (prompts/CINEMA_DISCIPLINE_REVEAL.md) — the retrace
+        // round itself is real (effects.js's _cinemaPathPlan/poseAt inserts it via this same
+        // _ov.reveal flag, transparently to this file — plan.poseAt already returns the extended
+        // film). _reveal is captured here only for logging/future ghost-visual wiring, not because
+        // this file's own bake loop needs to branch on it. Ghost/hide/shadow VISUALS (20% ARC/STR
+        // fade, per-discipline full-reveal, sunlight-through) are NOT built yet — Open Question 1.
         _reveal = !!_ov.reveal;
-        if (_reveal) console.log('§CPE_REVEAL flag=on — no render mechanism built yet ' +
-          '(spec: prompts/CINEMA_DISCIPLINE_REVEAL.md), bake proceeds unaffected');
+        if (_reveal) console.log('§CPE_REVEAL flag=on — retrace round is real (extra frames baked); ' +
+          'ghost/reveal visuals not built yet (spec: prompts/CINEMA_DISCIPLINE_REVEAL.md)');
         // §CPE_DAY_COUNTER_POS — the editor's corner choice. Absent (an older saved plan, or a bake
         // that never opened the editor) means TOP RIGHT, which is what shipped, so nothing re-bakes
         // differently by accident.

--- a/viewer/cinema_path_editor.js
+++ b/viewer/cinema_path_editor.js
@@ -643,8 +643,18 @@
     // multiplier: a hold is authored seconds, not distance to be priced.
     var holdSec = 0;
     for (var i = 0; i < s.bands.length; i++) holdSec += +(s.bands[i].hold || 0);
-    return { len: len, outSec: outSec + holdSec, holdSec: holdSec,
-             total: s.baseTotal - s.baseOutSec + outSec + holdSec };
+    // §CPE_DISCIPLINE_REVEAL — an ESTIMATE (same shape as effects.js's authoritative _natSec.reveal:
+    // there-and-back at the walk's own pace + ~2s/discipline + a final 2s together), so the total
+    // this panel shows/bakes to GROWS to fit the round instead of squeezing it out of the existing
+    // runtime. Exact seconds are computed authoritatively in effects.js at plan-build time — this
+    // only needs to be close enough that nFrames (cinema_maxq.js) allocates real frames for it.
+    var revealSec = 0;
+    if (s.reveal) {
+      var a = A(), discs = (a && typeof a.cpeRevealDiscsPresent === 'function') ? a.cpeRevealDiscsPresent() : [];
+      if (discs.length) revealSec = 2 * len / s.speed + (2 * discs.length + 2);
+    }
+    return { len: len, outSec: outSec + holdSec, holdSec: holdSec, revealSec: revealSec,
+             total: s.baseTotal - s.baseOutSec + outSec + holdSec + revealSec };
   }
   function _buildOverride() {
     var s = _state, nat = _naturalDuration();
@@ -839,7 +849,7 @@
           // ghost/pacing render mechanism is NOT built (spec Open Question 1, render approach, still
           // unresolved) — the hint says so, so checking it does not silently do nothing unexplained.
           '<label style="cursor:pointer;margin-left:10px"><input id="cpe-reveal" type="checkbox"> ' +
-          'Reveal</label> <span style="color:#666">(discipline ghost-parade — spec only, not yet live)</span></div>' +
+          'Reveal</label> <span style="color:#666">(extra retrace round + pause before the finale — the ghost/reveal visuals are not built yet)</span></div>' +
         // §CPE_DAY_COUNTER_POS — user 2026-08-02: "the movie maker panel puts the Day # counter top
         // right display option". Top right is the DEFAULT so an existing plan re-bakes identically.
         // Only meaningful with the buildup on (there is no day to show without one), which the hint
@@ -3249,16 +3259,19 @@
         if (!_state.roomTitle && _a.roomTitleLiveStop) _a.roomTitleLiveStop();
         _renderWhole(); _syncButtons();
       });
-      // §CPE_DISCIPLINE_REVEAL (prompts/CINEMA_DISCIPLINE_REVEAL.md) — panel-side wiring only. The
-      // flag round-trips through _buildOverride/_pathsSave/_pathsApply exactly like roomTitle, and
-      // cinema_maxq.js captures it at bake time, but NO render/pacing behavior is built yet — Open
-      // Question 1 (render approach for the ARCH/STR ghost) is still unresolved. Checking this box
-      // today changes nothing visible in the bake; the hint text next to it says so.
+      // §CPE_DISCIPLINE_REVEAL Mechanism C (prompts/CINEMA_DISCIPLINE_REVEAL.md) — geometry/timeline
+      // stage is real: checking this box inserts an extra retrace round (last stick -> first stick
+      // -> last stick, plus a tail pause) into the bake, effects.js's _cinemaPathPlan/poseAt. The
+      // ghost/hide/shadow VISUALS (20% ARC/STR fade, per-discipline full-reveal, sunlight-through)
+      // are NOT built yet — Open Question 1 (render approach) is still unresolved. The hint text next
+      // to the checkbox says so; do not let this comment or that text drift out of sync with which
+      // half is actually built.
       document.getElementById('cpe-reveal').addEventListener('change', function(e) {
         _state.reveal = !!e.target.checked;
         _markPreviewStale();
         console.log('§CPE_REVEAL ' + (_state.reveal ? 'ON' : 'off') +
-          ' — panel flag only, no render mechanism built yet (spec: prompts/CINEMA_DISCIPLINE_REVEAL.md)');
+          ' — extra retrace round (geometry/timeline only, real); ghost/reveal visuals not built yet' +
+          ' (spec: prompts/CINEMA_DISCIPLINE_REVEAL.md)');
         _renderWhole(); _syncButtons();
       });
       // Seeded from state, not left on the markup's first <option>: a plan re-opened from

--- a/viewer/effects.js
+++ b/viewer/effects.js
@@ -4856,6 +4856,28 @@ async function setupEffects(A, renderer, scene, camera) {
   // along"). A list of drag OPERATIONS layered on the derived path — never a stored polyline. See
   // _cinemaHoseApply for the arc-length law and §CPE_BANDS rule 6 for why operations, not points.
   var _cpeHose = null;
+  // §CPE_DISCIPLINE_REVEAL (bim-compiler prompts/CINEMA_DISCIPLINE_REVEAL.md, Mechanism C) — whether
+  // this bake inserts the retrace reveal round between the walk and the closing orbit. Same wrapper
+  // pattern as _cpeHose/_cpeBands above: set from ov.reveal in A.cinemaPathPlan, read inside
+  // _cinemaPathPlan's own closure, saved/restored around the call so it never leaks between plans.
+  var _cpeReveal = false;
+  // §CPE_DISCIPLINE_REVEAL — real, measured element counts, same 3-representation enumeration
+  // A.filterDiscs already uses (panels.js §NAV_FIND_002) — never an invented discipline list.
+  // Outer-scope and A.-exposed (not nested inside _cinemaPathPlan) so BOTH the plan builder here AND
+  // cinema_path_editor.js's own _naturalDuration() (the client-side seconds estimate that drives the
+  // bake's frame count) read the exact same list — one implementation, not two kept in sync by hand.
+  A.cpeRevealDiscsPresent = function() {
+    var counts = {};
+    function bump(d) { if (d && d !== 'ARC' && d !== 'STR') counts[d] = (counts[d] || 0) + 1; }
+    if (typeof A.collectMeshes === 'function') {
+      A.collectMeshes(function(o) { return o.isMesh && o.userData && o.userData.disc; })
+        .forEach(function(o) { bump(o.userData.disc); });
+    }
+    var _bmId, _imId;
+    for (_bmId in (A._batchMeta || {})) A._batchMeta[_bmId].forEach(function(m) { bump(m.disc); });
+    for (_imId in (A._instanceMeta || {})) A._instanceMeta[_imId].forEach(function(m) { bump(m.disc); });
+    return Object.keys(counts);
+  };
   function _cpeBandEnds(b) {
     var h = b.len / 2;
     return [{ x: b.c.x - b.d.x * h, y: b.c.y - b.d.y * h, z: b.c.z - b.d.z * h },
@@ -6668,6 +6690,28 @@ async function setupEffects(A, renderer, scene, camera) {
     }
     var _settleHoldSec = (_cpeBands && _cpeBands.length && isFinite(+_cpeBands[0].hold)) ? Math.max(0, +_cpeBands[0].hold) : 0;
     var _walkTurnDegVal = _walkTurnDeg();
+    // ══ §CPE_DISCIPLINE_REVEAL Mechanism C — the retrace reveal round ═════════════════════════════
+    // Spec: bim-compiler prompts/CINEMA_DISCIPLINE_REVEAL.md §Mechanism C. A.cpeRevealDiscsPresent
+    // (defined once, outer scope, below) is shared with cinema_path_editor.js's own duration
+    // estimate (_naturalDuration) — one discipline-count implementation, not two kept in sync by
+    // hand.
+    var _revealBackSec = 0, _revealFwdSec = 0, _revealTailSec = 0, _revealDiscs = [];
+    if (_cpeReveal) {
+      _revealDiscs = A.cpeRevealDiscsPresent();
+      if (_revealDiscs.length) {
+        // Same pace as the outbound walk (CINEMA_WALK_MPS/totalLen, already computed above for
+        // _natSec.out below) — there-and-back, no authored holds replayed (not requested). Tail:
+        // ~2s/discipline + a final 2s all-together, per the user's own 2026-08-14 pacing quote.
+        _revealBackSec = totalLen / CINEMA_WALK_MPS;
+        _revealFwdSec = totalLen / CINEMA_WALK_MPS;
+        _revealTailSec = 2 * _revealDiscs.length + 2;
+        console.log('§CPE_REVEAL_ROUND on backSec=' + _revealBackSec.toFixed(1) + ' fwdSec=' +
+          _revealFwdSec.toFixed(1) + ' tailSec=' + _revealTailSec.toFixed(1) + ' discs=[' +
+          _revealDiscs.join(',') + '] totalSec=' + (_revealBackSec + _revealFwdSec + _revealTailSec).toFixed(1));
+      } else {
+        console.log('§CPE_REVEAL_ROUND skipped — no non-ARC/STR discipline present in this building');
+      }
+    }
     var _natSec = {
       // §CPE_NOISE_LAW, second half — the same ratio that spaces the frames also BUYS the seconds
       // ("where sudden diff is adverse noise impact and introduce frames to smoothen", the user's
@@ -6694,10 +6738,13 @@ async function setupEffects(A, renderer, scene, camera) {
       // ("constant speed"): speed is constant EXCEPT at authored holds, which is the point of them.
       out:   (totalLen / CINEMA_WALK_MPS + _walkTurnDegVal / CINEMA_TURN_DPS) *
              (1 + (CINEMA_PACE_SWING - 1) * _walkBusy) + _holdTotal,
+      // §CPE_DISCIPLINE_REVEAL: never part of the user-typed total-seconds override system (no field
+      // for it in the panel) — always this measured value, computed just above, 0 when off/empty.
+      reveal: _revealBackSec + _revealFwdSec + _revealTailSec,
       rise:  Math.max(0.5, _pullDist / CINEMA_PULLBACK_MPS),
       orbit: 360 / CINEMA_TURN_DPS
     };
-    var _natTotal = _natSec.dive + _natSec.spin + _natSec.out + _natSec.rise + _natSec.orbit;
+    var _natTotal = _natSec.dive + _natSec.spin + _natSec.out + _natSec.reveal + _natSec.rise + _natSec.orbit;
     // Whitebox proof for §CPE_WALK_BUDGET_NOISE_BLIND — every term the formula reads, printed
     // together so a witness can recompute `out` from this line alone and compare against
     // _natSec.out, rather than trusting the arithmetic happened as claimed.
@@ -6724,7 +6771,7 @@ async function setupEffects(A, renderer, scene, camera) {
     // uniformly" true by construction.
     var _useSec = _cpeSecOverride
       ? { dive: CINEMA_DIVE_SEC, spin: CINEMA_SPIN_SEC, out: CINEMA_OUT_SEC, rise: CINEMA_RISE_SEC,
-          orbit: _natSec.orbit }
+          orbit: _natSec.orbit, reveal: _natSec.reveal }
       : _natSec;
     // The pose Beat 2 ends on: level, on the spin's final bearing. Beat 3 must START here.
     var _handYaw = yaw0 + dYaw;
@@ -6739,13 +6786,19 @@ async function setupEffects(A, renderer, scene, camera) {
     console.log('§CPE_SEAM_CONTINUOUS openDeg=' + _openDeg.toFixed(1) + ' openU=' + _openU.toFixed(4) +
       ' (~' + (_openU * _useSec.out).toFixed(2) + 's of the ' + _useSec.out.toFixed(1) +
       's walk) handoffYawDeg=' + (_handYaw * 180 / Math.PI).toFixed(1));
-    var _shapeTotal = _useSec.dive + _useSec.spin + _useSec.out + _useSec.rise + _useSec.orbit;
+    var _shapeTotal = _useSec.dive + _useSec.spin + _useSec.out + _useSec.reveal + _useSec.rise + _useSec.orbit;
     var tD = _useSec.dive / _shapeTotal;
     var tS = tD + _useSec.spin / _shapeTotal;
     var tO = tS + _useSec.out / _shapeTotal;
-    var tR = tO + _useSec.rise / _shapeTotal;
+    // §CPE_DISCIPLINE_REVEAL: tV is the reveal round's own end boundary. useSec.reveal is 0 when off
+    // or when the building has no non-ARC/STR discipline, which makes tV===tO exactly — the new
+    // poseAt branch below becomes zero-width and unreachable, and tR (below) is unchanged from
+    // today's formula, so an off/empty-building film is byte-identical to before this feature existed.
+    var tV = tO + _useSec.reveal / _shapeTotal;
+    var tR = tV + _useSec.rise / _shapeTotal;
     console.log('§CINEMA_PACING natural=' + _natTotal.toFixed(1) + 's = dive ' + _natSec.dive.toFixed(1) +
       ' + spin ' + _natSec.spin.toFixed(1) + ' + walk ' + _natSec.out.toFixed(1) +
+      ' + reveal ' + _natSec.reveal.toFixed(1) +
       ' + pullback ' + _natSec.rise.toFixed(1) + ' + orbit ' + _natSec.orbit.toFixed(1) +
       '  (walk ' + totalLen.toFixed(1) + 'm @' + CINEMA_WALK_MPS + 'm/s, dive ' + diveDist.toFixed(1) +
       'm @' + CINEMA_DIVE_MPS + 'm/s, pullback ' + _pullDist.toFixed(1) + 'm @' + CINEMA_PULLBACK_MPS +
@@ -6754,7 +6807,7 @@ async function setupEffects(A, renderer, scene, camera) {
       _spinBusyMult.toFixed(2) + ' busy)' +
       ' override=' + _cpeSecOverride + ' running=' + durationSec.toFixed(1) + 's');
     console.log('§CINEMA_BEATS dive=' + tD.toFixed(3) + ' spin=' + tS.toFixed(3) + ' out=' + tO.toFixed(3) +
-      ' rise=' + tR.toFixed(3) + ' turnOverlap=' + CINEMA_TURN_OVERLAP +
+      ' reveal=' + tV.toFixed(3) + ' rise=' + tR.toFixed(3) + ' turnOverlap=' + CINEMA_TURN_OVERLAP +
       ' (dur=' + durationSec.toFixed(1) + 's) route=' + outRoute +
       ' waypoints=' + outWp.length + ' pathLen=' + totalLen.toFixed(1) +
       ' spinDeg=' + Math.round(dYaw * 180 / Math.PI));
@@ -6970,12 +7023,22 @@ async function setupEffects(A, renderer, scene, camera) {
         return { x: p3f.x, y: p3f.y, z: p3f.z,
                  tx: p3f.x + g3.x * 20, ty: p3f.y + g3.y * 20, tz: p3f.z + g3.z * 20 };
       }
+      if (tNorm <= tV) {
+        // ── §CPE_DISCIPLINE_REVEAL Mechanism C: the retrace reveal round, inserted between the walk
+        // and the turn-and-rise ONLY when _cpeReveal is on. tV===tO (zero-width, unreachable — the
+        // tNorm<=tO branch above already caught everything up to here) whenever reveal is off or the
+        // building has no non-ARC/STR discipline, so an off/empty-building film never enters this
+        // branch and is byte-identical to before this feature existed.
+        return _revealPose((tNorm - tO) / Math.max(1e-6, tV - tO));
+      }
       if (tNorm <= tR) {
         // ── Beat 4: turn around to face the building and rise onto the orbit band. Ends EXACTLY
         // on _orbitPose(0), which is what keeps the handoff continuous (the old Act III handoff
         // did not, and measured a ~10.8m single-frame step at t≈0.80). The look-at picks up from
         // CINEMA_TURN_OVERLAP_MAX (where Beat 3 left it) rather than restarting at 0 — see above.
-        var e4 = _cinemaEaseFloored((tNorm - tO) / Math.max(1e-6, tR - tO));
+        // Boundary is tV, not tO — tV===tO when the reveal round is off/empty, so this formula
+        // reduces to today's exactly when there's nothing inserted before it.
+        var e4 = _cinemaEaseFloored((tNorm - tV) / Math.max(1e-6, tR - tV));
         var p4f = _beat4Pose(e4);
         // §CPE_GAZE_CONSTANT_RATE spans Beat 3 AND Beat 4 — see _gazeRateBuild. MEASURED: limiting
         // only the walk moved the whip rather than removing it (Terminal 4.1 -> 34.9 deg/frame at
@@ -6987,6 +7050,83 @@ async function setupEffects(A, renderer, scene, camera) {
                  tx: p4f.x + g4.x * 20, ty: p4f.y + g4.y * 20, tz: p4f.z + g4.z * 20 };
       }
       return _tailPose(tNorm);
+    }
+    // ══ §CPE_DISCIPLINE_REVEAL Mechanism C — the retrace reveal round ═════════════════════════════
+    // Spec: bim-compiler prompts/CINEMA_DISCIPLINE_REVEAL.md §Mechanism C. Position reuses _outPos(f)
+    // — the SAME curve Beat 3 walks — sampled backward then forward; no reverse-path utility needed
+    // or built (none existed, per that spec's own research). Deliberately does NOT reuse _beat3Pose's
+    // hold/pin/aim-depth machinery — kept isolated per this file's header rule ("touches
+    // _cinemaPathPlan as little as possible"). Generic gaze-blend helper (same yaw/pitch-lerp
+    // technique _cinemaGazeBlend already uses, generalized to an explicit target direction instead of
+    // always the pivot — this round looks along the WALK, not at the building centre).
+    function _dirBlend(px, py, pz, axd, ayd, azd, bxd, byd, bzd, w) {
+      var yawA = Math.atan2(azd, axd), pitA = Math.atan2(ayd, Math.hypot(axd, azd));
+      var yawB = Math.atan2(bzd, bxd), pitB = Math.atan2(byd, Math.hypot(bxd, bzd));
+      var raw = yawB - yawA;
+      var dYaw = raw - 2 * Math.PI * Math.round(raw / (2 * Math.PI));
+      var yaw = yawA + dYaw * w, pit = pitA + (pitB - pitA) * w, cp = Math.cos(pit);
+      return { x: px, y: py, z: pz,
+               tx: px + Math.cos(yaw) * 20 * cp, ty: py + Math.sin(pit) * 20, tz: pz + Math.sin(yaw) * 20 * cp };
+    }
+    function _revealTravelDir(f, dir) {
+      var eps = 1 / 64;
+      var pA = _outPos(Math.max(0, f - eps)), pB = _outPos(Math.min(1, f + eps));
+      var vx = (pB.x - pA.x) * dir, vy = (pB.y - pA.y) * dir, vz = (pB.z - pA.z) * dir;
+      var vL = Math.hypot(vx, vy, vz);
+      if (vL < 1e-6) return { x: _beat3EndDir.x, y: _beat3EndDir.y, z: _beat3EndDir.z };
+      return { x: vx / vL, y: vy / vL, z: vz / vL };
+    }
+    // §CPE_GAZE_CONSTANT_RATE interaction (found while witnessing this beat, real MEASURED jump —
+    // not assumed): Beat 3/4's ACTUAL rendered gaze at tO/tV is the RATE-LIMITED signal
+    // (_gazeRateAt(_spanFracOf(tNorm))), not the raw _beat3EndDir — the limiter can lag behind the
+    // raw signal on a fast turn. Anchoring this beat's seam blends to raw _beat3EndDir measured a
+    // 63deg instantaneous jump at the tO seam on Duplex (witness_cpe_reveal_round.js). Anchor to what
+    // is ACTUALLY on screen at that instant instead.
+    function _revealSeamDir(tNorm) {
+      var g = _gazeRateAt(_spanFracOf(tNorm));
+      return g || _beat3EndDir;
+    }
+    // First-guess tuning knob (flagged in the spec, not measured yet) — the fraction of each leg
+    // spent blending across a seam instead of pure travel-tangent gaze: reveal-start (Beat 3's
+    // actual rendered ending gaze -> looking back), the turnaround (back -> forward), and the forward
+    // leg's own end (travel-tangent -> Beat 4's actual e4=0 gaze), so the tail's hold and the Beat 4
+    // hand-off both pick up with zero kink.
+    var CPE_REVEAL_SEAM_FRAC = 0.08;
+    function _revealPose(w) {
+      w = Math.max(0, Math.min(1, w));
+      var totalSec = Math.max(1e-6, _revealBackSec + _revealFwdSec + _revealTailSec);
+      var backW = _revealBackSec / totalSec, fwdEndW = (_revealBackSec + _revealFwdSec) / totalSec;
+      var endDir = _revealSeamDir(tV);
+      if (w > fwdEndW) {
+        // Tail: holds at f=1 (the last stick) while disciplines cycle. Gaze holds at endDir — the
+        // SAME rate-limited direction Beat 4 actually renders at its own e4=0 — so the hand-off into
+        // Beat 4 is exact, matching every other beat seam in this file.
+        var pt = _outPos(1);
+        return { x: pt.x, y: pt.y, z: pt.z, tx: pt.x + endDir.x * 20,
+                 ty: pt.y + endDir.y * 20, tz: pt.z + endDir.z * 20 };
+      }
+      if (w <= backW) {
+        var startDir = _revealSeamDir(tO);
+        var wb = backW > 0 ? w / backW : 1, eb = _cinemaEaseFloored(wb);
+        var f = 1 - eb, p = _outPos(f), dv = _revealTravelDir(f, -1);
+        if (wb < CPE_REVEAL_SEAM_FRAC) {
+          return _dirBlend(p.x, p.y, p.z, startDir.x, startDir.y, startDir.z,
+            dv.x, dv.y, dv.z, _cinemaSmoothstep(wb / CPE_REVEAL_SEAM_FRAC));
+        }
+        return { x: p.x, y: p.y, z: p.z, tx: p.x + dv.x * 20, ty: p.y + dv.y * 20, tz: p.z + dv.z * 20 };
+      }
+      var wf = (fwdEndW > backW) ? (w - backW) / (fwdEndW - backW) : 1, ef = _cinemaEaseFloored(wf);
+      var pf = _outPos(ef), dvf = _revealTravelDir(ef, 1);
+      if (wf < CPE_REVEAL_SEAM_FRAC) {
+        var backEndDir = _revealTravelDir(0, -1);
+        return _dirBlend(pf.x, pf.y, pf.z, backEndDir.x, backEndDir.y, backEndDir.z,
+          dvf.x, dvf.y, dvf.z, _cinemaSmoothstep(wf / CPE_REVEAL_SEAM_FRAC));
+      }
+      if (wf > 1 - CPE_REVEAL_SEAM_FRAC) {
+        return _dirBlend(pf.x, pf.y, pf.z, dvf.x, dvf.y, dvf.z, endDir.x, endDir.y, endDir.z,
+          _cinemaSmoothstep((wf - (1 - CPE_REVEAL_SEAM_FRAC)) / CPE_REVEAL_SEAM_FRAC));
+      }
+      return { x: pf.x, y: pf.y, z: pf.z, tx: pf.x + dvf.x * 20, ty: pf.y + dvf.y * 20, tz: pf.z + dvf.z * 20 };
     }
     function _beat4Pose(e4) {
         var turnW4 = CINEMA_TURN_OVERLAP_MAX + (1 - CINEMA_TURN_OVERLAP_MAX) * _cinemaSmoothstep(e4);
@@ -7486,7 +7626,13 @@ async function setupEffects(A, renderer, scene, camera) {
           e = _evenTurnRemap(_cinemaEaseFloored(_holdMap(w3b)));
           p = _beat3Pose(e, w3b);
         } else {
-          p = _beat4Pose(_cinemaEaseFloored((tt - tO) / Math.max(1e-6, tR - tO)));
+          // §CPE_DISCIPLINE_REVEAL: Beat 4's real boundary is tV (not tO) whenever the reveal round
+          // is inserted — MUST match poseAt's own Beat 4 formula below or this table's Beat 4 portion
+          // (the only portion _spanFracOf ever actually looks up above tO — see that function's own
+          // comment) samples the wrong e4 entirely. tt in (tO,tV] clamps to e4=0 (_cinemaEaseFloored
+          // clamps internally) — dead, never-queried table entries, not wrong ones, since _spanFracOf
+          // only ever produces indices in [tS,tO] or [tV,tR], never inside the gap itself.
+          p = _beat4Pose(_cinemaEaseFloored((tt - tV) / Math.max(1e-6, tR - tV)));
         }
         dx = p.tx - p.x; dy = p.ty - p.y; dz = p.tz - p.z;
         L = Math.hypot(dx, dy, dz) || 1;
@@ -7595,7 +7741,7 @@ async function setupEffects(A, renderer, scene, camera) {
     return { base: base, envelope: envelope, arcOnly: !!arcBboxRaw, fillDistance: fillDistance,
              pushInRadius: pushInRadius, radiusMin: radiusMin, radiusMax: radiusMax,
              pivot: pivot, pivotSrc: pivotSrc, settle: settle, exit: chosenExit,
-             beats: { dive: tD, spin: tS, out: tO, rise: tR },
+             beats: { dive: tD, spin: tS, out: tO, reveal: tV, rise: tR },
              // §CINEMA_PATH_EDITOR: the editor's table renders `waypoints` (authored control points,
              // NOT the rounded flown polyline) and re-times off `pathLen`. `sec` echoes the beat
              // seconds actually in force for this plan so the editor never has to guess them back
@@ -7617,7 +7763,7 @@ async function setupEffects(A, renderer, scene, camera) {
                         lookAt: b.lookAt ? { x: b.lookAt.x, y: b.lookAt.y, z: b.lookAt.z } : null };
              }) : null,
              flownPoints: flowWp.length, pathLen: totalLen, route: outRoute, authored: outRoute === 'authored',
-             sec: { dive: _useSec.dive, spin: _useSec.spin, out: _useSec.out, rise: _useSec.rise },
+             sec: { dive: _useSec.dive, spin: _useSec.spin, out: _useSec.out, reveal: _useSec.reveal, rise: _useSec.rise },
              naturalSec: _natSec, naturalTotal: _natTotal,
              eyeM: CINEMA_EYE_M, lookdownDeg: CINEMA_LOOKDOWN_DEG, durationSec: durationSec,
              indoor: true, poseAt: poseAt,
@@ -7775,7 +7921,7 @@ async function setupEffects(A, renderer, scene, camera) {
       saved.push(_cpeGet(g));
       if (ov[k] != null && isFinite(ov[k])) _cpeSet(g, ov[k]);
     }
-    var savedWp = _cpeWp, savedBands = _cpeBands, savedHose = _cpeHose;
+    var savedWp = _cpeWp, savedBands = _cpeBands, savedHose = _cpeHose, savedReveal = _cpeReveal;
     // §CPE_HOSE: ops ride the same override object the editor already stages and saves, so a hosed
     // path travels through Save / reload / bake by the existing seam — no second persistence path.
     _cpeHose = (ov.hose && ov.hose.length) ? ov.hose : null;
@@ -7783,11 +7929,13 @@ async function setupEffects(A, renderer, scene, camera) {
     // §CPE_BANDS takes precedence: bands EXPAND to waypoints inside the plan, so passing both would
     // be ambiguous. Bands win because they carry the rigidity constraint that loose points cannot.
     if (ov.bands && ov.bands.length >= 2) { _cpeBands = ov.bands; _cpeWp = null; }
+    _cpeReveal = !!ov.reveal;
     try {
       return _cinemaPathPlan(durationSec);
     } finally {
       for (i = 0; i < _CPE_KEYS.length; i++) _cpeSet(_CPE_KEYS[i][1], saved[i]);
       _cpeWp = savedWp; _cpeBands = savedBands; _cpeHose = savedHose; _cpeSecOverride = savedSecOv;
+      _cpeReveal = savedReveal;
     }
   };
   A.cinemaPathPlanDerived = _cinemaPathPlan;   // unwrapped, for G1's byte-identity comparison

--- a/witness_cpe_reveal_round.js
+++ b/witness_cpe_reveal_round.js
@@ -1,0 +1,158 @@
+#!/usr/bin/env node
+/**
+ * §CPE_DISCIPLINE_REVEAL Mechanism C — the retrace reveal round (geometry/timeline stage only;
+ * ghost/hide/shadow visuals are a separate, not-yet-built layer). Spec: bim-compiler
+ * prompts/CINEMA_DISCIPLINE_REVEAL.md §Mechanism C. Numeric §-tagged proof only, per CLAUDE.md's
+ * FUNDAMENTAL LAW — no screenshots, no eyeballing.
+ * RUN: node witness_cpe_reveal_round.js
+ */
+'use strict';
+const http = require('http'), fs = require('fs'), path = require('path');
+const puppeteer = require('/home/red1/bim-compiler/node_modules/puppeteer');
+const ROOT = __dirname;
+const MIME = { '.html': 'text/html', '.js': 'text/javascript', '.wasm': 'application/wasm', '.db': 'application/octet-stream' };
+function makeServer(root) {
+  return http.createServer((q, r) => {
+    let p = decodeURIComponent(q.url.split('?')[0]);
+    fs.readFile(path.join(root, p), (e, b) => {
+      if (e) { r.writeHead(404); r.end('404'); return; }
+      r.writeHead(200, { 'Content-Type': MIME[path.extname(p)] || 'application/octet-stream' });
+      r.end(b);
+    });
+  });
+}
+let pass = 0, fail = 0;
+const chk = (n, c, x) => { if (c) { pass++; console.log('  ✅ ' + n + (x ? '  ' + x : '')); } else { fail++; console.log('  ❌ ' + n + (x ? '  ' + x : '')); } };
+const _watchdog = setTimeout(() => { console.log('\n§W-CPE-REVEAL-ROUND TIMEOUT — killed after 180s'); process.exit(3); }, 180000);
+
+(async () => {
+  const server = makeServer(ROOT);
+  await new Promise(r => server.listen(0, r));
+  const port = server.address().port;
+  const br = await puppeteer.launch({ headless: 'new', args: ['--no-sandbox', '--disable-setuid-sandbox'] });
+  const pg = await br.newPage();
+  await pg.setViewport({ width: 1400, height: 900 });
+  const errs = [], logs = [];
+  pg.on('pageerror', e => errs.push(String(e)));
+  pg.on('console', m => logs.push(m.text()));
+  const url = `http://localhost:${port}/viewer/viewer.html?db=buildings/Duplex_extracted.db`;
+  await pg.goto(url, { waitUntil: 'load', timeout: 60000 });
+  await pg.waitForFunction('!!window.APP && !!window.APP.camera && !!window.APP.db', { timeout: 45000 });
+  await new Promise(r => setTimeout(r, 2000));
+  await pg.evaluate(() => window.APP.loadNavigate ? window.APP.loadNavigate() : null);
+  await pg.evaluate(() => window.APP.ensureRooms ? window.APP.ensureRooms({}) : null);
+  await new Promise(r => setTimeout(r, 500));
+
+  // ── W-REVEAL-DISCS: cross-check against the SAME 3-representation enumeration A.filterDiscs
+  // already uses (panels.js §NAV_FIND_002), not against elements_meta.discipline directly — a real,
+  // measured gap found building this witness: Duplex's elements_meta has ELEC=81/PLB=14 rows (sqlite3
+  // CLI on the raw file), each WITH an element_transforms row, but NONE of those guids are reachable
+  // through collectMeshes/_batchMeta/_instanceMeta in the live scene (checked directly, zero found) —
+  // so A.filterDiscs(['ELEC']) would isolate nothing either. Pre-existing, building-specific gap in
+  // how these elements reach the renderer; not caused by or in scope for this feature. cpeRevealDiscsPresent
+  // must faithfully match what's actually live, not the raw DB file. ──
+  const discTest = await pg.evaluate(() => {
+    const A = window.APP;
+    if (typeof A.cpeRevealDiscsPresent !== 'function') return { ok: false, reason: 'cpeRevealDiscsPresent missing' };
+    var live = {};
+    function bump(d) { if (d && d !== 'ARC' && d !== 'STR') live[d] = true; }
+    A.collectMeshes(function(o) { return o.isMesh && o.userData && o.userData.disc; }).forEach(function(o) { bump(o.userData.disc); });
+    for (var k in (A._batchMeta || {})) A._batchMeta[k].forEach(function(m) { bump(m.disc); });
+    for (var k2 in (A._instanceMeta || {})) A._instanceMeta[k2].forEach(function(m) { bump(m.disc); });
+    return { ok: true, discs: A.cpeRevealDiscsPresent().slice().sort(), liveDiscs: Object.keys(live).sort() };
+  });
+  chk('A.cpeRevealDiscsPresent exists and returns the real discipline set', discTest.ok, discTest.reason || '');
+  if (discTest.ok) {
+    chk('discs matches an independent re-enumeration of the SAME live scene (not the raw DB file)',
+      JSON.stringify(discTest.discs) === JSON.stringify(discTest.liveDiscs), 'got=' + JSON.stringify(discTest.discs) +
+      ' independent=' + JSON.stringify(discTest.liveDiscs));
+    chk('at least one real, non-ARC/STR discipline reachable on Duplex (MEP)', discTest.discs.indexOf('MEP') !== -1,
+      'got=' + JSON.stringify(discTest.discs));
+  }
+
+  // ── W-REVEAL-OFF (Guardrail 2): no override at all -> the reveal beat is zero-width and
+  // unreachable, byte-identical to before this feature existed. ──
+  const offTest = await pg.evaluate(() => {
+    const A = window.APP;
+    const plan = A.cinemaPathPlan(15);
+    return { beatsReveal: plan.beats.reveal, beatsOut: plan.beats.out, secReveal: plan.sec.reveal };
+  });
+  chk('reveal OFF: plan.beats.reveal === plan.beats.out (zero-width, unreachable)',
+    offTest.beatsReveal === offTest.beatsOut, 'reveal=' + offTest.beatsReveal + ' out=' + offTest.beatsOut);
+  chk('reveal OFF: plan.sec.reveal === 0', offTest.secReveal === 0, 'got=' + offTest.secReveal);
+
+  // ── W-REVEAL-ON: open the real editor, check the box (PR #1349's wiring), OK, then re-derive the
+  // full plan from the returned override so poseAt/beats/sec can be probed directly. ──
+  const onTest = await pg.evaluate(async () => {
+    const A = window.APP;
+    let plan; try { plan = A.cinemaPathPlan(15); } catch (e) { return { ok: false, reason: 'cinemaPathPlan failed: ' + e.message }; }
+    const openPromise = A.cinemaPathEditor.open({ plan: plan, durationSec: 15, fps: 15 });
+    await new Promise(r => setTimeout(r, 400));
+    const cb = document.getElementById('cpe-reveal');
+    if (!cb) { document.getElementById('cpe-cancel') && document.getElementById('cpe-cancel').click(); return { ok: false, reason: 'no #cpe-reveal checkbox' }; }
+    cb.click();
+    await new Promise(r => setTimeout(r, 50));
+    document.getElementById('cpe-ok').click();
+    const res = await openPromise;
+    if (!res.override || !res.override.reveal) return { ok: false, reason: 'override.reveal not true: ' + JSON.stringify(res.override && res.override.reveal) };
+    const plan2 = A.cinemaPathPlan(res.durationSec, res.override);
+    const tO = plan2.beats.out, tV = plan2.beats.reveal, tR = plan2.beats.rise;
+    const eps = 1e-4;
+    const pAtO_minus = plan2.poseAt(tO - eps);   // last frame of Beat 3
+    const pAtO_plus  = plan2.poseAt(tO + eps);    // first frame of the reveal round
+    const pAtV_minus = plan2.poseAt(tV - eps);    // last frame of the reveal round (tail hold)
+    const pAtV_plus  = plan2.poseAt(tV + eps);    // first frame of Beat 4 (e4≈0)
+    function dist(a, b) { return Math.hypot(a.x - b.x, a.y - b.y, a.z - b.z); }
+    function gazeDeg(a, b) {
+      var ax = a.tx - a.x, ay = a.ty - a.y, az = a.tz - a.z, aL = Math.hypot(ax, ay, az) || 1;
+      var bx = b.tx - b.x, by = b.ty - b.y, bz = b.tz - b.z, bL = Math.hypot(bx, by, bz) || 1;
+      var dot = (ax / aL) * (bx / bL) + (ay / aL) * (by / bL) + (az / aL) * (bz / bL);
+      return Math.acos(Math.max(-1, Math.min(1, dot))) * 180 / Math.PI;
+    }
+    return {
+      ok: true, cpeRevealDurationSec: res.durationSec, tO: tO, tV: tV, tR: tR,
+      secReveal: plan2.sec.reveal, secOut: plan2.sec.out,
+      posJumpAtStart: dist(pAtO_minus, pAtO_plus), gazeJumpAtStartDeg: gazeDeg(pAtO_minus, pAtO_plus),
+      posJumpAtEnd: dist(pAtV_minus, pAtV_plus), gazeJumpAtEndDeg: gazeDeg(pAtV_minus, pAtV_plus),
+      tailPos: pAtV_minus, walkEndPos: pAtO_minus,
+      posDeltaTailVsWalkEnd: dist(pAtV_minus, pAtO_minus)
+    };
+  });
+  chk('reveal ON: OK returns override.reveal=true and a plan with the round inserted', onTest.ok, onTest.reason || '');
+  if (onTest.ok) {
+    chk('tV > tO (the round has real width)', onTest.tV > onTest.tO, 'tO=' + onTest.tO.toFixed(4) + ' tV=' + onTest.tV.toFixed(4));
+    chk('sec.reveal > 0', onTest.secReveal > 0, 'secReveal=' + onTest.secReveal.toFixed(2));
+    // Position is _outPos-continuous by construction (same curve, no teleport) — must be near-exact.
+    chk('position continuous at the tO seam (walk -> reveal round)', onTest.posJumpAtStart < 0.05,
+      onTest.posJumpAtStart.toFixed(4) + 'm');
+    chk('position continuous at the tV seam (reveal round -> Beat 4)', onTest.posJumpAtEnd < 0.05,
+      onTest.posJumpAtEnd.toFixed(4) + 'm');
+    // Seam blend anchors to the ACTUAL rate-limited gaze Beat 3/4 render at tO/tV (_gazeRateAt), not
+    // the raw _beat3EndDir — anchoring to raw measured a real 63deg/12deg instantaneous jump here
+    // before that fix (Duplex, this witness). A tight bound now catches a regression back to that.
+    chk('gaze continuous at the tO seam (walk -> reveal round)', onTest.gazeJumpAtStartDeg < 2,
+      onTest.gazeJumpAtStartDeg.toFixed(2) + 'deg');
+    chk('gaze continuous at the tV seam (reveal round -> Beat 4)', onTest.gazeJumpAtEndDeg < 2,
+      onTest.gazeJumpAtEndDeg.toFixed(2) + 'deg');
+    chk('the round returns to the same spot the walk ended (tail sits at the last stick)',
+      onTest.posDeltaTailVsWalkEnd < 0.05, onTest.posDeltaTailVsWalkEnd.toFixed(4) + 'm');
+    chk('the panel duration (drives nFrames) GREW to fit the round, not squeezed the rest of the film',
+      onTest.cpeRevealDurationSec > 15 + onTest.secReveal - 1, 'durationSec=' + onTest.cpeRevealDurationSec.toFixed(1) +
+      ' (base 15 + secReveal ' + onTest.secReveal.toFixed(1) + ')');
+  }
+
+  const revealLog = logs.filter(l => l.indexOf('§CPE_REVEAL_ROUND') !== -1);
+  chk('§CPE_REVEAL_ROUND logged with real disc list, non-empty', revealLog.some(l => l.indexOf('discs=[ELEC,MEP,PLB]') !== -1 || l.indexOf('discs=[') !== -1),
+    revealLog.join(' | '));
+  const gazeRateLog = logs.filter(l => l.indexOf('§CPE_GAZE_CONSTANT_RATE') !== -1);
+  chk('§CPE_GAZE_CONSTANT_RATE has no NaN/Infinity after the tV fix', gazeRateLog.length > 0 &&
+    !gazeRateLog.some(l => /NaN|Infinity/.test(l)), gazeRateLog.slice(-1)[0] || 'not found');
+
+  chk('zero pageerrors through the whole run', errs.length === 0, errs.join(' | '));
+
+  await br.close();
+  await server.close();
+  clearTimeout(_watchdog);
+  console.log('\n§W-CPE-REVEAL-ROUND DONE pass=' + pass + ' fail=' + fail);
+  process.exit(fail ? 1 : 0);
+})().catch(e => { console.log('\n§W-CPE-REVEAL-ROUND CRASHED ' + (e && e.stack || e)); process.exit(2); });


### PR DESCRIPTION
## Summary
- Inserts a new beat between the outbound walk and the closing orbit, gated on the Reveal checkbox (#1349): retraces the walked path backward to the first stick, forward again to the last stick, then holds for a tail where disciplines would cycle (visuals not built yet).
- Reuses `_outPos(f)` — the same curve Beat 3 walks — sampled backward then forward. No reverse-path utility existed or was needed.
- Zero-width and unreachable when reveal is off or the building has no non-ARC/STR discipline (Guardrail 2: byte-identical to before this PR).
- Duration is real and additive: `A.cpeRevealDiscsPresent()` (shared between the plan builder and the panel's own duration estimate) counts actual live non-ARC/STR elements; the bake's frame count grows to fit the round instead of squeezing it out of the existing runtime.
- Found + fixed while witnessing: seam gaze anchored to the raw `_beat3EndDir` instead of what Beat 3/4 actually render (`_gazeRateAt`, turn-rate-limited) — measured a real 63°/12° jump on Duplex, now 0.39°/0.02°. Also fixed a latent bug in `_gazeRateBuild`'s own copy of the Beat 4 formula (still referenced the old `tO` boundary).
- **NOT built yet:** the ghost/hide/shadow visuals (20% ARC/STR fade, full per-discipline reveal, sunlight-through). Checking the box today bakes real extra frames with no visible reveal effect — the checkbox hint and every relevant log line say so.

## Test plan
- [x] `node witness_cpe_reveal_round.js` — 17/17 (Guardrail 2, real duration growth, position+gaze continuity at both seams, real discipline count, no NaN in the gaze-rate table, zero pageerrors)
- [x] `node witness_cpe_reveal_panel.js` — 7/7 regression clean
- [x] `node witness_cpe_room_title.js` — 11/11 regression clean (shared functions: `_buildOverride`, `_naturalDuration`, `_gazeRateBuild`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)