### PR TITLE
fix(data): §HOSPITAL_COLOUR_BACKFILL — self-heal patch for stale cached Hospital meta colours

### DIFF
--- a/buildings/patches/Hospital_meta.db.sql
+++ b/buildings/patches/Hospital_meta.db.sql
@@ -9471,3 +9471,19 @@ INSERT OR IGNORE INTO rel_aggregates (parent_guid,child_guid) VALUES ('0KbYdy_nD
 INSERT OR IGNORE INTO rel_aggregates (parent_guid,child_guid) VALUES ('0nLMa_hqjDM9PNHQIvZ_TB','2wdkzews5FrOpF4P5iHYk8');
 INSERT OR IGNORE INTO rel_aggregates (parent_guid,child_guid) VALUES ('0nLMa_hqjDM9PNHQIvZ_TB','0nLMa_hqjDM9PNHQIvZ$uz');
 INSERT OR IGNORE INTO rel_aggregates (parent_guid,child_guid) VALUES ('0nLMa_hqjDM9PNHQIvZ_TB','0nLMa_hqjDM9PNHQIvZ$BU');
+
+-- §HOSPITAL_COLOUR_BACKFILL (2026-08-16 — PHOTOREAL_STILL_RENDER.md §HOSPITAL_META_DB_STALE):
+-- IndexedDB-cached copies of the June-2026 split meta predate the extraction that filled
+-- material_rgba for the 23 classes below (verified against the served bucket bytes: 0/N in the
+-- cached vintage, N/N in the current served DB). The value is copied verbatim from the current
+-- served Hospital_meta.db — a single uniform value across every gained element (checked by
+-- DISTINCT per class). Guarded to empty rows only, so it is a no-op on the current served DB and
+-- never invents colour for the 233 geometry-less aggregate ghosts (IfcCurtainWall/IfcStair/
+-- IfcRoof), whose material_rgba stays empty in the current extraction too.
+UPDATE elements_meta SET material_rgba='0.920,0.900,0.850,1.000'
+ WHERE (material_rgba IS NULL OR material_rgba='')
+   AND ifc_class IN ('IfcBeam','IfcBuildingElementProxy','IfcCableCarrierFitting',
+    'IfcCableCarrierSegment','IfcColumn','IfcCovering','IfcDistributionControlElement','IfcDoor',
+    'IfcDuctFitting','IfcDuctSegment','IfcElectricAppliance','IfcFireSuppressionTerminal',
+    'IfcFooting','IfcLightFixture','IfcMember','IfcPipeFitting','IfcPipeSegment','IfcRailing',
+    'IfcSlab','IfcSwitchingDevice','IfcValve','IfcWall','IfcWallStandardCase');

--- a/buildings/patches/Hospital_meta.db.sql.manifest.json
+++ b/buildings/patches/Hospital_meta.db.sql.manifest.json
@@ -1,49 +1,49 @@
 {
   "schema": "oci-patch-provenance/1",
-  "generated_at": "2026-07-25T07:45:16.808Z",
+  "generated_at": "2026-08-15T17:27:47.822Z",
   "bucket": "bim-ootb",
   "engine": {
-    "worktree": "/tmp/wt-main-baseline",
-    "sha": "491413ffb4e3e277c23b7e7f4a61dfb7f4bf57d2",
+    "worktree": "/tmp/wt-hospital-colour-patch",
+    "sha": "b60440d1730ca42c306700d5cebf710b5e73d570",
     "behind_origin_main": 0,
-    "ahead_origin_main": 0,
+    "ahead_origin_main": 1,
     "clean": true,
     "dirty_paths": []
   },
   "served_db": {
     "object": "buildings/Hospital_meta.db",
-    "etag": "2fd95d47-fde0-4fde-aaaa-039deac32233",
-    "content-md5": "cTpK9OHSgS1SDXGvbPPkHA==",
-    "size": "4342707",
-    "last-modified": "Sat, 06 Jun 2026 08:15:58 GMT",
+    "etag": "a84c5022-e123-45f0-b93a-be52cf82fa3b",
+    "content-md5": "S4DRfFRDGYsXcxoXfqsH8Q==",
+    "size": "4163894",
+    "last-modified": "Sat, 15 Aug 2026 17:20:49 GMT",
     "content-encoding": "gzip"
   },
   "artifact": {
     "file": "buildings/patches/Hospital_meta.db.sql",
-    "bytes": 226962,
-    "md5": "7e97413cd546d4065de67a8565a17b22",
-    "md5_b64": "fpdBPNVG1AZd5nqFZaF7Ig==",
+    "bytes": 1382739,
+    "md5": "f22a37aa2466981307f034fd03580f40",
+    "md5_b64": "8io3qiRmmBMH8DT9A1gPQA==",
     "object": "buildings/patches/Hospital_meta.db.sql",
     "content_type": "application/sql"
   },
   "target": {
     "exists": true,
-    "etag": "10d2a309-c67e-4c19-810c-61d3fd5b0f63",
-    "size": "144960",
-    "last-modified": "Sat, 25 Jul 2026 00:49:21 GMT"
+    "etag": "a8da8873-d3db-4bef-a64c-5eea3816486a",
+    "size": "1381433",
+    "last-modified": "Mon, 10 Aug 2026 02:58:55 GMT"
   },
   "verification": {
-    "cmd": "bash -c \"node /home/red1/bim-compiler/prompts/Modeller/DISC_Walker/poc_raster_cover.js /tmp/wt-main-baseline \\\"$GATE_DB\\\" | tail -25 | grep -q \\\"connected_rooms_below_30pct=0/\\\"\"",
+    "cmd": "bash scripts/verify_hospital_colour_backfill.sh",
     "exit": 0,
     "tail": [
-      ""
+      "§VERIFY_COLOUR_BACKFILL empty_outside_ghosts=0 ghosts_empty=233 (expect 0 / 233)"
     ]
   },
   "verdict": "PASS",
   "failures": [],
   "uploaded": {
-    "at": "2026-07-25T07:45:19.367Z",
-    "etag": "55b71e23-1b2b-4cf1-8710-b48eb7b5feef",
+    "at": "2026-08-15T17:27:52.505Z",
+    "etag": "cee44b7c-4491-4cb6-ab4c-6e508e42560c",
     "verified": true
   }
 }

--- a/scripts/verify_hospital_colour_backfill.sh
+++ b/scripts/verify_hospital_colour_backfill.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+# W-HOSPITAL-COLOUR-BACKFILL verifier — run by scripts/oci_patch_gate.js with $GATE_DB set to the
+# served Hospital_meta.db with buildings/patches/Hospital_meta.db.sql applied. Invariants:
+#   1. zero empty material_rgba rows outside the 3 geometry-less ghost classes
+#   2. the 233 aggregate ghosts (IfcCurtainWall/IfcStair/IfcRoof) remain EXACTLY empty (nothing invented)
+set -e
+[ -n "$GATE_DB" ] || { echo "GATE_DB unset"; exit 2; }
+empty=$(sqlite3 "$GATE_DB" "SELECT COUNT(*) FROM elements_meta WHERE (material_rgba IS NULL OR material_rgba='') AND ifc_class NOT IN ('IfcCurtainWall','IfcStair','IfcRoof')")
+ghosts=$(sqlite3 "$GATE_DB" "SELECT COUNT(*) FROM elements_meta WHERE (material_rgba IS NULL OR material_rgba='') AND ifc_class IN ('IfcCurtainWall','IfcStair','IfcRoof')")
+echo "§VERIFY_COLOUR_BACKFILL empty_outside_ghosts=$empty ghosts_empty=$ghosts (expect 0 / 233)"
+[ "$empty" = "0" ] && [ "$ghosts" = "233" ]

--- a/viewer/buildings/patches/Hospital_meta.db.sql
+++ b/viewer/buildings/patches/Hospital_meta.db.sql
@@ -9471,3 +9471,19 @@ INSERT OR IGNORE INTO rel_aggregates (parent_guid,child_guid) VALUES ('0KbYdy_nD
 INSERT OR IGNORE INTO rel_aggregates (parent_guid,child_guid) VALUES ('0nLMa_hqjDM9PNHQIvZ_TB','2wdkzews5FrOpF4P5iHYk8');
 INSERT OR IGNORE INTO rel_aggregates (parent_guid,child_guid) VALUES ('0nLMa_hqjDM9PNHQIvZ_TB','0nLMa_hqjDM9PNHQIvZ$uz');
 INSERT OR IGNORE INTO rel_aggregates (parent_guid,child_guid) VALUES ('0nLMa_hqjDM9PNHQIvZ_TB','0nLMa_hqjDM9PNHQIvZ$BU');
+
+-- §HOSPITAL_COLOUR_BACKFILL (2026-08-16 — PHOTOREAL_STILL_RENDER.md §HOSPITAL_META_DB_STALE):
+-- IndexedDB-cached copies of the June-2026 split meta predate the extraction that filled
+-- material_rgba for the 23 classes below (verified against the served bucket bytes: 0/N in the
+-- cached vintage, N/N in the current served DB). The value is copied verbatim from the current
+-- served Hospital_meta.db — a single uniform value across every gained element (checked by
+-- DISTINCT per class). Guarded to empty rows only, so it is a no-op on the current served DB and
+-- never invents colour for the 233 geometry-less aggregate ghosts (IfcCurtainWall/IfcStair/
+-- IfcRoof), whose material_rgba stays empty in the current extraction too.
+UPDATE elements_meta SET material_rgba='0.920,0.900,0.850,1.000'
+ WHERE (material_rgba IS NULL OR material_rgba='')
+   AND ifc_class IN ('IfcBeam','IfcBuildingElementProxy','IfcCableCarrierFitting',
+    'IfcCableCarrierSegment','IfcColumn','IfcCovering','IfcDistributionControlElement','IfcDoor',
+    'IfcDuctFitting','IfcDuctSegment','IfcElectricAppliance','IfcFireSuppressionTerminal',
+    'IfcFooting','IfcLightFixture','IfcMember','IfcPipeFitting','IfcPipeSegment','IfcRailing',
+    'IfcSlab','IfcSwitchingDevice','IfcValve','IfcWall','IfcWallStandardCase');


### PR DESCRIPTION
Companion to today's OCI re-upload of the regenerated Hospital split (gzip, content-encoding, fetch-back verified). `cachedFetch` serves IndexedDB blobs with no revalidation, so existing users keep the June meta (0/1970 beams coloured etc.) forever — this ships the fix to them via the existing `_applyPendingPatch` self-heal loader.

One guarded UPDATE, value copied verbatim from the current served meta (single DISTINCT value across all 51k gained elements); empty-rows-only so it is a no-op on the current DB and never touches the 233 aggregate ghosts. Verified three ways: locally against the actual old served bytes (23 classes → 0 empty, ghosts stay 233, beams 1970 cream), by the committed gate verifier on the gate-fetched served DB, and `scripts/oci_patch_gate.js` PASS → UPLOAD_VERIFIED (manifest committed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017ueYMa8fxEaJBdx6LfhVLQ