### PR TITLE
feat(cpe): §CPE_DISCIPLINE_REVEAL Mechanism C — visual layer (ARC/STR full hide, per-discipline tail)

### DIFF
--- a/viewer/cinema_maxq.js
+++ b/viewer/cinema_maxq.js
@@ -1070,15 +1070,14 @@
         }
         _buildup = !!_ov.buildup;
         _roomTitle = !!_ov.roomTitle; // §CPE_ROOM_TITLE — off unless the editor's checkbox set it
-        // §CPE_DISCIPLINE_REVEAL Mechanism C (prompts/CINEMA_DISCIPLINE_REVEAL.md) — the retrace
-        // round itself is real (effects.js's _cinemaPathPlan/poseAt inserts it via this same
-        // _ov.reveal flag, transparently to this file — plan.poseAt already returns the extended
-        // film). _reveal is captured here only for logging/future ghost-visual wiring, not because
-        // this file's own bake loop needs to branch on it. Ghost/hide/shadow VISUALS (20% ARC/STR
-        // fade, per-discipline full-reveal, sunlight-through) are NOT built yet — Open Question 1.
+        // §CPE_DISCIPLINE_REVEAL Mechanism C (prompts/CINEMA_DISCIPLINE_REVEAL.md) — both the round
+        // and its visuals are real. effects.js's _cinemaPathPlan/poseAt inserts the retrace via this
+        // same _ov.reveal flag, transparently to this file (plan.poseAt already returns the extended
+        // film); A.cpeRevealApplyVisual(plan,_tn), called from the per-frame loop below, drives the
+        // ARC/STR hide via A.filterDiscs. _reveal itself is only captured here for logging.
         _reveal = !!_ov.reveal;
-        if (_reveal) console.log('§CPE_REVEAL flag=on — retrace round is real (extra frames baked); ' +
-          'ghost/reveal visuals not built yet (spec: prompts/CINEMA_DISCIPLINE_REVEAL.md)');
+        if (_reveal) console.log('§CPE_REVEAL flag=on — retrace round + ARC/STR reveal are real ' +
+          '(spec: prompts/CINEMA_DISCIPLINE_REVEAL.md)');
         // §CPE_DAY_COUNTER_POS — the editor's corner choice. Absent (an older saved plan, or a bake
         // that never opened the editor) means TOP RIGHT, which is what shipped, so nothing re-bakes
         // differently by accident.
@@ -1291,6 +1290,10 @@
               (_ggO == null ? '' : ' groundOpacity=' + _ggO.toFixed(3)));
           }
         }
+        // §CPE_DISCIPLINE_REVEAL Mechanism C — pure function of (plan, tNorm), same call the preview
+        // loop makes (cinema_path_editor.js's _previewFly) so bake and preview cannot diverge. No-op
+        // (returns immediately, does nothing) when reveal is off or tNorm is outside the round.
+        if (A.cpeRevealApplyVisual) A.cpeRevealApplyVisual(plan, _tn);
         A.startStillRefine();
         // §SUN_ARC_STOMP_FIX (found live, 2026-08-11 — user report "not high noon" on a real
         // HHS_Office_Federated bake): startStillRefine() calls _applyPhotoStaging() synchronously,
@@ -1443,6 +1446,9 @@
       // §CPE_GHOST_GROUND: same contract, same exit — a ghosted ground left behind would follow the
       // user into normal navigation for the rest of the session.
       try { _ghostGroundRestore(); } catch (eGG) {}
+      // §CPE_DISCIPLINE_REVEAL: same contract — ARC/STR left hidden after a bake would follow the
+      // user into normal navigation. plan=null is the explicit "force restore" signal.
+      try { if (A.cpeRevealApplyVisual) A.cpeRevealApplyVisual(null, 0); } catch (eRV) {}
       _workPacingReset();
       // ══ §MAXQ_QUALITY — the run states its own health, ALWAYS, before anything is stitched.
       // The defect this exists for is a film that looks complete and plays fine while its last
