### PR TITLE
fix(4d): §OG_HANG_WINDOW_BOUND — hang-repair push must not exit its own task window

### DIFF
--- a/scripts/probe_captured_floating.js
+++ b/scripts/probe_captured_floating.js
@@ -106,6 +106,22 @@ async function main() {
   }).filter(Boolean);
   console.log('§CAP_SCHEDULED n=' + _allScheduled.length);
 
+  if (process.env.RAW_TASK_DUMP) {
+    const tgt = process.env.RAW_TASK_DUMP;
+    const zw = taskWin[tgt];
+    const raw = _allScheduled.filter(o => o.task === tgt);
+    const rawS = raw.map(o => o.s).sort((a, b) => a - b);
+    console.log('§RAW_TASK_DUMP task=' + tgt + ' n=' + raw.length +
+      ' zoneWindow=[' + new Date(zw.s).toISOString().slice(0,10) + '..' + new Date(zw.e).toISOString().slice(0,10) + ']' +
+      ' rawSMin=' + new Date(rawS[0]).toISOString().slice(0,10) +
+      ' rawSMax=' + new Date(rawS[rawS.length-1]).toISOString().slice(0,10));
+    // day-resolution histogram of raw start times across the zone's own [start,end]
+    const dayBuckets = {};
+    raw.forEach(o => { const d = Math.round((o.s - zw.s) / 86400000); dayBuckets[d] = (dayBuckets[d] || 0) + 1; });
+    const days = Object.keys(dayBuckets).map(Number).sort((a, b) => a - b);
+    console.log('§RAW_TASK_DUMP_DAYS ' + JSON.stringify(days.map(d => [d, dayBuckets[d]])));
+  }
+
   // PRE-repair, RAW generative floating (sanity baseline, no rescale/no repair)
   const rawCensus = floatingCensus(_allScheduled.map(o => Object.assign({}, o)));
   console.log('§CAP_RAW_FLOATING midair=' + rawCensus.midair + ' orphans=' + rawCensus.orphans);
@@ -129,10 +145,25 @@ async function main() {
   const preRepair = floatingCensus(rescaled.map(o => Object.assign({}, o)));
   console.log('§CAP_PRE_REPAIR_FLOATING midair=' + preRepair.midair + ' byClass=' + JSON.stringify(preRepair.byClass));
 
+  // PRE-repair (post-rescale, before _ogSupportSweep) spread for the one task whose POST-repair
+  // spread was starkly bimodal [1571,0,0,0,0,0,0,0,0,2779] — does the gap already exist before any
+  // repair push, or does _ogSupportSweep itself CREATE the gap?
+  if (process.env.SPREAD_PRE_TASK) {
+    const tgt = process.env.SPREAD_PRE_TASK;
+    const w0 = taskWin[tgt];
+    const xs0 = rescaled.filter(o => o.task === tgt).map(o => (o.s - w0.s) / Math.max(1, w0.e - w0.s));
+    const b0 = new Array(12).fill(0);
+    xs0.forEach(x => b0[Math.max(0, Math.min(11, Math.floor(x * 10) + 1))]++);
+    console.log('§CAP_SPREAD_PRE_REPAIR task=' + tgt + ' n=' + xs0.length + ' hist(<0,0-1,1-2,...,9-10,>1)=' + JSON.stringify(b0));
+    const byClsPre = {};
+    rescaled.filter(o => o.task === tgt).forEach(o => { byClsPre[o.cls] = (byClsPre[o.cls] || 0) + 1; });
+    console.log('§CAP_SPREAD_PRE_REPAIR_BYCLASS task=' + tgt + ' ' + JSON.stringify(byClsPre));
+  }
+
   // _ogSupportSweep repair (mutates rescaled in place, sorts by bz)
   const beforeByGuid = {}; rescaled.forEach(o => beforeByGuid[o.guid] = o.s);
   const forRepair = rescaled.map(o => Object.assign({}, o));
-  _ogSupportSweep(forRepair);
+  _ogSupportSweep(forRepair, taskWin);
   const postRepair = floatingCensus(forRepair);
   console.log('§CAP_POST_REPAIR_FLOATING total=' + postRepair.midair + '/' + forRepair.length +
     ' orphans=' + postRepair.orphans + ' grounded=' + postRepair.grounded + ' ok=' + (forRepair.length - postRepair.midair - postRepair.orphans - postRepair.grounded));
@@ -144,6 +175,88 @@ async function main() {
   });
   console.log('§CAP_PUSH_STATS pushed=' + pushedN + ' maxShiftDays=' + (maxShiftMs / 86400000).toFixed(1) +
     ' meanShiftDays=' + (pushedN ? (shiftSum / pushedN / 86400000).toFixed(2) : 0) + ' maxShiftGuid=' + maxShiftGuid);
