### PR TITLE
fix(4d): §ZONE_DISPLAY_AUTHORING — one schedule for movie and Gantt; real floating 2741 -> 265

### DIFF
--- a/scripts/probe_captured_floating.js
+++ b/scripts/probe_captured_floating.js
@@ -132,16 +132,18 @@ async function main() {
   // §GANTT_GAP_CLAMP_SPREAD rescale, verbatim (time_machine.js injectGantt _cap overlay) — each gap
   // gets its real value-scaled size OR the fair rank/count share, whichever is SMALLER (only
   // abnormal dead-air gaps get clamped; normal real gaps stay byte-identical to the original).
-  const rescaled = _allScheduled.map(o => Object.assign({}, o));
+  // §CHASE_TO_ZERO_WINDOW_AUTHORING (2026-08-16): the shipped rescale, extracted into a function so
+  // the EXP5 family can re-run the WHOLE pipeline under candidate window authorings. Body verbatim.
+  function applyGapClampRescale(items, win) {
   const _taskItems = {}, _taskSpan = {};
-  rescaled.forEach(function (item) {
+  items.forEach(function (item) {
     (_taskItems[item.task] = _taskItems[item.task] || []).push(item);
     const sp = _taskSpan[item.task] || (_taskSpan[item.task] = { min: Infinity, max: -Infinity });
     if (item.s < sp.min) sp.min = item.s;
     if (item.e > sp.max) sp.max = item.e;
   });
   Object.keys(_taskItems).forEach(function (tid) {
-    const arr = _taskItems[tid], w = taskWin[tid], sp = _taskSpan[tid];
+    const arr = _taskItems[tid], w = win[tid], sp = _taskSpan[tid];
     const tSpan = Math.max(1, w.e - w.s), lsSpan = Math.max(1, sp.max - sp.min);
     const durFactor = tSpan / lsSpan;
     arr.sort(function (a, b) { return a.s - b.s || (a.guid < b.guid ? -1 : a.guid > b.guid ? 1 : 0); });
@@ -180,6 +182,9 @@ async function main() {
       item.e = item.s + scaledDur;
     }
   });
+  }
+  const rescaled = _allScheduled.map(o => Object.assign({}, o));
+  applyGapClampRescale(rescaled, taskWin);
 
   const preRepair = floatingCensus(rescaled.map(o => Object.assign({}, o)));
   console.log('§CAP_PRE_REPAIR_FLOATING midair=' + preRepair.midair + ' byClass=' + JSON.stringify(preRepair.byClass));
@@ -446,5 +451,87 @@ async function main() {
     ' orphans=' + exp3Post.orphans + ' grounded=' + exp3Post.grounded +
     ' ok=' + (exp3ForRepair.length - exp3Post.midair - exp3Post.orphans - exp3Post.grounded));
   console.log('§EXP3_FINAL_BYCLASS ' + JSON.stringify(exp3Post.byClass));
+
+  // ══ §CHASE_TO_ZERO_WINDOW_AUTHORING (2026-08-16) — EXP5 family. The §CROSSTASK_JUDGE_PARITY
+  // residual is 100% WINDOW_BLOCKED, so zero requires the BARS to change, not the elements'
+  // relation to their bars. Both candidates run the FULL shipped pipeline (clamp rescale ->
+  // _ogSupportSweep -> _cjpJudgeParity) — the third-lever lesson: nothing is judged mid-pipe. ═════
+  function runPipeline(base, win) {
+    const items = base.map(o => Object.assign({}, o));
+    applyGapClampRescale(items, win);
+    _ogSupportSweep(items, win);
+    _cjpJudgeParity(items, win);
+    return items;
+  }
+  function measureWin(items, win) {
+    const c = floatingCensus(items.map(o => Object.assign({}, o)));
+    let inW = 0, outW = 0;
+    items.forEach(it => { const w = win[it.task]; if (!w) return; if (it.s >= w.s && it.e <= w.e) inW++; else outW++; });
+    return { c, inW, outW };
+  }
+  const DAY5 = 86400000;
+
+  // EXP5a — minimal authored-END extension, whole-pipeline fixpoint. Only ends move, only where a
+  // WINDOW_BLOCKED element measurably needs it, day-quantized, iterated because an extension
+  // changes that task's own rescale (durFactor) and can move other tasks' first-contact times.
+  {
+    const win5 = {}; Object.keys(taskWin).forEach(t => win5[t] = { s: taskWin[t].s, e: taskWin[t].e });
+    const extTotals = {};
+    let iter = 0, final = null, converged = false;
+    for (; iter < 8; iter++) {
+      const items = runPipeline(_allScheduled, win5);
+      const m = measureWin(items, win5);
+      const G5 = _contactGraph(items);
+      const ext = {}; let blocked = 0; const gapDays = [];
+      for (let i = 0; i < items.length; i++) {
+        const list = G5.contacts[i]; if (!list) continue;
+        const T = items[i];
+        let first = Infinity;
+        for (const k of list) { if (items[k].s < first) first = items[k].s; }
+        if (first <= T.s + 1) continue;
+        const w = win5[T.task]; if (!w) continue;
+        const dur = Math.max(60000, T.e - T.s);
+        const need = (first + dur) - w.e;
+        if (need > 0) { blocked++; gapDays.push(need / DAY5); ext[T.task] = Math.max(ext[T.task] || 0, need); }
+      }
+      if (iter === 0 && gapDays.length) {
+        gapDays.sort((a, b) => a - b);
+        const gN = gapDays.length;
+        console.log('§EXP5_DIAG blockedNeedingExt=' + blocked + ' tasks=' + Object.keys(ext).length +
+          ' needDays p50=' + gapDays[Math.floor(gN * 0.5)].toFixed(1) +
+          ' p90=' + gapDays[Math.floor(gN * 0.9)].toFixed(1) + ' max=' + gapDays[gN - 1].toFixed(1));
+        console.log('§EXP5_DIAG_TASKS ' + JSON.stringify(Object.entries(ext).map(e => [e[0], (e[1] / DAY5).toFixed(1)]).sort((a, b) => b[1] - a[1]).slice(0, 8)));
+      }
+      console.log('§EXP5A_ITER ' + iter + ' floating=' + m.c.midair + ' blockedNeedingExt=' + blocked +
+        ' inWindow=' + m.inW + ' outWindow=' + m.outW);
+      final = m;
+      if (!blocked) { converged = true; break; }
+      Object.keys(ext).forEach(t => {
+        const addDays = Math.ceil(ext[t] / DAY5);
+        win5[t].e += addDays * DAY5;
+        extTotals[t] = (extTotals[t] || 0) + addDays;
+      });
+    }
+    const extList = Object.entries(extTotals).sort((a, b) => b[1] - a[1]);
+    let maxE0 = 0, maxE1 = 0;
+    Object.keys(taskWin).forEach(t => { if (taskWin[t].e > maxE0) maxE0 = taskWin[t].e; });
+    Object.keys(win5).forEach(t => { if (win5[t].e > maxE1) maxE1 = win5[t].e; });
+    console.log('§EXP5A_FINAL floating=' + final.c.midair + ' converged=' + converged + ' iters=' + (iter + 1) +
+      ' tasksExtended=' + extList.length + ' inWindow=' + final.inW + ' outWindow=' + final.outW +
+      ' totalDaysDelta=' + Math.round((maxE1 - maxE0) / DAY5) +
+      ' orphans=' + final.c.orphans + ' grounded=' + final.c.grounded);
+    console.log('§EXP5A_EXT_DAYS_BYTASK ' + JSON.stringify(extList.slice(0, 8)));
+  }
+
+  // EXP5b — EXP3 revisited WITH the parity layer: windows derived FROM the repaired raw times,
+  // then the full shipped pipeline. preZoneItems/taskWin2/zoneTaskId2 come from the EXP3 block.
+  {
+    const base5b = preZoneItems.map(o => Object.assign({}, o, { task: zoneTaskId2[o.zoneId] }));
+    const items = runPipeline(base5b, taskWin2);
+    const m = measureWin(items, taskWin2);
+    console.log('§EXP5B_FINAL floating=' + m.c.midair + ' inWindow=' + m.inW + ' outWindow=' + m.outW +
+      ' orphans=' + m.c.orphans + ' grounded=' + m.c.grounded);
+    console.log('§EXP5B_FINAL_BYCLASS ' + JSON.stringify(m.c.byClass));
+  }
 }
 main().catch(e => { console.error(e); process.exit(1); });

--- a/scripts/probe_captured_floating.js
+++ b/scripts/probe_captured_floating.js
@@ -533,5 +533,167 @@ async function main() {
       ' orphans=' + m.c.orphans + ' grounded=' + m.c.grounded);
     console.log('§EXP5B_FINAL_BYCLASS ' + JSON.stringify(m.c.byClass));
   }
+
+  // ══ EXP6 — BROWSER-FAITHFUL captured pipeline (2026-08-16, §CHASE_TO_ZERO_WINDOW_AUTHORING
+  // correction from the user's live Hospital log). Everything above feeds the rescale from
+  // computeSchedule's RAW times — but the real injectGantt overlay reads kernel_ops timestamps,
+  // which carry the TWO-TIER DISPLAY timeline (_twoTierRemap + _midairRepair, §TIER_SERIAL 420d on
+  // Hospital), while task windows are authored from the RAW schedule (334d). Live divergence proof:
+  // browser §PHASE_OVERLAP_SUPPORT_GUARD pushed=4117 vs this probe's raw-fed 1152. This section
+  // reproduces the REAL input using witness_midair_zero.js's validated display-timeline recipe. ════
+  {
+    const vm = require('vm');
+    function sliceAt(src, name, which, optional) {
+      let from = 0;
+      for (let pass = 0; pass <= (which || 0); pass++) {
+        const idx = src.indexOf('function ' + name + '(', from);
+        if (idx < 0) { if (optional) return null; throw new Error(name + ' not found'); }
+        let depth = 0, i = idx, seenOpen = false;
+        for (; i < src.length; i++) {
+          if (src[i] === '{') { depth++; seenOpen = true; }
+          else if (src[i] === '}') { depth--; if (seenOpen && depth === 0) break; }
+        }
+        if (pass === (which || 0)) return src.slice(idx, i + 1);
+        from = i + 1;
+      }
+    }
+    let mrCount = 0, mrFrom = 0;
+    for (;;) { const k = tmSrc.indexOf('function _midairRepair(', mrFrom); if (k < 0) break; mrCount++; mrFrom = k + 1; }
+    const zoneParts = [sliceAt(tmSrc, '_zoneIndexBuild', 0, true), sliceAt(tmSrc, '_zoneIndex', 0, true)].filter(Boolean);
+    const classifyParts = [sliceAt(tmSrc, '_classifyNameOverride', 0, true), sliceAt(tmSrc, '_classifyRule', 0, true)].filter(Boolean);
+    const sliced = ["var _TIER1_ORDER = ['Substructure', 'Superstructure', 'Architecture'];",
+      (zoneParts.length === 2 ? 'var _zoneMemo = [];' : ''), zoneParts[0] || '', zoneParts[1] || '',
+      sliceAt(tmSrc, '_zoneOf', 0, true) || '', classifyParts[0] || '', classifyParts[1] || '',
+      sliceAt(tmSrc, '_promoteRoofLoadPath'), sliceAt(tmSrc, '_buildXrayElements'),
+      sliceAt(tmSrc, '_tier1Extents'), sliceAt(tmSrc, '_tier1Serialize'),
+      sliceAt(tmSrc, '_tier1Protrusion'), sliceAt(tmSrc, '_tierAuditRegate'),
+      sliceAt(tmSrc, '_twoTierRemap'), sliceAt(tmSrc, '_contactGraph'),
+      sliceAt(tmSrc, '_midairRepair', mrCount - 1)].join('\n');
+    const sandbox = { console: { log: () => {}, warn: () => {} }, performance: { now: () => Date.now() },
+      window: { SEQUENCE_RULES: RATES.SEQUENCE_RULES, SEQUENCE_DEFAULT: RATES.SEQUENCE_DEFAULT,
+        SEQUENCE_NAME_OVERRIDES: RATES.SEQUENCE_NAME_OVERRIDES },
+      ScheduleGate: ScheduleGate, Math: Math, A: () => ({ db: db }) };
+    vm.createContext(sandbox);
+    vm.runInContext(sliced + '\nthis.__bxe = _buildXrayElements; this.__remap = _twoTierRemap; this.__repair = _midairRepair;', sandbox);
+    const els6 = sandbox.__bxe();
+    const nameOf = {};
+    const nr = db.exec("SELECT guid, ifc_class, COALESCE(element_name,'') FROM elements_meta");
+    if (nr.length) nr[0].values.forEach(v => { nameOf[v[0]] = v[2]; });
+    const frag = ScheduleAuthor._classFragmentation(db, RATES.RATES);
+    const lin = ScheduleAuthor._linearWeighting(db, RATES.RATES);
+    const geoEls = els6.filter(e => !(e.x0 === e.x1 && e.y0 === e.y1 && e.base_z === e.top_z));
+    geoEls.forEach(e => {
+      const rule = ScheduleAuthor.matchNameOverride(e.cls, nameOf[e.guid] || '', RATES.SEQUENCE_NAME_OVERRIDES) ||
+        ScheduleAuthor.matchRule(e.cls, RATES.SEQUENCE_RULES, RATES.SEQUENCE_DEFAULT);
+      if (!e.phase) e.phase = rule.phase;
+      e.resource = rule.resource || '_DEFAULT';
+      const realQty = (frag.fragmented[e.cls] && frag.area[e.guid] != null) ? frag.area[e.guid] : null;
+      const span = Math.max(e.x1 - e.x0, e.y1 - e.y0, e.top_z - e.base_z);
+      const avgLen = lin.avgLength[e.cls];
+      const lengthRatio = (realQty == null && span > 0 && avgLen > 0) ? span / avgLen : null;
+      e.installSecs = ScheduleAuthor._installSecs(e.cls, rule, RATES.LABOR_RATES, realQty, lengthRatio);
+    });
+    const sched6 = ScheduleGate.computeSchedule(geoEls, 0, 1, maxCrews, SHIFT_HOURS);
+    // windows from RAW schedule — materializeZones semantics (what the browser's tasks table holds)
+    const rolled6 = ScheduleGate.deriveZones(geoEls, sched6);
+    const minStart6 = Math.min.apply(null, rolled6.zones.map(z => z.start));
+    const zoneTaskId6 = {}, taskWin6 = {};
+    rolled6.zones.forEach(function (z) {
+      const tid = 'TASK_' + _slug(z.phase) + '_' + _slug(z.storey);
+      zoneTaskId6[z.id] = tid;
+      const sD = Math.round((z.start - minStart6) / DAY5);
+      let eD = Math.round((z.end - minStart6) / DAY5);
+      if (eD <= sD) eD = sD + 1;
+      taskWin6[tid] = { s: minStart6 + sD * DAY5, e: minStart6 + eD * DAY5 };
+    });
+    // DISPLAY timeline (what kernel_ops actually carries): two-tier remap + midair repair
+    const disp = geoEls.map(e => ({ guid: e.guid, s: sched6[e.guid].start, e: sched6[e.guid].end,
+      bz: e.base_z, tz: e.top_z, x0: e.x0, x1: e.x1, y0: e.y0, y1: e.y1,
+      cls: e.cls, seq: e.seq, phase: e.phase, storey: e.storey }));
+    sandbox.__items = disp;
+    vm.runInContext('this.__remap(this.__items); this.__repair(this.__items);', sandbox);
+    let noTask = 0;
+    const cap6 = disp.map(o => {
+      const zid = (o.phase || '_UNPHASED') + '||' + ScheduleGate.collapsePhase(o.storey);
+      const tid = zoneTaskId6[zid];
+      if (!tid) { noTask++; return null; }
+      return Object.assign({}, o, { task: tid, zoneId: zid });
+    }).filter(Boolean);
+    console.log('§EXP6_INPUT n=' + cap6.length + ' noTask=' + noTask +
+      ' displaySpanDays=' + Math.round((Math.max.apply(null, disp.map(o => o.e)) - Math.min.apply(null, disp.map(o => o.s))) / DAY5) +
+      ' rawWindowSpanDays=' + Math.round((Math.max.apply(null, Object.values(taskWin6).map(w => w.e)) - minStart6) / DAY5));
+    const rawC6 = floatingCensus(cap6.map(o => Object.assign({}, o)));
+    console.log('§EXP6_DISPLAY_FLOATING midair=' + rawC6.midair + ' orphans=' + rawC6.orphans + ' (pre-overlay, the kernel_ops truth)');
+    applyGapClampRescale(cap6, taskWin6);
+    const preC6 = floatingCensus(cap6.map(o => Object.assign({}, o)));
+    console.log('§EXP6_PRE_REPAIR_FLOATING midair=' + preC6.midair);
+    const sweep6 = _ogSupportSweep(cap6, taskWin6);
+    console.log('§EXP6_OGSWEEP pushed=' + sweep6.pushed + ' sweeps=' + sweep6.sweeps + ' (live browser said 4117/2 on Hospital)');
+    const postSweep6 = floatingCensus(cap6.map(o => Object.assign({}, o)));
+    console.log('§EXP6_POST_SWEEP_FLOATING midair=' + postSweep6.midair + ' byClass=' + JSON.stringify(postSweep6.byClass));
+    const r6 = _cjpJudgeParity(cap6, taskWin6);
+    const final6 = floatingCensus(cap6.map(o => Object.assign({}, o)));
+    let inW6 = 0, outW6 = 0;
+    cap6.forEach(it => { const w = taskWin6[it.task]; if (!w) return; if (it.s >= w.s && it.e <= w.e) inW6++; else outW6++; });
+    console.log('§EXP6_FINAL floating=' + final6.midair + '/' + cap6.length + ' parityPushed=' + r6.pushed +
+      ' (live said 542) inWindow=' + inW6 + ' outWindow=' + outW6 +
+      ' orphans=' + final6.orphans + ' grounded=' + final6.grounded);
+    console.log('§EXP6_FINAL_BYCLASS ' + JSON.stringify(final6.byClass));
+
+    // ── EXP7 — author the windows FROM the display timeline (the schedule the movie actually
+    // plays), so windows and element times describe ONE schedule instead of two. Same overlay
+    // pipeline afterwards. Prediction: rescale ≈ identity, floating → ~0, fidelity → ~100%. ────────
+    const dispMap = {};
+    disp.forEach(o => { dispMap[o.guid] = { start: o.s, end: o.e }; });
+    const rolled7 = ScheduleGate.deriveZones(geoEls, dispMap);
+    const minStart7 = Math.min.apply(null, rolled7.zones.map(z => z.start));
+    const zoneTaskId7 = {}, taskWin7 = {};
+    rolled7.zones.forEach(function (z) {
+      const tid = 'TASK_' + _slug(z.phase) + '_' + _slug(z.storey);
+      zoneTaskId7[z.id] = tid;
+      const sD = Math.round((z.start - minStart7) / DAY5);
+      let eD = Math.round((z.end - minStart7) / DAY5);
+      if (eD <= sD) eD = sD + 1;
+      taskWin7[tid] = { s: minStart7 + sD * DAY5, e: minStart7 + eD * DAY5 };
+    });
+    const cap7 = disp.map(o => {
+      const zid = (o.phase || '_UNPHASED') + '||' + ScheduleGate.collapsePhase(o.storey);
+      const tid = zoneTaskId7[zid];
+      return tid ? Object.assign({}, o, { task: tid, zoneId: zid }) : null;
+    }).filter(Boolean);
+    applyGapClampRescale(cap7, taskWin7);
+    const preC7 = floatingCensus(cap7.map(o => Object.assign({}, o)));
+    const sweep7 = _ogSupportSweep(cap7, taskWin7);
+    const r7 = _cjpJudgeParity(cap7, taskWin7);
+    const final7 = floatingCensus(cap7.map(o => Object.assign({}, o)));
+    let inW7 = 0, outW7 = 0;
+    cap7.forEach(it => { const w = taskWin7[it.task]; if (!w) return; if (it.s >= w.s && it.e <= w.e) inW7++; else outW7++; });
+    console.log('§EXP7_FINAL floating=' + final7.midair + '/' + cap7.length +
+      ' preRepair=' + preC7.midair + ' sweepPushed=' + sweep7.pushed + ' parityPushed=' + r7.pushed +
+      ' inWindow=' + inW7 + ' outWindow=' + outW7 + ' totalDays=' +
+      Math.round((Math.max.apply(null, Object.values(taskWin7).map(w => w.e)) - minStart7) / DAY5));
+    console.log('§EXP7_FINAL_BYCLASS ' + JSON.stringify(final7.byClass));
+
+    // ── EXP8 — consistent windows (from display timeline), NO _ogSupportSweep: rescale → parity
+    // only. The sweep enforces the STRICT end-based bar (§SUPPORT_CHECK), which §MIDAIR_REPAIR's
+    // header deliberately does NOT enforce on the display timeline ("a slab arriving over a glowing
+    // half-built column is resting, not hanging") — on a consistent-window overlay its ~24k pushes
+    // are the main source of out-of-window overshoot. Does dropping it reach ~0/~100%? ─────────────
+    const cap8 = disp.map(o => {
+      const zid = (o.phase || '_UNPHASED') + '||' + ScheduleGate.collapsePhase(o.storey);
+      const tid = zoneTaskId7[zid];
+      return tid ? Object.assign({}, o, { task: tid, zoneId: zid }) : null;
+    }).filter(Boolean);
+    applyGapClampRescale(cap8, taskWin7);
+    const preC8 = floatingCensus(cap8.map(o => Object.assign({}, o)));
+    const r8 = _cjpJudgeParity(cap8, taskWin7);
+    const final8 = floatingCensus(cap8.map(o => Object.assign({}, o)));
+    let inW8 = 0, outW8 = 0;
+    cap8.forEach(it => { const w = taskWin7[it.task]; if (!w) return; if (it.s >= w.s && it.e <= w.e) inW8++; else outW8++; });
+    console.log('§EXP8_FINAL floating=' + final8.midair + '/' + cap8.length +
+      ' preRepair=' + preC8.midair + ' parityPushed=' + r8.pushed +
+      ' inWindow=' + inW8 + ' outWindow=' + outW8);
+    console.log('§EXP8_FINAL_BYCLASS ' + JSON.stringify(final8.byClass));
+  }
 }
 main().catch(e => { console.error(e); process.exit(1); });

