### PR TITLE
fix(photo): §GROUND_EARTH_DEFAULT — Alt+S/Alt+C bake ground back to 'earth'

### DIFF
--- a/viewer/effects.js
+++ b/viewer/effects.js
@@ -3187,10 +3187,16 @@ async function setupEffects(A, renderer, scene, camera) {
       A.ground.visible = true;
       A._calcGroundY();
       // §PHOTO_GROUND_LIT (user ask, "It is almost black"): was 'earth' + a dark 0x6a5238 tint —
-      // too dark once the evening exposure/ambient cuts also apply on top of it. Switched to the
-      // existing 'paved' texture (same real asset Shadow mode already uses — concrete look, per
-      // user's own suggestion) with a much brighter warm tint. Fancier grass+paved-rectangle
-      // pattern is a separate later experiment, not needed just to fix "too dark."
+      // too dark once the evening exposure/ambient cuts also apply on top of it. Switched to
+      // 'paved' (same real asset Shadow mode already uses — concrete look, per user's own
+      // suggestion) with a much brighter warm tint.
+      // §GROUND_EARTH_DEFAULT (2026-08-16, user: "more realistic even surface feel" — 'paved'
+      // carries concrete_floor_01's rectangular slab-joint relief, which is what the §GROUND_DETAIL
+      // normal map (#1388) was amplifying through lighting; 'earth' has no such hard rectangular
+      // structure). Back to 'earth' for the movie/still bake default — the ORIGINAL "too dark"
+      // complaint this section's own §GROUND_ALBEDO gain already fixed (earth's measured mean
+      // 0.1599 vs paved's 0.155 GROUND_TEX_AVG_LUM below — near-identical, so the same gain still
+      // lands at the same real-dry-ground target albedo, no recalibration needed).
       // §GROUND_ALBEDO (2026-07-28, user: "the Alt+S evening ground is too dark… albedo, try it") —
       // Witness: W-GROUND-ALBEDO. Set BEFORE _applyGroundTexture, because that function calls
       // _setGroundColor itself (with the remembered solid colour) as soon as the texture lands.
@@ -3199,7 +3205,7 @@ async function setupEffects(A, renderer, scene, camera) {
       // for the A/B the user asked for: APP._photoGroundAlbedoGain = 1.0 (default look) / 2.3 / 3.5,
       // then Alt+S again. See tools.js §GROUND_ALBEDO for why a gain and not more fill light.
       A._groundAlbedoGain = A._photoGroundAlbedoGain;
-      A._applyGroundTexture('paved');
+      A._applyGroundTexture('earth');
       if (A._setGroundColor) A._setGroundColor(0xd9c39a);  // bright warm sunlit-concrete tone
       console.log('§GROUND_ALBEDO gain=' + A._groundAlbedoGain.toFixed(2) + ' texAvgLum=' +
         GROUND_TEX_AVG_LUM.toFixed(3) + ' effAlbedo=' + (GROUND_TEX_AVG_LUM * A._groundAlbedoGain).toFixed(3) +

--- a/viewer/panels.js
+++ b/viewer/panels.js
@@ -1571,7 +1571,7 @@ function setupPanels(A) {
       var row = document.createElement('div');
       row.id = 'drawer-row-shadow';
       row.className = 'bim-drawer-row';
-      row.title = 'Shadow + Ground — cycle Off → Grass → Earth → Paved';
+      row.title = 'Shadow + Ground — cycle Off → Earth → Grass → Paved';
 
       var cloudBtn = document.createElement('button');
       cloudBtn.id = 'shadow-ground-cloud-btn';
@@ -1585,7 +1585,7 @@ function setupPanels(A) {
       cloudBtn.innerHTML = '<svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">' + I.cloud.svg + '</svg>';
       row.appendChild(cloudBtn);
 
-      var _keys = ['grass', 'earth', 'paved'];
+      var _keys = ['earth', 'grass', 'paved'];  // §GROUND_EARTH_DEFAULT — matches _SG_CYCLE order
       var _boxes = {};
       _keys.forEach(function(key) {
         var box = document.createElement('span');

--- a/viewer/sw.js
+++ b/viewer/sw.js
@@ -8,7 +8,11 @@
 // Cache-first for heavy assets (.wasm, images). DB files skip SW (IndexedDB handles them).
 //
 // DEPLOY: bump CACHE_VERSION on every OCI upload. Old caches are purged on activate.
-const CACHE_VERSION = 'v1043';   // bump on each deploy; per-change detail is the git commit message.
+const CACHE_VERSION = 'v1044';   // bump on each deploy; per-change detail is the git commit message.
+// v1044 (2026-08-16) §GROUND_EARTH_DEFAULT: Alt+S/Alt+C bake staging ground texture switched from
+// 'paved' back to 'earth' (effects.js?v=21) — user: "more realistic even surface feel", avoids
+// paved's rectangular slab-joint relief entirely. Shadow-mode toggle cycle reordered so 'earth' is
+// the first real choice (tools.js?v=42 _SG_CYCLE, panels.js?v=44 swatch row + tooltip).
 // v1043 (2026-08-16) §ZONE_DISPLAY_AUTHORING: task windows authored from the display timeline
 // (schedule_author.js displayRemap hook + time_machine.js _tmDisplayRemap), strict-bar sweep skipped
 // on display-authored schedules, §CJP live census in the §CROSSTASK_JUDGE_PARITY log line.

--- a/viewer/tools.js
+++ b/viewer/tools.js
@@ -791,7 +791,11 @@ function setupTools(A) {
   // which only needs to swap the ground texture — shadow map itself doesn't change).
   A._shadowOn = false;
   A._shadowGroundKey = 'off';                 // 'off' | 'grass' | 'earth' | 'paved'
-  var _SG_CYCLE = ['off', 'grass', 'earth', 'paved'];
+  // §GROUND_EARTH_DEFAULT (2026-08-16, user: "more realistic even surface feel" — 'earth' has no
+  // rectangular slab-joint relief the way 'paved' does): 'earth' is now the first real choice the
+  // Shadow toggle lands on, matching the same default the Alt+S/Alt+C bake staging switched to
+  // (effects.js _applyPhotoStaging). Was ['off','grass','earth','paved'].
+  var _SG_CYCLE = ['off', 'earth', 'grass', 'paved'];
   A.toggleShadow = function() {
     var prev = A._shadowGroundKey || 'off';
     var next = _SG_CYCLE[(_SG_CYCLE.indexOf(prev) + 1) % _SG_CYCLE.length];

--- a/viewer/viewer.html
+++ b/viewer/viewer.html
@@ -822,7 +822,7 @@ html.bim-embedded, html.bim-embedded body { background: #0b0b0b; }
 <script src="qrcode.min.js?v=1" onerror="console.warn('§LOAD_FAIL qrcode.min.js — QR sharing disabled')"></script>
 <script src="config.js?v=4" onerror="console.warn('§LOAD_FAIL config.js')"></script>
 <script src="db_resolve.js?v=2" onerror="console.warn('§LOAD_FAIL db_resolve.js')"></script>
-<script src="effects.js?v=20" onerror="console.warn('§LOAD_FAIL effects.js')"></script>
+<script src="effects.js?v=21" onerror="console.warn('§LOAD_FAIL effects.js')"></script>
 <script src="effects_gi_poc.js?v=3" onerror="console.warn('§LOAD_FAIL effects_gi_poc.js')"></script>
 <script src="lib/mp4_mux.js?v=1" onerror="console.warn('§LOAD_FAIL mp4_mux.js — MaxQ falls back to webm')"></script>
 <script src="cinema_path_editor.js?v=14" onerror="console.warn('§LOAD_FAIL cinema_path_editor.js — Alt+C path editing disabled')"></script>
@@ -839,8 +839,8 @@ html.bim-embedded, html.bim-embedded body { background: #0b0b0b; }
 <script src="helpers.js?v=6" onerror="console.warn('§LOAD_FAIL helpers.js')"></script>
 <script src="streaming.js?v=62" onerror="console.warn('§LOAD_FAIL streaming.js')"></script>
 <script src="dlod.js?v=8" onerror="console.warn('§LOAD_FAIL dlod.js')"></script>
-<script src="panels.js?v=43" onerror="console.warn('§LOAD_FAIL panels.js')"></script>
-<script src="tools.js?v=41" onerror="console.warn('§LOAD_FAIL tools.js')"></script>
+<script src="panels.js?v=44" onerror="console.warn('§LOAD_FAIL panels.js')"></script>
+<script src="tools.js?v=42" onerror="console.warn('§LOAD_FAIL tools.js')"></script>
 <script src="picking.js?v=30" onerror="console.warn('§LOAD_FAIL picking.js')"></script>
 <script src="hover_name.js?v=1" onerror="console.warn('§LOAD_FAIL hover_name.js — hover-name disabled')"></script>
 <script src="cpe_room_title.js?v=1" onerror="console.warn('§LOAD_FAIL cpe_room_title.js — room titles disabled')"></script>


### PR DESCRIPTION
## Summary
- User: "more realistic even surface feel" — 'paved' (concrete_floor_01) carries a rectangular slab-joint relief pattern; 'earth' has no such hard rectangular structure.
- `_applyPhotoStaging()`'s ground texture (used by both Alt+S stills and Alt+C movie bakes) switches from 'paved' back to 'earth'. The existing §GROUND_ALBEDO gain calibration carries over unchanged — earth's measured mean (0.1599) is within 3% of paved's (0.155).
- Shadow-mode toggle cycle (`_SG_CYCLE`) reordered so 'earth' is the first real choice instead of 'grass'. Matching swatch-row order + tooltip in panels.js.

## Test plan
- [x] `node --check` on all 4 edited JS files
- [x] Headless: first `toggleShadow()` press lands on `_shadowGroundKey='earth'` (PASS)
- [x] Headless: Alt+S staging's real `§GROUND_MAP` log confirms `key=earth` with both nor/rough maps loaded (PASS)

🤖 Generated with [Claude Code](https://claude.com/claude-code)