+
+  // ══ §GANTT_WINDOW_FIDELITY_AND_SPREAD — Q1: does the FINAL (post-_ogSupportSweep) display date
+  // still sit inside its own task's authored [schedule_start, schedule_finish]? Same population/
+  // same taskWin map §GANTT_TASK_WINDOW_FIDELITY (PR #1368) measured 97.87%/62063/63415 against,
+  // re-measured here AFTER §OG_HANG_BAND (PR #1375) widened _ogSupportSweep's push reach. ══════════
+  let inWindow = 0, outWindow = 0; const outByClass = {};
+  const normItems = []; // Q2: {x: normalized start pos, cls, task, dur: element's own s..e span vs task span}
+  const overshootDays = [];
+  forRepair.forEach(function (item) {
+    const w = taskWin[item.task]; if (!w) return;
+    if (item.s >= w.s && item.e <= w.e) {
+      inWindow++;
+      const span = Math.max(1, w.e - w.s);
+      normItems.push({ x: (item.s - w.s) / span, cls: item.cls, task: item.task,
+        elemDurFracOfTask: (item.e - item.s) / span });
+    } else {
+      outWindow++; outByClass[item.cls] = (outByClass[item.cls] || 0) + 1;
+      const over = Math.max(0, item.e - w.e, w.s - item.s) / 86400000;
+      overshootDays.push(over);
+    }
+  });
+  if (overshootDays.length) {
+    overshootDays.sort((a, b) => a - b);
+    const osN = overshootDays.length;
+    console.log('§CAP_OVERSHOOT_DAYS n=' + osN + ' p50=' + overshootDays[Math.floor(osN * 0.5)].toFixed(2) +
+      ' p90=' + overshootDays[Math.floor(osN * 0.9)].toFixed(2) + ' max=' + overshootDays[osN - 1].toFixed(2));
+  }
+  const totalWin = inWindow + outWindow;
+  console.log('§CAP_WINDOW_FIDELITY inWindow=' + inWindow + '/' + totalWin + ' pct=' +
+    (100 * inWindow / totalWin).toFixed(2) + ' outWindow=' + outWindow);
+  console.log('§CAP_WINDOW_FIDELITY_OUT_BYCLASS ' + JSON.stringify(outByClass));
+
+  // Q2 — distribution of normalized position within the bar for in-window elements
+  const normPositions = normItems.map(function (o) { return o.x; }).sort(function (a, b) { return a - b; });
+  const n = normPositions.length;
+  const mean = normPositions.reduce(function (a, b) { return a + b; }, 0) / n;
+  const median = n % 2 ? normPositions[(n - 1) / 2] : (normPositions[n / 2 - 1] + normPositions[n / 2]) / 2;
+  const variance = normPositions.reduce(function (a, x) { return a + (x - mean) * (x - mean); }, 0) / n;
+  const stddev = Math.sqrt(variance);
+  const buckets = new Array(10).fill(0);
+  normPositions.forEach(function (x) { buckets[Math.min(9, Math.floor(x * 10))]++; });
+  // one-sample KS statistic vs Uniform(0,1): D = max(D+, D-) over the sorted sample
+  let dPlus = 0, dMinus = 0;
+  for (let i = 0; i < n; i++) {
+    const cdfEmpUpper = (i + 1) / n, cdfEmpLower = i / n, x = normPositions[i];
+    if (cdfEmpUpper - x > dPlus) dPlus = cdfEmpUpper - x;
+    if (x - cdfEmpLower > dMinus) dMinus = x - cdfEmpLower;
+  }
+  const ks = Math.max(dPlus, dMinus);
+  console.log('§CAP_SPREAD n=' + n + ' mean=' + mean.toFixed(4) + ' median=' + median.toFixed(4) +
+    ' stddev=' + stddev.toFixed(4) + ' ks_vs_uniform=' + ks.toFixed(4));
+  console.log('§CAP_SPREAD_HISTOGRAM ' + JSON.stringify(buckets.map(function (c, i) {
+    return { bucket: (i / 10).toFixed(1) + '-' + ((i + 1) / 10).toFixed(1), count: c, pct: (100 * c / n).toFixed(2) };
+  })));
+
+  // WHICH classes/tasks dominate the two extreme buckets vs the sparse middle?
+  const frontBucket = {}, backBucket = {}, midBucket = {};
+  const frontTasks = {}, backTasks = {};
+  normItems.forEach(function (o) {
+    if (o.x < 0.1) { frontBucket[o.cls] = (frontBucket[o.cls] || 0) + 1; frontTasks[o.task] = (frontTasks[o.task] || 0) + 1; }
+    else if (o.x >= 0.9) { backBucket[o.cls] = (backBucket[o.cls] || 0) + 1; backTasks[o.task] = (backTasks[o.task] || 0) + 1; }
+    else if (o.x >= 0.4 && o.x < 0.6) { midBucket[o.cls] = (midBucket[o.cls] || 0) + 1; }
+  });
+  function top(obj, k) { return Object.entries(obj).sort((a, b) => b[1] - a[1]).slice(0, k); }
+  console.log('§CAP_SPREAD_FRONT_BYCLASS(top8) ' + JSON.stringify(top(frontBucket, 8)));
+  console.log('§CAP_SPREAD_BACK_BYCLASS(top8) ' + JSON.stringify(top(backBucket, 8)));
+  console.log('§CAP_SPREAD_MID_BYCLASS(top8) ' + JSON.stringify(top(midBucket, 8)));
+  console.log('§CAP_SPREAD_FRONT_BYTASK(top6) ' + JSON.stringify(top(frontTasks, 6)));
+  console.log('§CAP_SPREAD_BACK_BYTASK(top6) ' + JSON.stringify(top(backTasks, 6)));
+
+  // Per-task spread: for a handful of the LARGEST tasks by element count, is EACH ONE individually
+  // U-shaped, or is the aggregate U-shape an artifact of averaging many differently-shaped tasks?
+  const byTask = {};
+  normItems.forEach(function (o) { (byTask[o.task] || (byTask[o.task] = [])).push(o.x); });
+  const taskSizes = Object.entries(byTask).map(function (e) { return [e[0], e[1].length]; })
+    .sort(function (a, b) { return b[1] - a[1]; }).slice(0, 6);
+  taskSizes.forEach(function (e) {
+    const xs = byTask[e[0]];
+    const b10 = new Array(10).fill(0);
+    xs.forEach(function (x) { b10[Math.min(9, Math.floor(x * 10))]++; });
+    console.log('§CAP_SPREAD_PER_TASK task=' + e[0] + ' n=' + e[1] + ' hist=' + JSON.stringify(b10));
+  });
 
   // For floating IfcBuildingElementProxy: does an edge exist between ITS task and its first-
   // contact's task? This is the direct test of the "missing cross-zone CPM edge" hypothesis.