--- a/viewer/schedule_author.js
+++ b/viewer/schedule_author.js
@@ -215,6 +215,16 @@
     try { db.run('ALTER TABLE schedules ADD COLUMN gen_version INTEGER'); } catch (e) {}
   }
 
+  // §ZONE_DISPLAY_AUTHORING (2026-08-16, 4D_SCHEDULE_PERFECTION.md §CHASE_TO_ZERO_WINDOW_AUTHORING):
+  // marks a schedule whose task windows were derived from the DISPLAY timeline (opts.displayRemap
+  // below) rather than the raw generative schedule. The captured overlay reads this to skip the
+  // strict end-bar repair (_ogSupportSweep) that only existed because windows and movie described
+  // two different schedules. Guarded ALTER, same shape as gen_version above.
+  function _ensureSchedulesDisplayAuthored(db) {
+    if (_cols(db, 'schedules').indexOf('display_authored') >= 0) return;
+    try { db.run('ALTER TABLE schedules ADD COLUMN display_authored INTEGER'); } catch (e) {}
+  }
+
   // Some shipped building DBs carry a LEGACY-thin `tasks` table
   // (task_id, schedule_id, name, start_date, finish_date, duration_days, status) that the read-path
   // `_cap` cannot consume (its query selects schedule_start/is_summary → errors → generative
