### PR TITLE
fix(photo): §TRINORM_LINEAR — triplanar normFactor sRGB/linear mismatch crushed metal to black

### DIFF
--- a/viewer/streaming.js
+++ b/viewer/streaming.js
@@ -481,25 +481,38 @@ function setupStreaming(A) {
     // specifically when staged, never in plain nav (uTriActive gates it to staging only).
     // Fix: normFactorRGB is the PER-CHANNEL inverse mean (removes the cast entirely, each
     // channel now genuinely centres at 1.0) instead of a single scalar broadcast to all three.
+    // §TRINORM_LINEAR (2026-08-16 — PHOTOREAL_STILL_RENDER.md §ONGOING_TINT root cause): every
+    // normFactor above (scalar AND per-channel) was derived from the JPG's raw sRGB byte means,
+    // but the shader multiply happens in LINEAR light — these textures are flagged
+    // SRGBColorSpace, so the GPU decodes them BEFORE texture2D() returns. In linear space the
+    // real means are far lower (metal 0.205/0.248/0.294, not 0.490/0.535/0.578), so the sRGB-
+    // derived factors under-normalize ~2.0-2.4x: the "centred at 1.0" product actually centred
+    // at ~0.42-0.53, and the contrast line `(x-1.0)*boost+1.0` then clamps every texel below
+    // 1-1/boost to LITERAL ZERO (metal boost 1.9 → 41% of texels → multiply-by-0 → pure-black
+    // pixels on every metal-class element under Alt+S, with a blue-dominant residue on the rest
+    // because the R factor over-crushes red hardest — the reported "bluish, darker" piping and
+    // the black valve pixels are both exactly this). normFactorRGB below is now the inverse of
+    // the LINEAR mean (sRGB-decoded before averaging); measured multiply now centres at 1.000
+    // per channel with 0.00% of texels clamping to zero, at unchanged contrastBoost.
     var _TRI_CONCRETE = {
       diffuse: 'textures/materials/concrete_color_1k.jpg',
       roughness: 'textures/materials/concrete_rough_1k.jpg',
       tileMeters: 2.5,     // world units per texture repeat
-      normFactorRGB: [1.3835, 1.3835, 1.3835],  // grayscale texture — identical to the old scalar
+      normFactorRGB: [2.0755, 2.0755, 2.0755],  // §TRINORM_LINEAR — inverse LINEAR mean (grayscale tex)
       contrastBoost: 1.6
     };
     var _TRI_PLASTER = {
       diffuse: 'textures/materials/plaster_color_1k.jpg',
       roughness: 'textures/materials/plaster_rough_1k.jpg',
       tileMeters: 2.0,
-      normFactorRGB: [1.3426, 1.3375, 1.3654],  // near-neutral texture, minor per-channel correction
+      normFactorRGB: [1.9428, 1.9262, 2.0172],  // §TRINORM_LINEAR — inverse LINEAR mean per channel
       contrastBoost: 1.5
     };
     var _TRI_METAL = {
       diffuse: 'textures/materials/metal_color_1k.jpg',
       roughness: 'textures/materials/metal_rough_1k.jpg',
       tileMeters: 0.6,     // finer tile — railings/pipes/ducts are thin members
-      normFactorRGB: [2.0406, 1.8679, 1.7290],  // real per-channel fix — was scalar 1.870 (1/0.535)
+      normFactorRGB: [4.8763, 4.0250, 3.3988],  // §TRINORM_LINEAR — inverse LINEAR mean per channel
       contrastBoost: 1.9
     };
     var TRIPLANAR_MAT = {

--- a/viewer/sw.js
+++ b/viewer/sw.js
@@ -8,7 +8,7 @@
 // Cache-first for heavy assets (.wasm, images). DB files skip SW (IndexedDB handles them).
 //
 // DEPLOY: bump CACHE_VERSION on every OCI upload. Old caches are purged on activate.
-const CACHE_VERSION = 'v1036';   // bump on each deploy; per-change detail is the git commit message.
+const CACHE_VERSION = 'v1037';   // bump on each deploy; per-change detail is the git commit message.
 // v1031 (2026-08-15) streaming.js envInt: beam/railing->0, +13 remaining MEP device classes->0.05
 // (a prior PR's version bump for this same change was lost in a squash-merge race -- see git log).
 // v1030 (2026-08-15) §PIPE_DUCT_BLUE_TINT / §PHOTO_ENVMAP_DOUBLE_BOOST_FIX (bim-ootb PRs #1367,

--- a/viewer/viewer.html
+++ b/viewer/viewer.html
@@ -837,7 +837,7 @@ html.bim-embedded, html.bim-embedded body { background: #0b0b0b; }
 <script src="scene.js?v=55" onerror="console.warn('§LOAD_FAIL scene.js')"></script>
 <script src="panel_nav.js?v=1" onerror="console.warn('§LOAD_FAIL panel_nav.js')"></script>
 <script src="helpers.js?v=6" onerror="console.warn('§LOAD_FAIL helpers.js')"></script>
-<script src="streaming.js?v=61" onerror="console.warn('§LOAD_FAIL streaming.js')"></script>
+<script src="streaming.js?v=62" onerror="console.warn('§LOAD_FAIL streaming.js')"></script>
 <script src="dlod.js?v=8" onerror="console.warn('§LOAD_FAIL dlod.js')"></script>
 <script src="panels.js?v=43" onerror="console.warn('§LOAD_FAIL panels.js')"></script>
 <script src="tools.js?v=39" onerror="console.warn('§LOAD_FAIL tools.js')"></script>


### PR DESCRIPTION
Root cause of PHOTOREAL_STILL_RENDER.md §ONGOING_TINT + §RED_GREY_MYSTERY (both open Alt+S bugs, one mechanism).

All triplanar `normFactorRGB` values (and the scalar before them) were derived from the JPG's **sRGB byte means**, but the shader multiply runs in **linear** light (textures are `SRGBColorSpace`, GPU-decoded before `texture2D` returns). That under-normalizes 2.0–2.4×, and the contrast line `(x-1)*boost+1` then clamps every texel below `1-1/boost` to **literal zero**:

- **metal** (boost 1.9): 41% of texels → multiply-by-0 → the pure-black valve pixels; the surviving mean multiply is `[0.000, 0.011, 0.071]` — a blue-dominant near-black = the reported "bluish tint… greyer piping gets similar dark treatment"
- **concrete/plaster**: uniform ×0.47 / ×0.53 → systemic Alt+S darkness

Fix: `normFactorRGB` = inverse **linear** mean (concrete 2.0755, plaster [1.9428, 1.9262, 2.0172], metal [4.8763, 4.0250, 3.3988]). Multiply now centres at 1.000/channel, 0.00% texels clamp to zero, contrastBoost unchanged.

**Witness** (isolated Hospital valve `0HuLVU0hf5gxwY8y9yDvc0`, raw single-frame render, 1681-sample grid): black 719 → **0**; meanRGB [119,79,66] vs triplanar-off reference [117,80,66]. Offline texture-histogram + live uniform-variant probes in session scratchpad (`probe_noop_recompile.js`, `probe_stale_uniform_diff.js`, `probe_contrast_crush_confirm.js`, `witness_trinorm_fix.js`).

Also explains why prior sessions' shader-checkpoint probes all read clean: every probe's `onBeforeCompile` **replaced** the triplanar patch, and the `uTriActive=0` rule-out was silently undone by the per-frame `onBeforeRender` self-heal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017ueYMa8fxEaJBdx6LfhVLQ