### PR TITLE
fix(4d): §CROSSTASK_JUDGE_PARITY — window-bounded judge-rule repair, captured floating 3090 -> 656

### DIFF
--- a/scripts/probe_captured_floating.js
+++ b/scripts/probe_captured_floating.js
@@ -28,8 +28,11 @@ function buildFn(srcParts, ret) {
 }
 const _contactGraph = buildFn([sliceFn(tmSrc, '_contactGraph')], '_contactGraph');
 const _ogSupportSweep = buildFn([sliceFn(tmSrc, '_ogSupportSweep')], '_ogSupportSweep');
+const _cjpJudgeParity = buildFn([sliceFn(tmSrc, '_contactGraph'), sliceFn(tmSrc, '_cjpJudgeParity')], '_cjpJudgeParity');
 const _TIER1_ORDER_LINE = "var _TIER1_ORDER = ['Substructure', 'Superstructure', 'Architecture'];";
-const _midairRepair = buildFn([_TIER1_ORDER_LINE, sliceFn(tmSrc, '_midairRepair')], '_midairRepair');
+// §MIDAIR_REPAIR_CONTACTGRAPH_DEDUP (bim-ootb PR #1378): _midairRepair now calls _contactGraph
+// instead of inlining its own copy, so this standalone build needs _contactGraph's source too.
+const _midairRepair = buildFn([_TIER1_ORDER_LINE, sliceFn(tmSrc, '_contactGraph'), sliceFn(tmSrc, '_midairRepair')], '_midairRepair');
 
 function _slug(name) { return String(name).replace(/[^A-Za-z0-9]+/g, '_').replace(/^_+|_+$/g, ''); }
 