@@ -370,10 +380,29 @@
     // (witnesses/probes that never pass it stay byte-identical) — only callers that pass it (the
     // real UI paths, below) change.
     var schedule = SG.computeSchedule(elements, 0, 1, maxCrews, opts.shiftHours);
+    // §ZONE_DISPLAY_AUTHORING (2026-08-16, 4D_SCHEDULE_PERFECTION.md §CHASE_TO_ZERO_WINDOW_AUTHORING):
+    // the movie plays the DISPLAY timeline (time_machine's two-tier remap + midair repair over this
+    // raw schedule), but task windows were authored from the RAW schedule — two different schedules,
+    // measured live 2026-08-16 (Hospital: display span 420d vs windows 334d; the captured overlay
+    // then manufactured 2211 violations from a 0-floating input). opts.displayRemap — supplied by
+    // time_machine at the real UI call sites, so the remap physics stays single-source there — maps
+    // (elements, rawSchedule) -> the display schedule; windows derived from it describe the SAME
+    // timeline the movie plays. Callers that omit it (probes/witnesses/legacy) stay byte-identical.
+    var _displayAuthored = 0;
+    if (typeof opts.displayRemap === 'function') {
+      try {
+        var _dr = opts.displayRemap(elements, schedule);
+        if (_dr) {
+          schedule = _dr; _displayAuthored = 1;
+          console.log('§ZONE_DISPLAY_AUTHORING task windows derived from the DISPLAY timeline (n=' + Object.keys(_dr).length + ')');
+        }
+      } catch (e) { console.log('§ZONE_DISPLAY_AUTHORING_FAIL ' + e.message + ' — raw-schedule windows kept'); }
+    }
     var rolled = SG.deriveZones(elements, schedule);
     if (!rolled.zones.length) { console.log('§AUTHOR_ZONES_FAIL reason=no_zones'); return { ok: false, reason: 'no_zones' }; }
 
     _ensureSchedulesGenVersion(db);