@@ -1494,6 +1500,7 @@
       // bake would look like a corrupted schedule to the next person who opens the timeline.
       try { if (_bkState && window.tmRestoreDerivedOrder) { window.tmRestoreDerivedOrder(); _bkState = null; } } catch (e3) {}
       try { _ghostGroundRestore(); } catch (e4) {}
+      try { if (A.cpeRevealApplyVisual) A.cpeRevealApplyVisual(null, 0); } catch (eRV2) {}
       try { _workPacingReset(); } catch (e5) {}
       // Recoverability FIRST: clearing the store can itself block for seconds behind the very
       // zombie connection that failed this run, and until these flags reset the next Alt+C is

--- a/viewer/cinema_path_editor.js
+++ b/viewer/cinema_path_editor.js
@@ -849,7 +849,7 @@
           // ghost/pacing render mechanism is NOT built (spec Open Question 1, render approach, still
           // unresolved) — the hint says so, so checking it does not silently do nothing unexplained.
           '<label style="cursor:pointer;margin-left:10px"><input id="cpe-reveal" type="checkbox"> ' +
-          'Reveal</label> <span style="color:#666">(extra retrace round + pause before the finale — the ghost/reveal visuals are not built yet)</span></div>' +
+          'Reveal</label> <span style="color:#666">(retraces the walk, hiding ARC/STR to show MEP, cycling each discipline before the finale)</span></div>' +
         // §CPE_DAY_COUNTER_POS — user 2026-08-02: "the movie maker panel puts the Day # counter top
         // right display option". Top right is the DEFAULT so an existing plan re-bakes identically.
         // Only meaningful with the buildup on (there is no day to show without one), which the hint
@@ -2410,6 +2410,10 @@
         _state.scrubTn = tn;
         _renderScrub();
         if (s.roomTitle && a.roomTitleLiveTick) a.roomTitleLiveTick(tn * _titleTotalSec);
+        // §CPE_DISCIPLINE_REVEAL Mechanism C (user, 2026-08-14: "during preview, it can also go along
+        // so user confident it is working") — pure function of (plan, tNorm), the SAME call the bake
+        // loop makes (cinema_maxq.js), so preview and bake cannot diverge. No-op when reveal is off.
+        if (s.reveal && a.cpeRevealApplyVisual) a.cpeRevealApplyVisual(s.plan, tn);
         // §CPE_BUILDUP_OWNS_TM: `bkPrev` alone is a snapshot taken once at flight-start — it never
         // saw a LIVE uncheck of #cpe-buildup mid-flight. Gate on `s.buildup` too so unchecking it
         // stops feeding the cursor on the very next frame, instead of racing the checkbox handler's
@@ -2459,6 +2463,10 @@
         if (a.buildupPacingReset) a.buildupPacingReset();
         if (a.roomTitleLiveStop) a.roomTitleLiveStop();
         if (a.dayCounterLiveStop) a.dayCounterLiveStop();
+        // §CPE_DISCIPLINE_REVEAL: same exit contract as ghostGroundRestore above — a rehearsal that
+        // ended mid-round (or right at it) must not leave ARC/STR hidden for the editing session that
+        // follows. plan=null is the explicit "force restore" signal cpeRevealApplyVisual reads.
+        if (a.cpeRevealApplyVisual) a.cpeRevealApplyVisual(null, 0);
         _state.flying = false;
         // §CPE_SCRUB_PLAY: natural completion — clear the pause hooks, this run is over, not paused.
         s._flyPauseAt = null; s._flyResume = null; s.flyPaused = false;
@@ -3131,7 +3139,7 @@
         roomTitle: false,
         origRoomTitle: false,
         // §CPE_DISCIPLINE_REVEAL: off by default, same reasoning as roomTitle — a deliberate choice,
-        // not a default-on behavior. Mechanism not built yet (see checkbox hint + spec file).
+        // not a default-on behavior (extra film time + a real visual change, see checkbox hint).
         reveal: false,
         origReveal: false,
         dayCounter: 'tr',        // §CPE_DAY_COUNTER_POS — the shipped position, unchanged by default
