### PR TITLE
fix(4d): Gantt schedule now self-heals like canvas (§GANTT_SCHEDULE_STALE)

### DIFF
--- a/viewer/schedule_author.js
+++ b/viewer/schedule_author.js
@@ -202,6 +202,19 @@
     return out;
   }
 
+  // §GANTT_SCHEDULE_STALE (4D_SCHEDULE_PERFECTION.md §GANTT_SHIFT_HOURS_DESYNC follow-up): the
+  // authored `schedules` table had NO staleness signal at all, unlike kernel_ops (canvas), which
+  // self-heals via _genVersion/_GANTT_CACHE_VERSION. Once a Gantt schedule was materialized it was
+  // NEVER re-derived, however much the underlying scheduling code (computeSchedule's gates, the
+  // display remap) changed since — a building's Gantt panel could be showing a schedule authored
+  // weeks ago under different code while canvas plays fresh, current placements. gen_version closes
+  // that gap the same way _GANTT_CACHE_VERSION already does for kernel_ops. Safe no-op if present.
+  function _ensureSchedulesGenVersion(db) {
+    db.run('CREATE TABLE IF NOT EXISTS schedules (schedule_id TEXT PRIMARY KEY, name TEXT, status TEXT, created_date TEXT)');
+    if (_cols(db, 'schedules').indexOf('gen_version') >= 0) return;
+    try { db.run('ALTER TABLE schedules ADD COLUMN gen_version INTEGER'); } catch (e) {}
+  }
+
   // Some shipped building DBs carry a LEGACY-thin `tasks` table
   // (task_id, schedule_id, name, start_date, finish_date, duration_days, status) that the read-path
   // `_cap` cannot consume (its query selects schedule_start/is_summary → errors → generative
@@ -360,7 +373,7 @@
     var rolled = SG.deriveZones(elements, schedule);
     if (!rolled.zones.length) { console.log('§AUTHOR_ZONES_FAIL reason=no_zones'); return { ok: false, reason: 'no_zones' }; }
 
-    db.run('CREATE TABLE IF NOT EXISTS schedules (schedule_id TEXT PRIMARY KEY, name TEXT, status TEXT, created_date TEXT)');
+    _ensureSchedulesGenVersion(db);
     _ensureWideTasks(db);
     db.run('CREATE TABLE IF NOT EXISTS task_elements (task_id TEXT, guid TEXT, PRIMARY KEY (task_id, guid))');
     db.run('CREATE TABLE IF NOT EXISTS task_sequences (predecessor_id TEXT, successor_id TEXT, sequence_type TEXT, lag_days REAL DEFAULT 0, PRIMARY KEY (predecessor_id, successor_id))');
@@ -370,7 +383,7 @@
     db.run('DELETE FROM task_sequences WHERE predecessor_id IN (SELECT task_id FROM tasks WHERE schedule_id=?) OR successor_id IN (SELECT task_id FROM tasks WHERE schedule_id=?)', [schedId, schedId]);
     db.run('DELETE FROM tasks WHERE schedule_id=?', [schedId]);
     db.run('DELETE FROM schedules WHERE schedule_id=?', [schedId]);
-    db.run('INSERT INTO schedules VALUES (?,?,?,?)', [schedId, 'Authored Schedule (zone detail)', 'PLANNED', start]);
+    db.run('INSERT INTO schedules VALUES (?,?,?,?,?)', [schedId, 'Authored Schedule (zone detail)', 'PLANNED', start, opts.genVersion != null ? opts.genVersion : null]);
 
     var rootId = 'TASK_ROOT';
     var minStart = Math.min.apply(null, rolled.zones.map(function (z) { return z.start; }));
@@ -444,7 +457,7 @@
     var qsRates = opts.rates || (global.RATES) || {};
 
     // Ensure the IFC-native 4D tables exist (mirror import_db_builder.js DDL exactly).
-    db.run('CREATE TABLE IF NOT EXISTS schedules (schedule_id TEXT PRIMARY KEY, name TEXT, status TEXT, created_date TEXT)');
+    _ensureSchedulesGenVersion(db);
     _ensureWideTasks(db);   // migrate any legacy-thin tasks table → the widened DDL `_cap` reads
     db.run('CREATE TABLE IF NOT EXISTS task_elements (task_id TEXT, guid TEXT, PRIMARY KEY (task_id, guid))');
     var _frag = _classFragmentation(db, qsRates);