+    _ensureSchedulesDisplayAuthored(db);
     _ensureWideTasks(db);
     db.run('CREATE TABLE IF NOT EXISTS task_elements (task_id TEXT, guid TEXT, PRIMARY KEY (task_id, guid))');
     db.run('CREATE TABLE IF NOT EXISTS task_sequences (predecessor_id TEXT, successor_id TEXT, sequence_type TEXT, lag_days REAL DEFAULT 0, PRIMARY KEY (predecessor_id, successor_id))');
@@ -383,7 +412,8 @@
     db.run('DELETE FROM task_sequences WHERE predecessor_id IN (SELECT task_id FROM tasks WHERE schedule_id=?) OR successor_id IN (SELECT task_id FROM tasks WHERE schedule_id=?)', [schedId, schedId]);
     db.run('DELETE FROM tasks WHERE schedule_id=?', [schedId]);
     db.run('DELETE FROM schedules WHERE schedule_id=?', [schedId]);
-    db.run('INSERT INTO schedules VALUES (?,?,?,?,?)', [schedId, 'Authored Schedule (zone detail)', 'PLANNED', start, opts.genVersion != null ? opts.genVersion : null]);
+    db.run('INSERT INTO schedules (schedule_id,name,status,created_date,gen_version,display_authored) VALUES (?,?,?,?,?,?)',
+      [schedId, 'Authored Schedule (zone detail)', 'PLANNED', start, opts.genVersion != null ? opts.genVersion : null, _displayAuthored]);
 
     var rootId = 'TASK_ROOT';
     var minStart = Math.min.apply(null, rolled.zones.map(function (z) { return z.start; }));
@@ -568,7 +598,8 @@
         ' (overlaps ' + Math.max(0, p.widthDays - p.lagDays) + 'd of the PREVIOUS phase\'s tail)');
     });
 
-    db.run('INSERT INTO schedules VALUES (?,?,?,?,?)', [schedId, 'Authored Schedule', 'PLANNED', start, opts.genVersion != null ? opts.genVersion : null]);
+    db.run('INSERT INTO schedules (schedule_id,name,status,created_date,gen_version) VALUES (?,?,?,?,?)',
+      [schedId, 'Authored Schedule', 'PLANNED', start, opts.genVersion != null ? opts.genVersion : null]);
 
     // ROOT summary task (is_summary=1 → excluded from _cap leaf window; spans the whole project).
     // In blank mode dates are NULL (the user originates them via scheduleDefault/the wizard).

--- a/viewer/sw.js
+++ b/viewer/sw.js
@@ -8,7 +8,11 @@
 // Cache-first for heavy assets (.wasm, images). DB files skip SW (IndexedDB handles them).
 //
 // DEPLOY: bump CACHE_VERSION on every OCI upload. Old caches are purged on activate.
-const CACHE_VERSION = 'v1041';   // bump on each deploy; per-change detail is the git commit message.
+const CACHE_VERSION = 'v1042';   // bump on each deploy; per-change detail is the git commit message.
+// v1042 (2026-08-16) §ZONE_DISPLAY_AUTHORING: task windows authored from the display timeline
+// (schedule_author.js displayRemap hook + time_machine.js _tmDisplayRemap), strict-bar sweep skipped
+// on display-authored schedules, §CJP live census in the §CROSSTASK_JUDGE_PARITY log line.
+// _GANTT_CACHE_VERSION 26->27. Probe §EXP8 Hospital: floating 664 -> 63, fidelity 97.03 -> 99.95.
 // v1041 (2026-08-16) §GROUND_DETAIL: ground normal/roughness maps + detail multiply + blotch
 // (tools.js?v=40, ground_config.json?v=2, 6 new textures/ground/*.jpg). Collided with #1387's
 // independent v1040 — took one past it, per this file's KEEP-BOTH/take-the-higher convention.

--- a/viewer/tests/witness_gantt_native_generate.js
+++ b/viewer/tests/witness_gantt_native_generate.js
@@ -30,7 +30,18 @@ function sliceFn(src, name) {
   }
   throw new Error('unbalanced braces for ' + name);
 }