@@ -242,6 +245,70 @@ async function main() {
   console.log('§CAP_WINDOW_FIDELITY inWindow=' + inWindow + '/' + totalWin + ' pct=' +
     (100 * inWindow / totalWin).toFixed(2) + ' outWindow=' + outWindow);
   console.log('§CAP_WINDOW_FIDELITY_OUT_BYCLASS ' + JSON.stringify(outByClass));
+
+  // ══ §CROSSTASK_JUDGE_PARITY Step 1 (2026-08-16, 4D_SCHEDULE_PERFECTION.md) — residual
+  // decomposition: WHY does each post-repair floating element stay floating? Two axes:
+  //   reachability — REACHABLE (first-contact start + own dur fits own window) / WINDOW_BLOCKED /
+  //                  ALREADY_OUT (element already sits outside its window);
+  //   role — GROUND_CARRIER (grounded && seq<=4 && every contact merely STANDS ON it —
+  //          S.bz >= T.tz - GAP, the judge's role-blind carrier-above clause) vs rest;
+  //   pool — first contact inside vs outside _ogSupportSweep's carrier pool. ══════════════════════
+  {
+    const GAPc = ScheduleGate.GAP;
+    const inPool = S => (S.seq <= 4 || (S.cls === 'IfcSlab' && S.seq > 4) || S.cls.indexOf('IfcWall') === 0);
+    const Gd = postRepair.G;
+    const reach = { REACHABLE: 0, WINDOW_BLOCKED: 0, ALREADY_OUT: 0 };
+    let groundCarrier = 0, poolIn = 0, poolOut = 0;
+    const gcByClass = {}, reachByClass = {};
+    for (let i = 0; i < forRepair.length; i++) {
+      const list = Gd.contacts[i]; if (!list) continue;
+      const T = forRepair[i];
+      let first = Infinity, firstIdx = -1;
+      for (const k of list) { if (forRepair[k].s < first) { first = forRepair[k].s; firstIdx = k; } }
+      if (first <= T.s + 1) continue;                       // not floating
+      const w = taskWin[T.task];
+      const dur = Math.max(60000, T.e - T.s);
+      let cat;
+      if (!w || T.s < w.s || T.e > w.e) cat = 'ALREADY_OUT';
+      else if (first + dur <= w.e) cat = 'REACHABLE';
+      else cat = 'WINDOW_BLOCKED';
+      reach[cat]++;
+      (reachByClass[cat] = reachByClass[cat] || {})[T.cls] = (reachByClass[cat][T.cls] || 0) + 1;
+      let allStandOn = true;
+      for (const k of list) { if (forRepair[k].bz < T.tz - GAPc) { allStandOn = false; break; } }
+      if (Gd.grounded[i] && T.seq <= 4 && allStandOn) { groundCarrier++; gcByClass[T.cls] = (gcByClass[T.cls] || 0) + 1; }
+      if (inPool(forRepair[firstIdx])) poolIn++; else poolOut++;
+    }
+    console.log('§CJP_DECOMP reach=' + JSON.stringify(reach) + ' groundCarrier=' + groundCarrier +
+      ' firstContactPool in=' + poolIn + ' out=' + poolOut);
+    console.log('§CJP_DECOMP_GROUND_BYCLASS ' + JSON.stringify(gcByClass));
+    Object.keys(reachByClass).forEach(cat =>
+      console.log('§CJP_DECOMP_' + cat + '_BYCLASS ' + JSON.stringify(reachByClass[cat])));
+  }
+
+  // ══ §CROSSTASK_JUDGE_PARITY Step 2 — EXP4: window-bounded judge-parity fixpoint AFTER
+  // _ogSupportSweep. The EXACT judge rule (§MIDAIR_REPAIR's weakest rule: an element may not appear
+  // before the first element it physically touches), pushed monotone-later only, clamped to the
+  // element's OWN task window (§OG_HANG_WINDOW_BOUND discipline — the thing the rejected 2026-08-13
+  // _midairRepair swap lacked). Never touches an element already out of window. ════════════════════
+  {
+    // sliced from the SHIPPED time_machine.js — the probe measures the real function, never a copy
+    const exp4 = forRepair.map(o => Object.assign({}, o));
+    const r4 = _cjpJudgeParity(exp4, taskWin);
+    const pushed = r4.pushed, sweeps = r4.sweeps;
+    const exp4Census = floatingCensus(exp4.map(o => Object.assign({}, o)));
+    let inW4 = 0, outW4 = 0;
+    exp4.forEach(function (item) {
+      const w = taskWin[item.task]; if (!w) return;
+      if (item.s >= w.s && item.e <= w.e) inW4++; else outW4++;
+    });
+    console.log('§EXP4_PUSH pushed=' + pushed + ' sweeps=' + sweeps);
+    console.log('§EXP4_FINAL total=' + exp4Census.midair + '/' + exp4.length +
+      ' orphans=' + exp4Census.orphans + ' grounded=' + exp4Census.grounded);
+    console.log('§EXP4_FINAL_BYCLASS ' + JSON.stringify(exp4Census.byClass));
+    console.log('§EXP4_WINDOW_FIDELITY inWindow=' + inW4 + '/' + (inW4 + outW4) + ' pct=' +
+      (100 * inW4 / Math.max(1, inW4 + outW4)).toFixed(2) + ' outWindow=' + outW4);
+  }
 
   // Q2 — distribution of normalized position within the bar for in-window elements
   const normPositions = normItems.map(function (o) { return o.x; }).sort(function (a, b) { return a - b; });

--- a/viewer/sw.js
+++ b/viewer/sw.js
@@ -8,7 +8,9 @@
 // Cache-first for heavy assets (.wasm, images). DB files skip SW (IndexedDB handles them).
 //
 // DEPLOY: bump CACHE_VERSION on every OCI upload. Old caches are purged on activate.
-const CACHE_VERSION = 'v1038';   // bump on each deploy; per-change detail is the git commit message.
+const CACHE_VERSION = 'v1039';   // bump on each deploy; per-change detail is the git commit message.
+// v1039 (2026-08-16) §CROSSTASK_JUDGE_PARITY: time_machine.js _cjpJudgeParity after _ogSupportSweep
+// — window-bounded judge-rule repair, captured floating 3090 -> 656 across the 7 buildings.
 // v1031 (2026-08-15) streaming.js envInt: beam/railing->0, +13 remaining MEP device classes->0.05
 // (a prior PR's version bump for this same change was lost in a squash-merge race -- see git log).
 // v1030 (2026-08-15) §PIPE_DUCT_BLUE_TINT / §PHOTO_ENVMAP_DOUBLE_BOOST_FIX (bim-ootb PRs #1367,

--- a/viewer/tests/witness_crosstask_judge_parity.js
+++ b/viewer/tests/witness_crosstask_judge_parity.js
@@ -1,0 +1,190 @@
+#!/usr/bin/env node
+// witness_crosstask_judge_parity.js — §CROSSTASK_JUDGE_PARITY (2026-08-16, bim-compiler
+// prompts/4D_SCHEDULE_PERFECTION.md).
+//
+// ISSUE this witness proves/disproves: the captured-path judge (_contactGraph, class-blind and
+// pool-blind — the 🔓→🔒 lock rule) flags floating that _ogSupportSweep can never repair (its
+// carrier pool is narrower than the judge's contact relation), so 3090 elements sat permanently
+// floating across the 7 shipped buildings. _cjpJudgeParity closes that mismatch with the
+// §MIDAIR_REPAIR weakest rule, window-bounded. The 2026-08-13 unbounded _midairRepair swap was
+// REJECTED for 100-300d window-crossing desync — so the load-bearing claims here are the bounds,
+// not just the improvement:
+//
+//   W-CJP-1  WIRING: injectGantt's captured path actually calls _cjpJudgeParity(_allScheduled,
+//            _cap.win) after _ogSupportSweep (§DOOR_WINDOW_HOST_WALL's lesson — an unwired gate
+//            is silently a no-op).
+//   W-CJP-2  THE BAR: on a real building schedule with judge-rule floating present, the pass
+//            strictly reduces it (numbers per building live in probe_captured_floating.js §EXP4 —
+//            measured 2026-08-16: 3090 -> 656 across the 7 buildings).
+//   W-CJP-3  WINDOW SAFETY (the anti-desync contract): every element the pass MOVES ends fully
+//            inside its own task's authored window, and the per-building in/out-window counts are
+//            byte-identical before vs after — the pass can never manufacture a Gantt desync.
+//   W-CJP-4  MONOTONE: zero elements start EARLIER after the pass (§TIER_SERIAL W-TS-3's property).
+//   W-CJP-5  JUDGE UNTOUCHED: orphans/grounded counts byte-identical — the pass repairs against
+//            the judge, it never weakens the judge.
+//   W-CJP-6  NOT VACUOUS + HONEST RESIDUAL (synthetic, no DB): a reachable violation is repaired
+//            to exactly its first contact's start; a WINDOW_BLOCKED violation and an
+//            already-out-of-window element are left byte-identical (honestly floating), never
+//            pushed to a fabricated in-window date.
+//
+// Command: BLD_DIR=~/bim-ootb/buildings node tests/witness_crosstask_judge_parity.js  (from viewer/)
+// Read the § log lines, not the exit code alone.
+'use strict';
+const fs = require('fs');
+const path = require('path');
+const initSqlJs = require(path.join(__dirname, '..', '..', 'modeller', 'lib', 'sql-wasm.js'));
+const ScheduleGate = require(path.join(__dirname, '..', 'schedule_gate.js'));
+const ScheduleAuthor = require(path.join(__dirname, '..', 'schedule_author.js'));
+const tmSrc = fs.readFileSync(path.join(__dirname, '..', 'time_machine.js'), 'utf8');
+
+let pass = 0, fail = 0;
+function assert(cond, msg) { if (cond) { pass++; console.log('  PASS ' + msg); } else { fail++; console.log('  FAIL ' + msg); } }
+function finish() { console.log('\n§CJP_WITNESS_SUMMARY pass=' + pass + ' fail=' + fail); process.exit(fail ? 1 : 0); }
+
+function sliceFn(src, name) {
+  const idx = src.lastIndexOf('function ' + name + '(');
+  if (idx < 0) throw new Error(name + ' not found');
+  let depth = 0, i = idx, seenOpen = false;
+  for (; i < src.length; i++) {
+    if (src[i] === '{') { depth++; seenOpen = true; }
+    else if (src[i] === '}') { depth--; if (seenOpen && depth === 0) break; }
+  }
+  return src.slice(idx, i + 1);
+}
+function buildFn(srcParts, ret) {
+  return new Function('ScheduleGate', srcParts.join('\n') + '\nreturn ' + ret + ';')(ScheduleGate);
+}
+const _contactGraph = buildFn([sliceFn(tmSrc, '_contactGraph')], '_contactGraph');
+const _cjpJudgeParity = buildFn([sliceFn(tmSrc, '_contactGraph'), sliceFn(tmSrc, '_cjpJudgeParity')], '_cjpJudgeParity');
+
+function census(items) {
+  const G = _contactGraph(items);
+  let midair = 0;
+  for (let i = 0; i < items.length; i++) {
+    const list = G.contacts[i]; if (!list) continue;
+    let first = Infinity;
+    for (const k of list) { if (items[k].s < first) first = items[k].s; }
+    if (first > items[i].s + 1) midair++;
+  }
+  return { midair, orphans: G.orphans, grounded: G.groundedN };
+}
+function windowCounts(items, taskWin) {
+  let inW = 0, outW = 0;
+  items.forEach(it => {
+    const w = taskWin[it.task]; if (!w) return;
+    if (it.s >= w.s && it.e <= w.e) inW++; else outW++;
+  });
+  return { inW, outW };
+}
+
+// ── W-CJP-1: wiring — the captured path calls the pass right after _ogSupportSweep ────────────
+console.log('W-CJP-1 wiring');
+const sweepCall = tmSrc.indexOf('_ogSupportSweep(_allScheduled, _cap.win)');
+const parityCall = tmSrc.indexOf('_cjpJudgeParity(_allScheduled, _cap.win)');
+assert(sweepCall >= 0 && parityCall > sweepCall && (parityCall - sweepCall) < 300,
+  'injectGantt captured path calls _cjpJudgeParity(_allScheduled, _cap.win) immediately after _ogSupportSweep');
+
+// ── W-CJP-6: synthetic contract (no DB) — vacuousness + honest residual ───────────────────────
+console.log('W-CJP-6 synthetic contract');
+const DAY = 86400000;
+function mk(guid, s, e, bz, tz, task) {
+  return { guid, s: s * DAY, e: e * DAY, bz, tz, x0: 0, x1: 2, y0: 0, y1: 2, cls: 'IfcSlab', seq: 5, task };
+}
+{
+  // carrier C (day 10) with three dependents resting on it, each floating (start day 0):
+  //   R in a window wide enough to absorb the push        -> must land exactly on C.s
+  //   B in a window that ends before C.s + dur            -> WINDOW_BLOCKED, byte-identical
+  //   O already outside its own window                    -> byte-identical
+  const C = mk('C', 10, 11, 0, 3, 'TC');
+  const R = mk('R', 0, 1, 3, 4, 'TR');
+  const B = mk('B', 0, 1, 3, 4, 'TB'); B.x0 = 10; B.x1 = 12; C.x1 = 12; // widen C to touch B too
+  const O = mk('O', 0, 1, 3, 4, 'TO'); O.y0 = 10; O.y1 = 12; C.y1 = 12; // widen C to touch O too
+  const taskWin = {
+    TC: { s: 0, e: 100 * DAY },
+    TR: { s: 0, e: 100 * DAY },
+    TB: { s: 0, e: 5 * DAY },
+    TO: { s: 5 * DAY, e: 100 * DAY }   // O.s=0 sits BEFORE its window -> already-out
+  };
+  const items = [C, R, B, O];
+  const before = census(items.map(o => Object.assign({}, o)));
+  const r = _cjpJudgeParity(items, taskWin);
+  assert(r.pushed >= 1, 'pass pushed at least the reachable violation (pushed=' + r.pushed + ')');
+  assert(R.s === C.s && R.e === R.s + 1 * DAY, 'reachable dependent lands exactly on first-contact start, duration preserved');
+  assert(B.s === 0 && B.e === 1 * DAY, 'WINDOW_BLOCKED dependent left byte-identical (honest floating)');
+  assert(O.s === 0 && O.e === 1 * DAY, 'already-out-of-window element left byte-identical');
+  assert(C.s === 10 * DAY, 'carrier itself never moved');
+  const after = census(items.map(o => Object.assign({}, o)));
+  assert(before.midair === 3 && after.midair === 2, 'census: 3 floating before, exactly the reachable one repaired (after=' + after.midair + ')');
+}
+
+// ── W-CJP-2..5: real buildings, full generative schedule + real task windows ──────────────────
+const BLD_DIR = process.env.BLD_DIR || path.join(require('os').homedir(), 'bim-ootb', 'buildings');
+const BUILDINGS = (process.env.CJP_BUILDINGS || 'Duplex_extracted,HHS_Office_Federated_extracted').split(',');
+function _slug(name) { return String(name).replace(/[^A-Za-z0-9]+/g, '_').replace(/^_+|_+$/g, ''); }
+
+async function main() {
+  const SQL = await initSqlJs({ wasmBinary: fs.readFileSync(path.join(__dirname, '..', '..', 'modeller', 'lib', 'sql-wasm.wasm')) });
+  const ratesSrc = fs.readFileSync(path.join(__dirname, '..', 'rates.js'), 'utf8');
+  const RATES = (new Function(ratesSrc +
+    '\nreturn {SEQUENCE_RULES:SEQUENCE_RULES, SEQUENCE_DEFAULT:SEQUENCE_DEFAULT, ' +
+    'SEQUENCE_NAME_OVERRIDES:SEQUENCE_NAME_OVERRIDES, LABOR_RATES:LABOR_RATES, RATES:RATES};'))();
+
+  for (const B of BUILDINGS) {
+    const dbPath = path.join(BLD_DIR, B + '.db');
+    if (!fs.existsSync(dbPath)) { console.log('  SKIP ' + B + ' (no DB)'); continue; }
+    console.log('W-CJP-2..5 ' + B);
+    const db = new SQL.Database(fs.readFileSync(dbPath));
+    const rawElements = ScheduleAuthor._buildScheduleElements(db, RATES.SEQUENCE_RULES, {
+      laborRates: RATES.LABOR_RATES, rates: RATES.RATES, nameOverrides: RATES.SEQUENCE_NAME_OVERRIDES,
+      defaultRule: RATES.SEQUENCE_DEFAULT
+    });
+    const elements = rawElements.map(it => Object.assign({}, it, { bz: it.base_z, tz: it.top_z }));
+    const maxCrews = {};
+    for (const res in RATES.LABOR_RATES) if (RATES.LABOR_RATES[res].max_crews) maxCrews[res] = RATES.LABOR_RATES[res].max_crews;
+    const schedule = ScheduleGate.computeSchedule(elements, 0, 1, maxCrews, 24);
+    const rolled = ScheduleGate.deriveZones(elements, schedule);
+    const minStart = Math.min.apply(null, rolled.zones.map(z => z.start));
+    const zoneTaskId = {}, taskWin = {};
+    rolled.zones.forEach(z => {
+      const tid = 'TASK_' + _slug(z.phase) + '_' + _slug(z.storey);
+      zoneTaskId[z.id] = tid;
+      const sDays = Math.round((z.start - minStart) / DAY);
+      let eDays = Math.round((z.end - minStart) / DAY);
+      if (eDays <= sDays) eDays = sDays + 1;
+      taskWin[tid] = { s: minStart + sDays * DAY, e: minStart + eDays * DAY };
+    });
+    const items = elements.map(el => {
+      const st = schedule[el.guid]; if (!st) return null;
+      const zid = (el.phase || '_UNPHASED') + '||' + ScheduleGate.collapsePhase(el.storey);
+      return { guid: el.guid, s: st.start, e: st.end, bz: el.bz, tz: el.tz,
+        x0: el.x0, x1: el.x1, y0: el.y0, y1: el.y1, cls: el.cls, seq: el.seq, task: zoneTaskId[zid] };
+    }).filter(Boolean);
+
+    const before = census(items.map(o => Object.assign({}, o)));
+    const winBefore = windowCounts(items, taskWin);
+    const sBefore = {}; items.forEach(o => sBefore[o.guid] = o.s);
+    const r = _cjpJudgeParity(items, taskWin);
+    const after = census(items.map(o => Object.assign({}, o)));
+    const winAfter = windowCounts(items, taskWin);
+    console.log('  §CJP_WITNESS ' + B + ' floating ' + before.midair + ' -> ' + after.midair +
+      ' pushed=' + r.pushed + ' inWindow ' + winBefore.inW + '->' + winAfter.inW);
+    assert(before.midair === 0 || after.midair < before.midair,
+      'W-CJP-2 floating strictly reduced (' + before.midair + ' -> ' + after.midair + ')');
+    let movedOut = 0, earlier = 0;
+    items.forEach(o => {
+      if (o.s < sBefore[o.guid]) earlier++;
+      if (o.s !== sBefore[o.guid]) {
+        const w = taskWin[o.task];
+        if (!w || o.s < w.s || o.e > w.e) movedOut++;
+      }
+    });
+    assert(movedOut === 0, 'W-CJP-3a every moved element ends fully inside its own task window (movedOut=' + movedOut + ')');
+    assert(winBefore.inW === winAfter.inW && winBefore.outW === winAfter.outW,
+      'W-CJP-3b in/out-window counts byte-identical (' + winBefore.inW + '/' + winBefore.outW + ')');
+    assert(earlier === 0, 'W-CJP-4 monotone — zero elements start earlier (earlier=' + earlier + ')');
+    assert(before.orphans === after.orphans && before.grounded === after.grounded,
+      'W-CJP-5 judge untouched — orphans/grounded byte-identical (' + after.orphans + '/' + after.grounded + ')');
+  }
+  finish();
+}
+main().catch(e => { console.error(e); process.exit(1); });

--- a/viewer/time_machine.js
+++ b/viewer/time_machine.js
@@ -4429,6 +4429,54 @@
       return { pushed: _ogPushed, sweeps: _ogSweeps };
   }
 