@@ -555,7 +568,7 @@
         ' (overlaps ' + Math.max(0, p.widthDays - p.lagDays) + 'd of the PREVIOUS phase\'s tail)');
     });
 
-    db.run('INSERT INTO schedules VALUES (?,?,?,?)', [schedId, 'Authored Schedule', 'PLANNED', start]);
+    db.run('INSERT INTO schedules VALUES (?,?,?,?,?)', [schedId, 'Authored Schedule', 'PLANNED', start, opts.genVersion != null ? opts.genVersion : null]);
 
     // ROOT summary task (is_summary=1 → excluded from _cap leaf window; spans the whole project).
     // In blank mode dates are NULL (the user originates them via scheduleDefault/the wizard).
@@ -624,13 +637,25 @@
     return { ok: true, guid: guid, taskId: taskId };
   }
 
-  // activeSchedule(db) — detect the schedule the wizard should EDIT. A model dropped from Bonsai/Revit
-  // arrives WITH a native IFC schedule (import_worker captures IfcWorkSchedule/IfcTask into these same
-  // tables, keyed by IFC GlobalId — NOT 'SCH_AUTHORED'). So the wizard must recognize an imported
-  // (captured) schedule and edit IT, never rule-generate a competing one (_cap reads ALL schedule_ids
-  // → two schedules = a doubled timeline). Priority: the user's own SCH_AUTHORED draft, else the
-  // imported schedule. Returns {id, name, taskCount, authored, captured} or null when no dated schedule.
-  function activeSchedule(db) {
+  // activeSchedule(db, opts) — detect the schedule the wizard should EDIT. A model dropped from
+  // Bonsai/Revit arrives WITH a native IFC schedule (import_worker captures IfcWorkSchedule/IfcTask
+  // into these same tables, keyed by IFC GlobalId — NOT 'SCH_AUTHORED'). So the wizard must recognize
+  // an imported (captured) schedule and edit IT, never rule-generate a competing one (_cap reads ALL
+  // schedule_ids → two schedules = a doubled timeline). Priority: the user's own SCH_AUTHORED draft,
+  // else the imported schedule. Returns {id, name, taskCount, authored, captured, stale, hasBaseline,
+  // safeToRegen} or null when no dated schedule.
+  //
+  // §GANTT_SCHEDULE_STALE — opts.currentGenVersion (optional): when passed, flags whether a
+  // non-captured schedule was materialized under an older scheduling-code version than the caller's
+  // current one (gen_version missing entirely counts as stale — it predates this tracking, which
+  // itself means real fixes since have never reached it). A captured (imported) schedule is NEVER
+  // flagged stale — it must not be auto-touched, full stop, same rule this function already enforced
+  // via `captured`. safeToRegen additionally requires no baseline (`task_baseline`) has been set for
+  // it — once the user has committed to a schedule as their real plan (⚑ Set Baseline), it is their
+  // edited product and must not be silently discarded merely because the code moved on. Callers that
+  // omit opts.currentGenVersion get stale=false/safeToRegen=false always — fully backward compatible.
+  function activeSchedule(db, opts) {
+    opts = opts || {};
     var r;
     try {
       r = db.exec("SELECT schedule_id, COUNT(*) AS n FROM tasks " +
@@ -642,18 +667,37 @@
       return { id: row[0], taskCount: row[1], authored: row[0] === 'SCH_AUTHORED' };
     });
     try {
-      var nr = db.exec("SELECT schedule_id, name FROM schedules");
+      var nr = db.exec("SELECT schedule_id, name, gen_version FROM schedules");
       if (nr.length && nr[0].values.length) {
-        var nm = {}; nr[0].values.forEach(function (x) { nm[x[0]] = x[1]; });
-        list.forEach(function (s) { s.name = nm[s.id] || s.id; });
+        var nm = {}, gv = {};
+        nr[0].values.forEach(function (x) { nm[x[0]] = x[1]; gv[x[0]] = x[2]; });
+        list.forEach(function (s) { s.name = nm[s.id] || s.id; s.genVersion = gv[s.id] != null ? gv[s.id] : null; });
       }
-    } catch (e) {}
+    } catch (e) {
+      // Pre-§GANTT_SCHEDULE_STALE building: schedules table predates the gen_version column.
+      list.forEach(function (s) { s.genVersion = null; });
+    }
     list.forEach(function (s) { if (!s.name) s.name = s.id; });
     var authored = list.filter(function (s) { return s.authored; })[0];
     var pick = authored || list[0];
     pick.captured = !pick.authored;
+    if (!pick.captured && opts.currentGenVersion != null) {
+      pick.stale = (pick.genVersion == null) || (pick.genVersion < opts.currentGenVersion);
+    } else {
+      pick.stale = false;
+    }
+    pick.hasBaseline = false;
+    if (pick.stale) {
+      try {
+        var br = db.exec('SELECT COUNT(*) AS n FROM task_baseline WHERE schedule_id=?', [pick.id]);
+        pick.hasBaseline = !!(br.length && br[0].values.length && br[0].values[0][0] > 0);
+      } catch (e) {}
+    }
+    pick.safeToRegen = pick.stale && !pick.hasBaseline;
     console.log('§AUTHOR_DETECT schedules=' + list.length + ' active=' + pick.id +
-      ' captured=' + pick.captured + ' tasks=' + pick.taskCount);
+      ' captured=' + pick.captured + ' tasks=' + pick.taskCount +
+      (opts.currentGenVersion != null ? ' genVersion=' + pick.genVersion + ' current=' + opts.currentGenVersion +
+        ' stale=' + pick.stale + ' hasBaseline=' + pick.hasBaseline + ' safeToRegen=' + pick.safeToRegen : ''));
     return pick;
   }
 

