### PR TITLE
fix(night): reduce NIGHT_LIGHT_INTENSITY 2.5->2.0 (-20%)

### DIFF
--- a/viewer/tools.js
+++ b/viewer/tools.js
@@ -948,7 +948,7 @@ function setupTools(A) {
     return NIGHT_AMBER;
   };
   var NIGHT_LIGHT_RANGE = 0; // §S277d: 0 = infinite range — no artificial cutoff, inverse-square does the physics (restores overhang/doorway/corridor spillover when outside)
-  var NIGHT_LIGHT_INTENSITY = 2.5; // §S277d, reduced 8.0->6.5->4.5->2.5 2026-08-08 (user: still too bright to make out individual PLs)
+  var NIGHT_LIGHT_INTENSITY = 2.0; // §S277d, reduced 8.0->6.5->4.5->2.5 2026-08-08, ->2.0 2026-08-14 (user: -20%, indoor MEP-reveal bake still reads too bright)
   // §NIGHT_LIGHT_NEARFIELD (2026-08-13, user: "bright lighting up surrounding when afar, but when
   // near not evident"). Confirmed against three.module.min.js's own shader (not guessed):
   // `getDistanceAttenuation` = 1 / max(pow(lightDistance, decayExponent), 0.01) — no lower


### PR DESCRIPTION
## Summary
- User: indoor MEP-reveal bake still reads too bright/washed-out at night, even after the 8.0->6.5->4.5->2.5 taper on 2026-08-08. Cuts another 20%.

## Test plan
- [x] `node -c viewer/tools.js` syntax check
- [x] Live verification (playwright, real GL, `--use-angle=gl`): loaded Hospital, called `A.toggleNightMode()`, read real `THREE.PointLight` objects — `A._nightLights[*].intensity` caps at exactly 2.0 (30 lights, all sampled at 2.0)