### PR TITLE
fix(scene): dispose orphaned PMREM env-map render targets (GPU leak) + BVH on clearStreamed

### DIFF
--- a/viewer/scene.js
+++ b/viewer/scene.js
@@ -196,6 +196,22 @@ async function setupScene(A) {
   _pmrem.compileCubemapShader();
   var _sky = null;
   var _sunVec = new THREE.Vector3();
+  // §MEMLEAK_PMREM_DISPOSE (2026-08-14): _pmrem.fromScene() allocates a brand-new
+  // WebGLRenderTarget (backing texture + framebuffer) on every call — it is NOT reused/pooled
+  // internally by THREE.PMREMGenerator, and three.js never garbage-collects WebGL resources on
+  // its own. Every prior caller here did `A._envMap = envRT.texture` with no reference kept to
+  // `envRT` itself, so the old render target was silently orphaned on the GPU every time. Measured
+  // via renderer.info.memory.textures in a live headless run (8 calls to A.updateSky(), 2s throttle
+  // apart): texture count climbed 2->10, i.e. +1 leaked GPU texture per call, unbounded — see
+  // prompts/VIEWER_MEMORY_LEAK.md in bim-compiler for the full before/after numbers. Track the
+  // current render target here (not just its .texture) so every future regen can dispose the
+  // previous one first.
+  var _envRT = null;
+  function _setEnvMap(newRT) {
+    if (_envRT && _envRT !== newRT) _envRT.dispose();
+    _envRT = newRT;
+    A._envMap = newRT ? newRT.texture : null;
+  }
   try {
     var _skyMod = await import('./lib/Sky.js');
     if (!_skyMod.Sky) throw new Error('Sky class not exported');
@@ -266,8 +282,7 @@ async function setupScene(A) {
           // alternating bright/dark movie. Every OTHER updateSky() caller (plain nav, Time Machine)
           // is unaffected — this flag is only ever true during a staged photoshoot.
           if (!A._envMapHdriActive) {
-            var envRT = _pmrem.fromScene(_sky);
-            A._envMap = envRT.texture;
+            _setEnvMap(_pmrem.fromScene(_sky));
           } else {
             console.log('§ENVMAP_STOMP_GUARD skipped procedural regen — HDRI active');
           }
@@ -290,8 +305,7 @@ async function setupScene(A) {
   // Also generate initial env map synchronously
   try {
     if (_sky) {
-      var _initRT = _pmrem.fromScene(_sky);
-      A._envMap = _initRT.texture;
+      _setEnvMap(_pmrem.fromScene(_sky));
       // §S276b: Don't set scene.environment — it overrides ground material.
       // Building materials get envMap via streaming.js _getMaterial().
       console.log('§ENV_MAP Sky-based atmospheric env map ready (per-material, not scene.environment)');
@@ -311,8 +325,7 @@ async function setupScene(A) {
       envGeo.setAttribute('color', new THREE.BufferAttribute(colors, 3));
       envScene2.add(new THREE.Mesh(envGeo, new THREE.MeshBasicMaterial({ vertexColors: true, side: THREE.BackSide })));
       envScene2.add(new THREE.AmbientLight(0xffffff, 1));
-      var envRT2 = _pmrem.fromScene(envScene2, 0.04);
-      A._envMap = envRT2.texture;
+      _setEnvMap(_pmrem.fromScene(envScene2, 0.04));
       envGeo.dispose();
       console.log('§ENV_MAP vertex-color gradient fallback applied');
     }

--- a/viewer/streaming.js
+++ b/viewer/streaming.js
@@ -2457,12 +2457,17 @@ function setupStreaming(A) {
     const toRemove = A.collectMeshes(o => o.isMesh || o.isInstancedMesh || o.isBatchedMesh);
     toRemove.forEach(obj => {
       A.scene.remove(obj);
+      // §MEMLEAK_BVH_DISPOSE: three-mesh-bvh's `geometry.boundsTree` is a monkey-patched
+      // property (loader.js) sitting outside BufferGeometry's own 'dispose' event chain —
+      // plain geometry.dispose() does NOT free it. Must call disposeBoundsTree() first.
+      if (obj.geometry && obj.geometry.boundsTree && obj.geometry.disposeBoundsTree) obj.geometry.disposeBoundsTree();
       if (obj.geometry) obj.geometry.dispose();
       if (obj.material) obj.material.dispose();
     });
     // Dispose cached geometry BLOBs — these are the raw BufferGeometry objects
     // that back all scene meshes. Safe to dispose now that meshes are removed.
     for (const geo of Object.values(A.meshCache)) {
+      if (geo && geo.boundsTree && geo.disposeBoundsTree) geo.disposeBoundsTree();
       if (geo && geo.dispose) geo.dispose();
     }
     A.meshCache = {};


### PR DESCRIPTION
## Summary
- **Real, measured GPU-resource leak fixed**: `scene.js`'s `A.updateSky()` regenerates the sky-driven env map via `THREE.PMREMGenerator.fromScene()` every ~2s while active (throttled), but only ever kept `A._envMap = envRT.texture` — the render target itself (`envRT`) was never disposed before being replaced. Measured via `renderer.info.memory.textures` in a headless run: 8 calls to `A.updateSky()` (2s throttle apart) → texture count climbed **2 → 10** (+1 leaked GPU texture per call, unbounded). This path fires every frame the sun moves during a CPE cinema bake (`effects.js` `_sunArcStep`), so a bake or repeated day/night cycling leaks continuously.
- Fix: track the current render target in a closure var and `dispose()` the previous one before every reassignment, at all 3 `fromScene()` call sites. Re-measured same loop post-fix: **textures flat at 2, delta=0**.
- Defensive correctness fix: `A.clearStreamed()` disposed cached geometries via `geometry.dispose()` without first calling `geometry.disposeBoundsTree()` (three-mesh-bvh's `boundsTree` sits outside `BufferGeometry`'s own dispose chain). Added the missing call at both disposal sites. Verified at production scale (HHS_Office_Federated, 3269 BVH-bearing geometries) — all correctly zero out post-clear, `rendererGeometries` 364→11, no errors.
- Investigated but **not changed**: `A._matCache`'s widened cache key (PR #1356) does not leak — cache-hit dedup prevents re-creation on revisit, and the existing `clearStreamed()` dispose loop correctly frees every entry when it runs (measured `matCache` 26→0, `meshCache` 3269→0 on HHS_Office). Growth during multi-building navigation is bounded by the dataset, unlike the PMREM leak above.

Full before/after numbers and method: `prompts/VIEWER_MEMORY_LEAK.md` (bim-compiler repo, sibling repo to this one).

## Test plan
- [x] `node --check viewer/scene.js` / `viewer/streaming.js` — both pass
- [x] Headless Chromium (Playwright + CDP), `renderer.info.memory` before/after 8x `A.updateSky()` loop — texture leak confirmed pre-fix (2→10), confirmed gone post-fix (2→2)
- [x] Real building load (HHS_Office_Federated, 63K+ elements) + `A.clearStreamed()` — matCache/meshCache/BVH counts all zero out correctly, no console errors
- [x] Small building (warehouse_gardenworld) smoke test — same disposal behavior confirmed

🤖 Generated with [Claude Code](https://claude.com/claude-code)