+  // ══ §CROSSTASK_JUDGE_PARITY (2026-08-16, bim-compiler prompts/4D_SCHEDULE_PERFECTION.md) ══════
+  // Runs AFTER _ogSupportSweep on the captured path. Closes the judge/repair mismatch that stranded
+  // 3090 elements floating across the 7 shipped buildings: the judge (_contactGraph/_midairAudit,
+  // the 🔓→🔒 lock rule) is class-blind and pool-blind, but _ogSupportSweep can only ever push past
+  // its NARROW carrier pool (seq<=4 ∪ promoted slabs, walls for promoted slabs) — so an element
+  // whose only real contacts live outside that pool (a fitting on a proxy, a tread on a stringer —
+  // the exact §MIDAIR_REPAIR (a)-population) is flagged floating forever and repaired never.
+  // This pass is §MIDAIR_REPAIR's already-shipped weakest rule — AN ELEMENT MAY NOT APPEAR BEFORE
+  // THE FIRST ELEMENT IT PHYSICALLY TOUCHES APPEARS — applied to the captured timeline WITH the
+  // §OG_HANG_WINDOW_BOUND discipline the rejected 2026-08-13 _midairRepair swap lacked (its failure
+  // was exactly window-crossing desync, 100-300d): a push lands ONLY when the element's whole
+  // rescheduled span stays inside its OWN task's authored window; an element already outside its
+  // window is never pushed further out; anything else stays honestly floating (WINDOW_BLOCKED —
+  // a real task-authoring conflict, §CPM_GENERATOR_UPSTREAM_SPEC's territory, never papered over).
+  // Monotone-later pushes reusing existing start values, fixpoint-swept, bounded — same
+  // termination argument as _midairRepair's own. MEASURED (probe_captured_floating.js §EXP4, all 7
+  // buildings, 2026-08-16): floating 3090 -> 656 (-78.8%), window fidelity byte-identical on every
+  // building, orphans/grounded untouched (the judge itself is never modified here).
+  function _cjpJudgeParity(items, taskWin) {
+    var _t0 = (typeof performance !== 'undefined' && performance.now) ? performance.now() : Date.now();
+    var G = _contactGraph(items);
+    if (!G.ok) return { pushed: 0, sweeps: 0 };
+    var pushed = 0, sweeps = 0, maxShift = 0;
+    for (; sweeps < 16; sweeps++) {
+      var moved = 0;
+      for (var i = 0; i < items.length; i++) {
+        var list = G.contacts[i]; if (!list) continue;
+        var T = items[i];
+        var first = Infinity;
+        for (var k = 0; k < list.length; k++) { var s = items[list[k]].s; if (s < first) first = s; }
+        if (first <= T.s + 1) continue;                    // not floating
+        var w = taskWin && taskWin[T.task]; if (!w) continue;
+        if (T.s < w.s || T.e > w.e) continue;              // already out of window — never worsen
+        var dur = Math.max(60000, T.e - T.s);
+        if (first + dur > w.e) continue;                   // WINDOW_BLOCKED — honest floating
+        var d = first - T.s;
+        T.s = first; T.e = T.s + dur;
+        pushed++; moved++; if (d > maxShift) maxShift = d;
+      }
+      if (!moved) break;
+    }
+    if (pushed) console.log('§CROSSTASK_JUDGE_PARITY pushed=' + pushed + ' sweeps=' + sweeps +
+      ' maxShiftDays=' + (maxShift / 86400000).toFixed(1) +
+      ' ms=' + Math.round(((typeof performance !== 'undefined' && performance.now) ? performance.now() : Date.now()) - _t0) +
+      ' — judge-rule floating repaired within each element\'s own task window');
+    return { pushed: pushed, sweeps: sweeps };
+  }
+
   // The two-tier orchestrator: serialize the backbone → re-gate every dependent after its real
   // supports (audit physics) → verify strictness; iterate (bounded). Converges structurally:
   // shifts never break Tier-1 internal order, regate pushes only ever move later and only enforce
