### PR TITLE
refactor(4d): collapse time_machine.js's duplicate matchRule/matchNameOverride into one shared delegate

### DIFF
--- a/viewer/tests/witness_class_fallback_blackbox.js
+++ b/viewer/tests/witness_class_fallback_blackbox.js
@@ -8,16 +8,25 @@
 // ({phase:'Architecture', sequence:6, resource:null}) lets any unrecognized ifc_class sail
 // through the schedule unflagged. Found live 2026-08-04 on real Hospital data:
 // IfcDistributionControlElement (861 elements) and IfcSwitchingDevice (113 elements) both
-// silently fall through in ALL THREE independent matchRule copies this codebase carries
-// (schedule_author.js:17, and two closures inside time_machine.js). A prior black-box witness
-// (witness_gantt_ops_blackbox.js) proved a DIFFERENT leak (a bookkeeping op polluting playback
-// bounds) using a SYNTHETIC 40-element fixture — it never touched real class data, which is
-// exactly why this gap went unnoticed. This witness is the general-purpose tool that was
-// actually asked for: it runs the REAL functions (required or sliced from the shipped files,
-// never reimplemented) against the REAL ifc_class population of REAL extracted building DBs,
-// and FAILS — no silent pass — on any of:
+// silently fall through. Originally this codebase carried THREE independent matchRule copies
+// (schedule_author.js:17, and two separate closures inside time_machine.js) that could silently
+// diverge from each other. §SCHEDULE_CLASSIFY_DEDUP (2026-08-15, bim-compiler prompts/
+// 4D_SCHEDULE_PERFECTION.md) collapsed the two time_machine.js closures into ONE shared pair
+// (_classifyNameOverride/_classifyRule) that delegates to schedule_author.js's canonical,
+// already-exported matchNameOverride/matchRule — with the old algorithm kept only as a fallback
+// for the (should-never-happen) case ScheduleAuthor failed to load. This witness now proves BOTH
+// halves of that: the delegating path agrees with the canonical implementation (should be true
+// by construction — this guards against a wiring bug), AND the fallback path — dead code unless
+// a script load fails — still agrees too, so it can't silently rot into a fourth divergent copy.
+// A prior black-box witness (witness_gantt_ops_blackbox.js) proved a DIFFERENT leak (a
+// bookkeeping op polluting playback bounds) using a SYNTHETIC 40-element fixture — it never
+// touched real class data, which is exactly why this gap went unnoticed. This witness is the
+// general-purpose tool that was actually asked for: it runs the REAL functions (required or
+// sliced from the shipped files, never reimplemented) against the REAL ifc_class population of
+// REAL extracted building DBs, and FAILS — no silent pass — on any of:
 //   G-A: a real class present in real data resolves to resource===null in ANY copy
-//   G-B: the three copies disagree with each other on phase for the same real class
+//   G-B: the three code paths (author.js canonical, TM delegating, TM fallback) disagree with
+//        each other on phase for the same real class
 //   G-C: any element in the DB is left completely unaccounted for by the audit
 // Run: node witness_class_fallback_blackbox.js  (reads buildings/ next to this repo checkout,
 // or set BLD_DIR to point elsewhere — DBs are OCI-distributed, not git-tracked, so a fresh
@@ -55,9 +64,12 @@ function hasExplicitRule(cls) {
   return false;
 }
 
-// ── Copies 2 & 3: time_machine.js — two independent closures, sliced by balanced braces (not
-// reimplemented) since neither is exported. A brace-counter, not a fixed line span, so this
-// stays correct even if the surrounding function grows/shrinks. ──
+// ── TM (shared): time_machine.js's _classifyNameOverride/_classifyRule, sliced by balanced
+// braces (not reimplemented) since neither is exported. A brace-counter, not a fixed line span,
+// so this stays correct even if the surrounding function grows/shrinks. Run TWICE: once with a
+// real `window.ScheduleAuthor` present (the delegating path — what production always exercises
+// past initial page load, both TM call sites go through this) and once without (the fallback
+// path — dead code unless a script load fails). Both must still agree with Copy 1. ──
 const tmSrc = fs.readFileSync(path.join(__dirname, '..', 'time_machine.js'), 'utf8');
 function extractBalanced(src, startIdx) {
   let depth = 0, i = startIdx, seenOpen = false;
@@ -67,25 +79,32 @@ function extractBalanced(src, startIdx) {
   }
   throw new Error('unbalanced braces from ' + startIdx);
 }