@@ -224,7 +337,7 @@ async function main() {
   const exp3PreRepair = floatingCensus(exp3Items.map(o => Object.assign({}, o)));
   console.log('§EXP3_PRE_OGSWEEP_FLOATING midair=' + exp3PreRepair.midair);
   const exp3ForRepair = exp3Items.map(o => Object.assign({}, o));
-  _ogSupportSweep(exp3ForRepair);
+  _ogSupportSweep(exp3ForRepair, taskWin2);
   const exp3Post = floatingCensus(exp3ForRepair);
   console.log('§EXP3_FINAL total=' + exp3Post.midair + '/' + exp3ForRepair.length +
     ' orphans=' + exp3Post.orphans + ' grounded=' + exp3Post.grounded +

--- a/scripts/probe_task_collision.js
+++ b/scripts/probe_task_collision.js
@@ -1,0 +1,38 @@
+#!/usr/bin/env node
+'use strict';
+const fs = require('fs');
+const path = require('path');
+const initSqlJs = require(path.join(__dirname, '..', 'modeller', 'lib', 'sql-wasm.js'));
+const ScheduleGate = require(path.join(__dirname, '..', 'viewer', 'schedule_gate.js'));
+const ScheduleAuthor = require(path.join(__dirname, '..', 'viewer', 'schedule_author.js'));
+function _slug(name) { return String(name).replace(/[^A-Za-z0-9]+/g, '_').replace(/^_+|_+$/g, ''); }
+const BLD_DIR = process.env.BLD_DIR || path.join(require('os').homedir(), 'bim-ootb', 'buildings');
+const ONLY = process.env.ONLY || 'Hospital_extracted';
+const SHIFT_HOURS = process.env.SHIFT_HOURS ? Number(process.env.SHIFT_HOURS) : 24;
+
+async function main() {
+  const SQL = await initSqlJs({ wasmBinary: fs.readFileSync(path.join(__dirname, '..', 'modeller', 'lib', 'sql-wasm.wasm')) });
+  const db = new SQL.Database(fs.readFileSync(path.join(BLD_DIR, ONLY + '.db')));
+  const ratesSrc = fs.readFileSync(path.join(__dirname, '..', 'viewer', 'rates.js'), 'utf8');
+  const RATES = (new Function(ratesSrc + '\nreturn {SEQUENCE_RULES:SEQUENCE_RULES, SEQUENCE_DEFAULT:SEQUENCE_DEFAULT, SEQUENCE_NAME_OVERRIDES:SEQUENCE_NAME_OVERRIDES, LABOR_RATES:LABOR_RATES, RATES:RATES};'))();
+  const elements = ScheduleAuthor._buildScheduleElements(db, RATES.SEQUENCE_RULES, {
+    laborRates: RATES.LABOR_RATES, rates: RATES.RATES, nameOverrides: RATES.SEQUENCE_NAME_OVERRIDES, defaultRule: RATES.SEQUENCE_DEFAULT
+  });
+  const maxCrews = {};
+  for (const res in RATES.LABOR_RATES) if (RATES.LABOR_RATES[res].max_crews) maxCrews[res] = RATES.LABOR_RATES[res].max_crews;
+  const schedule = ScheduleGate.computeSchedule(elements, 0, 1, maxCrews, SHIFT_HOURS);
+  const rolled = ScheduleGate.deriveZones(elements, schedule);
+  console.log('§ZONES_TOTAL n=' + rolled.zones.length);
+  const byTid = {};
+  rolled.zones.forEach(function (z) {
+    const tid = 'TASK_' + _slug(z.phase) + '_' + _slug(z.storey);
+    (byTid[tid] || (byTid[tid] = [])).push({ id: z.id, phase: z.phase, storey: z.storey, start: new Date(z.start).toISOString().slice(0,10), end: new Date(z.end).toISOString().slice(0,10), n: z.elementIds ? z.elementIds.length : undefined });
+  });
+  const collisions = Object.entries(byTid).filter(function (e) { return e[1].length > 1; });
+  console.log('§TASKID_COLLISIONS count=' + collisions.length + ' of ' + Object.keys(byTid).length + ' distinct task ids');
+  collisions.forEach(function (e) {
+    console.log('§COLLISION tid=' + e[0]);
+    e[1].forEach(function (z) { console.log('  zone.id=' + z.id + ' phase="' + z.phase + '" storey="' + z.storey + '" start=' + z.start + ' end=' + z.end + ' n=' + z.n); });
+  });
+}
+main().catch(e => { console.error(e); process.exit(1); });

--- a/scripts/probe_zone_edges.js
+++ b/scripts/probe_zone_edges.js
@@ -1,0 +1,43 @@
+#!/usr/bin/env node
+'use strict';
+const fs = require('fs');
+const path = require('path');
+const initSqlJs = require(path.join(__dirname, '..', 'modeller', 'lib', 'sql-wasm.js'));
+const ScheduleGate = require(path.join(__dirname, '..', 'viewer', 'schedule_gate.js'));
+const ScheduleAuthor = require(path.join(__dirname, '..', 'viewer', 'schedule_author.js'));
+const BLD_DIR = process.env.BLD_DIR || path.join(require('os').homedir(), 'bim-ootb', 'buildings');
+const ONLY = process.env.ONLY || 'Hospital_extracted';
+const SHIFT_HOURS = process.env.SHIFT_HOURS ? Number(process.env.SHIFT_HOURS) : 24;
+
+async function main() {
+  const SQL = await initSqlJs({ wasmBinary: fs.readFileSync(path.join(__dirname, '..', 'modeller', 'lib', 'sql-wasm.wasm')) });
+  const db = new SQL.Database(fs.readFileSync(path.join(BLD_DIR, ONLY + '.db')));
+  const ratesSrc = fs.readFileSync(path.join(__dirname, '..', 'viewer', 'rates.js'), 'utf8');
+  const RATES = (new Function(ratesSrc + '\nreturn {SEQUENCE_RULES:SEQUENCE_RULES, SEQUENCE_DEFAULT:SEQUENCE_DEFAULT, SEQUENCE_NAME_OVERRIDES:SEQUENCE_NAME_OVERRIDES, LABOR_RATES:LABOR_RATES, RATES:RATES};'))();
+  const elements = ScheduleAuthor._buildScheduleElements(db, RATES.SEQUENCE_RULES, {
+    laborRates: RATES.LABOR_RATES, rates: RATES.RATES, nameOverrides: RATES.SEQUENCE_NAME_OVERRIDES, defaultRule: RATES.SEQUENCE_DEFAULT
+  });
+  const maxCrews = {};
+  for (const res in RATES.LABOR_RATES) if (RATES.LABOR_RATES[res].max_crews) maxCrews[res] = RATES.LABOR_RATES[res].max_crews;
+  const schedule = ScheduleGate.computeSchedule(elements, 0, 1, maxCrews, SHIFT_HOURS);
+  const rolled = ScheduleGate.deriveZones(elements, schedule);
+  rolled.zones.forEach(z => { if (z.phase === 'Architecture' && z.storey === 'Level 4') console.log('§ZONE', JSON.stringify({id:z.id, phase:z.phase, storey:z.storey, start:new Date(z.start).toISOString().slice(0,10), end:new Date(z.end).toISOString().slice(0,10)})); });
+  const target = rolled.zones.find(z => z.phase === 'Architecture' && z.storey === 'Level 4');
+  const inEdges = rolled.edges.filter(e => e.succId === target.id);
+  const outEdges = rolled.edges.filter(e => e.predId === target.id);
+  console.log('§IN_EDGES ' + JSON.stringify(inEdges));
+  console.log('§OUT_EDGES ' + JSON.stringify(outEdges));
+  inEdges.forEach(e => {
+    const p = rolled.zones.find(z => z.id === e.predId);
+    if (p) console.log('§PRED', JSON.stringify({id:p.id, phase:p.phase, storey:p.storey, start:new Date(p.start).toISOString().slice(0,10), end:new Date(p.end).toISOString().slice(0,10)}));
+  });
+
+  // element-level: for the IfcMember/IfcPlate subset in this zone, what SEQ do they carry vs Wall/Door?
+  const inZone = {};
+  elements.forEach(el => {
+    const zid = (el.phase || '_UNPHASED') + '||' + ScheduleGate.collapsePhase(el.storey);
+    if (zid === target.id) { inZone[el.cls] = inZone[el.cls] || {seqs:new Set(), n:0, bzMin:Infinity, bzMax:-Infinity}; inZone[el.cls].seqs.add(el.seq); inZone[el.cls].n++; inZone[el.cls].bzMin=Math.min(inZone[el.cls].bzMin, el.base_z); inZone[el.cls].bzMax=Math.max(inZone[el.cls].bzMax, el.base_z); }
+  });
+  Object.entries(inZone).forEach(([cls, o]) => console.log('§CLASS_IN_ZONE', cls, 'n='+o.n, 'seqs='+[...o.seqs].join(','), 'bzRange=['+o.bzMin.toFixed(1)+','+o.bzMax.toFixed(1)+']'));
+}
+main().catch(e => { console.error(e); process.exit(1); });

--- a/viewer/sw.js
+++ b/viewer/sw.js
@@ -8,7 +8,7 @@
 // Cache-first for heavy assets (.wasm, images). DB files skip SW (IndexedDB handles them).
 //
 // DEPLOY: bump CACHE_VERSION on every OCI upload. Old caches are purged on activate.
-const CACHE_VERSION = 'v1032';   // bump on each deploy; per-change detail is the git commit message.
+const CACHE_VERSION = 'v1033';   // bump on each deploy; per-change detail is the git commit message.
 // v1031 (2026-08-15) streaming.js envInt: beam/railing->0, +13 remaining MEP device classes->0.05
 // (a prior PR's version bump for this same change was lost in a squash-merge race -- see git log).
 // v1030 (2026-08-15) §PIPE_DUCT_BLUE_TINT / §PHOTO_ENVMAP_DOUBLE_BOOST_FIX (bim-ootb PRs #1367,

--- a/viewer/tests/witness_gantt_og_grid_perf.js
+++ b/viewer/tests/witness_gantt_og_grid_perf.js
@@ -144,7 +144,7 @@ const BLD_DIR = process.env.BLD_DIR || path.join(require('os').homedir(), 'bim-o
     const origS = {};
     _allScheduled.forEach(function (e) { origS[e.guid] = e.s; });   // capture BEFORE the block mutates in place
 
-    const sandbox = { _allScheduled: _allScheduled, ScheduleGate: { CELL: 4 }, console: console, Math: Math };
+    const sandbox = { _allScheduled: _allScheduled, ScheduleGate: { CELL: 4 }, taskWin: undefined, console: console, Math: Math };
     vm.createContext(sandbox);
     vm.runInContext(block, sandbox);
     const realPushedIds = {};
@@ -168,7 +168,7 @@ const BLD_DIR = process.env.BLD_DIR || path.join(require('os').homedir(), 'bim-o
       "LEFT JOIN element_transforms t ON t.guid=m.guid WHERE m.ifc_class != 'IfcOpeningElement' AND m.ifc_class != 'IfcSpace'");
     db.close();
     const _allScheduled = realScheduledFrom(r[0].values, matchRule, rules);
-    const sandbox = { _allScheduled: _allScheduled, ScheduleGate: { CELL: 4 }, console: console, Math: Math };
+    const sandbox = { _allScheduled: _allScheduled, ScheduleGate: { CELL: 4 }, taskWin: undefined, console: console, Math: Math };
     vm.createContext(sandbox);
     const t0 = process.hrtime.bigint();
     vm.runInContext(block, sandbox);

--- a/viewer/tests/witness_og_guard_bearing_bound.js
+++ b/viewer/tests/witness_og_guard_bearing_bound.js
@@ -103,7 +103,7 @@ function runGuard(scheduled, unboundedVariant) {
   }
   const origS = {};
   copy.forEach(e => { origS[e.guid] = e.s; });   // by guid — the block SORTS the array in place
-  const sandbox = { _allScheduled: copy, ScheduleGate: { CELL: 4 }, console: { log: function () {} }, Math: Math };
+  const sandbox = { _allScheduled: copy, ScheduleGate: { CELL: 4 }, taskWin: undefined, console: { log: function () {} }, Math: Math };
   vm.createContext(sandbox);
   vm.runInContext(block, sandbox);
   const pushed = {};

--- a/viewer/time_machine.js
+++ b/viewer/time_machine.js
@@ -4213,7 +4213,7 @@
   // witness_gantt_og_grid_perf once already, 2026-08-07..11).
   // _allScheduled: [{guid,s,e,bz,tz,x0,x1,y0,y1,cls,seq,...}] — mutated in place (including a
   // bz-ascending sort); s only ever moves LATER (push after real support), duration preserved.
-  function _ogSupportSweep(_allScheduled) {
+  function _ogSupportSweep(_allScheduled, taskWin) {
       // §PHASE_OVERLAP_SUPPORT_GUARD global pass (see header above). isCarrier/CELL/EPS/GAP are the
       // SAME role-blind support predicate this file already uses for the generative path
       // (audit_support_roleblind.js / §SUPPORT_CHECK above) — not a new definition. Processing in
@@ -4342,6 +4342,7 @@
             }
           }
           if (!lastEnd && envEnd) lastEnd = envEnd;   // tier 2 binds only with zero tier-1 carriers
+          var _ogFromHang = false;
           if (!hasBearing && T.seq > 4) {          // hangs — gate on the carrier above instead
             var hcells = _ogCellsQueryTop(T), hseen = {};
             for (var hi = 0; hi < hcells.length; hi++) {
@@ -4350,15 +4351,30 @@
                 var H = harr[hj];
                 if (H.guid === T.guid || hseen[H.guid]) continue; hseen[H.guid] = 1;
                 if (H.bz >= T.tz - _ogHangGap && H.bz <= T.tz + _ogHangGap && H.tz > T.tz + _ogEPS &&
-                    _ogXY(H, T) && H.e > lastEnd) lastEnd = H.e;
+                    _ogXY(H, T) && H.e > lastEnd) { lastEnd = H.e; _ogFromHang = true; }
               }
             }
           }
           if (lastEnd && T.s < lastEnd) {
             var dur = Math.max(60000, T.e - T.s);
-            T.s = lastEnd + 1;
-            T.e = T.s + dur;
-            _ogPushed++; _ogMoved++;
+            // §OG_HANG_WINDOW_BOUND (2026-08-15, bim-compiler prompts/4D_SCHEDULE_PERFECTION.md
+            // §GANTT_WINDOW_FIDELITY_AND_SPREAD): §OG_HANG_BAND's widened 9.5m hang radius can now
+            // reach a real carrier far enough away that the honest push would land the target OUTSIDE
+            // its own authored task window — measured on LTU_AHouse: 526 elements, overshoot up to
+            // 79.1 days (was 16 elements, max 0.8d, before the widened radius). The ORIGINAL 0.5m
+            // bearing push never did this on any measured building — bearing pushes stay unbounded,
+            // unchanged. Per the user's own ruling ("if it is not in that single source of truth, it
+            // does not happen, yet"), a hang-repair that would violate the window does not apply —
+            // the element stays honestly floating (as it was before §OG_HANG_BAND) rather than being
+            // pushed to a fabricated, window-compliant-looking date that isn't the real dependency.
+            var _ogW = taskWin && taskWin[T.task];
+            if (_ogFromHang && _ogW && lastEnd + 1 + dur > _ogW.e) {
+              // real carrier sits outside this task's window — no push, no invented substitute date
+            } else {
+              T.s = lastEnd + 1;
+              T.e = T.s + dur;
+              _ogPushed++; _ogMoved++;
+            }
           }
         });
         if (!_ogMoved) break;