@@ -5699,6 +5747,7 @@
         }
       });
       _ogSupportSweep(_allScheduled, _cap.win);
+      _cjpJudgeParity(_allScheduled, _cap.win);   // §CROSSTASK_JUDGE_PARITY — judge/repair parity, window-bounded
       // §GANTT_REFOLD_HANG (fix/gantt-refold-hang, synced 2026-08-12 — CPE_4D_PERF_MEM_FINDINGS.md
       // §3-R2): the inline BEGIN→per-row UPDATE→COMMIT loop was the measured §WRITE_LOOP_TIMING
       // ms=2044.9 synchronous freeze on LTU (live log 2026-08-10). _writeScheduledChunked writes the
@@ -7850,7 +7899,9 @@
   // huts going first before the walls" AFTER a hard reset, because §GANTT_CACHE_HIT served a
   // gantt:v4 entry generated under the old ordering. A hard reset cannot clear it — the entry is in
   // IndexedDB, not the HTTP cache. This bump is that fix's second half.
-  var _GANTT_CACHE_VERSION = 25;   // §OG_HANG_UNBOUND (2026-08-15): _ogSupportSweep's hang repair
+  var _GANTT_CACHE_VERSION = 26;   // §CROSSTASK_JUDGE_PARITY (2026-08-16): window-bounded judge-rule
+                                   // repair after _ogSupportSweep — captured floating 3090 -> 656.
+                                   // Prior: 25 §OG_HANG_UNBOUND (2026-08-15): _ogSupportSweep's hang repair
   // now searches unbounded above (was capped 9.5m) — a kernel_ops table materialized under v24 or
   // earlier keeps replaying elements left floating that this version now repairs.
   // §GANTT_GAP_CLAMP_SPREAD (2026-08-15): the per-task rescale's

