### PR TITLE
chore(sw): bump effects.js/streaming.js version + CACHE_VERSION v1029->v1030

### DIFF
--- a/viewer/sw.js
+++ b/viewer/sw.js
@@ -8,7 +8,13 @@
 // Cache-first for heavy assets (.wasm, images). DB files skip SW (IndexedDB handles them).
 //
 // DEPLOY: bump CACHE_VERSION on every OCI upload. Old caches are purged on activate.
-const CACHE_VERSION = 'v1029';   // bump on each deploy; per-change detail is the git commit message.
+const CACHE_VERSION = 'v1030';   // bump on each deploy; per-change detail is the git commit message.
+// v1030 (2026-08-15) §PIPE_DUCT_BLUE_TINT / §PHOTO_ENVMAP_DOUBLE_BOOST_FIX (bim-ootb PRs #1367,
+// #1369) shipped without a viewer.html script-version bump, so an already-cached browser kept
+// serving pre-fix effects.js/streaming.js under the same ?v= URL — user report "why is this still
+// blue" after both fixes were confirmed merged. Fix is the viewer.html bump (effects.js?v=17->18,
+// streaming.js?v=59->60) in this same commit; CACHE_VERSION bumped alongside per this project's own
+// standing convention (every deploy bumps it) so the offline precache path is refreshed too.
 // v1029 (2026-08-15) §CPE_DISCIPLINE_REVEAL_PULLOUT: the there-and-back retrace round replaced with
 // a pull-out + a single repeated forward lap (effects.js/cinema_maxq.js/cinema_path_editor.js/
 // cpe_room_title.js). New beat boundary plan.beats.pullout; A.cpeRevealCaptionAt (new) swaps the

--- a/viewer/viewer.html
+++ b/viewer/viewer.html
@@ -822,7 +822,7 @@ html.bim-embedded, html.bim-embedded body { background: #0b0b0b; }
 <script src="qrcode.min.js?v=1" onerror="console.warn('§LOAD_FAIL qrcode.min.js — QR sharing disabled')"></script>
 <script src="config.js?v=4" onerror="console.warn('§LOAD_FAIL config.js')"></script>
 <script src="db_resolve.js?v=2" onerror="console.warn('§LOAD_FAIL db_resolve.js')"></script>
-<script src="effects.js?v=17" onerror="console.warn('§LOAD_FAIL effects.js')"></script>
+<script src="effects.js?v=18" onerror="console.warn('§LOAD_FAIL effects.js')"></script>
 <script src="effects_gi_poc.js?v=3" onerror="console.warn('§LOAD_FAIL effects_gi_poc.js')"></script>
 <script src="lib/mp4_mux.js?v=1" onerror="console.warn('§LOAD_FAIL mp4_mux.js — MaxQ falls back to webm')"></script>
 <script src="cinema_path_editor.js?v=14" onerror="console.warn('§LOAD_FAIL cinema_path_editor.js — Alt+C path editing disabled')"></script>
@@ -837,7 +837,7 @@ html.bim-embedded, html.bim-embedded body { background: #0b0b0b; }
 <script src="scene.js?v=55" onerror="console.warn('§LOAD_FAIL scene.js')"></script>
 <script src="panel_nav.js?v=1" onerror="console.warn('§LOAD_FAIL panel_nav.js')"></script>
 <script src="helpers.js?v=6" onerror="console.warn('§LOAD_FAIL helpers.js')"></script>
-<script src="streaming.js?v=59" onerror="console.warn('§LOAD_FAIL streaming.js')"></script>
+<script src="streaming.js?v=60" onerror="console.warn('§LOAD_FAIL streaming.js')"></script>
 <script src="dlod.js?v=8" onerror="console.warn('§LOAD_FAIL dlod.js')"></script>
 <script src="panels.js?v=43" onerror="console.warn('§LOAD_FAIL panels.js')"></script>
 <script src="tools.js?v=39" onerror="console.warn('§LOAD_FAIL tools.js')"></script>


### PR DESCRIPTION
## Summary
- PRs #1367 and #1369 (blue-tint reflection fixes) shipped without bumping viewer.html's script version query strings, so an already-cached browser kept serving pre-fix effects.js?v=17/streaming.js?v=59 under the same URL.
- effects.js?v=17->18, streaming.js?v=59->60, CACHE_VERSION v1029->v1030 (offline precache path too).

## Test plan
- [x] `node -c viewer/sw.js`
- [x] viewer.html script tags confirmed bumped