### PR TITLE
fix(4d): Gantt bars now run at the same clock speed as canvas (SHIFT_HOURS)

### DIFF
--- a/viewer/schedule_author.js
+++ b/viewer/schedule_author.js
@@ -349,7 +349,14 @@
     var laborRates = opts.laborRates || (global.LABOR_RATES) || {};
     var maxCrews = {};
     for (var res in laborRates) if (laborRates[res].max_crews) maxCrews[res] = laborRates[res].max_crews;
-    var schedule = SG.computeSchedule(elements, 0, 1, maxCrews);
+    // §GANTT_SHIFT_HOURS_DESYNC (4D_SCHEDULE_PERFECTION.md) — this call used to omit shiftHours,
+    // silently taking computeSchedule's internal 8h/day default while the real canvas movie
+    // (time_machine.js injectGantt) runs at rates.js SHIFT_HOURS (default 24). Gantt bars were
+    // authored 3x slower than the canvas actually plays, so elements visibly appear before their
+    // own bar starts. opts.shiftHours undefined leaves computeSchedule's own 8h default untouched
+    // (witnesses/probes that never pass it stay byte-identical) — only callers that pass it (the
+    // real UI paths, below) change.
+    var schedule = SG.computeSchedule(elements, 0, 1, maxCrews, opts.shiftHours);
     var rolled = SG.deriveZones(elements, schedule);
     if (!rolled.zones.length) { console.log('§AUTHOR_ZONES_FAIL reason=no_zones'); return { ok: false, reason: 'no_zones' }; }
 

--- a/viewer/time_machine.js
+++ b/viewer/time_machine.js
@@ -6724,7 +6724,8 @@
     if (act) return false;                       // schedule exists — injectGantt absorbs it, one pass
     var todayStart = new Date().toISOString().slice(0, 10);
     var SR = window.SEQUENCE_RULES || {}, LR = window.LABOR_RATES || {}, RT = window.RATES || {};
-    var res = SA.materializeZones(app.db, SR, { start: todayStart, laborRates: LR, rates: RT, scheduleGate: window.ScheduleGate });
+    var _shiftHoursGantt = (window.SHIFT_HOURS > 0) ? window.SHIFT_HOURS : 24; // §GANTT_SHIFT_HOURS_DESYNC — match injectGantt's real clock
+    var res = SA.materializeZones(app.db, SR, { start: todayStart, laborRates: LR, rates: RT, scheduleGate: window.ScheduleGate, shiftHours: _shiftHoursGantt });
     if (!res.ok && SA.materializeDefault) res = SA.materializeDefault(app.db, SR, { start: todayStart, laborRates: LR, blank: false });
     console.log('§GANTT_PREMATERIALIZE ' + (res.ok
       ? 'native schedule written BEFORE first injectGantt (zones=' + (res.zoneCount != null ? res.zoneCount : 'n/a') + ') — single-pass cold open'
@@ -6763,7 +6764,8 @@
     // the ruler to shift the whole project to a different start, same as any other edit.
     var todayStart = new Date().toISOString().slice(0, 10);
     var SR = window.SEQUENCE_RULES || {}, LR = window.LABOR_RATES || {}, RT = window.RATES || {};
-    var res = SA.materializeZones(app.db, SR, { start: todayStart, laborRates: LR, rates: RT, scheduleGate: window.ScheduleGate });
+    var _shiftHoursGantt = (window.SHIFT_HOURS > 0) ? window.SHIFT_HOURS : 24; // §GANTT_SHIFT_HOURS_DESYNC — match injectGantt's real clock
+    var res = SA.materializeZones(app.db, SR, { start: todayStart, laborRates: LR, rates: RT, scheduleGate: window.ScheduleGate, shiftHours: _shiftHoursGantt });
     if (!res.ok) {
       console.log('§GANTT_AUTHOR_ENTRY_ZONE_FALLBACK reason=' + (res.reason || 'unknown'));
       res = SA.materializeDefault ? SA.materializeDefault(app.db, SR, { start: todayStart, laborRates: LR, blank: false }) : { ok: false };


### PR DESCRIPTION
## Summary
- `materializeZones()` (schedule_author.js) called `computeSchedule()` without `shiftHours`, silently taking the internal 8h/day default while the real canvas movie (`time_machine.js` `injectGantt`) already runs at `rates.js SHIFT_HOURS` (24h). Gantt bars were authored ~3x slower than canvas actually plays, so elements visibly appear on the 3D canvas before their own Gantt bar shows them starting.
- Fix threads `shiftHours` through: `materializeZones` now forwards `opts.shiftHours` (omitted → unchanged 8h default, so every witness/probe that never passes it stays byte-identical); the two real UI entry points (`_materializeNativeSchedule`, `generateGanttSchedule`) now pass `window.SHIFT_HOURS` (default 24), matching `injectGantt`'s own established convention.

## Measured
Hospital_extracted.db, same data, before/after: old call (8h default) spans 88 days (Jan1–Mar31); fixed call (24h) spans 30 days (Jan1–Jan31) — 2.93x, matching the 24h/8h ratio exactly.

## Test plan
- [x] `node -c` syntax check both files
- [x] `witness_zone_cpm.js` 11/0
- [x] `witness_zone_cpm_duplex.js` (schema-unrelated pre-existing scratch-path error, not touched by this change)
- [x] `witness_gantt_bar_identity.js` 6/0
- [x] `witness_boq_charts_real_schedule.js` 91/0
- [x] `witness_geo_support_leak.js` 0 fail
- [x] `witness_gantt_edit_constraints.js` 18/0
- [x] Direct measurement proving the fix closes the ~3x gap (see Measured above)

Named/tracked in bim-compiler `prompts/4D_SCHEDULE_PERFECTION.md` §GANTT_SHIFT_HOURS_DESYNC.

🤖 Generated with [Claude Code](https://claude.com/claude-code)