-const sliced = sliceFn(tmSrc, 'generateGanttSchedule');
+// generateGanttSchedule references two module-level names this single-function slice lacks:
+//   _GANTT_CACHE_VERSION (since §GANTT_SCHEDULE_STALE 2026-08-14 — this witness has thrown
+//   ReferenceError and exited before asserting anything since then, verified on unmodified main
+//   2026-08-16) — read the REAL value out of the source, never a hand-typed copy to drift; and
+//   _tmDisplayRemap (§ZONE_DISPLAY_AUTHORING 2026-08-16) — stubbed to null here: the remap's own
+//   behavior is witnessed end-to-end in witness_zone_display_authoring.js, this witness owns the
+//   native-generate wiring only, and a null remap takes materializeZones' legacy branch.
+const _verMatch = tmSrc.match(/var _GANTT_CACHE_VERSION = (\d+);/);
+if (!_verMatch) throw new Error('_GANTT_CACHE_VERSION not found in time_machine.js');
+const sliced = 'var _GANTT_CACHE_VERSION = ' + _verMatch[1] + ';\n' +
+  'var _tmDisplayRemap = function () { return null; };\n' +
+  sliceFn(tmSrc, 'generateGanttSchedule');
 
 function loadRules() {
   var txt = fs.readFileSync(path.join(__dirname, '..', 'rates.js'), 'utf8');

--- a/viewer/tests/witness_zone_display_authoring.js
+++ b/viewer/tests/witness_zone_display_authoring.js
@@ -1,0 +1,195 @@
+#!/usr/bin/env node
+// witness_zone_display_authoring.js — §ZONE_DISPLAY_AUTHORING (2026-08-16, bim-compiler
+// prompts/4D_SCHEDULE_PERFECTION.md §CHASE_TO_ZERO_WINDOW_AUTHORING).
+//
+// ISSUE this witness proves/disproves: the Gantt's task windows were authored from the RAW
+// computeSchedule output while the movie plays the TWO-TIER DISPLAY timeline — two different
+// schedules. The captured overlay then rescaled display times into raw windows, manufacturing
+// order violations out of a 0-floating kernel_ops input (measured live 2026-08-16, Hospital:
+// 2211 pre-repair violations, 664 residual, 97.03% window fidelity). The fix authors windows FROM
+// the display timeline (materializeZones opts.displayRemap ← time_machine._tmDisplayRemap, one
+// physics) and skips the strict end-bar sweep on that path (schedules.display_authored=1).
+//
+//   W-ZDA-1  WIRING: all 3 real materializeZones call sites in time_machine.js pass
+//            displayRemap: _tmDisplayRemap (an unwired hook is a silent no-op).
+//   W-ZDA-2  FLAG: materializeZones WITH displayRemap writes schedules.display_authored=1;
+//            WITHOUT it writes 0 — imported/legacy schedules keep the old sweep.
+//   W-ZDA-3  SWEEP GUARD: the captured overlay skips _ogSupportSweep exactly when
+//            display_authored=1 and still always runs _cjpJudgeParity (source contract).
+//   W-ZDA-4  THE BAR (end-to-end, real buildings, shipped functions): under display-authored
+//            windows + parity-only repair, judge-rule floating is strictly below the
+//            raw-window+sweep baseline AND window fidelity is not worse.
+//   W-ZDA-5  LEGACY SAFETY: materializeZones WITHOUT displayRemap still writes a readable
+//            schedules row (named-column INSERT after the ALTER) and identical zone windows.
+//
+// Command: BLD_DIR=~/bim-ootb/buildings node tests/witness_zone_display_authoring.js  (from viewer/)
+// Read the § log lines, not the exit code alone.
+'use strict';
+const fs = require('fs');
+const path = require('path');
+const vm = require('vm');
+const initSqlJs = require(path.join(__dirname, '..', '..', 'modeller', 'lib', 'sql-wasm.js'));
+const ScheduleGate = require(path.join(__dirname, '..', 'schedule_gate.js'));
+const ScheduleAuthor = require(path.join(__dirname, '..', 'schedule_author.js'));
+const tmSrc = fs.readFileSync(path.join(__dirname, '..', 'time_machine.js'), 'utf8');
+
+let pass = 0, fail = 0;
+function assert(cond, msg) { if (cond) { pass++; console.log('  PASS ' + msg); } else { fail++; console.log('  FAIL ' + msg); } }
+
+function sliceFn(src, name, which, optional) {
+  let from = 0;
+  for (let p = 0; p <= (which || 0); p++) {
+    const idx = src.indexOf('function ' + name + '(', from);
+    if (idx < 0) { if (optional) return null; throw new Error(name + ' not found'); }
+    let depth = 0, i = idx, seenOpen = false;
+    for (; i < src.length; i++) {
+      if (src[i] === '{') { depth++; seenOpen = true; }
+      else if (src[i] === '}') { depth--; if (seenOpen && depth === 0) break; }
+    }
+    if (p === (which || 0)) return src.slice(idx, i + 1);
+    from = i + 1;
+  }
+}
+
+// ── W-ZDA-1/3: source-level wiring ────────────────────────────────────────────────────────────
+console.log('W-ZDA-1/3 wiring');
+const remapWires = (tmSrc.match(/displayRemap:\s*_tmDisplayRemap/g) || []).length;
+assert(remapWires === 3, 'all 3 materializeZones call sites pass displayRemap: _tmDisplayRemap (found ' + remapWires + ')');
+assert(/display_authored=1 LIMIT 1/.test(tmSrc) && /if \(_cjpDisplayAuthored\)/.test(tmSrc) &&
+  /else \{\s*\n\s*_ogSupportSweep\(_allScheduled, _cap\.win\);/.test(tmSrc),
+  'overlay skips _ogSupportSweep exactly on display_authored=1');
+const guardIdx = tmSrc.indexOf('_cjpDisplayAuthored');
+assert(guardIdx > 0 && /_cjpJudgeParity\(_allScheduled, _cap\.win\)/.test(tmSrc.slice(guardIdx, guardIdx + 2600)),
+  '_cjpJudgeParity still always runs after the guard');
+const saSrc = fs.readFileSync(path.join(__dirname, '..', 'schedule_author.js'), 'utf8');
+assert(/opts\.displayRemap/.test(saSrc) && /display_authored/.test(saSrc),
+  'schedule_author.js materializeZones consumes opts.displayRemap and persists display_authored');
+
+// ── shipped-function slices (one physics — the same functions the browser runs) ───────────────
+let mrCount = 0, mrFrom = 0;
+for (;;) { const k = tmSrc.indexOf('function _midairRepair(', mrFrom); if (k < 0) break; mrCount++; mrFrom = k + 1; }
+const zoneParts = [sliceFn(tmSrc, '_zoneIndexBuild', 0, true), sliceFn(tmSrc, '_zoneIndex', 0, true)].filter(Boolean);
+const sliced = ["var _TIER1_ORDER = ['Substructure', 'Superstructure', 'Architecture'];",
+  (zoneParts.length === 2 ? 'var _zoneMemo = [];' : ''), zoneParts[0] || '', zoneParts[1] || '',
+  sliceFn(tmSrc, '_zoneOf', 0, true) || '',
+  sliceFn(tmSrc, '_tier1Extents'), sliceFn(tmSrc, '_tier1Serialize'),
+  sliceFn(tmSrc, '_tier1Protrusion'), sliceFn(tmSrc, '_tierAuditRegate'),
+  sliceFn(tmSrc, '_twoTierRemap'), sliceFn(tmSrc, '_contactGraph'),
+  sliceFn(tmSrc, '_midairRepair', mrCount - 1),
+  sliceFn(tmSrc, '_ogSupportSweep'), sliceFn(tmSrc, '_cjpJudgeParity'),
+  sliceFn(tmSrc, '_capWindowRescale'), sliceFn(tmSrc, '_tmDisplayRemap')].join('\n');
+const sandbox = { console: { log: () => {}, warn: () => {} }, performance: { now: () => Date.now() },
+  ScheduleGate: ScheduleGate, Math: Math };
+vm.createContext(sandbox);
+vm.runInContext(sliced +
+  '\nthis.__remapHook = _tmDisplayRemap; this.__sweep = _ogSupportSweep; this.__parity = _cjpJudgeParity; this.__cg = _contactGraph; this.__rescale = _capWindowRescale;', sandbox);
+const _tmDisplayRemap = sandbox.__remapHook, _ogSupportSweep = sandbox.__sweep,
+  _cjpJudgeParity = sandbox.__parity, _contactGraph = sandbox.__cg, _capWindowRescale = sandbox.__rescale;
+
+function census(items) {
+  const G = _contactGraph(items);
+  let midair = 0;
+  for (let i = 0; i < items.length; i++) {
+    const list = G.contacts[i]; if (!list) continue;
+    let first = Infinity;
+    for (const k of list) { if (items[k].s < first) first = items[k].s; }
+    if (first > items[i].s + 1) midair++;
+  }
+  return midair;
+}
+function winCounts(items, taskWin) {
+  let inW = 0, outW = 0;
+  items.forEach(it => { const w = taskWin[it.task]; if (!w) return; (it.s >= w.s && it.e <= w.e) ? inW++ : outW++; });
+  return { inW, outW };
+}
+function readTaskWin(db) {
+  const win = {};
+  const tr = db.exec("SELECT task_id, schedule_start, schedule_finish FROM tasks WHERE schedule_start IS NOT NULL AND (is_summary IS NULL OR is_summary=0)");
+  if (tr.length) tr[0].values.forEach(r => { win[r[0]] = { s: Date.parse(r[1]), e: Date.parse(r[2]) }; });
+  return win;
+}
+function _slug(n) { return String(n).replace(/[^A-Za-z0-9]+/g, '_').replace(/^_+|_+$/g, ''); }
+
+const BLD_DIR = process.env.BLD_DIR || path.join(require('os').homedir(), 'bim-ootb', 'buildings');
+const BUILDINGS = (process.env.ZDA_BUILDINGS || 'Duplex_extracted,HHS_Office_Federated_extracted').split(',');
+
+async function main() {
+  const SQL = await initSqlJs({ wasmBinary: fs.readFileSync(path.join(__dirname, '..', '..', 'modeller', 'lib', 'sql-wasm.wasm')) });
+  const ratesSrc = fs.readFileSync(path.join(__dirname, '..', 'rates.js'), 'utf8');
+  const RATES = (new Function(ratesSrc +
+    '\nreturn {SEQUENCE_RULES:SEQUENCE_RULES, SEQUENCE_DEFAULT:SEQUENCE_DEFAULT, ' +
+    'SEQUENCE_NAME_OVERRIDES:SEQUENCE_NAME_OVERRIDES, LABOR_RATES:LABOR_RATES, RATES:RATES};'))();
+  const quiet = () => {};
+
+  for (const B of BUILDINGS) {
+    const dbPath = path.join(BLD_DIR, B + '.db');
+    if (!fs.existsSync(dbPath)) { console.log('  SKIP ' + B + ' (no DB)'); continue; }
+    console.log('W-ZDA-2/4/5 ' + B);
+    const bytes = fs.readFileSync(dbPath);
+    const mkOpts = extra => Object.assign({ laborRates: RATES.LABOR_RATES, rates: RATES.RATES,
+      nameOverrides: RATES.SEQUENCE_NAME_OVERRIDES, defaultRule: RATES.SEQUENCE_DEFAULT,
+      scheduleGate: ScheduleGate, shiftHours: 24, genVersion: 999, start: '2026-01-01' }, extra || {});
+
+    // legacy path (no hook)
+    const dbA = new SQL.Database(new Uint8Array(bytes));
+    const ql = console.log; console.log = quiet;
+    const resA = ScheduleAuthor.materializeZones(dbA, RATES.SEQUENCE_RULES, mkOpts());
+    console.log = ql;
+    const flagA = dbA.exec("SELECT COALESCE(display_authored,0) FROM schedules WHERE schedule_id='SCH_AUTHORED'");
+    assert(resA.ok && flagA.length && Number(flagA[0].values[0][0]) === 0,
+      'W-ZDA-2a legacy call writes display_authored=0 and a readable schedules row (named-column INSERT)');
+    const winA = readTaskWin(dbA);
+
+    // display-authored path (the shipped hook)
+    const dbB = new SQL.Database(new Uint8Array(bytes));
+    console.log = quiet;
+    const resB = ScheduleAuthor.materializeZones(dbB, RATES.SEQUENCE_RULES, mkOpts({ displayRemap: _tmDisplayRemap }));
+    console.log = ql;
+    const flagB = dbB.exec("SELECT COALESCE(display_authored,0) FROM schedules WHERE schedule_id='SCH_AUTHORED'");
+    assert(resB.ok && flagB.length && Number(flagB[0].values[0][0]) === 1,
+      'W-ZDA-2b displayRemap call writes display_authored=1');
+    const winB = readTaskWin(dbB);
+    assert(Object.keys(winA).length > 0 && Object.keys(winA).length === Object.keys(winB).length,
+      'W-ZDA-5 same task set under both paths (n=' + Object.keys(winA).length + ')');
+
+    // end-to-end overlay comparison, shipped functions only
+    console.log = quiet;
+    const elements = ScheduleAuthor._buildScheduleElements(dbA, RATES.SEQUENCE_RULES, mkOpts())
+      .map(it => Object.assign({}, it, { bz: it.base_z, tz: it.top_z }));
+    const maxCrews = {};
+    for (const rk in RATES.LABOR_RATES) if (RATES.LABOR_RATES[rk].max_crews) maxCrews[rk] = RATES.LABOR_RATES[rk].max_crews;
+    const rawSched = ScheduleGate.computeSchedule(elements, 0, 1, maxCrews, 24);
+    const dispSched = _tmDisplayRemap(elements, rawSched);
+    console.log = ql;
+    function capItems(schedMap, win) {
+      return elements.map(el => {
+        const st = schedMap[el.guid]; if (!st) return null;
+        const tid = 'TASK_' + _slug(el.phase || '_UNPHASED') + '_' + _slug(ScheduleGate.collapsePhase(el.storey));
+        if (!win[tid]) return null;
+        return { guid: el.guid, s: st.start, e: st.end, bz: el.bz, tz: el.tz,
+          x0: el.x0, x1: el.x1, y0: el.y0, y1: el.y1, cls: el.cls, seq: el.seq, task: tid };
+      }).filter(Boolean);
+    }
+    console.log = quiet;
+    // baseline: raw-authored windows, display input, SHIPPED rescale + sweep + parity (pre-change path)
+    const base = capItems(dispSched, winA);
+    _capWindowRescale(base, winA);
+    _ogSupportSweep(base, winA);
+    _cjpJudgeParity(base, winA);
+    const baseFloat = census(base), baseWin = winCounts(base, winA);
+    // new: display-authored windows, display input, SHIPPED rescale + parity only
+    const next = capItems(dispSched, winB);
+    _capWindowRescale(next, winB);
+    _cjpJudgeParity(next, winB);
+    const nextFloat = census(next), nextWin = winCounts(next, winB);
+    console.log = ql;
+    console.log('  §ZDA_WITNESS ' + B + ' floating ' + baseFloat + ' -> ' + nextFloat +
+      ' outWindow ' + baseWin.outW + ' -> ' + nextWin.outW);
+    assert(nextFloat <= baseFloat, 'W-ZDA-4a floating not worse under display-authored windows (' + baseFloat + ' -> ' + nextFloat + ')');
+    assert(nextWin.outW <= baseWin.outW, 'W-ZDA-4b window fidelity not worse (outWindow ' + baseWin.outW + ' -> ' + nextWin.outW + ')');
+    dbA.close(); dbB.close();
+  }
+  console.log('\n§ZDA_WITNESS_SUMMARY pass=' + pass + ' fail=' + fail);
+  process.exit(fail ? 1 : 0);
+}
+main().catch(e => { console.error(e); process.exit(1); });

--- a/viewer/time_machine.js
+++ b/viewer/time_machine.js
@@ -4470,11 +4470,52 @@
       }
       if (!moved) break;
     }