-function sliceMatcherPair(src, fromIdx) {
-  const noIdx = src.indexOf('function matchNameOverride(cls, name) {', fromIdx);
-  if (noIdx < 0) throw new Error('matchNameOverride not found from ' + fromIdx);
+function sliceClassifyPair(src) {
+  const noIdx = src.indexOf('function _classifyNameOverride(cls, name, nameOverrides) {');
+  if (noIdx < 0) throw new Error('_classifyNameOverride not found');
   const noBody = extractBalanced(src, noIdx);
-  const mrIdx = src.indexOf('function matchRule(cls, name) {', noIdx + noBody.length);
-  if (mrIdx < 0) throw new Error('matchRule not found after its matchNameOverride at ' + noIdx);
+  const secondNoIdx = src.indexOf('function _classifyNameOverride(cls, name, nameOverrides) {', noIdx + 1);
+  const mrIdx = src.indexOf('function _classifyRule(cls, name, rules, dflt, nameOverrides) {', noIdx + noBody.length);
+  if (mrIdx < 0) throw new Error('_classifyRule not found after its _classifyNameOverride');
   const mrBody = extractBalanced(src, mrIdx);
-  return noBody + '\n' + mrBody;
+  return { pair: noBody + '\n' + mrBody, secondNoIdx };
 }
-function mkMatcher(logic) {
-  const sandbox = { SR: SEQUENCE_RULES, SD: SEQUENCE_DEFAULT, NO: NAME_OVERRIDES };
-  vm.runInNewContext(logic + '\nglobalThis.__matchRule = matchRule;', sandbox);
+function mkMatcher(pair, withScheduleAuthor) {
+  const sandbox = {
+    window: withScheduleAuthor ? { ScheduleAuthor } : {}, console,
+    SR: SEQUENCE_RULES, SD: SEQUENCE_DEFAULT, NO: NAME_OVERRIDES
+  };
+  vm.runInNewContext(
+    pair + '\nglobalThis.__matchRule = function(cls, name) { return _classifyRule(cls, name, SR, SD, NO); };',
+    sandbox
+  );
   return sandbox.__matchRule;
 }
-const firstNoIdx = tmSrc.indexOf('function matchNameOverride(cls, name) {');
-const secondNoIdx = tmSrc.indexOf('function matchNameOverride(cls, name) {', firstNoIdx + 1);
-assert(firstNoIdx >= 0 && secondNoIdx > firstNoIdx, 'G-0 time_machine.js still carries exactly two matchRule/matchNameOverride closures (found at least 2)');
-const matchRule2 = mkMatcher(sliceMatcherPair(tmSrc, 0));
-const matchRule3 = mkMatcher(sliceMatcherPair(tmSrc, firstNoIdx + 1));
+const sliced = sliceClassifyPair(tmSrc);
+assert(sliced.secondNoIdx < 0,
+  'G-0 time_machine.js carries exactly ONE _classifyNameOverride/_classifyRule pair (dedup held, not regressed back to per-site copies)');
+const matchRuleTM = mkMatcher(sliced.pair, true);
+const matchRuleTMFallback = mkMatcher(sliced.pair, false);
 
 // ── Real building DBs — OCI-distributed, not git-tracked; point BLD_DIR at wherever they're
 // actually checked out (default: sibling of this worktree's parent checkout, ~/bim-ootb). ──
@@ -109,12 +128,12 @@ const BUILDINGS = (process.env.BLDS || 'Hospital,Terminal,LTU_AHouse,Duplex').sp
     db.close();
 
     console.log(`\n=== ${BLD} — ${rows.length} distinct classes, ${totalElements} elements ===`);
-    console.log('  class'.padEnd(34) + 'count'.padEnd(8) + 'author.js'.padEnd(20) + 'TM#1'.padEnd(20) + 'TM#2'.padEnd(20) + 'agree?');
+    console.log('  class'.padEnd(34) + 'count'.padEnd(8) + 'author.js'.padEnd(20) + 'TM(deleg)'.padEnd(20) + 'TM(fallback)'.padEnd(20) + 'agree?');
 
     let auditedThisBuilding = 0;
     rows.forEach(([cls, sampleName, count]) => {
       auditedThisBuilding += count;
-      const r1 = matchRule1(cls, sampleName), r2 = matchRule2(cls, sampleName), r3 = matchRule3(cls, sampleName);
+      const r1 = matchRule1(cls, sampleName), r2 = matchRuleTM(cls, sampleName), r3 = matchRuleTMFallback(cls, sampleName);
       const agree = r1.phase === r2.phase && r2.phase === r3.phase;
       const explicit = hasExplicitRule(cls);
       const silentFallback = !explicit; // no rule matched at all -> hit the generic default unflagged
@@ -139,8 +158,8 @@ const BUILDINGS = (process.env.BLDS || 'Hospital,Terminal,LTU_AHouse,Duplex').sp
     `G-A no real class silently matches NO rule at all (hitting the generic default unflagged) — hits=${allFallbackHits.length}` +
     (allFallbackHits.length ? '  [' + allFallbackHits.map(h => `${h.BLD}:${h.cls}(n=${h.count})`).join(', ') + ']' : ''));
   assert(allDisagreements.length === 0,
-    `G-B all three matchRule copies agree on phase for every real class — disagreements=${allDisagreements.length}` +
-    (allDisagreements.length ? '  [' + allDisagreements.map(d => `${d.BLD}:${d.cls} author=${d.r1} TM#1=${d.r2} TM#2=${d.r3}`).join(', ') + ']' : ''));
+    `G-B all three code paths (author.js, TM-delegating, TM-fallback) agree on phase for every real class — disagreements=${allDisagreements.length}` +
+    (allDisagreements.length ? '  [' + allDisagreements.map(d => `${d.BLD}:${d.cls} author=${d.r1} TM(deleg)=${d.r2} TM(fallback)=${d.r3}`).join(', ') + ']' : ''));
   assert(grandTotalAudited === grandTotalElements, `G-D grand total: ${grandTotalAudited}/${grandTotalElements} elements audited across all buildings`);
 
   console.log(`\n§BLACKBOX_CLASS_AUDIT SUMMARY pass=${pass} fail=${fail}`);

--- a/viewer/tests/witness_curtain_wall_opening.js
+++ b/viewer/tests/witness_curtain_wall_opening.js
@@ -173,6 +173,9 @@ function countEarly(pairs, getS, getE) {
   const sliced = ["var _TIER1_ORDER = ['Substructure', 'Superstructure', 'Architecture'];",
     (zoneParts.length === 2 ? 'var _zoneMemo = [];' : ''), zoneParts[0] || '', zoneParts[1] || '',
     sliceFn(tmSrc, '_zoneOf') || '',
+    // §SCHEDULE_CLASSIFY_DEDUP (2026-08-15): _buildXrayElements' local matchNameOverride/matchRule
+    // now delegate to this shared pair — rides along verbatim, same idiom as the zone helpers above.
+    sliceFn(tmSrc, '_classifyNameOverride'), sliceFn(tmSrc, '_classifyRule'),
     sliceFn(tmSrc, '_promoteRoofLoadPath'), sliceFn(tmSrc, '_buildXrayElements'),
     sliceFn(tmSrc, '_tier1Extents'), sliceFn(tmSrc, '_tier1Serialize'),
     sliceFn(tmSrc, '_tier1Protrusion'), sliceFn(tmSrc, '_tierAuditRegate'),

--- a/viewer/tests/witness_hosted_before_host.js
+++ b/viewer/tests/witness_hosted_before_host.js
@@ -157,6 +157,9 @@ function countEarly(pairs, get) {
   const sliced = ["var _TIER1_ORDER = ['Substructure', 'Superstructure', 'Architecture'];",
     (zoneParts.length === 2 ? 'var _zoneMemo = [];' : ''), zoneParts[0] || '', zoneParts[1] || '',
     sliceFn(tmSrc, '_zoneOf') || '',
+    // §SCHEDULE_CLASSIFY_DEDUP (2026-08-15): _buildXrayElements' local matchNameOverride/matchRule
+    // now delegate to this shared pair — rides along verbatim, same idiom as the zone helpers above.
+    sliceFn(tmSrc, '_classifyNameOverride'), sliceFn(tmSrc, '_classifyRule'),
     sliceFn(tmSrc, '_promoteRoofLoadPath'), sliceFn(tmSrc, '_buildXrayElements'),
     sliceFn(tmSrc, '_tier1Extents'), sliceFn(tmSrc, '_tier1Serialize'),
     sliceFn(tmSrc, '_tier1Protrusion'), sliceFn(tmSrc, '_tierAuditRegate'),

--- a/viewer/tests/witness_kernel_ops_sched_version.js
+++ b/viewer/tests/witness_kernel_ops_sched_version.js
@@ -81,10 +81,15 @@ if (tmSrc.indexOf(tierOrderLine) < 0) { assert(false, 'W-KOS-0c _TIER1_ORDER con
 // day. Found 2026-08-12 while landing §ARCH_START_TEMPO / M1 — which bumps the very constant this
 // witness guards, so a dead one here is not something to leave for later.
 const zoneParts = [sliceFn(tmSrc, '_zoneIndexBuild', true), sliceFn(tmSrc, '_zoneIndex', true)].filter(Boolean);
+// §SCHEDULE_CLASSIFY_DEDUP (2026-08-15): same class of gap as §ZONE_INDEX above — a new
+// module-level helper (_classifyNameOverride/_classifyRule) _buildXrayElements now delegates to
+// that this slice list didn't know about. Sliced the same optional way.
+const classifyParts = [sliceFn(tmSrc, '_classifyNameOverride', true), sliceFn(tmSrc, '_classifyRule', true)].filter(Boolean);
 const sliced = [
   tierOrderLine,
   (zoneParts.length === 2 ? 'var _zoneMemo = [];' : ''), zoneParts[0] || '', zoneParts[1] || '',
   sliceFn(tmSrc, '_zoneOf', true) || '',
+  classifyParts[0] || '', classifyParts[1] || '',
   sliceFn(tmSrc, '_kernelOpsSchedStale'),
   sliceFn(tmSrc, '_promoteRoofLoadPath'),
   sliceFn(tmSrc, '_buildXrayElements'),

--- a/viewer/tests/witness_midair_zero.js
+++ b/viewer/tests/witness_midair_zero.js
@@ -85,9 +85,18 @@ const tierOrderLine = "var _TIER1_ORDER = ['Substructure', 'Superstructure', 'Ar
 // measuring a single building — since #1313 landed. Sliced optionally, exactly as
 // bim-compiler/scripts/probe_arch_start.js does, so older revisions still run unchanged.
 const zoneParts = [sliceFn(tmSrc, '_zoneIndexBuild', 0, true), sliceFn(tmSrc, '_zoneIndex', 0, true)].filter(Boolean);
+// §SCHEDULE_CLASSIFY_DEDUP (2026-08-15) added _classifyNameOverride/_classifyRule — the shared
+// pair _buildXrayElements' local matchNameOverride/matchRule now delegate to. Same class of gap
+// as §ZONE_INDEX above (a new module-level helper this slice list didn't know about), sliced the
+// same optional way so older revisions still run unchanged. This sandbox's `window` has no
+// `ScheduleAuthor`, so the sliced pair runs its own fallback branch — the same reimplementation
+// the old inline closures used, functionally identical, not the delegating path (that path is
+// covered by witness_class_fallback_blackbox.js instead).
+const classifyParts = [sliceFn(tmSrc, '_classifyNameOverride', 0, true), sliceFn(tmSrc, '_classifyRule', 0, true)].filter(Boolean);
 const sliced = [tierOrderLine,
   (zoneParts.length === 2 ? 'var _zoneMemo = [];' : ''), zoneParts[0] || '', zoneParts[1] || '',
   sliceFn(tmSrc, '_zoneOf', 0, true) || '',
+  classifyParts[0] || '', classifyParts[1] || '',
   sliceFn(tmSrc, '_promoteRoofLoadPath'), sliceFn(tmSrc, '_buildXrayElements'),
   sliceFn(tmSrc, '_tier1Extents'), sliceFn(tmSrc, '_tier1Serialize'),
   sliceFn(tmSrc, '_tier1Protrusion'), sliceFn(tmSrc, '_tierAuditRegate'),
@@ -95,7 +104,8 @@ const sliced = [tierOrderLine,
   sliceFn(tmSrc, '_midairAudit'), sliceFn(tmSrc, '_midairRepair', _mrCount - 1)].join('\n');
 console.log('§MIDAIR_SLICE _midairRepairDefs=' + _mrCount + ' slicing #' + (_mrCount - 1) +
   ' (the LAST definition — what declaration hoisting makes the browser run)' +
-  ' zoneHelpers=' + (zoneParts.length === 2 ? 'present' : 'absent (pre-#1313 revision)'));
+  ' zoneHelpers=' + (zoneParts.length === 2 ? 'present' : 'absent (pre-#1313 revision)') +
+  ' classifyHelpers=' + (classifyParts.length === 2 ? 'present' : 'absent (pre-§SCHEDULE_CLASSIFY_DEDUP revision)'));
 
 // W-MZ-5 — the repair must be called on the kernel_ops path, not merely defined
 assert(/_twoTierRemap\(_twItems\);[\s\S]{0,600}_midairRepair\(_twItems\)/.test(tmSrc),

--- a/viewer/tests/witness_tier_serial_display.js
+++ b/viewer/tests/witness_tier_serial_display.js
@@ -86,6 +86,10 @@ const sliced = [
   sliceFn(tmSrc, '_zoneIndexBuild'),
   sliceFn(tmSrc, '_zoneIndex'),
   sliceFn(tmSrc, '_zoneOf'),
+  // §SCHEDULE_CLASSIFY_DEDUP (2026-08-15): _buildXrayElements' local matchNameOverride/matchRule
+  // now delegate to this shared pair — same idiom, rides along verbatim.
+  sliceFn(tmSrc, '_classifyNameOverride'),
+  sliceFn(tmSrc, '_classifyRule'),
   sliceFn(tmSrc, '_promoteRoofLoadPath'),
   sliceFn(tmSrc, '_buildXrayElements'),
   sliceFn(tmSrc, '_tier1Extents'),

--- a/viewer/time_machine.js
+++ b/viewer/time_machine.js
@@ -3484,6 +3484,46 @@
     return { total: loadPathOverrides, seedCount: lpSeed.length, m4Count: m4Promoted, guids: lpGuids };
   }
 
+  // §SCHEDULE_CLASSIFY_DEDUP (2026-08-15, bim-compiler prompts/4D_SCHEDULE_PERFECTION.md
+  // §SCHEDULE_CLASSIFY_DEDUP — Witness: witness_class_fallback_blackbox.js). Before this,
+  // matchNameOverride/matchRule were two BYTE-IDENTICAL closures, one inside _buildXrayElements
+  // and one inside injectGantt — on top of the canonical, already-exported implementation
+  // schedule_author.js carries (window.ScheduleAuthor.matchNameOverride/matchRule), same pattern
+  // the §TM_DURATION_SYNC comment above _installSecs already used for install-time. ONE shared
+  // pair now, delegating to ScheduleAuthor when loaded (always true past initial page load — this
+  // is only ever called from schedule generation, never at script-eval time) with the same
+  // algorithm kept as a fallback for the ScheduleAuthor-not-loaded case, matching this file's own
+  // established convention (see _installSecs's wrapper a few hundred lines below). Both call
+  // sites keep their own local matchNameOverride(cls,name)/matchRule(cls,name) wrappers — same
+  // names, same signatures — so this is a pure body-swap, not a call-site rewrite.
+  function _classifyNameOverride(cls, name, nameOverrides) {
+    if (window.ScheduleAuthor && window.ScheduleAuthor.matchNameOverride) {
+      return window.ScheduleAuthor.matchNameOverride(cls, name, nameOverrides);
+    }
+    if (!name || !nameOverrides) return null;
+    for (var i = 0; i < nameOverrides.length; i++) {
+      var ov = nameOverrides[i];
+      if (ov.classes && ov.classes.indexOf(cls) < 0) continue;
+      if (!ov._re) { try { ov._re = new RegExp(ov.pattern, ov.flags || 'i'); } catch (e) { ov._re = null; } }
+      if (ov._re && ov._re.test(name)) return ov;
+    }
+    return null;
+  }
+  function _classifyRule(cls, name, rules, dflt, nameOverrides) {
+    if (!cls) return dflt;
+    var ov = _classifyNameOverride(cls, name, nameOverrides);
+    if (ov) return ov;
+    if (window.ScheduleAuthor && window.ScheduleAuthor.matchRule) {
+      return window.ScheduleAuthor.matchRule(cls, rules, dflt);
+    }
+    var bestKey = null, bestLen = 0;
+    for (var key in rules) {
+      if (cls.indexOf(key) >= 0 && key.length > bestLen) { bestKey = key; bestLen = key.length; }
+    }
+    if (!bestKey) console.warn('§CLASS_UNMATCHED cls=' + cls + ' falling back to default phase=' + dflt.phase);
+    return bestKey ? rules[bestKey] : dflt;
+  }
+
   // ══════════════════════════════════════════════════════════════════
   // ── §ZONE_INDEX (2026-08-12, bim-compiler prompts/4D_SCHEDULE_PERFECTION.md §ZONE_INDEX —
   // Witness: viewer/tests/witness_zone_index.js W-ZONE) ────────────────────────────────────────
@@ -3648,28 +3688,11 @@
     var SR = window.SEQUENCE_RULES || {};
     var SD = window.SEQUENCE_DEFAULT || { phase: 'Architecture', sequence: 6, resource: null };
     var NO = window.SEQUENCE_NAME_OVERRIDES || [];
-    function matchNameOverride(cls, name) {
-      if (!name) return null;
-      for (var i = 0; i < NO.length; i++) {
-        var ov = NO[i];
-        if (ov.classes && ov.classes.indexOf(cls) < 0) continue;
-        if (!ov._re) { try { ov._re = new RegExp(ov.pattern, ov.flags || 'i'); } catch (e) { ov._re = null; } }
-        if (ov._re && ov._re.test(name)) return ov;
-      }
-      return null;
-    }
-    function matchRule(cls, name) {
-      if (!cls) return SD;
-      var ov = matchNameOverride(cls, name);
-      if (ov) return ov;
-      var bestKey = null, bestLen = 0;
-      for (var key in SR) {
-        if (cls.indexOf(key) >= 0 && key.length > bestLen) { bestKey = key; bestLen = key.length; }
-      }
-      // §CLASS_UNMATCHED_FALLBACK (2026-08-04) — see schedule_author.js's matchRule for the finding.
-      if (!bestKey) console.warn('§CLASS_UNMATCHED cls=' + cls + ' falling back to default phase=' + SD.phase);
-      return bestKey ? SR[bestKey] : SD;
-    }
+    // §SCHEDULE_CLASSIFY_DEDUP — body delegates to the one shared pair above (_classifyNameOverride/
+    // _classifyRule), which itself defers to schedule_author.js's canonical, already-exported
+    // matchNameOverride/matchRule. Local name/signature unchanged so nothing below this line moves.
+    function matchNameOverride(cls, name) { return _classifyNameOverride(cls, name, NO); }
+    function matchRule(cls, name) { return _classifyRule(cls, name, SR, SD, NO); }
     var r;
     try {
       r = db.exec(
@@ -4957,28 +4980,9 @@
     // from genuinely structural plates/members (e.g. Terminal's Metal Deck IfcPlate, seq 4 is correct
     // there) — name is the only extracted signal. Checked BEFORE the class lookup, never replacing it:
     // an element that matches no override keeps its plain class-default seq.
-    function matchNameOverride(cls, name) {
-      if (!name) return null;
-      for (var i = 0; i < NO.length; i++) {
-        var ov = NO[i];
-        if (ov.classes && ov.classes.indexOf(cls) < 0) continue;
-        if (!ov._re) { try { ov._re = new RegExp(ov.pattern, ov.flags || 'i'); } catch (e) { ov._re = null; } }
-        if (ov._re && ov._re.test(name)) return ov;
-      }
-      return null;
-    }
-    function matchRule(cls, name) {
-      if (!cls) return SD;
-      var ov = matchNameOverride(cls, name);
-      if (ov) return ov;
-      var bestKey = null, bestLen = 0;
-      for (var key in SR) {
-        if (cls.indexOf(key) >= 0 && key.length > bestLen) { bestKey = key; bestLen = key.length; }
-      }
-      // §CLASS_UNMATCHED_FALLBACK (2026-08-04) — see schedule_author.js's matchRule for the finding.
-      if (!bestKey) console.warn('§CLASS_UNMATCHED cls=' + cls + ' falling back to default phase=' + SD.phase);
-      return bestKey ? SR[bestKey] : SD;
-    }
+    // §SCHEDULE_CLASSIFY_DEDUP — same shared pair as _buildXrayElements above, see that comment.
+    function matchNameOverride(cls, name) { return _classifyNameOverride(cls, name, NO); }
+    function matchRule(cls, name) { return _classifyRule(cls, name, SR, SD, NO); }
     // §TM_DURATION_SYNC (viewer/schedule_author.js commit d35366a §LABOR_QUANTITY_WEIGHT): this used
     // to be a hand-duplicated copy of the per-unit-rate formula with NO fragmentation/area-weighting —
     // Terminal's 33,324 "Metal Deck" IfcPlate fragments (avg 0.074 m² each) each got a full per-element


### PR DESCRIPTION
## Summary
- `time_machine.js` carried two byte-identical closures (`_buildXrayElements`, `injectGantt`) reimplementing `matchNameOverride`/`matchRule`, on top of the canonical, already-exported `schedule_author.js` versions (`window.ScheduleAuthor.matchNameOverride`/`matchRule`).
- Collapsed to one shared pair (`_classifyNameOverride`/`_classifyRule`) that delegates to `ScheduleAuthor` when loaded, with the old algorithm kept only as a fallback (same convention already used for `_installSecs`). Both call sites keep their own local `matchNameOverride(cls,name)`/`matchRule(cls,name)` wrapper names — pure body-swap, zero call-site change.
- Closes a live silent-divergence risk: previously any classification-logic change in `schedule_author.js` had to be hand-mirrored in two more places with nothing catching a miss.
- Scoped narrower than the original consolidation spec's literal ask (a new `schedule_classify.js` file, ~150-250 lines moved): closer reading showed `assignStoreyByZ` and `getInstallSecs` aren't real 3-way duplicates — `assignStoreyByZ` already shares `_zoneIndex()` between both TM call sites, and `injectGantt`'s `getInstallSecs` already delegates to `ScheduleAuthor._installSecs`. Only `matchNameOverride`/`matchRule` were live duplicated algorithm. This also means **zero edits to `schedule_author.js`**, avoiding merge-conflict surface against the parallel `materializeZones`/`IfcBuildingElementProxy` fix landing separately this same session.
- No `_GANTT_CACHE_VERSION` bump — `computeSchedule`'s gating and the display remap are unchanged (proven below, not asserted).

## Verification
- `witness_class_fallback_blackbox.js` rewritten to compare `schedule_author.js`'s canonical output against both the TM-delegating and TM-fallback code paths, across all 8 shipped buildings (321,509 elements, 0 disagreements, 0 silent fallback hits).
- 5 other witnesses slice `_buildXrayElements` out of `time_machine.js` by name and needed their slice list updated to include the new shared functions (same maintenance PR #1272 already established for `_promoteRoofLoadPath`). All now produce numbers byte-identical to unmodified `main`:
  - `witness_midair_zero.js` 38/38
  - `witness_kernel_ops_sched_version.js` 12/12
  - `witness_tier_serial_display.js` 57/57
  - `witness_curtain_wall_opening.js` 5/5 (byte-identical viaCurtainWall/noHostAtAll/gen/remap/display counts vs. `main`)
  - `witness_hosted_before_host.js` 4/4 (byte-identical G-HOST-MATCH counts vs. `main`)
- `scripts/gate_4d.sh`: `pass=7 fail=0 missing=1` — unchanged from baseline (the 1 missing witness, `witness_arch_area_weight.js`, is absent from `main` too, unrelated to this PR).
- 5 unrelated pre-existing dead witnesses found during this sweep (`witness_tm_geo_order_cycles.js`, `probe_bars_vs_ops.js`, `probe_midair_census.js`, `probe_named_element_times.js`, `witness_big_element_support_coverage.js`, `witness_gantt_lock_integrity.js`) — all fail identically on unmodified `main` with `ReferenceError: _zoneIndex is not defined`, a gap from the 2026-08-12 `§ZONE_INDEX` migration never being backfilled into their slice lists. Confirmed pre-existing, not touched by this PR (out of scope).

## Test plan
- [x] `node --check` on all 7 changed files
- [x] `witness_class_fallback_blackbox.js` — 321,509 elements across 8 buildings, 0 disagreements
- [x] `witness_midair_zero.js`, `witness_kernel_ops_sched_version.js`, `witness_tier_serial_display.js`, `witness_curtain_wall_opening.js`, `witness_hosted_before_host.js` — numbers byte-identical to `main`
- [x] `scripts/gate_4d.sh` — pass=7 fail=0 (unchanged from baseline)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JnzfsTYEKQpEugADhrTNuG