--- a/viewer/sw.js
+++ b/viewer/sw.js
@@ -8,7 +8,18 @@
 // Cache-first for heavy assets (.wasm, images). DB files skip SW (IndexedDB handles them).
 //
 // DEPLOY: bump CACHE_VERSION on every OCI upload. Old caches are purged on activate.
-const CACHE_VERSION = 'v1027';   // bump on each deploy; per-change detail is the git commit message.
+const CACHE_VERSION = 'v1028';   // bump on each deploy; per-change detail is the git commit message.
+// v1028 (2026-08-14) §GANTT_SCHEDULE_STALE: the authored Gantt (schedules/tasks/task_elements) had
+// NO staleness signal at all, unlike kernel_ops (canvas), which self-heals via _genVersion/
+// _GANTT_CACHE_VERSION. Once materialized, a building's Gantt panel was frozen forever — never
+// re-derived however much the scheduling code (gates, display remap, §GANTT_SHIFT_HOURS_DESYNC
+// itself) changed since, while canvas kept rendering fresh placements. schedules.gen_version now
+// mirrors that same self-heal: a non-captured (synthetic SCH_AUTHORED), non-baselined schedule
+// materialized under an older gen_version is re-materialized in place the next time the Gantt
+// drawer builds its task index (buildTaskIndex, time_machine.js). Captured (imported) schedules and
+// anything with a baseline set are NEVER touched — verified with 6 direct cases (fresh/unstamped/
+// stale/baselined/re-stamped/captured), all match spec exactly. See
+// prompts/4D_SCHEDULE_PERFECTION.md §GANTT_SCHEDULE_STALE.
 // v1027 (2026-08-14) §GANTT_SHIFT_HOURS_DESYNC: schedule_author.js materializeZones() was calling
 // computeSchedule() without shiftHours, silently taking the internal 8h/day default while the real
 // canvas movie (time_machine.js injectGantt) runs at rates.js SHIFT_HOURS (24h) — Gantt bars authored

--- a/viewer/time_machine.js
+++ b/viewer/time_machine.js
@@ -5600,14 +5600,36 @@
     _taskIndexFor = key;
     _taskIndex = { ok: false, guidTask: {}, tasks: {}, scheduleId: null, n: 0 };
     if (!app || !app.db) return null;