-    if (pushed) console.log('§CROSSTASK_JUDGE_PARITY pushed=' + pushed + ' sweeps=' + sweeps +
+    // §CJP_LIVE_CENSUS (2026-08-16): the user-facing truth this pass leaves behind, computed from
+    // the SAME contact graph (no extra scan) — without this line a live session cannot say how much
+    // floating actually remains (the 2026-08-16 "still lots of floating" report had no number).
+    var floating = 0, blocked = 0;
+    for (var ci = 0; ci < items.length; ci++) {
+      var cl = G.contacts[ci]; if (!cl) continue;
+      var Tc = items[ci], cf = Infinity;
+      for (var ck = 0; ck < cl.length; ck++) { var cs = items[cl[ck]].s; if (cs < cf) cf = cs; }
+      if (cf > Tc.s + 1) {
+        floating++;
+        var cw = taskWin && taskWin[Tc.task];
+        if (cw && cf + Math.max(60000, Tc.e - Tc.s) > cw.e) blocked++;
+      }
+    }
+    console.log('§CROSSTASK_JUDGE_PARITY pushed=' + pushed + ' sweeps=' + sweeps +
       ' maxShiftDays=' + (maxShift / 86400000).toFixed(1) +
+      ' floating=' + floating + '/' + items.length + ' windowBlocked=' + blocked +
       ' ms=' + Math.round(((typeof performance !== 'undefined' && performance.now) ? performance.now() : Date.now()) - _t0) +
       ' — judge-rule floating repaired within each element\'s own task window');
-    return { pushed: pushed, sweeps: sweeps };
+    return { pushed: pushed, sweeps: sweeps, floating: floating, windowBlocked: blocked };
+  }
+
+  // §ZONE_DISPLAY_AUTHORING (2026-08-16, bim-compiler prompts/4D_SCHEDULE_PERFECTION.md
+  // §CHASE_TO_ZERO_WINDOW_AUTHORING) — the displayRemap hook handed to ScheduleAuthor.materializeZones
+  // by every real UI call site in this file. The Gantt's task windows used to be derived from the RAW
+  // computeSchedule output while the movie plays the TWO-TIER DISPLAY timeline (_twoTierRemap +
+  // _midairRepair) — two different schedules; measured live 2026-08-16 on Hospital: display span 420d
+  // vs authored windows 334d, and the captured overlay manufactured 2211 order violations out of a
+  // 0-floating kernel_ops input. This hook maps the raw schedule through the SAME two functions the
+  // kernel_ops write path runs — one physics, no copy — so authored windows and the movie describe
+  // ONE schedule. Probe §EXP7/§EXP8 (probe_captured_floating.js, browser-faithful pipeline):
+  // Hospital floating 664 -> 63, window fidelity 97.03% -> 99.95%.
+  function _tmDisplayRemap(elements, schedule) {
+    var items = [];
+    elements.forEach(function (el) {
+      var st = schedule[el.guid]; if (!st) return;
+      items.push({ guid: el.guid, s: st.start, e: st.end, bz: el.base_z, tz: el.top_z,
+        x0: el.x0, x1: el.x1, y0: el.y0, y1: el.y1,
+        cls: el.cls, seq: el.seq, phase: el.phase, storey: el.storey });
+    });
+    if (!items.length) return null;
+    _twoTierRemap(items);
+    _midairRepair(items);
+    var out = {};
+    items.forEach(function (it) { out[it.guid] = { start: it.s, end: it.e }; });
+    return out;
   }
 
   // The two-tier orchestrator: serialize the backbone → re-gate every dependent after its real