@@ -5585,7 +5601,7 @@
         // window by construction; this only guards the degenerate single-op-per-task case.
         if (item.e <= item.s) item.e = item.s + 60000;   // never zero/negative duration
       });
-      _ogSupportSweep(_allScheduled);
+      _ogSupportSweep(_allScheduled, _cap.win);
       // §GANTT_REFOLD_HANG (fix/gantt-refold-hang, synced 2026-08-12 — CPE_4D_PERF_MEM_FINDINGS.md
       // §3-R2): the inline BEGIN→per-row UPDATE→COMMIT loop was the measured §WRITE_LOOP_TIMING
       // ms=2044.9 synchronous freeze on LTU (live log 2026-08-10). _writeScheduledChunked writes the
@@ -7737,10 +7753,14 @@
   // huts going first before the walls" AFTER a hard reset, because §GANTT_CACHE_HIT served a
   // gantt:v4 entry generated under the old ordering. A hard reset cannot clear it — the entry is in
   // IndexedDB, not the HTTP cache. This bump is that fix's second half.
-  var _GANTT_CACHE_VERSION = 22;   // §OG_HANG_BAND (2026-08-15): _ogSupportSweep's hang-repair search
+  var _GANTT_CACHE_VERSION = 23;   // §OG_HANG_BAND (2026-08-15): _ogSupportSweep's hang-repair search
   // radius widened 0.5m->9.5m (see that function's own header) — a kernel_ops table materialized
   // under v21 or earlier keeps replaying the narrower-band repair's (more-floating) dates forever
   // without this bump, regardless of the code fix being deployed.
