### PR TITLE
fix(4d): §OG_HANG_BAND — widen captured-path repair's hang radius 0.5m->9.5m

### DIFF
--- a/scripts/probe_captured_floating.js
+++ b/scripts/probe_captured_floating.js
@@ -1,0 +1,234 @@
+#!/usr/bin/env node
+// probe_captured_floating.js — faithful node-side reproduction of the CAPTURED-path floating
+// measurement (§AUDIT_FLOATING / §HOSPITAL_LIGHTING_STILL_FLOATING, 4D_SCHEDULE_PERFECTION.md):
+// materializeZones' zones -> per-task window -> §GANTT_TASK_WINDOW_FIDELITY per-element rescale
+// (time_machine.js injectGantt _cap overlay, ~5527-5563) -> _ogSupportSweep repair (~4193) ->
+// floating audit (_contactGraph/_midairAudit, ~4557/4601). Pure node, no DOM — every step sliced
+// verbatim from the shipped files so a fix measured here matches what the browser actually plays.
+'use strict';
+const fs = require('fs');
+const path = require('path');
+const initSqlJs = require(path.join(__dirname, '..', 'modeller', 'lib', 'sql-wasm.js'));
+const ScheduleGate = require(path.join(__dirname, '..', 'viewer', 'schedule_gate.js'));
+const ScheduleAuthor = require(path.join(__dirname, '..', 'viewer', 'schedule_author.js'));
+const tmSrc = fs.readFileSync(path.join(__dirname, '..', 'viewer', 'time_machine.js'), 'utf8');
+
+function sliceFn(src, name) {
+  const idx = src.lastIndexOf('function ' + name + '(');
+  if (idx < 0) throw new Error(name + ' not found');
+  let depth = 0, i = idx, seenOpen = false;
+  for (; i < src.length; i++) {
+    if (src[i] === '{') { depth++; seenOpen = true; }
+    else if (src[i] === '}') { depth--; if (seenOpen && depth === 0) break; }
+  }
+  return src.slice(idx, i + 1);
+}
+function buildFn(srcParts, ret) {
+  return new Function('ScheduleGate', srcParts.join('\n') + '\nreturn ' + ret + ';')(ScheduleGate);
+}
+const _contactGraph = buildFn([sliceFn(tmSrc, '_contactGraph')], '_contactGraph');
+const _ogSupportSweep = buildFn([sliceFn(tmSrc, '_ogSupportSweep')], '_ogSupportSweep');
+const _TIER1_ORDER_LINE = "var _TIER1_ORDER = ['Substructure', 'Superstructure', 'Architecture'];";
+const _midairRepair = buildFn([_TIER1_ORDER_LINE, sliceFn(tmSrc, '_midairRepair')], '_midairRepair');
+
+function _slug(name) { return String(name).replace(/[^A-Za-z0-9]+/g, '_').replace(/^_+|_+$/g, ''); }
+
+const BLD_DIR = process.env.BLD_DIR || path.join(require('os').homedir(), 'bim-ootb', 'buildings');
+const ONLY = process.env.ONLY || 'Hospital_extracted';
+const SHIFT_HOURS = process.env.SHIFT_HOURS ? Number(process.env.SHIFT_HOURS) : 24;
+
+function floatingCensus(items) {
+  const G = _contactGraph(items);
+  let midair = 0, byClass = {}, guids = [];
+  const byGuid = {}; items.forEach((it, i) => byGuid[it.guid] = i);
+  for (let i = 0; i < items.length; i++) {
+    const list = G.contacts[i]; if (!list) continue;
+    let first = Infinity;
+    for (const k of list) { const s = items[k].s; if (s < first) first = s; }
+    if (first > items[i].s + 1) {
+      midair++; byClass[items[i].cls] = (byClass[items[i].cls] || 0) + 1;
+      if (guids.length < 2000) guids.push({ guid: items[i].guid, cls: items[i].cls, task: items[i].task });
+    }
+  }
+  return { midair, orphans: G.orphans, grounded: G.groundedN, byClass, guids, G };
+}
+
+async function main() {
+  const SQL = await initSqlJs({ wasmBinary: fs.readFileSync(path.join(__dirname, '..', 'modeller', 'lib', 'sql-wasm.wasm')) });
+  const dbPath = path.join(BLD_DIR, ONLY + '.db');
+  const db = new SQL.Database(fs.readFileSync(dbPath));
+
+  const ratesSrc = fs.readFileSync(path.join(__dirname, '..', 'viewer', 'rates.js'), 'utf8');
+  const RATES = (new Function(ratesSrc +
+    '\nreturn {SEQUENCE_RULES:SEQUENCE_RULES, SEQUENCE_DEFAULT:SEQUENCE_DEFAULT, ' +
+    'SEQUENCE_NAME_OVERRIDES:SEQUENCE_NAME_OVERRIDES, LABOR_RATES:LABOR_RATES, RATES:RATES};'))();
+
+  const rawElements = ScheduleAuthor._buildScheduleElements(db, RATES.SEQUENCE_RULES, {
+    laborRates: RATES.LABOR_RATES, rates: RATES.RATES, nameOverrides: RATES.SEQUENCE_NAME_OVERRIDES,
+    defaultRule: RATES.SEQUENCE_DEFAULT
+  });
+  const elements = rawElements.map(function (it) { return Object.assign({}, it, { bz: it.base_z, tz: it.top_z }); });
+  console.log('§CAP_ELEMENTS n=' + elements.length);
+
+  const maxCrews = {};
+  for (const res in RATES.LABOR_RATES) if (RATES.LABOR_RATES[res].max_crews) maxCrews[res] = RATES.LABOR_RATES[res].max_crews;
+  const schedule = ScheduleGate.computeSchedule(elements, 0, 1, maxCrews, SHIFT_HOURS);
+  const rolled = ScheduleGate.deriveZones(elements, schedule);
+  console.log('§CAP_ZONES n=' + rolled.zones.length + ' edges=' + rolled.edges.length);
+
+  // materializeZones' own task-id + window construction, verbatim (schedule_author.js:397-411)
+  const minStart = Math.min.apply(null, rolled.zones.map(z => z.start));
+  const zoneTaskId = {}, taskWin = {};
+  rolled.zones.forEach(function (z) {
+    const tid = 'TASK_' + _slug(z.phase) + '_' + _slug(z.storey);
+    zoneTaskId[z.id] = tid;
+    const sDays = Math.round((z.start - minStart) / 86400000);
+    let eDays = Math.round((z.end - minStart) / 86400000);
+    if (eDays <= sDays) eDays = sDays + 1;
+    taskWin[tid] = { s: minStart + sDays * 86400000, e: minStart + eDays * 86400000 };
+  });
+  // §ZONE_EDGE_LEAD-equivalent: edge existence between two TASKS (post phase/storey grouping)
+  const taskEdge = {};
+  rolled.edges.forEach(function (e) {
+    const p = zoneTaskId[e.predId], s = zoneTaskId[e.succId]; if (!p || !s || p === s) return;
+    taskEdge[p + '->' + s] = 1;
+  });
+
+  // per-element zone id + task assignment (mirrors deriveZones' own zid construction)
+  function zoneIdOf(e) { return (e.phase || '_UNPHASED') + '||' + ScheduleGate.collapsePhase(e.storey); }
+
+  const _allScheduled = elements.map(function (el) {
+    const st = schedule[el.guid]; if (!st) return null;
+    const zid = zoneIdOf(el), tid = zoneTaskId[zid];
+    return { guid: el.guid, s: st.start, e: st.end, bz: el.bz, tz: el.tz,
+      x0: el.x0, x1: el.x1, y0: el.y0, y1: el.y1, cls: el.cls, seq: el.seq,
+      task: tid, zoneId: zid };
+  }).filter(Boolean);
+  console.log('§CAP_SCHEDULED n=' + _allScheduled.length);
+
+  // PRE-repair, RAW generative floating (sanity baseline, no rescale/no repair)
+  const rawCensus = floatingCensus(_allScheduled.map(o => Object.assign({}, o)));
+  console.log('§CAP_RAW_FLOATING midair=' + rawCensus.midair + ' orphans=' + rawCensus.orphans);
+
+  // §GANTT_TASK_WINDOW_FIDELITY rescale, verbatim (time_machine.js:5548-5563)
+  const rescaled = _allScheduled.map(o => Object.assign({}, o));
+  const _taskSpan = {};
+  rescaled.forEach(function (item) {
+    const sp = _taskSpan[item.task] || (_taskSpan[item.task] = { min: Infinity, max: -Infinity });
+    if (item.s < sp.min) sp.min = item.s;
+    if (item.e > sp.max) sp.max = item.e;
+  });
+  rescaled.forEach(function (item) {
+    const w = taskWin[item.task], sp = _taskSpan[item.task];
+    const tSpan = Math.max(1, w.e - w.s), lsSpan = Math.max(1, sp.max - sp.min);
+    item.s = w.s + Math.floor(((item.s - sp.min) / lsSpan) * tSpan);
+    item.e = w.s + Math.floor(((item.e - sp.min) / lsSpan) * tSpan);
+    if (item.e <= item.s) item.e = item.s + 60000;
+  });
+
+  const preRepair = floatingCensus(rescaled.map(o => Object.assign({}, o)));
+  console.log('§CAP_PRE_REPAIR_FLOATING midair=' + preRepair.midair + ' byClass=' + JSON.stringify(preRepair.byClass));
+
+  // _ogSupportSweep repair (mutates rescaled in place, sorts by bz)
+  const beforeByGuid = {}; rescaled.forEach(o => beforeByGuid[o.guid] = o.s);
+  const forRepair = rescaled.map(o => Object.assign({}, o));
+  _ogSupportSweep(forRepair);
+  const postRepair = floatingCensus(forRepair);
+  console.log('§CAP_POST_REPAIR_FLOATING total=' + postRepair.midair + '/' + forRepair.length +
+    ' orphans=' + postRepair.orphans + ' grounded=' + postRepair.grounded + ' ok=' + (forRepair.length - postRepair.midair - postRepair.orphans - postRepair.grounded));
+  console.log('§CAP_POST_REPAIR_BYCLASS ' + JSON.stringify(postRepair.byClass));
+  let maxShiftMs = 0, maxShiftGuid = null, pushedN = 0, shiftSum = 0;
+  forRepair.forEach(o => {
+    const d = o.s - beforeByGuid[o.guid];
+    if (d > 0) { pushedN++; shiftSum += d; if (d > maxShiftMs) { maxShiftMs = d; maxShiftGuid = o.guid; } }
+  });
+  console.log('§CAP_PUSH_STATS pushed=' + pushedN + ' maxShiftDays=' + (maxShiftMs / 86400000).toFixed(1) +
+    ' meanShiftDays=' + (pushedN ? (shiftSum / pushedN / 86400000).toFixed(2) : 0) + ' maxShiftGuid=' + maxShiftGuid);
+
+  // For floating IfcBuildingElementProxy: does an edge exist between ITS task and its first-
+  // contact's task? This is the direct test of the "missing cross-zone CPM edge" hypothesis.
+  const byGuid = {}; forRepair.forEach((o, i) => byGuid[o.guid] = i);
+  const G = postRepair.G;
+  let edgeMissing = 0, edgeExists = 0, sameTask = 0, sampleGaps = [];
+  for (let i = 0; i < forRepair.length; i++) {
+    const T = forRepair[i];
+    if (T.cls !== 'IfcBuildingElementProxy') continue;
+    const list = G.contacts[i]; if (!list) continue;
+    let first = Infinity, firstIdx = -1;
+    for (const k of list) { if (forRepair[k].s < first) { first = forRepair[k].s; firstIdx = k; } }
+    if (first <= T.s + 1) continue; // not floating
+    const S = forRepair[firstIdx];
+    if (S.task === T.task) { sameTask++; continue; }
+    const has = taskEdge[S.task + '->' + T.task];
+    if (has) edgeExists++; else {
+      edgeMissing++;
+      if (sampleGaps.length < 15) sampleGaps.push({ proxy: T.guid, proxyTask: T.task, carrierCls: S.cls, carrierTask: S.task, gapDays: ((first - T.s) / 86400000).toFixed(1) });
+    }
+  }
+  console.log('§CAP_PROXY_EDGE_CHECK sameTask=' + sameTask + ' edgeExists=' + edgeExists + ' edgeMissing=' + edgeMissing);
+  console.log('§CAP_PROXY_EDGE_SAMPLES ' + JSON.stringify(sampleGaps, null, 1));
+
+  // ══ EXPERIMENT 3 — repair BEFORE the window is computed, not after ═══════════════════════════
+  // Prior 2 attempts (documented, both ruled out) ran a repair AFTER materializeZones had already
+  // computed each task's window from the raw generative times, so a cross-zone push necessarily
+  // desynced the display from the already-fixed Gantt dates. Untried variant: run the SAME proven
+  // fixpoint (_midairRepair, already gets generative floating to 0 on all 7 buildings) on the RAW
+  // per-element schedule BEFORE deriveZones ever computes zone start/end — so materializeZones'
+  // window is built FROM the corrected times, and can never be "desynced" from a Gantt that is
+  // itself derived from those same corrected times. No display-layer trick, no bolt-on: this is
+  // "give the task a window that already accounts for its real physical dependency", literally.
+  const preZoneItems = _allScheduled.map(o => Object.assign({}, o));
+  const mrStats = _midairRepair(preZoneItems);
+  console.log('§EXP3_MIDAIR_REPAIR_RAW ' + JSON.stringify(mrStats));
+  const repairedCensusRaw = floatingCensus(preZoneItems.map(o => Object.assign({}, o)));
+  console.log('§EXP3_RAW_POST_REPAIR midair=' + repairedCensusRaw.midair);
+
+  // Re-derive zones/windows from the REPAIRED per-element times (same deriveZones call, different input)
+  const repairedSchedule = {};
+  preZoneItems.forEach(function (it) { repairedSchedule[it.guid] = { start: it.s, end: it.e }; });
+  const rolled2 = ScheduleGate.deriveZones(elements, repairedSchedule);
+  const minStart2 = Math.min.apply(null, rolled2.zones.map(z => z.start));
+  const zoneTaskId2 = {}, taskWin2 = {};
+  rolled2.zones.forEach(function (z) {
+    const tid = 'TASK_' + _slug(z.phase) + '_' + _slug(z.storey);
+    zoneTaskId2[z.id] = tid;
+    const sDays = Math.round((z.start - minStart2) / 86400000);
+    let eDays = Math.round((z.end - minStart2) / 86400000);
+    if (eDays <= sDays) eDays = sDays + 1;
+    taskWin2[tid] = { s: minStart2 + sDays * 86400000, e: minStart2 + eDays * 86400000 };
+  });
+  // compare total project span: does authoring off repaired times blow up totalDays?
+  const maxEnd2 = Math.max.apply(null, rolled2.zones.map(z => z.end));
+  const totalDays2 = Math.round((maxEnd2 - minStart2) / 86400000);
+  const maxEnd1 = Math.max.apply(null, rolled.zones.map(z => z.end));
+  const totalDays1 = Math.round((maxEnd1 - minStart) / 86400000);
+  console.log('§EXP3_TOTAL_DAYS before=' + totalDays1 + ' after=' + totalDays2 + ' delta=' + (totalDays2 - totalDays1));
+
+  // full pipeline on the repaired-zone windows: same rescale + _ogSupportSweep as the shipped path
+  const exp3Items = preZoneItems.map(function (o) {
+    return Object.assign({}, o, { task: zoneTaskId2[o.zoneId] });
+  });
+  const _taskSpan3 = {};
+  exp3Items.forEach(function (item) {
+    const sp = _taskSpan3[item.task] || (_taskSpan3[item.task] = { min: Infinity, max: -Infinity });
+    if (item.s < sp.min) sp.min = item.s;
+    if (item.e > sp.max) sp.max = item.e;
+  });
+  exp3Items.forEach(function (item) {
+    const w = taskWin2[item.task], sp = _taskSpan3[item.task];
+    const tSpan = Math.max(1, w.e - w.s), lsSpan = Math.max(1, sp.max - sp.min);
+    item.s = w.s + Math.floor(((item.s - sp.min) / lsSpan) * tSpan);
+    item.e = w.s + Math.floor(((item.e - sp.min) / lsSpan) * tSpan);
+    if (item.e <= item.s) item.e = item.s + 60000;
+  });
+  const exp3PreRepair = floatingCensus(exp3Items.map(o => Object.assign({}, o)));
+  console.log('§EXP3_PRE_OGSWEEP_FLOATING midair=' + exp3PreRepair.midair);
+  const exp3ForRepair = exp3Items.map(o => Object.assign({}, o));
+  _ogSupportSweep(exp3ForRepair);
+  const exp3Post = floatingCensus(exp3ForRepair);
+  console.log('§EXP3_FINAL total=' + exp3Post.midair + '/' + exp3ForRepair.length +
+    ' orphans=' + exp3Post.orphans + ' grounded=' + exp3Post.grounded +
+    ' ok=' + (exp3ForRepair.length - exp3Post.midair - exp3Post.orphans - exp3Post.grounded));
+  console.log('§EXP3_FINAL_BYCLASS ' + JSON.stringify(exp3Post.byClass));
+}
+main().catch(e => { console.error(e); process.exit(1); });