@@ -3259,18 +3267,18 @@
         if (!_state.roomTitle && _a.roomTitleLiveStop) _a.roomTitleLiveStop();
         _renderWhole(); _syncButtons();
       });
-      // §CPE_DISCIPLINE_REVEAL Mechanism C (prompts/CINEMA_DISCIPLINE_REVEAL.md) — geometry/timeline
-      // stage is real: checking this box inserts an extra retrace round (last stick -> first stick
-      // -> last stick, plus a tail pause) into the bake, effects.js's _cinemaPathPlan/poseAt. The
-      // ghost/hide/shadow VISUALS (20% ARC/STR fade, per-discipline full-reveal, sunlight-through)
-      // are NOT built yet — Open Question 1 (render approach) is still unresolved. The hint text next
-      // to the checkbox says so; do not let this comment or that text drift out of sync with which
-      // half is actually built.
+      // §CPE_DISCIPLINE_REVEAL Mechanism C (prompts/CINEMA_DISCIPLINE_REVEAL.md) — checking this box
+      // inserts an extra retrace round (last stick -> first stick -> last stick, plus a tail pause)
+      // into the bake AND preview (effects.js's _cinemaPathPlan/poseAt for the camera, A.cpeReveal
+      // ApplyVisual/A.filterDiscs for hiding ARC/STR — full hide, not a translucent fade: checked
+      // live, ~80% of ARC/STR geometry is batched/instanced with materials shared across disciplines
+      // by colour, so a scoped translucent ghost would need per-instance shader work; full hide
+      // reuses existing code and gets the sunlight-through effect for free).
       document.getElementById('cpe-reveal').addEventListener('change', function(e) {
         _state.reveal = !!e.target.checked;
         _markPreviewStale();
         console.log('§CPE_REVEAL ' + (_state.reveal ? 'ON' : 'off') +
-          ' — extra retrace round (geometry/timeline only, real); ghost/reveal visuals not built yet' +
+          ' — extra retrace round, ARC/STR hides to reveal MEP/other disciplines' +
           ' (spec: prompts/CINEMA_DISCIPLINE_REVEAL.md)');
         _renderWhole(); _syncButtons();
       });

--- a/viewer/effects.js
+++ b/viewer/effects.js
@@ -4878,6 +4878,59 @@ async function setupEffects(A, renderer, scene, camera) {
     for (_imId in (A._instanceMeta || {})) A._instanceMeta[_imId].forEach(function(m) { bump(m.disc); });
     return Object.keys(counts);
   };