-    var db = app.db, sched = null;
+    var db = app.db, sched = null, SA = null;
     try {
-      var SA = (typeof window !== 'undefined') && window.ScheduleAuthor;
-      if (SA && SA.activeSchedule) sched = SA.activeSchedule(db);
+      SA = (typeof window !== 'undefined') && window.ScheduleAuthor;
+      if (SA && SA.activeSchedule) sched = SA.activeSchedule(db, { currentGenVersion: _GANTT_CACHE_VERSION });
     } catch (e) { sched = null; }
     if (!sched || !sched.id) {
       console.log('§GANTT_BAR_IDENTITY schedule=none bars stay non-editable (no authored schedule)');
       return null;
+    }
+    // §GANTT_SCHEDULE_STALE (4D_SCHEDULE_PERFECTION.md §GANTT_SHIFT_HOURS_DESYNC follow-up): the
+    // authored Gantt had no equivalent of kernel_ops's _genVersion self-heal — once materialized it
+    // was frozen forever regardless of how much the scheduling code changed since. Re-materialize in
+    // place, same real UI opts shape as _materializeNativeSchedule/generateGanttSchedule, BEFORE the
+    // task index is built from it. sched.safeToRegen already excludes captured (imported) schedules
+    // and anything with a baseline set (the user's committed, edited product) — see activeSchedule's
+    // own header for the exact contract.
+    if (sched.safeToRegen && SA.materializeZones) {
+      console.log('§GANTT_SCHEDULE_STALE_REGEN id=' + sched.id + ' genVersion=' + sched.genVersion +
+        ' current=' + _GANTT_CACHE_VERSION + ' — re-materializing in place');
+      try {
+        var _SR = window.SEQUENCE_RULES || {}, _LR = window.LABOR_RATES || {}, _RT = window.RATES || {};
+        var _shGantt = (window.SHIFT_HOURS > 0) ? window.SHIFT_HOURS : 24;
+        var rres = SA.materializeZones(db, _SR, { start: '2026-01-01', laborRates: _LR, rates: _RT,
+          scheduleGate: window.ScheduleGate, shiftHours: _shGantt, genVersion: _GANTT_CACHE_VERSION });
+        if ((!rres || !rres.ok) && SA.materializeDefault) {
+          rres = SA.materializeDefault(db, _SR, { start: '2026-01-01', laborRates: _LR, blank: false,
+            genVersion: _GANTT_CACHE_VERSION });
+        }
+        console.log('§GANTT_SCHEDULE_STALE_REGEN_RESULT ok=' + !!(rres && rres.ok));
+      } catch (e) { console.log('§GANTT_SCHEDULE_STALE_REGEN_FAIL ' + e.message); }
     }
     try {
       var tr = db.exec('SELECT task_id, name, schedule_start, schedule_finish FROM tasks ' +
@@ -6725,8 +6747,8 @@
     var todayStart = new Date().toISOString().slice(0, 10);
     var SR = window.SEQUENCE_RULES || {}, LR = window.LABOR_RATES || {}, RT = window.RATES || {};
     var _shiftHoursGantt = (window.SHIFT_HOURS > 0) ? window.SHIFT_HOURS : 24; // §GANTT_SHIFT_HOURS_DESYNC — match injectGantt's real clock
-    var res = SA.materializeZones(app.db, SR, { start: todayStart, laborRates: LR, rates: RT, scheduleGate: window.ScheduleGate, shiftHours: _shiftHoursGantt });
-    if (!res.ok && SA.materializeDefault) res = SA.materializeDefault(app.db, SR, { start: todayStart, laborRates: LR, blank: false });
+    var res = SA.materializeZones(app.db, SR, { start: todayStart, laborRates: LR, rates: RT, scheduleGate: window.ScheduleGate, shiftHours: _shiftHoursGantt, genVersion: _GANTT_CACHE_VERSION });
+    if (!res.ok && SA.materializeDefault) res = SA.materializeDefault(app.db, SR, { start: todayStart, laborRates: LR, blank: false, genVersion: _GANTT_CACHE_VERSION });
     console.log('§GANTT_PREMATERIALIZE ' + (res.ok
       ? 'native schedule written BEFORE first injectGantt (zones=' + (res.zoneCount != null ? res.zoneCount : 'n/a') + ') — single-pass cold open'
       : 'failed reason=' + (res.reason || 'unknown') + ' — legacy auto-generate fallback will handle it'));
@@ -6765,10 +6787,10 @@
     var todayStart = new Date().toISOString().slice(0, 10);
     var SR = window.SEQUENCE_RULES || {}, LR = window.LABOR_RATES || {}, RT = window.RATES || {};
     var _shiftHoursGantt = (window.SHIFT_HOURS > 0) ? window.SHIFT_HOURS : 24; // §GANTT_SHIFT_HOURS_DESYNC — match injectGantt's real clock
-    var res = SA.materializeZones(app.db, SR, { start: todayStart, laborRates: LR, rates: RT, scheduleGate: window.ScheduleGate, shiftHours: _shiftHoursGantt });
+    var res = SA.materializeZones(app.db, SR, { start: todayStart, laborRates: LR, rates: RT, scheduleGate: window.ScheduleGate, shiftHours: _shiftHoursGantt, genVersion: _GANTT_CACHE_VERSION });
     if (!res.ok) {
       console.log('§GANTT_AUTHOR_ENTRY_ZONE_FALLBACK reason=' + (res.reason || 'unknown'));
-      res = SA.materializeDefault ? SA.materializeDefault(app.db, SR, { start: todayStart, laborRates: LR, blank: false }) : { ok: false };
+      res = SA.materializeDefault ? SA.materializeDefault(app.db, SR, { start: todayStart, laborRates: LR, blank: false, genVersion: _GANTT_CACHE_VERSION }) : { ok: false };
     }
     if (!res.ok) {
       console.log('§GANTT_AUTHOR_ENTRY_FAIL reason=' + (res.reason || 'materialize_failed'));


### PR DESCRIPTION
## Summary
- `kernel_ops` (canvas) self-heals whenever the scheduling code changes, via `_genVersion`/`_GANTT_CACHE_VERSION`. The authored Gantt (`schedules`/`tasks`/`task_elements`) had no equivalent — `activeSchedule()` just checked "does a dated schedule exist" and served it forever, regardless of how many gate/remap fixes (including the just-shipped #1355 §GANTT_SHIFT_HOURS_DESYNC) landed since. A building's Gantt panel could show a schedule authored under old code while canvas renders current placements — no reason for the needle position and canvas to agree.
- Fix: `schedules.gen_version` stamps the scheduling-code version at materialize time (reuses `_GANTT_CACHE_VERSION`, threaded from `time_machine.js`). `activeSchedule(db, opts)` now reports `stale`/`hasBaseline`/`safeToRegen`. `buildTaskIndex()` — the Gantt drawer's one real choke point — re-materializes in place when `safeToRegen` is true, before the task index is built.

## Safety
Verified with 6 direct cases against real Hospital data:
- No opts passed → `stale=false` always (fully backward compatible).
- Unstamped/older schedule → `stale=true`, `safeToRegen=true` (no baseline).
- Same schedule after ⚑ Set Baseline → `hasBaseline=true`, `safeToRegen=false`. A user-committed schedule is never silently discarded.
- Re-stamped at current version → `stale=false` at that version.
- Captured (imported, Bonsai/Revit) schedule → `stale=false` regardless of version gap. Never touched.

**Known residual limit, documented not hidden:** a user who dragged/resized/linked bars without ever setting a baseline has no persisted "edited" signal this can see — such edits could still be regenerated on a stale check. Named as a follow-on (a proper per-edit dirty flag), not blocking this fix.

## Test plan
- [x] `node -c` both files
- [x] `witness_zone_cpm.js` 11/0
- [x] `witness_gantt_bar_identity.js` 6/0
- [x] `witness_boq_charts_real_schedule.js` 91/0
- [x] `witness_geo_support_leak.js` 0 fail
- [x] `witness_gantt_edit_constraints.js` 18/0
- [x] 6 direct staleness/safety cases against real Hospital data (see Safety above)
- [x] sw.js CACHE_VERSION bumped in the same commit (learned from the orphaned-bump landmine on #1355/#1357)

Named in bim-compiler `prompts/4D_SCHEDULE_PERFECTION.md` §GANTT_SCHEDULE_STALE.

🤖 Generated with [Claude Code](https://claude.com/claude-code)