--- a/scripts/probe_proxy_carrier_classes.js
+++ b/scripts/probe_proxy_carrier_classes.js
@@ -1,0 +1,97 @@
+#!/usr/bin/env node
+// probe_proxy_carrier_classes.js — MEASURE (not guess) what IfcBuildingElementProxy's real
+// geometric carriers are, before reclassifying anything. Per this project's rule: extract, never
+// invent a regex. Pure geometry (_contactGraph), independent of any schedule/timeline — answers
+// "what does each floating-candidate proxy actually touch" so a phase/sequence fix targets the
+// real population, not a guess.
+'use strict';
+const fs = require('fs');
+const path = require('path');
+const initSqlJs = require(path.join(__dirname, '..', 'modeller', 'lib', 'sql-wasm.js'));
+const ScheduleGate = require(path.join(__dirname, '..', 'viewer', 'schedule_gate.js'));
+const ScheduleAuthor = require(path.join(__dirname, '..', 'viewer', 'schedule_author.js'));
+const tmSrc = fs.readFileSync(path.join(__dirname, '..', 'viewer', 'time_machine.js'), 'utf8');
+
+function sliceFn(src, name) {
+  const idx = src.lastIndexOf('function ' + name + '(');
+  if (idx < 0) throw new Error(name + ' not found');
+  let depth = 0, i = idx, seenOpen = false;
+  for (; i < src.length; i++) {
+    if (src[i] === '{') { depth++; seenOpen = true; }
+    else if (src[i] === '}') { depth--; if (seenOpen && depth === 0) break; }
+  }
+  return src.slice(idx, i + 1);
+}
+const _contactGraphSrc = sliceFn(tmSrc, '_contactGraph');
+const _contactGraph = (function () {
+  const f = new Function('ScheduleGate', _contactGraphSrc + '\nreturn _contactGraph;');
+  return f(ScheduleGate);
+})();
+
+const BLD_DIR = process.env.BLD_DIR || path.join(require('os').homedir(), 'bim-ootb', 'buildings');
+const ONLY = process.env.ONLY || 'Hospital_extracted';
+
+async function main() {
+  const SQL = await initSqlJs({ wasmBinary: fs.readFileSync(path.join(__dirname, '..', 'modeller', 'lib', 'sql-wasm.wasm')) });
+  const dbPath = path.join(BLD_DIR, ONLY + '.db');
+  const buf = fs.readFileSync(dbPath);
+  const db = new SQL.Database(buf);
+  // rates.js is a plain top-level-var script (browser global scope), not a CommonJS module — load
+  // it the same way witness_midair_zero.js's loadRatesTable() does, via `new Function`.
+  const ratesSrc = fs.readFileSync(path.join(__dirname, '..', 'viewer', 'rates.js'), 'utf8');
+  const RATES = (new Function(ratesSrc +
+    '\nreturn {SEQUENCE_RULES:SEQUENCE_RULES, SEQUENCE_DEFAULT:SEQUENCE_DEFAULT, ' +
+    'SEQUENCE_NAME_OVERRIDES:SEQUENCE_NAME_OVERRIDES, LABOR_RATES:LABOR_RATES, RATES:RATES};'))();
+  const rawItems = ScheduleAuthor._buildScheduleElements(db, RATES.SEQUENCE_RULES, {
+    laborRates: RATES.LABOR_RATES, rates: RATES.RATES, nameOverrides: RATES.SEQUENCE_NAME_OVERRIDES,
+    defaultRule: RATES.SEQUENCE_DEFAULT
+  });
+  // _contactGraph reads bz/tz (time_machine.js's own call sites remap base_z/top_z -> bz/tz before
+  // calling it, e.g. time_machine.js:5303) — _buildScheduleElements returns base_z/top_z, so remap.
+  const items = rawItems.map(function (it) {
+    return Object.assign({}, it, { bz: it.base_z, tz: it.top_z });
+  });
+  console.log('§PROBE_ITEMS total=' + items.length);
+
+  const G = _contactGraph(items);
+  console.log('§PROBE_CONTACT_GRAPH ok=' + G.ok + ' orphans=' + G.orphans + ' grounded=' + G.groundedN);
+
+  // For every IfcBuildingElementProxy, what class(es) does it actually touch?
+  const proxyIdx = [];
+  for (let i = 0; i < items.length; i++) if (items[i].cls === 'IfcBuildingElementProxy') proxyIdx.push(i);
+  console.log('§PROBE_PROXY_COUNT n=' + proxyIdx.length);
+
+  const carrierClassCount = {}; // class of a real touching neighbour -> count of proxies touching it
+  const proxyPhaseOfCarrierPhase = {}; // 'ArchitectureCarrier'|'MEPCarrier'|'orphan'|'groundedOnly' -> count
+  const nameByBucket = { mep: {}, other: {}, orphanNames: {} };
+  const MEP_CARRIER_CLASSES = /^Ifc(Duct|Pipe|Cable|FlowSegment|FlowFitting|FlowController|FlowMovingDevice|FlowStorageDevice|FlowTerminal|FlowTreatmentDevice|DistributionChamberElement|DistributionElement|DistributionControlElement|DistributionPort|Junction|EnergyConversionDevice|ElectricDistributionBoard)/;
+
+  for (const i of proxyIdx) {
+    const it = items[i];
+    const list = G.contacts[i];
+    let bucket;
+    if (!list || !list.length) {
+      bucket = G.grounded[i] ? 'grounded_no_contact' : 'orphan';
+    } else {
+      let sawMep = false, sawArch = false;
+      for (const j of list) {
+        const ccls = items[j].cls;
+        carrierClassCount[ccls] = (carrierClassCount[ccls] || 0) + 1;
+        if (MEP_CARRIER_CLASSES.test(ccls)) sawMep = true;
+        else sawArch = true;
+      }
+      bucket = sawMep && !sawArch ? 'mep_only' : sawMep && sawArch ? 'mep_and_arch' : 'arch_only';
+    }
+    proxyPhaseOfCarrierPhase[bucket] = (proxyPhaseOfCarrierPhase[bucket] || 0) + 1;
+    const nb = /boiler|valve|chiller|pump|ahu|vav|fcu|coil|tank|compressor|generator|transformer|panel|switchgear|duct|damper|diffuser|grille/i.test(it.name) ? 'mep' : 'other';
+    nameByBucket[nb][it.name] = (nameByBucket[nb][it.name] || 0) + 1;
+  }
+
+  console.log('§PROBE_PROXY_BUCKETS ' + JSON.stringify(proxyPhaseOfCarrierPhase));
+  console.log('§PROBE_CARRIER_CLASSES ' + JSON.stringify(carrierClassCount));
+  console.log('§PROBE_NAME_SAMPLE_MEP_BUCKET top20=' + JSON.stringify(
+    Object.entries(nameByBucket.mep).sort((a, b) => b[1] - a[1]).slice(0, 20)));
+  console.log('§PROBE_NAME_SAMPLE_OTHER_BUCKET top20=' + JSON.stringify(
+    Object.entries(nameByBucket.other).sort((a, b) => b[1] - a[1]).slice(0, 20)));
+}
+main().catch(e => { console.error(e); process.exit(1); });