+  // §CPE_DISCIPLINE_REVEAL — pure function of (plan, tNorm): which visual phase, if any, this
+  // instant of the retrace round falls in. Called identically from the bake loop (cinema_maxq.js)
+  // and the preview loop (cinema_path_editor.js's _previewFly) so the two can never diverge — same
+  // "one poseAt, no state leakage either direction" property this file already relies on elsewhere
+  // (§CPE_AIM_SIMPLIFY). Backward leg (plain retrace) and outside-the-round both return null — ARC/STR
+  // stays solid; only the forward leg (full hide, all discs together) and the tail (cycle one at a
+  // time, then all together) actually change anything. Full HIDE, not partial opacity — checked live
+  // (Duplex, 2026-08-14): ~80% of ARC/STR geometry is batched/instanced with materials SHARED across
+  // disciplines by colour, not owned per-discipline, so a translucent ghost scoped to ARC/STR alone
+  // would need per-instance shader work; A.filterDiscs's existing .visible=false hide sidesteps that
+  // entirely AND gets the "sunlight plays through" effect for free (Three.js excludes invisible
+  // objects from the shadow pass).
+  A.cpeRevealVisualAt = function(plan, tNorm) {
+    var b = plan && plan.beats, rv = plan && plan.reveal;
+    if (!b || !rv || !rv.discs || !rv.discs.length || !(b.reveal > b.out)) return null;
+    if (tNorm <= b.out || tNorm >= b.reveal) return null;
+    var totalSec = Math.max(1e-6, rv.backSec + rv.fwdSec + rv.tailSec);
+    var w = (tNorm - b.out) / Math.max(1e-6, b.reveal - b.out);
+    var backW = rv.backSec / totalSec, fwdEndW = (rv.backSec + rv.fwdSec) / totalSec;
+    if (w <= backW) return null;
+    if (w <= fwdEndW) return { phase: 'ghost', discs: rv.discs.slice() };
+    var tailW = (w - fwdEndW) / Math.max(1e-6, 1 - fwdEndW);
+    var tailSec = tailW * rv.tailSec, perDisc = 2, n = rv.discs.length;
+    var idx = Math.floor(tailSec / perDisc);
+    if (idx >= n) return { phase: 'tail-all', discs: rv.discs.slice() };
+    return { phase: 'tail-one', discs: [rv.discs[idx]] };
+  };
+  // Applies the state above to the live scene via A.filterDiscs (panels.js §NAV_FIND_002) — reused
+  // as-is, not forked. Snapshots whatever discipline filter the user already had active (Role filter,
+  // Find isolate, ...) on first entering the round, and restores EXACTLY that on exit — never a blind
+  // "show everything" that would clobber an unrelated filter the user had running before the bake/
+  // preview started. Skips the (scene-traversing) _applyDiscVisibility call entirely when nothing
+  // actually changed since the last tick — cheap to call every frame.
+  A._cpeRevealSavedHidden = null;
+  A._cpeRevealVisualKey = null;
+  A.cpeRevealApplyVisual = function(plan, tNorm) {
+    if (typeof A.filterDiscs !== 'function' || !A.hiddenDiscs) return;
+    var st = plan ? A.cpeRevealVisualAt(plan, tNorm) : null;
+    var key = st ? (st.phase + ':' + st.discs.join(',')) : '';
+    if (A._cpeRevealVisualKey === key) return;
+    if (!st) {
+      if (A._cpeRevealSavedHidden) {
+        A.hiddenDiscs.clear();
+        A._cpeRevealSavedHidden.forEach(function(d) { A.hiddenDiscs.add(d); });
+        if (A._applyDiscVisibility) A._applyDiscVisibility();
+        A._cpeRevealSavedHidden = null;
+      }
+    } else {
+      if (!A._cpeRevealSavedHidden) A._cpeRevealSavedHidden = new Set(A.hiddenDiscs);
+      A.filterDiscs(st.discs);
+    }
+    A._cpeRevealVisualKey = key;
+  };
   function _cpeBandEnds(b) {
     var h = b.len / 2;
     return [{ x: b.c.x - b.d.x * h, y: b.c.y - b.d.y * h, z: b.c.z - b.d.z * h },
@@ -7742,6 +7795,10 @@ async function setupEffects(A, renderer, scene, camera) {
              pushInRadius: pushInRadius, radiusMin: radiusMin, radiusMax: radiusMax,
              pivot: pivot, pivotSrc: pivotSrc, settle: settle, exit: chosenExit,
              beats: { dive: tD, spin: tS, out: tO, reveal: tV, rise: tR },
+             // §CPE_DISCIPLINE_REVEAL — the pacing info A.cpeRevealVisualAt(plan, tNorm) needs to
+             // compute which visual phase a given tNorm falls in, exposed here rather than recomputed
+             // (or duplicated) outside this closure.
+             reveal: { discs: _revealDiscs, backSec: _revealBackSec, fwdSec: _revealFwdSec, tailSec: _revealTailSec },
              // §CINEMA_PATH_EDITOR: the editor's table renders `waypoints` (authored control points,
              // NOT the rounded flown polyline) and re-times off `pathLen`. `sec` echoes the beat
              // seconds actually in force for this plan so the editor never has to guess them back

--- a/witness_cpe_reveal_round.js
+++ b/witness_cpe_reveal_round.js
@@ -148,6 +148,69 @@ const _watchdog = setTimeout(() => { console.log('\n§W-CPE-REVEAL-ROUND TIMEOUT
   chk('§CPE_GAZE_CONSTANT_RATE has no NaN/Infinity after the tV fix', gazeRateLog.length > 0 &&
     !gazeRateLog.some(l => /NaN|Infinity/.test(l)), gazeRateLog.slice(-1)[0] || 'not found');
 
+  // ── W-REVEAL-VISUAL: the visual layer (A.cpeRevealVisualAt / A.cpeRevealApplyVisual) — full hide
+  // via the existing A.filterDiscs, phase-correct at each point in the round, snapshot/restore of a
+  // PRE-EXISTING filter (not a blind "show everything"), and skips redundant scene traversal. ──
+  const visTest = await pg.evaluate(async () => {
+    const A = window.APP;
+    let plan; try { plan = A.cinemaPathPlan(15); } catch (e) { return { ok: false, reason: 'cinemaPathPlan failed: ' + e.message }; }
+    const openPromise = A.cinemaPathEditor.open({ plan: plan, durationSec: 15, fps: 15 });
+    await new Promise(r => setTimeout(r, 400));
+    document.getElementById('cpe-reveal').click();
+    await new Promise(r => setTimeout(r, 50));
+    document.getElementById('cpe-ok').click();
+    const res = await openPromise;
+    const plan2 = A.cinemaPathPlan(res.durationSec, res.override);
+    const tO = plan2.beats.out, tV = plan2.beats.reveal;
+    const eps = 1e-4;
+    const phaseAt = (frac) => A.cpeRevealVisualAt(plan2, tO + (tV - tO) * frac);
+    // Boundaries derived from the plan's own reveal info, not guessed: backW/fwdEndW split the
+    // round into back/fwd/tail exactly as A.cpeRevealVisualAt itself computes them.
+    const rv = plan2.reveal, totalSec = rv.backSec + rv.fwdSec + rv.tailSec;
+    const fwdEndW = (rv.backSec + rv.fwdSec) / totalSec;
+    const phases = { back: phaseAt(0.02), fwd: phaseAt(0.45),
+      tailStart: phaseAt(fwdEndW + 0.03), tailAll: phaseAt(0.99), outside: A.cpeRevealVisualAt(plan2, tO - eps) };
+    // A PRE-EXISTING filter (simulates a Role/Find isolate already active) — the round must restore
+    // exactly THIS on exit, not blindly show everything.
+    A.filterDiscs(['STR']);
+    const preExisting = Array.from(A.hiddenDiscs).sort();
+    let applyCalls = 0;
+    const origApply = A._applyDiscVisibility;
+    A._applyDiscVisibility = function() { applyCalls++; return origApply.apply(this, arguments); };
+    A.cpeRevealApplyVisual(plan2, tO + (tV - tO) * 0.45);   // forward-leg ghost
+    const hiddenDuringGhost = Array.from(A.hiddenDiscs).sort();
+    const callsAfterFirst = applyCalls;
+    A.cpeRevealApplyVisual(plan2, tO + (tV - tO) * 0.451);  // same phase/discs, tiny tNorm change — must be a no-op
+    const callsAfterRepeat = applyCalls;
+    A.cpeRevealApplyVisual(null, 0);                        // force restore
+    const hiddenAfterRestore = Array.from(A.hiddenDiscs).sort();
+    A._applyDiscVisibility = origApply;
+    A.filterDiscs(null);   // clean up this witness's own probe filter
+    return { ok: true, phases, preExisting, hiddenDuringGhost, callsAfterFirst, callsAfterRepeat, hiddenAfterRestore };
+  });
+  chk('visual layer probe ran', visTest.ok, visTest.reason || '');
+  if (visTest.ok) {
+    chk('backward leg: no visual override (ARC/STR stays solid)', visTest.phases.back === null, JSON.stringify(visTest.phases.back));
+    chk('outside the round: no visual override', visTest.phases.outside === null, JSON.stringify(visTest.phases.outside));
+    chk('forward leg: phase=ghost, all discs shown together', visTest.phases.fwd &&
+      visTest.phases.fwd.phase === 'ghost' && JSON.stringify(visTest.phases.fwd.discs) === '["MEP"]',
+      JSON.stringify(visTest.phases.fwd));
+    chk('tail (early): phase=tail-one, exactly one discipline', visTest.phases.tailStart &&
+      visTest.phases.tailStart.phase === 'tail-one' && visTest.phases.tailStart.discs.length === 1,
+      JSON.stringify(visTest.phases.tailStart));
+    chk('tail (late): phase=tail-all, every discipline together', visTest.phases.tailAll &&
+      visTest.phases.tailAll.phase === 'tail-all' && JSON.stringify(visTest.phases.tailAll.discs) === '["MEP"]',
+      JSON.stringify(visTest.phases.tailAll));
+    chk('forward-leg apply hides ARC+STR, leaves MEP visible', JSON.stringify(visTest.hiddenDuringGhost) === '["ARC","STR"]',
+      'got=' + JSON.stringify(visTest.hiddenDuringGhost));
+    chk('a real scene traversal happened on the first apply', visTest.callsAfterFirst > 0, 'calls=' + visTest.callsAfterFirst);
+    chk('a same-phase re-apply skips the (expensive) scene traversal', visTest.callsAfterRepeat === visTest.callsAfterFirst,
+      'before=' + visTest.callsAfterFirst + ' after=' + visTest.callsAfterRepeat);
+    chk('restore brings back the PRE-EXISTING filter exactly, not a blind "show all"',
+      JSON.stringify(visTest.hiddenAfterRestore) === JSON.stringify(visTest.preExisting),
+      'preExisting=' + JSON.stringify(visTest.preExisting) + ' afterRestore=' + JSON.stringify(visTest.hiddenAfterRestore));
+  }
+
   chk('zero pageerrors through the whole run', errs.length === 0, errs.join(' | '));
 
   await br.close();


### PR DESCRIPTION
## Summary
- Adds the visual half of the retrace reveal round (geometry/timeline shipped in #1350): forward leg hides ARC/STR entirely (showing every other discipline together), tail cycles each discipline alone for ~2s then all together for a final ~2s.
- Design change from the original "20% translucent ghost" ask, confirmed live before building (Duplex): ~80% of ARC/STR geometry is batched/instanced with materials shared across disciplines by colour, not owned per-discipline — a scoped translucent fade would need per-instance shader work. Full hide (`A.filterDiscs`, already existed) ships now with zero new rendering risk, still reveals MEP clearly, and gets "sunlight plays through" for free (Three.js excludes invisible objects from the shadow pass). User confirmed this trade explicitly before it was built.
- `A.cpeRevealVisualAt(plan, tNorm)` is a pure function (phase + which discs to show); `A.cpeRevealApplyVisual(plan, tNorm)` applies it via the existing `A.filterDiscs`, snapshotting whatever discipline filter was already active and restoring exactly that on exit — never a blind "show everything."
- Wired identically into both the bake loop (`cinema_maxq.js`) and the preview loop (`cinema_path_editor.js`'s `_previewFly`) so bake and preview can't diverge — user asked for preview parity explicitly. Restore-on-exit added to both loops' existing exit contracts (normal completion, cancel, throw/finally).

## Test plan
- [x] `node witness_cpe_reveal_round.js` — 27/27 (phase-correct at every point in the round, full hide correctly excludes only ARC+STR, redundant-apply skips the real scene traversal, restore brings back a pre-existing filter exactly, zero pageerrors)
- [x] `node witness_cpe_reveal_panel.js` — 7/7 regression clean
- [x] `node witness_cpe_room_title.js` — 11/11 regression clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)