### PR TITLE
fix(viewer): Hospital beam/railing envMapIntensity — real sky was dominating real colour

### DIFF
--- a/viewer/streaming.js
+++ b/viewer/streaming.js
@@ -372,9 +372,19 @@ function setupStreaming(A) {
       IfcWallStandardCase:    { r: 0.92, g: 0.91, b: 0.88, rough: 0.75, metal: 0.00 },  // painted plaster
       IfcSlab:                { r: 0.72, g: 0.70, b: 0.68, rough: 0.90, metal: 0.00 },  // cast concrete
       IfcColumn:              { r: 0.65, g: 0.64, b: 0.62, rough: 0.80, metal: 0.05 },  // reinforced concrete
-      IfcBeam:                { r: 0.55, g: 0.57, b: 0.60, rough: 0.35, metal: 0.65 },  // steel I-beam
-      IfcMember:              { r: 0.50, g: 0.52, b: 0.55, rough: 0.40, metal: 0.60 },  // steel section
-      IfcPlate:               { r: 0.48, g: 0.50, b: 0.53, rough: 0.30, metal: 0.70 },  // steel plate
+      // §HOSPITAL_BLUE_TINT (2026-08-14 session 2, CINEMA_DISCIPLINE_REVEAL.md): these 3 + IfcRailing
+      // below are the 4 highest `metal` values in this whole table — envInt overrides the global
+      // envMapIntensity=0.6 (streaming.js _getMaterial, below) down to 0.18 for JUST these 4 classes.
+      // Measured+analytically confirmed root cause: the sky's own PMREM-reflected colour is strongly,
+      // legitimately blue (A.updateSky(45,180) + Sky.js's configured rayleigh=2/turbidity=4 — computed
+      // directly from that formula, zenith sat=0.767; live-rendered probe at these classes' own
+      // roughness/reflection angle: sat=0.141), and these classes' unusually high metalness (0.55-0.70,
+      // vs 0.35-0.50 for every other reflective MEP/steel class in this table) lets that real sky
+      // colour dominate the final hue over the REAL, correctly-trusted IFC albedo underneath (never
+      // touched here — only the reflection strength is dialled back for these classes).
+      IfcBeam:                { r: 0.55, g: 0.57, b: 0.60, rough: 0.35, metal: 0.65, envInt: 0.18 },  // steel I-beam
+      IfcMember:              { r: 0.50, g: 0.52, b: 0.55, rough: 0.40, metal: 0.60, envInt: 0.18 },  // steel section
+      IfcPlate:               { r: 0.48, g: 0.50, b: 0.53, rough: 0.30, metal: 0.70, envInt: 0.18 },  // steel plate
       IfcFooting:             { r: 0.60, g: 0.58, b: 0.56, rough: 0.95, metal: 0.00 },  // foundation
       IfcPile:                { r: 0.58, g: 0.56, b: 0.54, rough: 0.95, metal: 0.00 },  // deep foundation
       // ── Envelope ──
@@ -386,7 +396,7 @@ function setupStreaming(A) {
       IfcWindow:              { r: 0.70, g: 0.82, b: 0.88, rough: 0.05, metal: 0.00 },  // glass
       // ── Circulation ──
       IfcStair:               { r: 0.68, g: 0.66, b: 0.63, rough: 0.80, metal: 0.00 },  // concrete/stone
-      IfcRailing:             { r: 0.50, g: 0.49, b: 0.47, rough: 0.35, metal: 0.55 },  // brushed-steel warm grey (was blue-leaning, §Findings 2026-08-14 stair "boring blue" cause)
+      IfcRailing:             { r: 0.50, g: 0.49, b: 0.47, rough: 0.35, metal: 0.55, envInt: 0.18 },  // brushed-steel warm grey (was blue-leaning, §Findings 2026-08-14 stair "boring blue" cause). §HOSPITAL_BLUE_TINT envInt: metal alone measured NOT to move this class's blue hue (near-achromatic base — F0=0.04 dielectric reflectance alone already carried it), envMapIntensity is the lever that actually works here.
       IfcRamp:                { r: 0.70, g: 0.68, b: 0.65, rough: 0.85, metal: 0.00 },  // concrete ramp
       // ── Furniture/fittings ──
       IfcFurniture:           { r: 0.65, g: 0.48, b: 0.32, rough: 0.60, metal: 0.00 },  // wood/fabric
@@ -544,7 +554,11 @@ function setupStreaming(A) {
     opts.roughness = Math.max(0.08, _rough * 0.75);
     opts.metalness = stdMat ? stdMat.metal : 0.08; // §refl: slight metal lift gives surfaces real specular response
     opts.side = THREE.DoubleSide; // §S260d: IFC geometry has inconsistent normals — DoubleSide ensures pick works
-    if (A._envMap) { opts.envMap = A._envMap; opts.envMapIntensity = 0.6; } // §refl: 0.3->0.6 — more realistic reflection emphasis
+    // §refl: 0.3->0.6 — more realistic reflection emphasis (global default).
+    // §HOSPITAL_BLUE_TINT: per-class override (STD_MAT[...].envInt) for the small set of classes
+    // whose unusually high metalness otherwise lets the sky's real, strongly-blue PMREM reflection
+    // dominate the hue over their own correctly-trusted real IFC albedo — see STD_MAT comments above.
+    if (A._envMap) { opts.envMap = A._envMap; opts.envMapIntensity = (stdMat && stdMat.envInt != null) ? stdMat.envInt : 0.6; }
     const mat = new THREE.MeshStandardMaterial(opts);
     // §TRIPLANAR: classes with a real texture set skip the fake-grain perturbation below —
     // the real photo texture takes over that job, stacking both would double-bump the normal


### PR DESCRIPTION
## Summary
- Hospital beams and stair railings read "horribly blue" in a baked Alt+C mp4, despite having REAL, populated IFC `material_rgba` (cream beam, grey railing) — confirmed live, not from a stale DB copy (the OCI-hosted production Hospital DB is actually stale/NULL there; the up-to-date copy was used for measurement).
- Root cause led from the code's own formula tables (per explicit steering this session), not DB row-mining: `STD_MAT`'s `IfcBeam/IfcMember/IfcPlate/IfcRailing` carry the 4 highest `metal` values (0.55-0.70) in the whole table, and a flat global `envMapIntensity=0.6` never discounted them. The sky itself (`A.updateSky(45,180)` + `Sky.js`'s `rayleigh=2`, double the shader's own default) is genuinely, strongly blue — computed directly from the shader's own GLSL formula ported to plain JS, no browser: zenith saturation 0.767 after the real ACES+exposure pipeline.
- Live-render confirmation (real `A._getMaterial`/`A._envMap`/`A.renderer`, offscreen `readRenderTargetPixels`, no screenshots) validated the hypothesis and showed `envMapIntensity`, not `metalness` alone, is the lever that fixes BOTH the bright cream beam and the near-achromatic grey railing.

## Fix
Per-class `envInt` override (0.6→0.18) on 4 `STD_MAT` entries only (`IfcBeam`/`IfcMember`/`IfcPlate`/`IfcRailing`), reusing the existing per-class `metal`/`rough` lookup pattern. No real colour channel touched anywhere — real IFC `material_rgba` passes through exactly as before. Every other class keeps `envMapIntensity=0.6`.

## Measured before/after (live pipeline, offscreen render target readback)
| | before (sat) | after (sat) | Δ |
|---|---|---|---|
| Beam (top-flange-safe / vertical-web angle) | 0.028, hue 248.6° (blue) | 0.009, hue 330° | -68% |
| Railing | 0.032, hue 247.5° (blue) | 0.008, hue 270° (noise-level) | -75% |

Regression-checked PR #1356's MEP-tint fix live on HHS_Office_Federated: still 3390 elements / 7 distinct trade colours, bit-identical — different STD_MAT entries, untouched code path.

Full investigation write-up (formula-table analysis, analytic sky computation, live-render matchback, before/after): `bim-compiler` repo `prompts/CINEMA_DISCIPLINE_REVEAL.md` §Findings 2026-08-14 (session 2).

## Test plan
- [x] `node --check viewer/streaming.js`
- [x] Live-render measurement before fix (7+ ablation configs, real production pipeline)
- [x] Live-render measurement after fix (same methodology) — beam/railing both out of the blue hue band
- [x] Regression witness for PR #1356's MEP-tint fix — unchanged, 7 distinct colours
- [x] `git status --short` clean aside from the one intended file

🤖 Generated with [Claude Code](https://claude.com/claude-code)