@@ -5697,6 +5738,10 @@
       // right lever there; named for a future session, not chased further this pass — Terminal was
       // already imperfectly spread pre-fix (KS 0.0946), this is a real but same-axis regression,
       // not a new correctness class.
+      // §ZONE_DISPLAY_AUTHORING (2026-08-16): extracted into the named _capWindowRescale so
+      // witnesses/probes can slice the SHIPPED rescale instead of maintaining copies — body verbatim.
+      _capWindowRescale(_allScheduled, _cap.win);
+      function _capWindowRescale(_allScheduled, _win) {
       var _GANTT_GAP_CLAMP_K = 500;
       var _taskItems = {}, _taskSpan = {};
       _allScheduled.forEach(function (item) {
@@ -5707,7 +5752,7 @@
       });
       Object.keys(_taskItems).forEach(function (tid) {
         var arr = _taskItems[tid];
-        var w = _cap.win[tid];
+        var w = _win[tid];
         var sp = _taskSpan[tid];
         var tSpan = Math.max(1, w.e - w.s);
         var lsSpan = Math.max(1, sp.max - sp.min);
@@ -5746,7 +5791,27 @@
           item.e = item.s + scaledDur;       // never zero/negative duration (floor already >=60000)
         }
       });
-      _ogSupportSweep(_allScheduled, _cap.win);
+      }
+      // §ZONE_DISPLAY_AUTHORING (2026-08-16): when the task windows were authored FROM the display
+      // timeline (schedules.display_authored=1, written by materializeZones' displayRemap path),
+      // the strict end-bar sweep is SKIPPED. _ogSupportSweep enforces "start after the carrier
+      // FINISHES" — a bar §MIDAIR_REPAIR's own header deliberately does NOT enforce on the display
+      // timeline (a frontier-glowing half-built support reads as resting, not hanging) — and it
+      // only existed here because windows and movie described two different schedules. Measured on
+      // the browser-faithful probe (§EXP7 vs §EXP8, Hospital): keeping the sweep = 1781 elements
+      // pushed OUT of their own bars (97.2% fidelity); skipping it = 31 out (99.95%), floating
+      // 79 -> 63. Imported/legacy/edited-window schedules (flag absent or 0) keep the sweep —
+      // their windows are not the display envelope, so the old repair still earns its keep there.
+      var _cjpDisplayAuthored = false;
+      try {
+        var _daR = db.exec('SELECT 1 FROM schedules WHERE display_authored=1 LIMIT 1');
+        _cjpDisplayAuthored = !!(_daR.length && _daR[0].values.length);
+      } catch (e) { /* legacy DB without the column — sweep stays */ }
+      if (_cjpDisplayAuthored) {
+        console.log('§OG_SWEEP_SKIP display-authored windows — strict end-bar repair not applied (weak-bar parity below is the acceptance bar)');
+      } else {
+        _ogSupportSweep(_allScheduled, _cap.win);
+      }
       _cjpJudgeParity(_allScheduled, _cap.win);   // §CROSSTASK_JUDGE_PARITY — judge/repair parity, window-bounded
       // §GANTT_REFOLD_HANG (fix/gantt-refold-hang, synced 2026-08-12 — CPE_4D_PERF_MEM_FINDINGS.md
       // §3-R2): the inline BEGIN→per-row UPDATE→COMMIT loop was the measured §WRITE_LOOP_TIMING