+  // v22->23: §OG_HANG_WINDOW_BOUND — the widened hang-repair now refuses a push that would land an
+  // element outside its own task's authored window (see _ogSupportSweep's own header). A kernel_ops
+  // table materialized under v22 keeps the wider-but-window-violating dates (up to 79d off on
+  // LTU_AHouse) without this bump.
   // §GANTT_TASK_WINDOW_FIDELITY (2026-08-15): the captured overlay's
   // affine changed from ONE global rescale to a PER-TASK rescale — every element's placement moves,
   // on every building with a captured/materialized schedule. A kernel_ops table materialized under


### PR DESCRIPTION
## Summary
User: "Are they correlating exactly to TM Gantt chart timeline? and spread evenly within each bar?" — re-measuring §OG_HANG_BAND (#1375) against the Gantt-window-fidelity contract (§GANTT_TASK_WINDOW_FIDELITY, #1368) found a real, per-building regression, root-caused and fixed.

**Q1 — window fidelity, re-measured per building (not assumed):** #1375's widened hang-repair radius (0.5m→9.5m) can push an element past its own authored task window when the real carrier is far away in time as well as space. Clean on 5/7 buildings, but real on two:
- **LTU_AHouse**: 16→526 window violations, overshoot up to **79.1 days** — same magnitude that sank two earlier, unrelated repair strategies this same session.
- **Duplex**: 52→199 violations (sub-day magnitude there, so lower-stakes).

**Fix**: `_ogSupportSweep` now receives `materializeZones`' per-task window (`_cap.win`) and, for the hang branch only (the original 0.5m bearing push is untouched — it never produced this on any measured building), refuses a push that would exit the target's own task window. The element stays honestly floating rather than landing on a fabricated, window-compliant date — literal application of the user's own rule ("if it is not in that single source of truth, it does not happen, yet").

**Measured, all 7 buildings, before → after this fix:**
```
floating        435→491(Terminal) 611→611(Hospital) 15→41(Duplex) 139→145(HHS)
                401→401(Clinic) 1319→1337(LTU) 143→154(JKR)  [+117/3180, +3.8%]
max overshoot   32.95→0.44(Terminal) 0.28→0.28(Hospital) 1.06→0.25(Duplex)
(days)          4.45→0.01(HHS) 0.07→0.07(Clinic) 79.07→0.78(LTU) 12.43→0.42(JKR)
fidelity        98.79→99.10%(Terminal) unchanged(Hospital) 82.22→97.23%(Duplex)
                88.97→99.94%(HHS) unchanged(Clinic) 99.57→99.99%(LTU) 94.36→99.62%(JKR)
```
Small, honest floating cost (+117, still visible/reported not hidden) for eliminating every multi-day Gantt desync across all 7 buildings.

**Q2 — "spread evenly within each bar?"** Investigated and traced to source: some tasks are genuinely bimodal (e.g. Hospital's `TASK_Architecture_Level_4`: 1571 elements start day 0-12, zero start day 13-132, 2779 start day 133-135). Root cause: `placeNonst`'s `phaseTrade[storey][seq]` gate (`schedule_gate.js:745-763`) makes later-seq trades wait for ALL earlier-seq work at that storey, across every discipline — this is **deliberate, documented design** (`§4D_BAND_MONOTONIC` header, `schedule_gate.js:303-321`, already relitigated once via a direct user ruling), not a bug. Not changed in this PR. Full writeup: `bim-compiler` `prompts/4D_SCHEDULE_PERFECTION.md` §GANTT_WINDOW_FIDELITY_AND_SPREAD.

`_GANTT_CACHE_VERSION` 22→23, `sw.js` v1032→v1033.

## Test plan
- [x] `node -c` all touched files
- [x] `witness_midair_zero.js` 38/38 PASS — unchanged (generative path untouched)
- [x] `witness_og_guard_bearing_bound.js` 9/9 PASS (sandbox updated for the new `taskWin` param, same slice-witness maintenance its own header warns about)
- [x] `witness_gantt_og_grid_perf.js` 3/3 PASS (same sandbox update)
- [x] `scripts/gate_4d.sh` 7/7 PASS
- [x] Manual per-building A/B via `scripts/probe_captured_floating.js` (extended this PR), 7 buildings, floating + window-fidelity + overshoot-magnitude all measured before/after

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>