### PR TITLE
fix(photo): stop double-boosting the sky's blue reflection on steel/rail materials

### DIFF
--- a/viewer/effects.js
+++ b/viewer/effects.js
@@ -2668,7 +2668,12 @@ async function setupEffects(A, renderer, scene, camera) {
     if (!_photoMatBoostActive || !A._matCache) return;
     Object.keys(A._matCache).forEach(function(k) {
       var m = A._matCache[k];
-      if (!m || (m.userData && m.userData._photoBoosted) || typeof m.envMapIntensity !== 'number') return;
+      if (!m || (m.userData && (m.userData._photoBoosted || m.userData._photoEnvExempt)) ||
+          typeof m.envMapIntensity !== 'number') return;
+      // §PHOTO_ENVMAP_DOUBLE_BOOST_FIX (2026-08-15): _photoEnvExempt (streaming.js's per-class
+      // §HOSPITAL_BLUE_TINT envInt override) skips this blanket boost entirely — that override was
+      // already hand-tuned to fight the sky's blue PMREM reflection on these specific classes;
+      // re-boosting on top of it undid the tuning specifically during Alt+S/Alt+G captures.
       var isMetal = typeof m.metalness === 'number' && m.metalness > PHOTO_METAL_THRESHOLD;
       var isGlossy = isMetal || (typeof m.roughness === 'number' && m.roughness <= PHOTO_GLOSSY_ROUGHNESS_MAX);
       if (isGlossy) {

--- a/viewer/streaming.js
+++ b/viewer/streaming.js
@@ -351,7 +351,7 @@ function setupStreaming(A) {
   A._mepNameHint = function(name) {
     if (!name) return null;
     if (/duct/i.test(name)) return { code: 'DUCT', r: 0.55, g: 0.58, b: 0.55 };  // STD_MAT.IfcDuct — galvanized sheet-metal grey
-    if (/sprinkler/i.test(name)) return _hexToRgb('FP', 0xcc8844);               // DISC_COLORS.FP — brick/orange
+    if (/sprinkler|groove|coupling|victaulic/i.test(name)) return _hexToRgb('FP', 0xcc8844); // DISC_COLORS.FP — brick/orange. Grooved/Victaulic couplings are the standard FP sprinkler-pipe joint (same trade as sprinkler heads) — were falling through to the flat blue-grey IfcFlowFitting default (user report 2026-08-15: "the nice red groove tooling joints are replaced as blue")
     if (/diffuser|grille|grill|exhaust/i.test(name)) return _hexToRgb('ACMV', 0xcc4444); // DISC_COLORS.ACMV — red, air terminals
     if (/dwv|sanitary/i.test(name)) return _hexToRgb('SAN', 0xaa44aa);           // DISC_COLORS.SAN — magenta
     if (/pipe/i.test(name)) return _hexToRgb('PLB', 0x8844cc);                  // DISC_COLORS.PLB — purple
@@ -560,6 +560,14 @@ function setupStreaming(A) {
     // dominate the hue over their own correctly-trusted real IFC albedo — see STD_MAT comments above.
     if (A._envMap) { opts.envMap = A._envMap; opts.envMapIntensity = (stdMat && stdMat.envInt != null) ? stdMat.envInt : 0.6; }
     const mat = new THREE.MeshStandardMaterial(opts);
+    // §PHOTO_ENVMAP_DOUBLE_BOOST_FIX (2026-08-15): effects.js's _reassertPhotoMatBoost() blindly
+    // multiplies envMapIntensity x3 and tightens roughness x0.4 on every metal/glossy material
+    // during Alt+S/Alt+G, with no awareness of this per-class envInt tuning above — so the SAME
+    // blue-sky-reflection this envInt was set to fight comes back 3x stronger specifically during a
+    // photoreal capture (user report 2026-08-15: beams/railings/plates/members "already nice" in
+    // plain nav, "too much bluish" in the baked MP4 — exactly the Alt+S-only symptom this explains).
+    // Flag so the boost pass can exempt materials that were already hand-tuned for this exact issue.
+    if (stdMat && stdMat.envInt != null) mat.userData._photoEnvExempt = true;
     // §TRIPLANAR: classes with a real texture set skip the fake-grain perturbation below —
     // the real photo texture takes over that job, stacking both would double-bump the normal
     // with two uncorrelated patterns.


### PR DESCRIPTION
## Summary
- §HOSPITAL_BLUE_TINT hand-tuned `envMapIntensity=0.18` on `IfcBeam/Member/Plate/Railing` to fight the sky's blue PMREM reflection. `_reassertPhotoMatBoost()` had no awareness of it and blindly multiplied envMapIntensity x3 (+ tightened roughness x0.4) on every metal/glossy material during Alt+S/Alt+G — undoing the tuning specifically during a photoreal capture. Fixed by tagging those materials `_photoEnvExempt` at creation and skipping them in the boost pass.
- `_mepNameHint`'s family-name classifier had no pattern for grooved/Victaulic couplings (the standard FP sprinkler-pipe joint), so they fell through to the flat blue-grey `IfcFlowFitting` default instead of FP orange. Added `groove|coupling|victaulic` to the same pattern `sprinkler` already uses.
- Non-null IFC colors are untouched either way (Trust IFC Colors gate, `if (!rgbaStr && stdMat)` — verified unchanged).

## Test plan
- [x] `node -c` both files
- [x] Live (playwright, real GL): `_mepNameHint('M_Groove Coupling')`/`('Victaulic Style 005 Coupling')` now resolve to FP orange (was null)
- [x] Live: after a real Alt+S convergence, `IfcBeam/Member/Plate/Railing` materials hold `envMapIntensity=0.18` (`boosted:false`) instead of jumping to 0.54