### PR TITLE
fix(cpe): §CPE_DISCIPLINE_REVEAL — Reveal checkbox must replan before Preview

### DIFF
--- a/viewer/cinema_path_editor.js
+++ b/viewer/cinema_path_editor.js
@@ -3277,6 +3277,16 @@
       document.getElementById('cpe-reveal').addEventListener('change', function(e) {
         _state.reveal = !!e.target.checked;
         _markPreviewStale();
+        // §CPE_DISCIPLINE_REVEAL — real bug found live (user, 2026-08-14: "Preview also do not go
+        // 2nd round" / "the pov timeline numbering did double but the alt-c still remains not").
+        // _markPreviewStale() only bumps a counter; it does NOT rebuild _state.plan. Unlike
+        // buildup/roomTitle (flags read live by their own draw code), reveal changes the PLAN'S OWN
+        // BEAT BOUNDARIES (tV/tR) — poseAt/buildupTopoutU read _state.plan directly, so without an
+        // explicit _replanFilm() here, the next preview click keeps flying the STALE pre-toggle plan
+        // (reveal effectively off) until some unrelated edit (a band drag) happens to trigger one.
+        // Duration LABELS (_buildOverride()._total, called fresh each time) looked right regardless —
+        // that's the "numbering did double but the camera still remains not" split exactly.
+        _replanFilm(); _redrawScene(); _renderClock();
         console.log('§CPE_REVEAL ' + (_state.reveal ? 'ON' : 'off') +
           ' — extra retrace round, ARC/STR hides to reveal MEP/other disciplines' +
           ' (spec: prompts/CINEMA_DISCIPLINE_REVEAL.md)');

--- a/witness_cpe_reveal_round.js
+++ b/witness_cpe_reveal_round.js
@@ -193,6 +193,38 @@ const _watchdog = setTimeout(() => { console.log('\n§W-CPE-REVEAL-ROUND TIMEOUT
       ' (tV=' + topoutTest.tV.toFixed(3) + ')');
   }
 
+  // ── W-REVEAL-PREVIEW-REPLAN: real defect found live (user, 2026-08-14: "Preview also do not go
+  // 2nd round" / "the pov timeline numbering did double but the alt-c still remains not"). Root
+  // cause: the reveal checkbox's change handler only called _markPreviewStale() (bumps a counter),
+  // never _replanFilm() (the only thing that rebuilds _state.plan) — unlike buildup/roomTitle, reveal
+  // changes the PLAN'S OWN beat boundaries, so poseAt/buildupTopoutU kept reading the stale pre-toggle
+  // plan until an unrelated edit (a band drag) happened to trigger a replan. Checks the EDITOR'S OWN
+  // live _state.plan (via the exposed _probePlanRef test hook), NOT a freshly-built plan the way the
+  // topout test above does — that distinction is exactly what this bug hid. ──
+  const previewReplanTest = await pg.evaluate(async () => {
+    const A = window.APP;
+    let plan; try { plan = A.cinemaPathPlan(15); } catch (e) { return { ok: false, reason: 'cinemaPathPlan failed: ' + e.message }; }
+    const openPromise = A.cinemaPathEditor.open({ plan: plan, durationSec: 15, fps: 15 });
+    await new Promise(r => setTimeout(r, 400));
+    const beforeToggle = A.cinemaPathEditor._probePlanRef();
+    const beforeWidth = beforeToggle ? (beforeToggle.beats.reveal - beforeToggle.beats.out) : null;
+    document.getElementById('cpe-reveal').click();     // toggle ON — NO band drag, NO other edit
+    await new Promise(r => setTimeout(r, 50));
+    const afterToggle = A.cinemaPathEditor._probePlanRef();   // the editor's LIVE plan, same one Preview flies
+    document.getElementById('cpe-cancel').click();
+    if (!afterToggle) return { ok: false, reason: 'no _state.plan after toggle' };
+    return { ok: true, beforeWidth, tO: afterToggle.beats.out, tV: afterToggle.beats.reveal };
+  });
+  chk('preview-replan probe ran', previewReplanTest.ok, previewReplanTest.reason || '');
+  if (previewReplanTest.ok) {
+    chk('before toggle: editor\'s live plan has the round at zero width (reveal was off)',
+      previewReplanTest.beforeWidth === 0, 'got=' + previewReplanTest.beforeWidth);
+    chk('checking Reveal alone (no band drag) immediately widens the EDITOR\'S OWN live plan — ' +
+      'the exact plan Preview flies, not a freshly-built one',
+      previewReplanTest.tV > previewReplanTest.tO,
+      'tO=' + previewReplanTest.tO.toFixed(3) + ' tV=' + previewReplanTest.tV.toFixed(3));
+  }
+
   // ── W-REVEAL-VISUAL: the visual layer (A.cpeRevealVisualAt / A.cpeRevealApplyVisual) — full hide
   // via the existing A.filterDiscs, phase-correct at each point in the round, snapshot/restore of a
   // PRE-EXISTING filter (not a blind "show everything"), and skips redundant scene traversal. ──


### PR DESCRIPTION
## Summary
Real defect found live (user: "Preview also do not go 2nd round" / "the pov timeline numbering did double but the alt-c still remains not").

The reveal checkbox's change handler only called `_markPreviewStale()` (bumps a "have you seen this version" counter) — never `_replanFilm()`, the only thing that rebuilds `_state.plan`. `buildup`/`roomTitle` get away without this because they're flags read live each frame; reveal changes the plan's own beat boundaries (`tV`/`tR`), and both `poseAt` and `buildupTopoutU` read `_state.plan` directly. Without an explicit replan, Preview kept flying the stale pre-toggle plan until an unrelated edit (a band drag) happened to trigger one. Duration labels looked right regardless since those recompute fresh — exactly the split the user described.

**Fix:** the checkbox handler now calls `_replanFilm()` (+ redraw/clock refresh), matching every band/hose-editing handler's existing pattern.

## Test plan
- [x] `node witness_cpe_reveal_round.js` — extended to 36/36: new check reads the editor's own live `_state.plan` (via the exposed `_probePlanRef` hook — the exact object Preview flies) immediately after a bare checkbox click with no band drag, confirms it widens correctly
- [x] `node witness_cpe_reveal_panel.js` — 7/7 regression clean
- [x] `node witness_cpe_room_title.js` — 11/11 regression clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)