### PR TITLE
fix(photo): §SKY_SUNPOS_INIT — black sky on Alt+S (sunPosition uniform never initialized)

### DIFF
--- a/viewer/scene.js
+++ b/viewer/scene.js
@@ -239,7 +239,15 @@ async function setupScene(A) {
     var theta = THREE.MathUtils.degToRad(azimuth);
     _sunVec.setFromSphericalCoords(1, phi, theta);
     // §S276b: Update sky shader — never hide, Preetham darkens naturally below horizon.
-    if (_sky && _sky.visible) {
+    // §SKY_SUNPOS_INIT (2026-08-16): the uniform copy must NOT be gated on _sky.visible. The
+    // Sky shader ships with a default sunPosition of (0,0,0), and the init-time
+    // A.updateSky(45,180) call runs while the sky is still hidden — with the old
+    // `if (_sky && _sky.visible)` guard that skipped the copy, so any path that later flips
+    // _sky.visible=true WITHOUT calling updateSky (Alt+S non-dusk staging since #1379) rendered
+    // the Preetham shader with a zero sun vector: fully black sky, live-reproduced (sky band
+    // 192/192 black px, uniform read back [0,0,0]). Copying a uniform on a hidden object is
+    // free — keep it unconditionally in sync so "make visible" is always safe.
+    if (_sky) {
       _sky.material.uniforms['sunPosition'].value.copy(_sunVec);
     }
     // Update directional light to match sky sun

--- a/viewer/sw.js
+++ b/viewer/sw.js
@@ -8,7 +8,7 @@
 // Cache-first for heavy assets (.wasm, images). DB files skip SW (IndexedDB handles them).
 //
 // DEPLOY: bump CACHE_VERSION on every OCI upload. Old caches are purged on activate.
-const CACHE_VERSION = 'v1037';   // bump on each deploy; per-change detail is the git commit message.
+const CACHE_VERSION = 'v1038';   // bump on each deploy; per-change detail is the git commit message.
 // v1031 (2026-08-15) streaming.js envInt: beam/railing->0, +13 remaining MEP device classes->0.05
 // (a prior PR's version bump for this same change was lost in a squash-merge race -- see git log).
 // v1030 (2026-08-15) §PIPE_DUCT_BLUE_TINT / §PHOTO_ENVMAP_DOUBLE_BOOST_FIX (bim-ootb PRs #1367,

--- a/viewer/viewer.html
+++ b/viewer/viewer.html
@@ -834,7 +834,7 @@ html.bim-embedded, html.bim-embedded body { background: #0b0b0b; }
 <script src="list_builder.js?v=1" onerror="console.warn('§LOAD_FAIL list_builder.js')"></script>
 <script src="settings_editor.js?v=1" onerror="console.warn('§LOAD_FAIL settings_editor.js')"></script>
 <script src="../common/history_tap.js?v=7" onerror="console.warn('§LOAD_FAIL history_tap.js')"></script>
-<script src="scene.js?v=55" onerror="console.warn('§LOAD_FAIL scene.js')"></script>
+<script src="scene.js?v=56" onerror="console.warn('§LOAD_FAIL scene.js')"></script>
 <script src="panel_nav.js?v=1" onerror="console.warn('§LOAD_FAIL panel_nav.js')"></script>
 <script src="helpers.js?v=6" onerror="console.warn('§LOAD_FAIL helpers.js')"></script>
 <script src="streaming.js?v=62" onerror="console.warn('§LOAD_FAIL streaming.js')"></script>


### PR DESCRIPTION
Root cause of the recurring black-sky-on-Alt+S report (PHOTOREAL_STILL_RENDER.md §SKY_SYNC_REGRESSION symptom, new trigger).

`updateSky()` copies the Sky shader's `sunPosition` uniform only `if (_sky && _sky.visible)`. At init the sky is hidden, so `A.updateSky(45,180)` skips the copy and the shader keeps its stock `(0,0,0)` sun vector. Since #1379 the non-dusk Alt+S shows the sky **without** calling `updateSky`, so a fresh session's first Alt+S renders Preetham with a zero sun → fully black sky.

**Live-reproduced on main** (headless, Hospital): post-Alt+S sky band 192/192 black px, uniform read back `[0,0,0]`. Setting the uniform from `A.sun.position.normalize()` restores meanRGB [178,211,236] — and equals the `setFromSphericalCoords` direction to 1e-16, answering the equivalence question the #1381 revert note left open.

**Fix**: copy the uniform unconditionally (uniform write on a hidden object is free) so any later `visible = true` is safe regardless of caller. **Witness on fixed code**: fresh load → Alt+S → sky band 0/192 black, meanRGB [178,211,236].

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017ueYMa8fxEaJBdx6LfhVLQ