--- a/viewer/sw.js
+++ b/viewer/sw.js
@@ -8,7 +8,7 @@
 // Cache-first for heavy assets (.wasm, images). DB files skip SW (IndexedDB handles them).
 //
 // DEPLOY: bump CACHE_VERSION on every OCI upload. Old caches are purged on activate.
-const CACHE_VERSION = 'v1031';   // bump on each deploy; per-change detail is the git commit message.
+const CACHE_VERSION = 'v1032';   // bump on each deploy; per-change detail is the git commit message.
 // v1031 (2026-08-15) streaming.js envInt: beam/railing->0, +13 remaining MEP device classes->0.05
 // (a prior PR's version bump for this same change was lost in a squash-merge race -- see git log).
 // v1030 (2026-08-15) §PIPE_DUCT_BLUE_TINT / §PHOTO_ENVMAP_DOUBLE_BOOST_FIX (bim-ootb PRs #1367,

--- a/viewer/tests/witness_gantt_og_grid_perf.js
+++ b/viewer/tests/witness_gantt_og_grid_perf.js
@@ -76,6 +76,10 @@ function realScheduledFrom(rows, matchRule, rules) {
 //   wall pool offered to promoted slabs only; hang-carrier fallback for bearingless seq>4.
 function bruteForcePush(elements) {
   const EPS = 0.05, GAP = 0.5;
+  // §OG_HANG_BAND (2026-08-15, time_machine.js _ogSupportSweep): the hang/carrier-above search
+  // (bearingless seq>4 fallback) widened from GAP=0.5 to 9.5 — reused, not re-guessed, the same
+  // measured band this codebase already cited once (§HANG_NEAREST, 0.5-9.5m). Bearing stays at GAP.
+  const HANG_GAP = 9.5;
   const xy = function (a, b) { return a.x0 <= b.x1 && a.x1 >= b.x0 && a.y0 <= b.y1 && a.y1 >= b.y0; };
   const work = elements.map(function (e) { return { guid: e.guid, s: e.s, e: e.e, cls: e.cls, seq: e.seq, bz: e.bz, tz: e.tz, x0: e.x0, x1: e.x1, y0: e.y0, y1: e.y1 }; });
   work.sort(function (a, b) { return a.bz - b.bz; });
@@ -104,7 +108,7 @@ function bruteForcePush(elements) {
       if (!hasBearing && T.seq > 4) {
         for (let i = 0; i < work.length; i++) {
           const H = work[i]; if (H.guid === T.guid || !(H.seq <= 4 || (H.cls === 'IfcSlab' && H.seq > 4))) continue;   // §PROMOTED_CARRIER_POOL: hang pool == struct pool (audit parity)
-          if (H.bz >= T.tz - GAP && H.bz <= T.tz + GAP && H.tz > T.tz + EPS && xy(H, T) && H.e > lastEnd) lastEnd = H.e;
+          if (H.bz >= T.tz - HANG_GAP && H.bz <= T.tz + HANG_GAP && H.tz > T.tz + EPS && xy(H, T) && H.e > lastEnd) lastEnd = H.e;
         }
       }
       if (lastEnd && T.s < lastEnd) {

--- a/viewer/time_machine.js
+++ b/viewer/time_machine.js
@@ -4209,6 +4209,25 @@
       // now gated on the TARGET being a promoted slab.
       var _ogCELL = (typeof ScheduleGate !== 'undefined' && ScheduleGate.CELL) || 4;
       var _ogEPS = 0.05, _ogGAP = 0.5;
+      // §OG_HANG_BAND (2026-08-15, bim-compiler prompts/4D_SCHEDULE_PERFECTION.md
+      // §HOSPITAL_LIGHTING_STILL_FLOATING — captured-path repair vs judge parity, same doctrine as
+      // §4D_LAYER_TRUTH/§GROUNDED_OVERRIDE_FIX/§OG_BEARING_BOUND: guard and judge must share one
+      // physics). _contactGraph's hang/carrier-above relation (the JUDGE _midairAudit reads) has NO
+      // upper Z bound by design — measured+kept in §DAY_GAP_TAIL (bounding IT strands elements as
+      // orphans, 3-40x blowup, rejected on its own numbers). But _ogSupportSweep's OWN hang-repair
+      // query below reused the tight bearing tolerance (_ogGAP=0.5m, meant for near-zero physical
+      // touching gaps) as its search radius too — so it could only ever REPAIR a hang relation whose
+      // carrier's underside sits within 0.5m of the target's top, while the judge (correctly) accepts
+      // real carrier-above relations much further away (a ceiling-hung/embedded item's true structural
+      // carrier is routinely several metres up through a void). MEASURED on Hospital's still-floating
+      // IfcBuildingElementProxy population (post-repair, hang-classified, 821 elements): the real
+      // carrier the judge picks sits p25=1.05m p50=2.00m p90=3.75m max=10.62m above the target —
+      // 812/821 (99%) within 9.5m — the SAME band this codebase already measured and cited once before
+      // for the identical relation (§HANG_NEAREST, "0.5-9.5m, Hospital ducts p50 1.22m") — reused here,
+      // not re-guessed. Unlike the rejected judge-side bound, widening the REPAIR's search radius can
+      // only ever find MORE of what the judge already accepts as real — it cannot create a single new
+      // orphan (orphan/grounded counts come from _contactGraph alone, untouched by this function).
+      var _ogHangGap = 9.5;
       // §OG_GRID_Z_BAND (2026-08-05, measured not guessed — 4D_SCHEDULE_PERFECTION.md §Open Decisions
       // named this block "NOT yet measured, prime suspect"). The grid used to bucket by XY only, so
       // a small-footprint TALL building stacks every floor's structural elements into the SAME cell —
@@ -4251,7 +4270,7 @@
       // hang-carrier, swept to fixpoint (≤16, monotone pushes, acyclic relation).
       // Hang lookup queries the target's TOP z-neighborhood (carrier underside within ±GAP of T.tz,
       // carrier top strictly above T.tz — the same antisymmetric predicate as schedule_gate.js).
-      var _ogCellsQueryTop = function (e) { return _ogCellsFor(e.x0, e.x1, e.y0, e.y1, e.tz - _ogGAP, e.tz + _ogGAP); };
+      var _ogCellsQueryTop = function (e) { return _ogCellsFor(e.x0, e.x1, e.y0, e.y1, e.tz - _ogHangGap, e.tz + _ogHangGap); };
       var _ogPushed = 0, _ogSweeps = 0;
       for (; _ogSweeps < 16; _ogSweeps++) {
         var _ogMoved = 0;
@@ -4307,7 +4326,7 @@
               if (harr) for (var hj = 0; hj < harr.length; hj++) {
                 var H = harr[hj];
                 if (H.guid === T.guid || hseen[H.guid]) continue; hseen[H.guid] = 1;
-                if (H.bz >= T.tz - _ogGAP && H.bz <= T.tz + _ogGAP && H.tz > T.tz + _ogEPS &&
+                if (H.bz >= T.tz - _ogHangGap && H.bz <= T.tz + _ogHangGap && H.tz > T.tz + _ogEPS &&
                     _ogXY(H, T) && H.e > lastEnd) lastEnd = H.e;
               }
             }
@@ -7714,7 +7733,11 @@
   // huts going first before the walls" AFTER a hard reset, because §GANTT_CACHE_HIT served a
   // gantt:v4 entry generated under the old ordering. A hard reset cannot clear it — the entry is in
   // IndexedDB, not the HTTP cache. This bump is that fix's second half.
-  var _GANTT_CACHE_VERSION = 21;   // §GANTT_TASK_WINDOW_FIDELITY (2026-08-15): the captured overlay's
+  var _GANTT_CACHE_VERSION = 22;   // §OG_HANG_BAND (2026-08-15): _ogSupportSweep's hang-repair search
+  // radius widened 0.5m->9.5m (see that function's own header) — a kernel_ops table materialized
+  // under v21 or earlier keeps replaying the narrower-band repair's (more-floating) dates forever
+  // without this bump, regardless of the code fix being deployed.
+  // §GANTT_TASK_WINDOW_FIDELITY (2026-08-15): the captured overlay's
   // affine changed from ONE global rescale to a PER-TASK rescale — every element's placement moves,
   // on every building with a captured/materialized schedule. A kernel_ops table materialized under
   // v20 replays the old global-affine dates forever without this bump. Previous: §CAP_SHADOW_FIX


### PR DESCRIPTION
## Summary
- `_ogSupportSweep` (the CAPTURED-path/materializeZones repair) reused the 0.5m bearing tolerance as its hang/carrier-above search radius too, so it could only fix a hang relation whose real carrier sat within 0.5m above the target — far tighter than what the judge (`_contactGraph`/`_midairAudit`) already accepts as real. Widened to 9.5m, reusing the already-measured `§HANG_NEAREST` band from this same codebase's history (not re-guessed).
- Measured, all 7 buildings (captured-path floating, post-repair): Terminal 570→435, **Hospital 1581→611 (-61%)**, Duplex 34→15, HHS 198→139, Clinic 431→401, LTU_AHouse 1341→1319, JKR 184→143. Total 4339→3063 (-29%). Hospital's `IfcBuildingElementProxy` specifically: 1012→55 (-95%).
- Two other repair-layer levers were tried and ruled out THIS session before this fix (pool-widening: 1510→2233 worse; pre-window `_midairRepair`: 1581→2406 worse) — full trail in `prompts/4D_SCHEDULE_PERFECTION.md` (bim-compiler repo).
- `_GANTT_CACHE_VERSION` 21→22, `sw.js` v1031→v1032 (non-optional per this lane's own established rule — a materialized kernel_ops table replays the old repair's dates forever without it).
- `witness_gantt_og_grid_perf.js`'s O(n²) brute-force reference updated to match the new band (was hardcoded to 0.5m, causing a real grid-vs-brute-force mismatch).

## Test plan
- [x] `witness_midair_zero.js` 38/0 (generative path — untouched, confirms no cross-path regression)
- [x] `witness_og_guard_bearing_bound.js` 9/9
- [x] `witness_gantt_og_grid_perf.js` 3/3 (after updating its reference)
- [x] `scripts/gate_4d.sh` 7/7 pass, 1 pre-existing MISS (unrelated)
- [x] `witness_gantt_lock_integrity.js` / `witness_big_element_support_coverage.js` / `witness_door_window_host_wall.js` — pre-existing failures verified identical on unmodified `main` (dead `_zoneIndex` slice, unrelated `openingGate` gap), not caused by this change
- [x] `maxShiftDays` stays well under the range the two rejected repair-layer attempts produced (100-300d): worst is LTU 99.1d, most buildings under 40d — confirms no reintroduction of the previously-rejected Gantt-window desync

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JnzfsTYEKQpEugADhrTNuG