### PR TITLE
fix(photo): recover the 13 MEP classes a squash-merge race dropped, zero out beam/railing

### DIFF
--- a/viewer/streaming.js
+++ b/viewer/streaming.js
@@ -382,7 +382,7 @@ function setupStreaming(A) {
       // vs 0.35-0.50 for every other reflective MEP/steel class in this table) lets that real sky
       // colour dominate the final hue over the REAL, correctly-trusted IFC albedo underneath (never
       // touched here — only the reflection strength is dialled back for these classes).
-      IfcBeam:                { r: 0.55, g: 0.57, b: 0.60, rough: 0.35, metal: 0.65, envInt: 0.05 },  // steel I-beam
+      IfcBeam:                { r: 0.55, g: 0.57, b: 0.60, rough: 0.35, metal: 0.65, envInt: 0 },  // steel I-beam — zero sky reflection, user 2026-08-15: "get rid of those railings and overhead beams from been recolorized"
       IfcMember:              { r: 0.50, g: 0.52, b: 0.55, rough: 0.40, metal: 0.60, envInt: 0.05 },  // steel section
       IfcPlate:               { r: 0.48, g: 0.50, b: 0.53, rough: 0.30, metal: 0.70, envInt: 0.05 },  // steel plate
       IfcFooting:             { r: 0.60, g: 0.58, b: 0.56, rough: 0.95, metal: 0.00 },  // foundation
@@ -396,7 +396,7 @@ function setupStreaming(A) {
       IfcWindow:              { r: 0.70, g: 0.82, b: 0.88, rough: 0.05, metal: 0.00 },  // glass
       // ── Circulation ──
       IfcStair:               { r: 0.68, g: 0.66, b: 0.63, rough: 0.80, metal: 0.00 },  // concrete/stone
-      IfcRailing:             { r: 0.50, g: 0.49, b: 0.47, rough: 0.35, metal: 0.55, envInt: 0.05 },  // brushed-steel warm grey (was blue-leaning, §Findings 2026-08-14 stair "boring blue" cause). §HOSPITAL_BLUE_TINT envInt: metal alone measured NOT to move this class's blue hue (near-achromatic base — F0=0.04 dielectric reflectance alone already carried it), envMapIntensity is the lever that actually works here.
+      IfcRailing:             { r: 0.50, g: 0.49, b: 0.47, rough: 0.35, metal: 0.55, envInt: 0 },  // brushed-steel warm grey — zero sky reflection, user 2026-08-15: "get rid of those railings and overhead beams from been recolorized"
       IfcRamp:                { r: 0.70, g: 0.68, b: 0.65, rough: 0.85, metal: 0.00 },  // concrete ramp
       // ── Furniture/fittings ──
       IfcFurniture:           { r: 0.65, g: 0.48, b: 0.32, rough: 0.60, metal: 0.00 },  // wood/fabric

--- a/viewer/streaming.js
+++ b/viewer/streaming.js
@@ -421,20 +421,20 @@ function setupStreaming(A) {
       IfcFlowTerminal:        { r: 0.45, g: 0.50, b: 0.55, rough: 0.40, metal: 0.30, envInt: 0.05 },
       IfcFlowSegment:         { r: 0.48, g: 0.52, b: 0.58, rough: 0.40, metal: 0.30, envInt: 0.05 },
       IfcFlowFitting:         { r: 0.50, g: 0.53, b: 0.57, rough: 0.40, metal: 0.30, envInt: 0.05 },
-      IfcFlowController:      { r: 0.80, g: 0.30, b: 0.25, rough: 0.50, metal: 0.20 },  // red valve
-      IfcFlowMovingDevice:    { r: 0.50, g: 0.60, b: 0.55, rough: 0.45, metal: 0.30 },
-      IfcFlowTreatmentDevice: { r: 0.50, g: 0.58, b: 0.55, rough: 0.50, metal: 0.20 },
-      IfcEnergyConversionDevice: { r: 0.45, g: 0.55, b: 0.50, rough: 0.50, metal: 0.25 },
-      IfcLightFixture:        { r: 0.80, g: 0.75, b: 0.50, rough: 0.25, metal: 0.30 },  // brass/chrome
-      IfcSanitaryTerminal:    { r: 0.88, g: 0.88, b: 0.85, rough: 0.15, metal: 0.05 },  // ceramic
-      IfcAirTerminal:         { r: 0.55, g: 0.65, b: 0.70, rough: 0.40, metal: 0.30 },
-      IfcFireSuppressionTerminal: { r: 0.80, g: 0.30, b: 0.25, rough: 0.50, metal: 0.30 }, // red
-      IfcValve:               { r: 0.55, g: 0.50, b: 0.45, rough: 0.40, metal: 0.45 },
-      IfcAlarm:               { r: 0.75, g: 0.25, b: 0.25, rough: 0.50, metal: 0.20 },  // red
-      IfcElectricAppliance:   { r: 0.60, g: 0.65, b: 0.55, rough: 0.50, metal: 0.15 },
+      IfcFlowController:      { r: 0.80, g: 0.30, b: 0.25, rough: 0.50, metal: 0.20 , envInt: 0.05 },  // red valve
+      IfcFlowMovingDevice:    { r: 0.50, g: 0.60, b: 0.55, rough: 0.45, metal: 0.30 , envInt: 0.05 },
+      IfcFlowTreatmentDevice: { r: 0.50, g: 0.58, b: 0.55, rough: 0.50, metal: 0.20 , envInt: 0.05 },
+      IfcEnergyConversionDevice: { r: 0.45, g: 0.55, b: 0.50, rough: 0.50, metal: 0.25 , envInt: 0.05 },
+      IfcLightFixture:        { r: 0.80, g: 0.75, b: 0.50, rough: 0.25, metal: 0.30 , envInt: 0.05 },  // brass/chrome
+      IfcSanitaryTerminal:    { r: 0.88, g: 0.88, b: 0.85, rough: 0.15, metal: 0.05 , envInt: 0.05 },  // ceramic
+      IfcAirTerminal:         { r: 0.55, g: 0.65, b: 0.70, rough: 0.40, metal: 0.30 , envInt: 0.05 },
+      IfcFireSuppressionTerminal: { r: 0.80, g: 0.30, b: 0.25, rough: 0.50, metal: 0.30 , envInt: 0.05 }, // red
+      IfcValve:               { r: 0.55, g: 0.50, b: 0.45, rough: 0.40, metal: 0.45 , envInt: 0.05 },
+      IfcAlarm:               { r: 0.75, g: 0.25, b: 0.25, rough: 0.50, metal: 0.20 , envInt: 0.05 },  // red
+      IfcElectricAppliance:   { r: 0.60, g: 0.65, b: 0.55, rough: 0.50, metal: 0.15 , envInt: 0.05 },
       // ── Proxy/other ──
-      IfcBuildingElementProxy:{ r: 0.00, g: 0.78, b: 0.78, rough: 0.50, metal: 0.10 },  // teal
-      IfcTransportElement:    { r: 0.50, g: 0.50, b: 0.55, rough: 0.40, metal: 0.50 },  // elevator
+      IfcBuildingElementProxy:{ r: 0.00, g: 0.78, b: 0.78, rough: 0.50, metal: 0.10 , envInt: 0.05 },  // teal
+      IfcTransportElement:    { r: 0.50, g: 0.50, b: 0.55, rough: 0.40, metal: 0.50 , envInt: 0.05 },  // elevator
     };
 
     // §MEP_DISC_TINT: the 3 IFC2x3 generic-MEP classes with no per-trade colour of their own —

--- a/viewer/sw.js
+++ b/viewer/sw.js
@@ -8,7 +8,9 @@
 // Cache-first for heavy assets (.wasm, images). DB files skip SW (IndexedDB handles them).
 //
 // DEPLOY: bump CACHE_VERSION on every OCI upload. Old caches are purged on activate.
-const CACHE_VERSION = 'v1030';   // bump on each deploy; per-change detail is the git commit message.
+const CACHE_VERSION = 'v1031';   // bump on each deploy; per-change detail is the git commit message.
+// v1031 (2026-08-15) streaming.js envInt: beam/railing->0, +13 remaining MEP device classes->0.05
+// (a prior PR's version bump for this same change was lost in a squash-merge race -- see git log).
 // v1030 (2026-08-15) §PIPE_DUCT_BLUE_TINT / §PHOTO_ENVMAP_DOUBLE_BOOST_FIX (bim-ootb PRs #1367,
 // #1369) shipped without a viewer.html script-version bump, so an already-cached browser kept
 // serving pre-fix effects.js/streaming.js under the same ?v= URL — user report "why is this still

--- a/viewer/viewer.html
+++ b/viewer/viewer.html
@@ -837,7 +837,7 @@ html.bim-embedded, html.bim-embedded body { background: #0b0b0b; }
 <script src="scene.js?v=55" onerror="console.warn('§LOAD_FAIL scene.js')"></script>
 <script src="panel_nav.js?v=1" onerror="console.warn('§LOAD_FAIL panel_nav.js')"></script>
 <script src="helpers.js?v=6" onerror="console.warn('§LOAD_FAIL helpers.js')"></script>
-<script src="streaming.js?v=60" onerror="console.warn('§LOAD_FAIL streaming.js')"></script>
+<script src="streaming.js?v=61" onerror="console.warn('§LOAD_FAIL streaming.js')"></script>
 <script src="dlod.js?v=8" onerror="console.warn('§LOAD_FAIL dlod.js')"></script>
 <script src="panels.js?v=43" onerror="console.warn('§LOAD_FAIL panels.js')"></script>
 <script src="tools.js?v=39" onerror="console.warn('§LOAD_FAIL tools.js')"></script>


### PR DESCRIPTION
## Summary
- PR #1371's second commit never actually landed on main -- gh pr merge --auto --squash locked content at an earlier branch state. Confirmed by reading origin/main directly: FlowController/Valve/Alarm/FireSuppressionTerminal/etc had no envInt at all, still full-strength reflection.
- Re-applies all 13 missing classes (envInt=0.05) plus beam/railing (envInt=0, per direct user request) plus the version bump, all in one commit this time.

## Test plan
- [x] `node -c` all 3 files
- [x] Live (playwright, real GL, Hospital): all 15 touched classes verified at intended envMapIntensity via direct _getMaterial() calls
- [ ] Will verify origin/main's raw content directly after this merges -- not just merge status