--- a/viewer/viewer.html
+++ b/viewer/viewer.html
@@ -932,7 +932,7 @@ html.bim-embedded, html.bim-embedded body { background: #0b0b0b; }
 <script src="wizard_classify.js?v=1" onerror="console.warn('§LOAD_FAIL wizard_classify.js')"></script>
 <script src="precision_cam.js?v=8" onerror="console.warn('§LOAD_FAIL precision_cam.js')"></script>
 <script src="schedule_gate.js?v=3" onerror="console.warn('§LOAD_FAIL schedule_gate.js')"></script>
-<script src="time_machine.js?v=67" onerror="console.warn('§LOAD_FAIL time_machine.js')"></script>
+<script src="time_machine.js?v=68" onerror="console.warn('§LOAD_FAIL time_machine.js')"></script>
 <script src="dlod_nav.js?v=2" onerror="console.warn('§LOAD_FAIL dlod_nav.js')"></script>
 <script src="schedule_author.js?v=12" onerror="console.warn('§LOAD_FAIL schedule_author.js')"></script>
 <script src="schedule_sync.js?v=3" onerror="console.warn('§LOAD_FAIL schedule_sync.js')"></script>


### PR DESCRIPTION
## §CROSSTASK_JUDGE_PARITY — window-bounded judge-rule repair after `_ogSupportSweep`

**Root cause (bim-compiler `prompts/4D_SCHEDULE_PERFECTION.md` §CROSSTASK_JUDGE_PARITY):** the
captured-path judge (`_contactGraph`/`_midairAudit` — the 🔓→🔒 lock rule) is class-blind and
pool-blind, but the repair (`_ogSupportSweep`) can only push past its narrow carrier pool
(seq<=4 ∪ promoted slabs, walls for promoted slabs). An element whose only real contacts live
outside that pool — a fitting on a proxy, a tread on a stringer, the exact §MIDAIR_REPAIR
(a)-population — was flagged floating forever and repaired never. 3090 elements sat in that gap
across the 7 shipped buildings.

**Fix:** `_cjpJudgeParity` — §MIDAIR_REPAIR's already-shipped weakest rule ("an element may not
appear before the first element it physically touches appears") applied to the captured timeline,
WITH the §OG_HANG_WINDOW_BOUND discipline the rejected 2026-08-13 `_midairRepair` swap lacked: a
push lands only when the whole rescheduled span stays inside the element's OWN task's authored
window; elements already out of window are never pushed further; everything else stays honestly
floating (WINDOW_BLOCKED — real task-authoring conflicts, §CPM_GENERATOR_UPSTREAM_SPEC territory).

**Measured (probe_captured_floating.js §EXP4, now slicing the shipped function, all 7 buildings):**

| Building | floating before → after | Δ |
|---|---|---|
| Terminal | 436 → 201 | -235 |
| Hospital | 643 → 39 | -604 |
| Duplex | 19 → 7 | -12 |
| HHS | 142 → 36 | -106 |
| Clinic | 413 → 72 | -341 |
| LTU_AHouse | 1302 → 230 | -1072 |
| JKR | 135 → 71 | -64 |
| **Total** | **3090 → 656** | **-2434 (-78.8%)** |

Window fidelity **byte-identical** on every building (the clamp guarantees it; verified anyway).
Orphans/grounded counts untouched — the judge is never modified.

**Witnesses:** new `witness_crosstask_judge_parity.js` 17/17 (wiring, strict reduction, window
safety, monotone, judge-untouched, synthetic non-vacuousness + honest-residual contract);
`witness_midair_zero.js` PASS; `witness_og_guard_bearing_bound.js` PASS;
`witness_gantt_og_grid_perf.js` PASS; `witness_class_fallback_blackbox.js` PASS; `gate_4d.sh` run.

`_GANTT_CACHE_VERSION` 25→26, `sw.js` v1038→v1039, `viewer.html` time_machine `?v=67→68`.

Also: `probe_captured_floating.js` gets the §MIDAIR_REPAIR_CONTACTGRAPH_DEDUP slice fix
(`_midairRepair` needs `_contactGraph`'s source since PR #1378) plus the §CJP residual
decomposition (REACHABLE / WINDOW_BLOCKED / ALREADY_OUT × groundCarrier × pool axes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017cU8nsfjcoTtK8tEkUCu7b