@@ -5825,7 +5890,8 @@
         var _SR = window.SEQUENCE_RULES || {}, _LR = window.LABOR_RATES || {}, _RT = window.RATES || {};
         var _shGantt = (window.SHIFT_HOURS > 0) ? window.SHIFT_HOURS : 24;
         var rres = SA.materializeZones(db, _SR, { start: '2026-01-01', laborRates: _LR, rates: _RT,
-          scheduleGate: window.ScheduleGate, shiftHours: _shGantt, genVersion: _GANTT_CACHE_VERSION });
+          scheduleGate: window.ScheduleGate, shiftHours: _shGantt, genVersion: _GANTT_CACHE_VERSION,
+          displayRemap: _tmDisplayRemap });   // §ZONE_DISPLAY_AUTHORING
         if ((!rres || !rres.ok) && SA.materializeDefault) {
           rres = SA.materializeDefault(db, _SR, { start: '2026-01-01', laborRates: _LR, blank: false,
             genVersion: _GANTT_CACHE_VERSION });
@@ -6949,7 +7015,7 @@
     var todayStart = new Date().toISOString().slice(0, 10);
     var SR = window.SEQUENCE_RULES || {}, LR = window.LABOR_RATES || {}, RT = window.RATES || {};
     var _shiftHoursGantt = (window.SHIFT_HOURS > 0) ? window.SHIFT_HOURS : 24; // §GANTT_SHIFT_HOURS_DESYNC — match injectGantt's real clock
-    var res = SA.materializeZones(app.db, SR, { start: todayStart, laborRates: LR, rates: RT, scheduleGate: window.ScheduleGate, shiftHours: _shiftHoursGantt, genVersion: _GANTT_CACHE_VERSION });
+    var res = SA.materializeZones(app.db, SR, { start: todayStart, laborRates: LR, rates: RT, scheduleGate: window.ScheduleGate, shiftHours: _shiftHoursGantt, genVersion: _GANTT_CACHE_VERSION, displayRemap: _tmDisplayRemap });   // §ZONE_DISPLAY_AUTHORING
     if (!res.ok && SA.materializeDefault) res = SA.materializeDefault(app.db, SR, { start: todayStart, laborRates: LR, blank: false, genVersion: _GANTT_CACHE_VERSION });
     console.log('§GANTT_PREMATERIALIZE ' + (res.ok
       ? 'native schedule written BEFORE first injectGantt (zones=' + (res.zoneCount != null ? res.zoneCount : 'n/a') + ') — single-pass cold open'
@@ -6989,7 +7055,7 @@
     var todayStart = new Date().toISOString().slice(0, 10);
     var SR = window.SEQUENCE_RULES || {}, LR = window.LABOR_RATES || {}, RT = window.RATES || {};
     var _shiftHoursGantt = (window.SHIFT_HOURS > 0) ? window.SHIFT_HOURS : 24; // §GANTT_SHIFT_HOURS_DESYNC — match injectGantt's real clock
-    var res = SA.materializeZones(app.db, SR, { start: todayStart, laborRates: LR, rates: RT, scheduleGate: window.ScheduleGate, shiftHours: _shiftHoursGantt, genVersion: _GANTT_CACHE_VERSION });
+    var res = SA.materializeZones(app.db, SR, { start: todayStart, laborRates: LR, rates: RT, scheduleGate: window.ScheduleGate, shiftHours: _shiftHoursGantt, genVersion: _GANTT_CACHE_VERSION, displayRemap: _tmDisplayRemap });   // §ZONE_DISPLAY_AUTHORING
     if (!res.ok) {
       console.log('§GANTT_AUTHOR_ENTRY_ZONE_FALLBACK reason=' + (res.reason || 'unknown'));
       res = SA.materializeDefault ? SA.materializeDefault(app.db, SR, { start: todayStart, laborRates: LR, blank: false, genVersion: _GANTT_CACHE_VERSION }) : { ok: false };
@@ -7899,7 +7965,11 @@
   // huts going first before the walls" AFTER a hard reset, because §GANTT_CACHE_HIT served a
   // gantt:v4 entry generated under the old ordering. A hard reset cannot clear it — the entry is in
   // IndexedDB, not the HTTP cache. This bump is that fix's second half.
-  var _GANTT_CACHE_VERSION = 26;   // §CROSSTASK_JUDGE_PARITY (2026-08-16): window-bounded judge-rule
+  var _GANTT_CACHE_VERSION = 27;   // §ZONE_DISPLAY_AUTHORING (2026-08-16): task windows authored from
+                                   // the DISPLAY timeline + strict-bar sweep skipped on that path —
+                                   // one schedule for movie and Gantt. Bump re-materializes stale
+                                   // authored Gantts + regenerates kernel_ops under the new windows.
+                                   // Prior: 26 §CROSSTASK_JUDGE_PARITY (2026-08-16): window-bounded judge-rule
                                    // repair after _ogSupportSweep — captured floating 3090 -> 656.
                                    // Prior: 25 §OG_HANG_UNBOUND (2026-08-15): _ogSupportSweep's hang repair
   // now searches unbounded above (was capped 9.5m) — a kernel_ops table materialized under v24 or

--- a/viewer/viewer.html
+++ b/viewer/viewer.html
@@ -932,9 +932,9 @@ html.bim-embedded, html.bim-embedded body { background: #0b0b0b; }
 <script src="wizard_classify.js?v=1" onerror="console.warn('§LOAD_FAIL wizard_classify.js')"></script>
 <script src="precision_cam.js?v=8" onerror="console.warn('§LOAD_FAIL precision_cam.js')"></script>
 <script src="schedule_gate.js?v=3" onerror="console.warn('§LOAD_FAIL schedule_gate.js')"></script>
-<script src="time_machine.js?v=68" onerror="console.warn('§LOAD_FAIL time_machine.js')"></script>
+<script src="time_machine.js?v=69" onerror="console.warn('§LOAD_FAIL time_machine.js')"></script>
 <script src="dlod_nav.js?v=2" onerror="console.warn('§LOAD_FAIL dlod_nav.js')"></script>
-<script src="schedule_author.js?v=12" onerror="console.warn('§LOAD_FAIL schedule_author.js')"></script>
+<script src="schedule_author.js?v=13" onerror="console.warn('§LOAD_FAIL schedule_author.js')"></script>
 <script src="schedule_sync.js?v=3" onerror="console.warn('§LOAD_FAIL schedule_sync.js')"></script>
 <script src="schedule_author_ui.js?v=9" onerror="console.warn('§LOAD_FAIL schedule_author_ui.js')"></script>
 <script src="error_reporter.js?v=1" onerror="console.warn('§LOAD_FAIL error_reporter.js')"></script>


### PR DESCRIPTION
## §ZONE_DISPLAY_AUTHORING — one schedule for movie and Gantt; floating (real model) 2741 → 265

**Root cause, from the user's own live Hospital console (bim-compiler
`prompts/4D_SCHEDULE_PERFECTION.md` §CHASE_TO_ZERO_WINDOW_AUTHORING):** the Gantt's task windows
were authored from the RAW `computeSchedule` output (334 days on Hospital) while the movie plays the
TWO-TIER DISPLAY timeline written to kernel_ops (`§TIER_SERIAL` 420 days) — two different schedules.
The captured overlay rescaled display times into raw windows and **manufactured 2211 order
violations out of a 0-floating kernel_ops input**. Every prior probe modeled raw times on both sides
(live `§PHASE_OVERLAP_SUPPORT_GUARD pushed=4117` vs probe's 1152 was the tell), so the shipped
numbers understated live floating badly (browser-faithful model: 2741 fleet-wide, LTU alone 1617).

**Fix (three parts, one physics):**
1. `materializeZones` gains `opts.displayRemap` — supplied by time_machine's new `_tmDisplayRemap`
   (a thin wrapper over the SAME `_twoTierRemap` + `_midairRepair` the kernel_ops write path runs) —
   so authored task windows are derived from the display timeline. Persisted as
   `schedules.display_authored=1` (guarded ALTER; both schedules INSERTs now named-column).
   All 3 real call sites wired (prematerialize, drawer generate, §GANTT_SCHEDULE_STALE self-heal).
2. On display-authored schedules the captured overlay **skips `_ogSupportSweep`** — the strict
   end-bar it enforces is deliberately NOT the acceptance bar (§MIDAIR_REPAIR header: a
   frontier-glowing half-built support reads as resting), and its pushes were the main source of
   out-of-window damage (Hospital: 1781 pushed out of their own bars). Imported/legacy schedules
   (flag 0/absent) keep the sweep. `_cjpJudgeParity` (weak bar, window-bounded) always runs.
3. `§CROSSTASK_JUDGE_PARITY` now logs `floating=`/`windowBlocked=` (live census from its own
   contact graph, zero extra cost) — "still lots of floating" becomes a number in every session log.
   The inline window rescale is extracted as named `_capWindowRescale` (sliceable, no more copies).

**Measured — browser-faithful probe (`§EXP6` = today's live behavior vs `§EXP8` = this change), all 7:**

| Building | floating today → new | outWindow today → new |
|---|---|---|
| Terminal | 257 → 27 | 268 → 51 |
| Hospital | 664 → 63 | 1874 → 31 |
| Duplex | 7 → 3 | 8 → 1 |
| HHS | 35 → 11 | 4 → 1 |
| Clinic | 60 → 91 † | 8 → 4 |
| LTU_AHouse | 1617 → 43 | 12154 → 19 |
| JKR | 101 → 27 | 1104 → 6 |
| **Total** | **2741 → 265 (-90%)** | **15420 → 113 (-99.3%)** |

† Clinic's floating rises +31 (all honest WINDOW_BLOCKED) while its fidelity improves — named
follow-up, not hidden.

**Witnesses:** NEW `witness_zone_display_authoring.js` 14/14 (wiring ×3 sites, flag semantics,
sweep-guard contract, end-to-end bars on real buildings with the SHIPPED sliced functions, legacy
named-INSERT safety); `witness_midair_zero` 38/0; bearing-bound 9/9; grid-perf 3/3; blackbox 8/8;
`witness_crosstask_judge_parity` 17/17; gantt_native_generate / kernel_ops_sched_version /
gantt_baseline green; `gate_4d.sh` pass=7 fail=0 missing=1 (pre-existing).

`_GANTT_CACHE_VERSION` 26→27 (stale authored Gantts re-materialize with display windows; kernel_ops
regenerate), `sw.js` v1042, `viewer.html` time_machine ?v=69 + schedule_author ?v=13.

Also: probe `§EXP5`–`§EXP8` instrumentation (browser-faithful reproduction via
witness_midair_zero's slice recipe) committed for the record.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017cU8nsfjcoTtK8tEkUCu7b
