### PR TITLE
fix(cpe): Discipline Reveal — smooth pull-out->round-2 seam, sort discs, fade tail transitions

### DIFF
--- a/viewer/cinema_path_editor.js
+++ b/viewer/cinema_path_editor.js
@@ -644,18 +644,19 @@
     var holdSec = 0;
     for (var i = 0; i < s.bands.length; i++) holdSec += +(s.bands[i].hold || 0);
     // §CPE_DISCIPLINE_REVEAL_PULLOUT — an ESTIMATE (same shape as effects.js's authoritative
-    // pullout+reveal(round2)+tail seconds: a short pull-out + ONE lap at the walk's own pace + ~2s/
-    // discipline + a final 2s together — see bim-compiler prompts/CINEMA_DISCIPLINE_REVEAL.md's
-    // 2026-08-14 pull-out-restructure section), so the total this panel shows/bakes to GROWS to fit
-    // the round instead of squeezing it out of the existing runtime. Exact seconds are computed
-    // authoritatively in effects.js at plan-build time — this only needs to be close enough that
-    // nFrames (cinema_maxq.js) allocates real frames for it. `1.5` mirrors effects.js's
-    // CINEMA_REVEAL_PULLOUT_SEC constant — duplicated here as a literal, same precedent this
-    // estimate already followed for the tail's `2 * discs.length + 2` before this restructure.
+    // pullout+flyback+reveal(round2)+tail seconds: a short pull-out + a fast retrace fly-back + ONE
+    // lap at the walk's own pace + ~2s/discipline + a final 2s together — see bim-compiler prompts/
+    // CINEMA_DISCIPLINE_REVEAL.md's 2026-08-14 pull-out-restructure and 2026-08-16 fly-back sections),
+    // so the total this panel shows/bakes to GROWS to fit the round instead of squeezing it out of the
+    // existing runtime. Exact seconds are computed authoritatively in effects.js at plan-build time —
+    // this only needs to be close enough that nFrames (cinema_maxq.js) allocates real frames for it.
+    // `1.5` mirrors effects.js's CINEMA_REVEAL_PULLOUT_SEC constant, `6.5` mirrors CINEMA_PULLBACK_MPS
+    // (the fly-back's own pace) — both duplicated here as literals, same precedent this estimate
+    // already followed for the tail's `2 * discs.length + 2` before this restructure.
     var revealSec = 0;
     if (s.reveal) {
       var a = A(), discs = (a && typeof a.cpeRevealDiscsPresent === 'function') ? a.cpeRevealDiscsPresent() : [];
-      if (discs.length) revealSec = 1.5 + len / s.speed + (2 * discs.length + 2);
+      if (discs.length) revealSec = 1.5 + (len / 6.5) + len / s.speed + (2 * discs.length + 2);
     }
     return { len: len, outSec: outSec + holdSec, holdSec: holdSec, revealSec: revealSec,
              total: s.baseTotal - s.baseOutSec + outSec + holdSec + revealSec };

--- a/viewer/effects.js
+++ b/viewer/effects.js
@@ -4844,6 +4844,15 @@ async function setupEffects(A, renderer, scene, camera) {
   // (the tail's own 2s/discipline slot). Distance is DERIVED from the existing CINEMA_PULLBACK_MPS
   // constant (reused, not a new speed invented) — dist = CINEMA_REVEAL_PULLOUT_SEC * CINEMA_PULLBACK_MPS.
   var CINEMA_REVEAL_PULLOUT_SEC = 1.5;
+  // §CPE_DISCIPLINE_REVEAL_FADE (2026-08-16, bim-compiler prompts/CINEMA_DISCIPLINE_REVEAL.md's
+  // dated section). A.filterDiscs/A._applyDiscVisibility (panels.js) is a pure boolean visible
+  // toggle across plain/Instanced/BatchedMesh — no per-element opacity channel exists in this
+  // pipeline (Instanced/BatchedMesh share ONE material per batch, so animating opacity would fade
+  // the WHOLE batch, not just the disc entering/leaving). This is the closest honest approximation
+  // to a fade with that real constraint: how long the outgoing and incoming discipline stay visible
+  // TOGETHER at each tail-parade boundary before narrowing to just the incoming one. Not a literal
+  // dissolve — documented as such in A.cpeRevealVisualAt so it's never mistaken for one later.
+  var CPE_REVEAL_FADE_SEC = 0.4;
   // §CPE_NOISE_LAW — the user's ONE pacing dial ("have a speed range… don't overdo it"), and the
   // only knob the noise ratio is allowed to have. Declared here, at module scope, because the law
   // governs EVERY beat: the dive's cost table (built with the plan) and the walk's blended cost
@@ -5021,7 +5030,42 @@ async function setupEffects(A, renderer, scene, camera) {
     var _bmId, _imId;
     for (_bmId in (A._batchMeta || {})) A._batchMeta[_bmId].forEach(function(m) { bump(m.disc); });
     for (_imId in (A._instanceMeta || {})) A._instanceMeta[_imId].forEach(function(m) { bump(m.disc); });
-    return Object.keys(counts);
+    var discs = Object.keys(counts);
+    // §CPE_DISCIPLINE_REVEAL_ORDER (2026-08-16, bim-compiler prompts/CINEMA_DISCIPLINE_REVEAL.md's
+    // dated section). Sort ascending by real average element bbox volume (element_transforms.bbox_x/
+    // y/z, guid-joined to elements_meta — the ONLY per-element size data this schema carries;
+    // elements_meta itself has no dimension column, confirmed by a read-only extraction check before
+    // this was written, not assumed). Finest-grained (smallest average element) disciplines reveal
+    // FIRST, while the viewer's attention is freshest. The literal 'MEP' discipline code is forced to
+    // the LAST position regardless of its measured size — user's own framing 2026-08-16: MEP reads as
+    // "most easily sighted" (large ducts/pipes/cable-trays are obvious even glimpsed briefly), so it
+    // doesn't need the early slot the way small/fine disciplines do. Degrades to the original
+    // unordered list if A.dbQuery is unavailable or the query fails — DEGRADE, DON'T DISABLE, same
+    // rule A.cpeRevealDiscQtyCost (below) already follows.
+    if (discs.length > 1 && typeof A.dbQuery === 'function') {
+      try {
+        var inList = discs.map(function(d) { return "'" + d.replace(/'/g, "''") + "'"; }).join(',');
+        var rows = A.dbQuery('SELECT m.discipline, AVG(t.bbox_x * t.bbox_y * t.bbox_z) FROM elements_meta m ' +
+          'JOIN element_transforms t ON m.guid = t.guid WHERE m.discipline IN (' + inList + ') ' +
+          'AND t.bbox_x IS NOT NULL AND t.bbox_x > 0 GROUP BY m.discipline');
+        var avgVol = {};
+        (rows || []).forEach(function(r) { avgVol[r[0]] = +r[1]; });
+        discs.sort(function(a, b) {
+          if (a === 'MEP' && b !== 'MEP') return 1;
+          if (b === 'MEP' && a !== 'MEP') return -1;
+          var va = avgVol[a], vb = avgVol[b];
+          if (va == null && vb == null) return 0;
+          if (va == null) return 1;   // no size data for this discipline -> push to end, never invent a rank
+          if (vb == null) return -1;
+          return va - vb;
+        });
+        console.log('§CPE_REVEAL_DISC_ORDER [' + discs.map(function(d) {
+          return d + '=' + (avgVol[d] != null ? avgVol[d].toFixed(3) : 'n/a'); }).join(',') + ']');
+      } catch (e) {
+        console.warn('§CPE_REVEAL_DISC_ORDER query failed, using unordered fallback: ' + e.message);
+      }
+    }
+    return discs;
   };
   // §CPE_DISCIPLINE_REVEAL_PULLOUT (restructure 2026-08-14, bim-compiler prompts/
   // CINEMA_DISCIPLINE_REVEAL.md's dated section — supersedes the there-and-back Mechanism C shape).
@@ -5034,6 +5078,12 @@ async function setupEffects(A, renderer, scene, camera) {
   //                                     transition beat, not part of either "round").
   //   round 2   (b.pullout .. b.reveal) — 'ghost': ARC/STR fully hidden, every non-ARC/STR discipline
   //                                     shown together — UNCHANGED from the original ghost phase.
+  //                                     §CPE_DISCIPLINE_REVEAL_FLYBACK (2026-08-16): this span now
+  //                                     covers BOTH the fly-back sub-beat (camera retracing the path
+  //                                     back to the first stick) AND the forward lap after it — the
+  //                                     boundary here is unchanged (still b.pullout..b.reveal), only
+  //                                     poseAt's camera motion inside it gained a sub-beat, so no
+  //                                     edit was needed in THIS function for that change.
   //   rise/tail (b.reveal .. b.rise, first rv.tailSec seconds) — 'tail-one'/'tail-all': the disc
   //             parade, folded into the EXISTING rise beat's own time budget (see poseAt below —
   //             the camera motion there is the unmodified _beat4Pose, never a new motion).
@@ -5053,7 +5103,15 @@ async function setupEffects(A, renderer, scene, camera) {
     var perDisc = 2, n = rv.discs.length;
     var idx = Math.floor(wSec / perDisc);
     if (idx >= n) return { phase: 'tail-all', discs: rv.discs.slice() };
-    return { phase: 'tail-one', discs: [rv.discs[idx]] };
+    // §CPE_DISCIPLINE_REVEAL_FADE (2026-08-16): `discs` (caption/key identity) always names the
+    // CURRENT slot's own discipline — the caption must never show the outgoing one. `visDiscs` (what
+    // A.cpeRevealApplyVisual actually shows) widens to include the PREVIOUS slot's discipline for the
+    // first CPE_REVEAL_FADE_SEC of a new slot (idx===0 has no previous slot to overlap with), so the
+    // hard swap softens into a brief overlap instead of an instant cut.
+    var slotFrac = wSec - idx * perDisc;
+    var visDiscs = (slotFrac < CPE_REVEAL_FADE_SEC && idx > 0)
+      ? [rv.discs[idx - 1], rv.discs[idx]] : [rv.discs[idx]];
+    return { phase: 'tail-one', discs: [rv.discs[idx]], visDiscs: visDiscs };
   };
   // §CPE_DISCIPLINE_REVEAL — a discipline code's human-readable label, reused (not invented) from
   // A.PHASE_MAP (config.js), which already carries friendly names for the common trades
@@ -5127,7 +5185,11 @@ async function setupEffects(A, renderer, scene, camera) {
   A.cpeRevealApplyVisual = function(plan, tNorm) {
     if (typeof A.filterDiscs !== 'function' || !A.hiddenDiscs) return;
     var st = plan ? A.cpeRevealVisualAt(plan, tNorm) : null;
-    var key = st ? (st.phase + ':' + st.discs.join(',')) : '';
+    // §CPE_DISCIPLINE_REVEAL_FADE: key on visDiscs (what's actually SHOWN), not discs (the caption
+    // identity) — within a single tail-one slot, discs[0] never changes but visDiscs does (drops the
+    // overlap partner after CPE_REVEAL_FADE_SEC), and that drop must still re-trigger filterDiscs.
+    var shown = (st && st.visDiscs) || (st && st.discs);
+    var key = st ? (st.phase + ':' + shown.join(',')) : '';
     if (A._cpeRevealVisualKey === key) return;
     if (!st) {
       if (A._cpeRevealSavedHidden) {
@@ -5138,7 +5200,7 @@ async function setupEffects(A, renderer, scene, camera) {
       }
     } else {
       if (!A._cpeRevealSavedHidden) A._cpeRevealSavedHidden = new Set(A.hiddenDiscs);
-      A.filterDiscs(st.discs);
+      A.filterDiscs(shown);
     }
     A._cpeRevealVisualKey = key;
   };
@@ -5443,7 +5505,11 @@ async function setupEffects(A, renderer, scene, camera) {
   // that: §CPE_AIM_PIN (Part C) added real behaviour here (`_buildPinZones`/`_pinLookAtAt` inside
   // `_beat3Pose`) but this string was never bumped for it, breaking the file's own "bump on EVERY
   // behaviour change" rule for one release. Fixed now, not left for a future session to rediscover.
-  var EFFECTS_V = 'v20 (' +
+  var EFFECTS_V = 'v21 (' +
+    '§CPE_DISCIPLINE_REVEAL_FLYBACK new fast eased retrace sub-beat replaces the pull-out->round-2 ' +
+      'teleport cut; §CPE_DISCIPLINE_REVEAL_ORDER discs sorted ascending by real avg bbox volume, ' +
+      'MEP forced last; §CPE_DISCIPLINE_REVEAL_FADE tail-parade boundaries get a brief overlap ' +
+      'window instead of an instant swap; ' +
     '§CPE_AIM_SIMPLIFY §CPE_AIM_DENSITY RETIRED (was: turn toward nearest mass when outside the ' +
       'building with nothing substantial near — a third, independent trigger the user\'s own model ' +
       'never asked for, and the likely source of reported "facing sky" swings); §CPE_AIM_DEPTH is ' +
@@ -6962,23 +7028,29 @@ async function setupEffects(A, renderer, scene, camera) {
     // time budget, not a separate beat (see _natSec.rise below and poseAt). A.cpeRevealDiscsPresent
     // (outer scope) is shared with cinema_path_editor.js's own duration estimate (_naturalDuration)
     // — one discipline-count implementation, not two kept in sync by hand.
-    var _revealPulloutSec = 0, _revealRoundSec = 0, _revealTailSec = 0, _revealDiscs = [], _revealQtyCost = {};
+    var _revealPulloutSec = 0, _revealFlybackSec = 0, _revealRoundSec = 0, _revealTailSec = 0, _revealDiscs = [], _revealQtyCost = {};
     if (_cpeReveal) {
       _revealDiscs = A.cpeRevealDiscsPresent();
       if (_revealDiscs.length) {
         // Pull-out: fixed 1.5s (CINEMA_REVEAL_PULLOUT_SEC, author's call — see the constant's own
-        // comment). Round 2: same pace as the outbound walk, ONE lap forward only — no there-and-back,
-        // no authored holds replayed (matches the original Mechanism C's own "not requested" note).
-        // Tail: ~2s/discipline + a final 2s all-together — KEPT (see spec file's dated section for why
-        // the all-together slot was kept rather than dropped: the user asked for it repeatedly
-        // elsewhere in this file's own history, e.g. the ORIGIN ask and the Mechanism B pacing quote).
+        // comment). §CPE_DISCIPLINE_REVEAL_FLYBACK (2026-08-16, bim-compiler prompts/
+        // CINEMA_DISCIPLINE_REVEAL.md's dated section): retraces the SAME walked path backward
+        // (f:1->0) at CINEMA_PULLBACK_MPS ("flying, not walking" — reused, not a new speed invented)
+        // to smooth the old teleport-cut back onto the first stick. Round 2: same pace as the
+        // outbound walk, ONE lap forward only — no there-and-back, no authored holds replayed
+        // (matches the original Mechanism C's own "not requested" note). Tail: ~2s/discipline + a
+        // final 2s all-together — KEPT (see spec file's dated section for why the all-together slot
+        // was kept rather than dropped: the user asked for it repeatedly elsewhere in this file's
+        // own history, e.g. the ORIGIN ask and the Mechanism B pacing quote).
         _revealPulloutSec = CINEMA_REVEAL_PULLOUT_SEC;
+        _revealFlybackSec = totalLen / CINEMA_PULLBACK_MPS;
         _revealRoundSec = totalLen / CINEMA_WALK_MPS;
         _revealTailSec = 2 * _revealDiscs.length + 2;
         _revealQtyCost = A.cpeRevealDiscQtyCost ? A.cpeRevealDiscQtyCost(_revealDiscs) : {};
-        console.log('§CPE_REVEAL_ROUND on pulloutSec=' + _revealPulloutSec.toFixed(1) + ' round2Sec=' +
-          _revealRoundSec.toFixed(1) + ' tailSec=' + _revealTailSec.toFixed(1) + ' discs=[' +
-          _revealDiscs.join(',') + '] totalSec=' + (_revealPulloutSec + _revealRoundSec + _revealTailSec).toFixed(1));
+        console.log('§CPE_REVEAL_ROUND on pulloutSec=' + _revealPulloutSec.toFixed(1) + ' flybackSec=' +
+          _revealFlybackSec.toFixed(1) + ' round2Sec=' + _revealRoundSec.toFixed(1) + ' tailSec=' +
+          _revealTailSec.toFixed(1) + ' discs=[' + _revealDiscs.join(',') + '] totalSec=' +
+          (_revealPulloutSec + _revealFlybackSec + _revealRoundSec + _revealTailSec).toFixed(1));
       } else {
         console.log('§CPE_REVEAL_ROUND skipped — no non-ARC/STR discipline present in this building');
       }
@@ -7009,17 +7081,18 @@ async function setupEffects(A, renderer, scene, camera) {
       // ("constant speed"): speed is constant EXCEPT at authored holds, which is the point of them.
       out:   (totalLen / CINEMA_WALK_MPS + _walkTurnDegVal / CINEMA_TURN_DPS) *
              (1 + (CINEMA_PACE_SWING - 1) * _walkBusy) + _holdTotal,
-      // §CPE_DISCIPLINE_REVEAL_PULLOUT: none of pullout/reveal(round2)/tail are ever part of the
-      // user-typed total-seconds override system (no field for any of them in the panel) — always
-      // these measured values, computed just above, 0 when off/empty.
+      // §CPE_DISCIPLINE_REVEAL_PULLOUT: none of pullout/flyback/reveal(round2)/tail are ever part
+      // of the user-typed total-seconds override system (no field for any of them in the panel) —
+      // always these measured values, computed just above, 0 when off/empty.
       pullout: _revealPulloutSec,
+      flyback: _revealFlybackSec,       // §CPE_DISCIPLINE_REVEAL_FLYBACK: retrace back to the first stick
       reveal: _revealRoundSec,          // round 2's own seconds — the repeated forward lap only
       tail:   _revealTailSec,           // folded into `rise` below, not its own beat boundary
       rise:  Math.max(0.5, _pullDist / CINEMA_PULLBACK_MPS),
       orbit: 360 / CINEMA_TURN_DPS
     };
-    var _natTotal = _natSec.dive + _natSec.spin + _natSec.out + _natSec.pullout + _natSec.reveal +
-                    _natSec.tail + _natSec.rise + _natSec.orbit;
+    var _natTotal = _natSec.dive + _natSec.spin + _natSec.out + _natSec.pullout + _natSec.flyback +
+                    _natSec.reveal + _natSec.tail + _natSec.rise + _natSec.orbit;
     // Whitebox proof for §CPE_WALK_BUDGET_NOISE_BLIND — every term the formula reads, printed
     // together so a witness can recompute `out` from this line alone and compare against
     // _natSec.out, rather than trusting the arithmetic happened as claimed.
@@ -7046,7 +7119,8 @@ async function setupEffects(A, renderer, scene, camera) {
     // uniformly" true by construction.
     var _useSec = _cpeSecOverride
       ? { dive: CINEMA_DIVE_SEC, spin: CINEMA_SPIN_SEC, out: CINEMA_OUT_SEC, rise: CINEMA_RISE_SEC,
-          orbit: _natSec.orbit, reveal: _natSec.reveal, pullout: _natSec.pullout, tail: _natSec.tail }
+          orbit: _natSec.orbit, reveal: _natSec.reveal, pullout: _natSec.pullout,
+          flyback: _natSec.flyback, tail: _natSec.tail }
       : _natSec;
     // The pose Beat 2 ends on: level, on the spin's final bearing. Beat 3 must START here.
     var _handYaw = yaw0 + dYaw;
@@ -7079,24 +7153,27 @@ async function setupEffects(A, renderer, scene, camera) {
     // `_useSec.rise` (and therefore `sec.rise`/`naturalSec.rise`) stays the TRUE unfolded pull-back
     // budget always, safe to round-trip through the override channel any number of times.
     var _riseFolded = _useSec.rise + (_useSec.tail || 0);
-    var _shapeTotal = _useSec.dive + _useSec.spin + _useSec.out + _useSec.pullout + _useSec.reveal +
-                       _riseFolded + _useSec.orbit;
+    var _shapeTotal = _useSec.dive + _useSec.spin + _useSec.out + _useSec.pullout + _useSec.flyback +
+                       _useSec.reveal + _riseFolded + _useSec.orbit;
     var tD = _useSec.dive / _shapeTotal;
     var tS = tD + _useSec.spin / _shapeTotal;
     var tO = tS + _useSec.out / _shapeTotal;
-    // §CPE_DISCIPLINE_REVEAL_PULLOUT: tP is the pull-out sub-beat's own end boundary; tV is round
-    // 2's own end boundary (the SECOND arrival at the last stick — the real "STOP", per the spec).
-    // useSec.pullout/reveal are both 0 when off or when the building has no non-ARC/STR discipline,
-    // which makes tP===tV===tO exactly — every poseAt branch below becomes zero-width and
-    // unreachable, and tR (below) folds in a 0 tail too, so an off/empty-building film is
-    // byte-identical to before this feature existed (Guardrail 2).
+    // §CPE_DISCIPLINE_REVEAL_PULLOUT: tP is the pull-out sub-beat's own end boundary.
+    // §CPE_DISCIPLINE_REVEAL_FLYBACK (2026-08-16): tF is the fly-back's own end boundary — the
+    // instant the camera is back on the first stick, replacing the old teleport cut that used to
+    // sit right at tP. tV is round 2's own end boundary (the SECOND arrival at the last stick — the
+    // real "STOP", per the spec). useSec.pullout/flyback/reveal are all 0 when off or when the
+    // building has no non-ARC/STR discipline, which makes tP===tF===tV===tO exactly — every poseAt
+    // branch below becomes zero-width and unreachable, and tR (below) folds in a 0 tail too, so an
+    // off/empty-building film is byte-identical to before this feature existed (Guardrail 2).
     var tP = tO + _useSec.pullout / _shapeTotal;
-    var tV = tP + _useSec.reveal / _shapeTotal;
+    var tF = tP + _useSec.flyback / _shapeTotal;
+    var tV = tF + _useSec.reveal / _shapeTotal;
     var tR = tV + _riseFolded / _shapeTotal;   // folded (includes the tail) — see _riseFolded above
     console.log('§CINEMA_PACING natural=' + _natTotal.toFixed(1) + 's = dive ' + _natSec.dive.toFixed(1) +
       ' + spin ' + _natSec.spin.toFixed(1) + ' + walk ' + _natSec.out.toFixed(1) +
-      ' + pullout ' + _natSec.pullout.toFixed(1) + ' + round2 ' + _natSec.reveal.toFixed(1) +
-      ' + tail ' + _natSec.tail.toFixed(1) +
+      ' + pullout ' + _natSec.pullout.toFixed(1) + ' + flyback ' + _natSec.flyback.toFixed(1) +
+      ' + round2 ' + _natSec.reveal.toFixed(1) + ' + tail ' + _natSec.tail.toFixed(1) +
       ' + pullback ' + _natSec.rise.toFixed(1) + ' + orbit ' + _natSec.orbit.toFixed(1) +
       '  (walk ' + totalLen.toFixed(1) + 'm @' + CINEMA_WALK_MPS + 'm/s, dive ' + diveDist.toFixed(1) +
       'm @' + CINEMA_DIVE_MPS + 'm/s, pullback ' + _pullDist.toFixed(1) + 'm @' + CINEMA_PULLBACK_MPS +
@@ -7105,8 +7182,8 @@ async function setupEffects(A, renderer, scene, camera) {
       _spinBusyMult.toFixed(2) + ' busy)' +
       ' override=' + _cpeSecOverride + ' running=' + durationSec.toFixed(1) + 's');
     console.log('§CINEMA_BEATS dive=' + tD.toFixed(3) + ' spin=' + tS.toFixed(3) + ' out=' + tO.toFixed(3) +
-      ' pullout=' + tP.toFixed(3) + ' round2=' + tV.toFixed(3) + ' rise=' + tR.toFixed(3) +
-      ' turnOverlap=' + CINEMA_TURN_OVERLAP +
+      ' pullout=' + tP.toFixed(3) + ' flyback=' + tF.toFixed(3) + ' round2=' + tV.toFixed(3) +
+      ' rise=' + tR.toFixed(3) + ' turnOverlap=' + CINEMA_TURN_OVERLAP +
       ' (dur=' + durationSec.toFixed(1) + 's) route=' + outRoute +
       ' waypoints=' + outWp.length + ' pathLen=' + totalLen.toFixed(1) +
       ' spinDeg=' + Math.round(dYaw * 180 / Math.PI));
@@ -7330,10 +7407,17 @@ async function setupEffects(A, renderer, scene, camera) {
         // to before this feature existed.
         return _pullOutPose((tNorm - tO) / Math.max(1e-6, tP - tO));
       }
+      if (tNorm <= tF) {
+        // ── §CPE_DISCIPLINE_REVEAL_FLYBACK (2026-08-16): fast eased retrace back onto the first
+        // stick, replacing the old teleport cut that used to sit right here. tF===tP (zero-width,
+        // unreachable) under the same off/empty conditions as tP above.
+        return _flyBackPose((tNorm - tP) / Math.max(1e-6, tF - tP));
+      }
       if (tNorm <= tV) {
         // ── §CPE_DISCIPLINE_REVEAL_PULLOUT: round 2 — the SAME path flown again, forward only, no
-        // retrace. tV===tP (zero-width, unreachable) under the same off/empty conditions as tP above.
-        return _revealPose((tNorm - tP) / Math.max(1e-6, tV - tP));
+        // retrace. Now starts CLEAN (the fly-back above already put the camera on the first stick),
+        // no cut. tV===tF (zero-width, unreachable) under the same off/empty conditions as tP above.
+        return _revealPose((tNorm - tF) / Math.max(1e-6, tV - tF));
       }
       if (tNorm <= tR) {
         // ── Beat 4: turn around to face the building and rise onto the orbit band. Ends EXACTLY
@@ -7404,9 +7488,12 @@ async function setupEffects(A, renderer, scene, camera) {
     // in the spec file, not user-dictated): a straight dolly-back along the NEGATIVE of the "angle of
     // attack" — with gaze held CONSTANT (still looking forward along that same direction, i.e. toward
     // where round 2 will re-enter). No gaze blend: this is the simplest defensible pull-out (position
-    // retreats, look direction doesn't change), and round 2 begins with a clean CUT back to the first
-    // stick regardless (see _revealPose below) — smoothing gaze across a position cut that is about
-    // to happen anyway would not read as continuous motion, so none is attempted here.
+    // retreats, look direction doesn't change). §CPE_DISCIPLINE_REVEAL_FLYBACK (2026-08-16,
+    // bim-compiler prompts/CINEMA_DISCIPLINE_REVEAL.md's dated section) SUPERSEDES the note that
+    // used to be here about round 2 starting with "a clean CUT back to the first stick" — user
+    // feedback on a live bake found that cut read as an abrupt, jarring switch. The pull-out itself
+    // is UNCHANGED (still gaze-constant, still no blend) — see `_flyBackPose` below for the new
+    // sub-beat that now bridges from here to the first stick.
     // ⚠ BUG FOUND BY THE WITNESS (not assumed correct on paper, same discipline the original build's
     // own comments describe): the "angle of attack" direction is the RATE-LIMITED gaze Beat 3 ACTUALLY
     // renders at tO (_revealSeamDir(tO)), not the raw _beat3EndDir — witness_cpe_reveal_pullout.js
@@ -7424,11 +7511,50 @@ async function setupEffects(A, renderer, scene, camera) {
       var px = pt.x - dir.x * dist * e, py = pt.y - dir.y * dist * e, pz = pt.z - dir.z * dist * e;
       return { x: px, y: py, z: pz, tx: px + dir.x * 20, ty: py + dir.y * 20, tz: pz + dir.z * 20 };
     }
-    // §CPE_DISCIPLINE_REVEAL_PULLOUT: round 2 (tP..tV) — the SAME path flown again, forward only
-    // (0->1), no there-and-back. Starts with a clean CUT from the pull-out's retreated position back
-    // to the first stick ("resume as stick start to stop another round", the user's own words) — only
-    // the END is seam-blended, into Beat 4's actual e4=0 gaze, matching every other beat seam in this
-    // file (§CPE_GAZE_CONSTANT_RATE).
+    // §CPE_DISCIPLINE_REVEAL_FLYBACK (2026-08-16) — the sub-beat between the pull-out (tP) and round
+    // 2's forward lap (tF), replacing the old teleport cut. Retraces the SAME `_outPos(f)` curve the
+    // walk itself already validated as collision-free, backward (f: 1->0) — NOT a straight line
+    // between the pull-out's retreated point and the first stick, which would risk clipping through
+    // walls at any turn the corridor takes (exactly the class of bug `_revealSeamDir`/
+    // §CPE_GAZE_CONSTANT_RATE already exist to prevent elsewhere in this file). Paced at
+    // CINEMA_PULLBACK_MPS ("flying, not walking" — reused, not a new speed invented), so this is
+    // "fast" relative to round 2's own CINEMA_WALK_MPS retrace, not instant. Position blends from the
+    // pull-out's actual final (off-path) point onto the path's f=1 point over the first
+    // CPE_REVEAL_SEAM_FRAC width (same seam-blend idiom `_revealPose`'s own ending already uses),
+    // then retraces the path for the remainder. Gaze holds at the pull-out's own "angle of attack"
+    // (`_revealSeamDir(tO)` — matches pull-out's own constant-gaze choice, no reason to start turning
+    // the head before the camera is even back on the path) through the position blend, then blends
+    // into the forward travel tangent at f=0 over the FINAL CPE_REVEAL_SEAM_FRAC width, so round 2's
+    // own opening gaze picks up with zero kink — same contract _revealPose's own end seam keeps at
+    // the Beat 4 handoff.
+    function _flyBackPose(w) {
+      w = Math.max(0, Math.min(1, w));
+      var e = _cinemaEaseFloored(w);
+      var holdDir = _revealSeamDir(tO);           // same "angle of attack" the pull-out opened on
+      var pOut = _pullOutPose(1);                 // the pull-out's own final point — this beat's start
+      var onPath = _outPos(1 - e);                // retrace target at this instant
+      var pos;
+      if (w < CPE_REVEAL_SEAM_FRAC) {
+        var s = _cinemaSmoothstep(w / CPE_REVEAL_SEAM_FRAC);
+        pos = { x: pOut.x + (onPath.x - pOut.x) * s, y: pOut.y + (onPath.y - pOut.y) * s,
+                z: pOut.z + (onPath.z - pOut.z) * s };
+      } else {
+        pos = onPath;
+      }
+      if (w > 1 - CPE_REVEAL_SEAM_FRAC) {
+        var endDir = _revealTravelDir(0, 1);      // round 2's own opening gaze
+        return _dirBlend(pos.x, pos.y, pos.z, holdDir.x, holdDir.y, holdDir.z,
+          endDir.x, endDir.y, endDir.z,
+          _cinemaSmoothstep((w - (1 - CPE_REVEAL_SEAM_FRAC)) / CPE_REVEAL_SEAM_FRAC));
+      }
+      return { x: pos.x, y: pos.y, z: pos.z,
+               tx: pos.x + holdDir.x * 20, ty: pos.y + holdDir.y * 20, tz: pos.z + holdDir.z * 20 };
+    }
+    // §CPE_DISCIPLINE_REVEAL_PULLOUT: round 2 (tF..tV) — the SAME path flown again, forward only
+    // (0->1), no there-and-back. Starts CLEAN now — the fly-back above already puts the camera on
+    // the first stick with the correct opening gaze, so no cut happens here any more. Only the END
+    // is seam-blended, into Beat 4's actual e4=0 gaze, matching every other beat seam in this file
+    // (§CPE_GAZE_CONSTANT_RATE).
     function _revealPose(w) {
       w = Math.max(0, Math.min(1, w));
       var e = _cinemaEaseFloored(w);
@@ -8053,7 +8179,7 @@ async function setupEffects(A, renderer, scene, camera) {
     return { base: base, envelope: envelope, arcOnly: !!arcBboxRaw, fillDistance: fillDistance,
              pushInRadius: pushInRadius, radiusMin: radiusMin, radiusMax: radiusMax,
              pivot: pivot, pivotSrc: pivotSrc, settle: settle, exit: chosenExit,
-             beats: { dive: tD, spin: tS, out: tO, pullout: tP, reveal: tV, rise: tR },
+             beats: { dive: tD, spin: tS, out: tO, pullout: tP, flyback: tF, reveal: tV, rise: tR },
              // §CPE_DISCIPLINE_REVEAL_PULLOUT — the pacing info A.cpeRevealVisualAt(plan, tNorm) and
              // A.cpeRevealCaptionAt(plan, tNorm) need to compute which visual phase/caption a given
              // tNorm falls in, exposed here rather than recomputed (or duplicated) outside this
@@ -8085,7 +8211,7 @@ async function setupEffects(A, renderer, scene, camera) {
              }) : null,
              flownPoints: flowWp.length, pathLen: totalLen, route: outRoute, authored: outRoute === 'authored',
              sec: { dive: _useSec.dive, spin: _useSec.spin, out: _useSec.out, pullout: _useSec.pullout,
-                    reveal: _useSec.reveal, rise: _useSec.rise },
+                    flyback: _useSec.flyback, reveal: _useSec.reveal, rise: _useSec.rise },
              naturalSec: _natSec, naturalTotal: _natTotal,
              eyeM: CINEMA_EYE_M, lookdownDeg: CINEMA_LOOKDOWN_DEG, durationSec: durationSec,
              indoor: true, poseAt: poseAt,

--- a/viewer/sw.js
+++ b/viewer/sw.js
@@ -8,7 +8,14 @@
 // Cache-first for heavy assets (.wasm, images). DB files skip SW (IndexedDB handles them).
 //
 // DEPLOY: bump CACHE_VERSION on every OCI upload. Old caches are purged on activate.
-const CACHE_VERSION = 'v1043';   // bump on each deploy; per-change detail is the git commit message.
+const CACHE_VERSION = 'v1044';   // bump on each deploy; per-change detail is the git commit message.
+// v1044 (2026-08-16) §CPE_DISCIPLINE_REVEAL_FLYBACK/§_ORDER/§_FADE: the pull-out->round-2 teleport
+// cut replaced with a fast eased retrace fly-back (new plan.beats.flyback boundary); tail-parade
+// discipline order now sorted ascending by real avg element bbox volume (element_transforms.bbox_x/
+// y/z), MEP forced last, "All Disciplines" capstone unchanged; tail-parade boundaries get a brief
+// overlap window (filterDiscs has no opacity channel — documented as an honest approximation, not a
+// literal fade) instead of an instant swap (effects.js?v=20->21, cinema_path_editor.js?v=14->15).
+// See bim-compiler prompts/CINEMA_DISCIPLINE_REVEAL.md's 2026-08-16 dated section for the full spec.
 // v1043 (2026-08-16) §ZONE_DISPLAY_AUTHORING: task windows authored from the display timeline
 // (schedule_author.js displayRemap hook + time_machine.js _tmDisplayRemap), strict-bar sweep skipped
 // on display-authored schedules, §CJP live census in the §CROSSTASK_JUDGE_PARITY log line.

--- a/viewer/viewer.html
+++ b/viewer/viewer.html
@@ -822,10 +822,10 @@ html.bim-embedded, html.bim-embedded body { background: #0b0b0b; }
 <script src="qrcode.min.js?v=1" onerror="console.warn('§LOAD_FAIL qrcode.min.js — QR sharing disabled')"></script>
 <script src="config.js?v=4" onerror="console.warn('§LOAD_FAIL config.js')"></script>
 <script src="db_resolve.js?v=2" onerror="console.warn('§LOAD_FAIL db_resolve.js')"></script>
-<script src="effects.js?v=20" onerror="console.warn('§LOAD_FAIL effects.js')"></script>
+<script src="effects.js?v=21" onerror="console.warn('§LOAD_FAIL effects.js')"></script>
 <script src="effects_gi_poc.js?v=3" onerror="console.warn('§LOAD_FAIL effects_gi_poc.js')"></script>
 <script src="lib/mp4_mux.js?v=1" onerror="console.warn('§LOAD_FAIL mp4_mux.js — MaxQ falls back to webm')"></script>
-<script src="cinema_path_editor.js?v=14" onerror="console.warn('§LOAD_FAIL cinema_path_editor.js — Alt+C path editing disabled')"></script>
+<script src="cinema_path_editor.js?v=15" onerror="console.warn('§LOAD_FAIL cinema_path_editor.js — Alt+C path editing disabled')"></script>
 <script src="cpe_walk.js?v=6" onerror="console.warn('§LOAD_FAIL cpe_walk.js — CPE walk-mode disabled')"></script>
 <script src="cpe_xr.js?v=1" onerror="console.warn('§LOAD_FAIL cpe_xr.js — VR entry disabled')"></script>
 <script src="cinema_maxq.js?v=5" onerror="console.warn('§LOAD_FAIL cinema_maxq.js — Alt+M MaxQ export disabled')"></script>

--- a/witness_cpe_reveal_pullout.js
+++ b/witness_cpe_reveal_pullout.js
@@ -90,7 +90,8 @@ const _watchdog = setTimeout(() => { console.log('\n§W-CPE-REVEAL-PULLOUT TIMEO
     const res = await openPromise;
     if (!res.override || !res.override.reveal) return { ok: false, reason: 'override.reveal not true: ' + JSON.stringify(res.override && res.override.reveal) };
     const plan2 = A.cinemaPathPlan(res.durationSec, res.override);
-    const tO = plan2.beats.out, tP = plan2.beats.pullout, tV = plan2.beats.reveal, tR = plan2.beats.rise;
+    const tO = plan2.beats.out, tP = plan2.beats.pullout, tF = plan2.beats.flyback,
+          tV = plan2.beats.reveal, tR = plan2.beats.rise;
     const eps = 1e-4;
     function dist(a, b) { return Math.hypot(a.x - b.x, a.y - b.y, a.z - b.z); }
     function gazeDir(a) {
@@ -104,24 +105,36 @@ const _watchdog = setTimeout(() => { console.log('\n§W-CPE-REVEAL-PULLOUT TIMEO
     }
     const pAtO_minus = plan2.poseAt(tO - eps);   // last frame of Beat 3 (round 1's own end)
     const pAtO       = plan2.poseAt(tO);          // pull-out's own w=0 (boundary is inclusive to the EARLIER beat per <=, so this is Beat3's e3=1 too)
-    const pAtP       = plan2.poseAt(tP);          // pull-out's own w=1 (boundary <= leans to pullout, not round2)
+    const pAtP       = plan2.poseAt(tP);          // pull-out's own w=1 (boundary <= leans to pullout, not flyback)
     const pAtP_mid    = plan2.poseAt(tO + (tP - tO) * 0.5);
-    const pAtV_start = plan2.poseAt(tP + eps);    // round 2's own first frame (a CUT back to the first stick)
+    // §CPE_DISCIPLINE_REVEAL_FLYBACK: the fly-back sub-beat (tP..tF) now bridges the pull-out's end
+    // back onto the first stick — the old teleport cut used to sit right at tP. Both new seams
+    // (tP->flyback-start, flyback-end->tV) must be continuous in position AND gaze.
+    const pAtF_start = plan2.poseAt(tP + eps);    // fly-back's own first frame
+    const pAtF       = plan2.poseAt(tF);          // fly-back's own w=1 (boundary <= leans to flyback, not round2)
+    const pAtV_start = plan2.poseAt(tF + eps);    // round 2's own first frame (should now be ON the first stick)
     const pAtV_minus = plan2.poseAt(tV - eps);    // round 2's own last frame
     const pAtV_plus  = plan2.poseAt(tV + eps);    // first frame of Beat 4 (e4≈0, folded rise+tail)
     return {
-      ok: true, cpeRevealDurationSec: res.durationSec, tO, tP, tV, tR,
-      secPullout: plan2.sec.pullout, secReveal: plan2.sec.reveal,
+      ok: true, cpeRevealDurationSec: res.durationSec, tO, tP, tF, tV, tR,
+      secPullout: plan2.sec.pullout, secFlyback: plan2.sec.flyback, secReveal: plan2.sec.reveal,
       revealPulloutSec: plan2.reveal.pulloutSec, revealRoundSec: plan2.reveal.roundSec,
       revealTailSec: plan2.reveal.tailSec, revealRiseSec: plan2.reveal.riseSec,
-      discs: plan2.reveal.discs,
+      discs: plan2.reveal.discs, pathLen: plan2.pathLen,
       // pull-out geometry: displacement from the last stick, and gaze constancy through the beat.
       // Uses pAtO (the EXACT tO boundary, poseAt's <= convention) rather than pAtO_minus, so this
       // is an exact arithmetic check (9.75m to float precision), not one padded for sampling error.
       pulloutDisplacement: dist(pAtP, pAtO),
       gazeConstThroughPullout: Math.max(gazeDeg(pAtO, pAtP_mid), gazeDeg(pAtO, pAtP)),
-      // the tP -> tV seam is now a deliberate CUT (round 2 restarts at the first stick)
-      posJumpAtRound2Start: dist(pAtP, pAtV_start),
+      // the tP -> flyback-start seam must be continuous (position AND gaze) — the fly-back picks up
+      // exactly where the pull-out left off, no cut any more.
+      posJumpAtFlybackStart: dist(pAtP, pAtF_start), gazeJumpAtFlybackStartDeg: gazeDeg(pAtP, pAtF_start),
+      // the flyback-end -> tV (round 2 start) seam must ALSO be continuous now — this is the exact
+      // seam that used to be the "clean CUT" this session's fix removes.
+      posJumpAtRound2Start: dist(pAtF, pAtV_start), gazeJumpAtRound2StartDeg: gazeDeg(pAtF, pAtV_start),
+      // the fly-back must actually land ON the first stick (round 1's own start, _outPos(0)) by tF —
+      // otherwise round 2 would silently start somewhere else.
+      posDeltaFlybackEndVsRound2Pose: dist(pAtF, pAtV_start),
       // round 2 ends at the SAME spot round 1 did (same _outPos(1))
       posDeltaRound2EndVsRound1End: dist(pAtV_minus, pAtO_minus),
       // the tV -> tR seam (round 2 -> the folded rise/tail beat) must still be continuous —
@@ -132,11 +145,12 @@ const _watchdog = setTimeout(() => { console.log('\n§W-CPE-REVEAL-PULLOUT TIMEO
       posJumpAtPulloutStart: dist(pAtO_minus, pAtO), gazeJumpAtPulloutStartDeg: gazeDeg(pAtO_minus, pAtO)
     };
   });
-  chk('reveal ON: OK returns override.reveal=true and a plan with pullout+round2 inserted', onTest.ok, onTest.reason || '');
+  chk('reveal ON: OK returns override.reveal=true and a plan with pullout+flyback+round2 inserted', onTest.ok, onTest.reason || '');
   if (onTest.ok) {
-    chk('tO < tP < tV < tR (all four beats have real width)',
-      onTest.tO < onTest.tP && onTest.tP < onTest.tV && onTest.tV < onTest.tR,
-      'tO=' + onTest.tO.toFixed(4) + ' tP=' + onTest.tP.toFixed(4) + ' tV=' + onTest.tV.toFixed(4) + ' tR=' + onTest.tR.toFixed(4));
+    chk('tO < tP < tF < tV < tR (all five beats have real width)',
+      onTest.tO < onTest.tP && onTest.tP < onTest.tF && onTest.tF < onTest.tV && onTest.tV < onTest.tR,
+      'tO=' + onTest.tO.toFixed(4) + ' tP=' + onTest.tP.toFixed(4) + ' tF=' + onTest.tF.toFixed(4) +
+      ' tV=' + onTest.tV.toFixed(4) + ' tR=' + onTest.tR.toFixed(4));
     chk('sec.pullout === reveal.pulloutSec === 1.5 (CINEMA_REVEAL_PULLOUT_SEC)',
       onTest.secPullout === 1.5 && onTest.revealPulloutSec === 1.5,
       'sec.pullout=' + onTest.secPullout + ' reveal.pulloutSec=' + onTest.revealPulloutSec);
@@ -146,6 +160,11 @@ const _watchdog = setTimeout(() => { console.log('\n§W-CPE-REVEAL-PULLOUT TIMEO
     chk('reveal.tailSec === 2*discs.length + 2 (per-discipline + kept all-together slot)',
       onTest.revealTailSec === 2 * onTest.discs.length + 2,
       'tailSec=' + onTest.revealTailSec + ' discs=' + JSON.stringify(onTest.discs));
+    // §CPE_DISCIPLINE_REVEAL_FLYBACK: sec.flyback === pathLen / CINEMA_PULLBACK_MPS(6.5), a real,
+    // precise, derived duration (never a new speed invented).
+    chk('sec.flyback === pathLen / CINEMA_PULLBACK_MPS (6.5) — derived, not invented',
+      Math.abs(onTest.secFlyback - onTest.pathLen / 6.5) < 0.01,
+      'secFlyback=' + onTest.secFlyback.toFixed(3) + ' pathLen/6.5=' + (onTest.pathLen / 6.5).toFixed(3));
     // Pull-out: continuous hand-off from round 1's arrival (position AND gaze), then a real,
     // precise displacement — CINEMA_REVEAL_PULLOUT_SEC(1.5) * CINEMA_PULLBACK_MPS(6.5) = 9.75m —
     // and gaze held CONSTANT throughout (author's own call, see spec file).
@@ -157,11 +176,21 @@ const _watchdog = setTimeout(() => { console.log('\n§W-CPE-REVEAL-PULLOUT TIMEO
       Math.abs(onTest.pulloutDisplacement - 9.75) < 0.05, 'got=' + onTest.pulloutDisplacement.toFixed(4) + 'm');
     chk('gaze held constant through the pull-out (no blend — author\'s own call)',
       onTest.gazeConstThroughPullout < 0.5, onTest.gazeConstThroughPullout.toFixed(3) + 'deg');
-    // Round 2 is a deliberate CUT back to the first stick, not a continuation — the exact opposite
-    // of the OLD there-and-back's continuity property at this seam. A real, walk-scale jump proves
-    // the retrace leg is genuinely gone, not just renamed.
-    chk('tP -> tV seam is a real CUT (round 2 restarts at the first stick, not a continuation)',
-      onTest.posJumpAtRound2Start > 1, onTest.posJumpAtRound2Start.toFixed(2) + 'm');
+    // §CPE_DISCIPLINE_REVEAL_FLYBACK (2026-08-16): the old "clean CUT" at this seam is GONE — this is
+    // the exact regression proof that the user's "abrupt, not smooth" report is now fixed. Both new
+    // seams (pull-out -> fly-back, fly-back -> round 2) must be continuous in position AND gaze,
+    // the OPPOSITE of what the superseded test above used to assert here.
+    chk('position continuous at the tP seam (pull-out -> fly-back start) — the old cut is gone',
+      onTest.posJumpAtFlybackStart < 0.05, onTest.posJumpAtFlybackStart.toFixed(4) + 'm');
+    chk('gaze continuous at the tP seam (pull-out -> fly-back start)',
+      onTest.gazeJumpAtFlybackStartDeg < 2, onTest.gazeJumpAtFlybackStartDeg.toFixed(2) + 'deg');
+    chk('position continuous at the tF seam (fly-back end -> round 2 start) — this IS the seam ' +
+      'that used to be an abrupt teleport; now it must be smooth',
+      onTest.posJumpAtRound2Start < 0.05, onTest.posJumpAtRound2Start.toFixed(4) + 'm');
+    chk('gaze continuous at the tF seam (fly-back end -> round 2 start)',
+      onTest.gazeJumpAtRound2StartDeg < 2, onTest.gazeJumpAtRound2StartDeg.toFixed(2) + 'deg');
+    chk('the fly-back actually lands ON the first stick (round 2\'s own start pose) by tF',
+      onTest.posDeltaFlybackEndVsRound2Pose < 0.05, onTest.posDeltaFlybackEndVsRound2Pose.toFixed(4) + 'm');
     chk('round 2 ends at the SAME spot round 1 did (both are _outPos(1))',
       onTest.posDeltaRound2EndVsRound1End < 0.05, onTest.posDeltaRound2EndVsRound1End.toFixed(4) + 'm');
     // tV -> tR seam: UNCHANGED code path from before the restructure — must still be exactly as
@@ -180,8 +209,9 @@ const _watchdog = setTimeout(() => { console.log('\n§W-CPE-REVEAL-PULLOUT TIMEO
     revealLog.some(l => l.indexOf('pulloutSec=') !== -1 && l.indexOf('round2Sec=') !== -1 && l.indexOf('discs=[') !== -1),
     revealLog.join(' | '));
   const beatsLog = logs.filter(l => l.indexOf('§CINEMA_BEATS') !== -1);
-  chk('§CINEMA_BEATS logs pullout=/round2= (new boundary names, not the old reveal= there-and-back)',
-    beatsLog.some(l => l.indexOf('pullout=') !== -1 && l.indexOf('round2=') !== -1), beatsLog.slice(-1)[0] || 'not found');
+  chk('§CINEMA_BEATS logs pullout=/flyback=/round2= (flyback is the new boundary this session added)',
+    beatsLog.some(l => l.indexOf('pullout=') !== -1 && l.indexOf('flyback=') !== -1 && l.indexOf('round2=') !== -1),
+    beatsLog.slice(-1)[0] || 'not found');
 
   // ── W-PULLOUT-TOPOUT: buildup's 100%-complete moment must land at tP (end of pull-out), not tO
   // (instant of arrival — the "way before" bug this restructure fixes) and not tR (the "way after"
@@ -277,36 +307,65 @@ const _watchdog = setTimeout(() => { console.log('\n§W-CPE-REVEAL-PULLOUT TIMEO
     document.getElementById('cpe-ok').click();
     const res = await openPromise;
     const plan2 = A.cinemaPathPlan(res.durationSec, res.override);
-    const tO = plan2.beats.out, tP = plan2.beats.pullout, tV = plan2.beats.reveal, tR = plan2.beats.rise;
+    const tO = plan2.beats.out, tP = plan2.beats.pullout, tF = plan2.beats.flyback,
+          tV = plan2.beats.reveal, tR = plan2.beats.rise;
     const rv = plan2.reveal;
     const riseSpanSec = rv.riseSec + rv.tailSec, tailFrac = rv.tailSec / riseSpanSec;
     const at = (tn) => A.cpeRevealVisualAt(plan2, tn);
     const capAt = (tn) => A.cpeRevealCaptionAt(plan2, tn);
     const pulloutMid = tO + (tP - tO) * 0.5;
-    const round2Mid = tP + (tV - tP) * 0.5;
+    const flybackMid = tP + (tF - tP) * 0.5;
+    const round2Mid = tF + (tV - tF) * 0.5;
     const tailEarly = tV + (tR - tV) * (tailFrac * 0.05);
     const tailLate = tV + (tR - tV) * (tailFrac * 0.99);     // near the end of tailSec -> tail-all
     const riseProper = tV + (tR - tV) * Math.min(0.999, tailFrac * 1.2);
+    // §CPE_DISCIPLINE_REVEAL_FADE: sample right AFTER the first tail-one->tail-one slot boundary
+    // (idx 0 -> idx 1, 2s into the tail, requires >=2 discs) and again well past its own
+    // CPE_REVEAL_FADE_SEC (0.4s) window, to prove the overlap widens then narrows.
+    const perDiscSec = 2;
+    const slot1StartFrac = perDiscSec / riseSpanSec;
+    const fadeEarly = tV + (tR - tV) * (slot1StartFrac + 0.1 / riseSpanSec);   // ~0.1s into slot 1
+    const fadeLate  = tV + (tR - tV) * (slot1StartFrac + 0.9 / riseSpanSec);   // ~0.9s into slot 1 (past 0.4s)
     return {
       ok: true,
-      pullout: at(pulloutMid), round2: at(round2Mid), tailEarly: at(tailEarly), tailLate: at(tailLate),
+      pullout: at(pulloutMid), flyback: at(flybackMid), round2: at(round2Mid),
+      tailEarly: at(tailEarly), tailLate: at(tailLate),
       riseProper: at(riseProper), outside: at(tO - 1e-4),
       capPullout: capAt(pulloutMid), capRound2: capAt(round2Mid),
       capTailEarly: capAt(tailEarly), capTailLate: capAt(tailLate), capRiseProper: capAt(riseProper),
       discLabelELEC: A.cpeRevealDiscLabel ? A.cpeRevealDiscLabel('ELEC') : null,
       discLabelUnknown: A.cpeRevealDiscLabel ? A.cpeRevealDiscLabel('ZZZ') : null,
-      qtyCostShape: A.cpeRevealDiscQtyCost ? A.cpeRevealDiscQtyCost(rv.discs) : null
+      qtyCostShape: A.cpeRevealDiscQtyCost ? A.cpeRevealDiscQtyCost(rv.discs) : null,
+      discs: rv.discs, fadeEarly: at(fadeEarly), fadeLate: at(fadeLate)
     };
   });
   chk('visual/caption probe ran', visTest.ok, visTest.reason || '');
   if (visTest.ok) {
     chk('outside the round: no visual override', visTest.outside === null, JSON.stringify(visTest.outside));
     chk('pull-out: no visual override (ARC/STR stays solid — author\'s own call)', visTest.pullout === null, JSON.stringify(visTest.pullout));
+    chk('fly-back: phase=ghost (same zone as round 2 — the discs stay revealed WHILE the camera ' +
+      'retraces back to the first stick, not a hard cut in visibility either)',
+      visTest.flyback && visTest.flyback.phase === 'ghost', JSON.stringify(visTest.flyback));
     chk('round 2: phase=ghost, all non-ARC/STR discs shown together (unchanged from before)',
       visTest.round2 && visTest.round2.phase === 'ghost', JSON.stringify(visTest.round2));
     chk('tail (early, folded into rise): phase=tail-one, exactly one discipline',
       visTest.tailEarly && visTest.tailEarly.phase === 'tail-one' && visTest.tailEarly.discs.length === 1,
       JSON.stringify(visTest.tailEarly));
+    if (visTest.discs.length > 1) {
+      chk('§CPE_DISCIPLINE_REVEAL_FADE: shortly after a tail-one slot boundary, visDiscs widens to ' +
+        'BOTH the outgoing and incoming discipline (the overlap window, not an instant swap)',
+        visTest.fadeEarly && visTest.fadeEarly.phase === 'tail-one' && visTest.fadeEarly.visDiscs &&
+        visTest.fadeEarly.visDiscs.length === 2, JSON.stringify(visTest.fadeEarly));
+      chk('§CPE_DISCIPLINE_REVEAL_FADE: well past the overlap window, visDiscs narrows back to just ' +
+        'the incoming discipline',
+        visTest.fadeLate && visTest.fadeLate.phase === 'tail-one' && visTest.fadeLate.visDiscs &&
+        visTest.fadeLate.visDiscs.length === 1, JSON.stringify(visTest.fadeLate));
+      chk('the caption identity (discs[0]) during the overlap is the INCOMING discipline, never the outgoing one',
+        visTest.fadeEarly && visTest.fadeEarly.discs[0] === visTest.fadeEarly.visDiscs[1],
+        JSON.stringify(visTest.fadeEarly));
+    } else {
+      console.log('  (skipped §CPE_DISCIPLINE_REVEAL_FADE overlap checks — fixture building has < 2 disciplines)');
+    }
     chk('tail (late, folded into rise): phase=tail-all — KEPT (user asked for it elsewhere in this file)',
       visTest.tailLate && visTest.tailLate.phase === 'tail-all', JSON.stringify(visTest.tailLate));
     chk('rise proper (after the tail): no visual override, ARC/STR solid again', visTest.riseProper === null,
@@ -355,6 +414,55 @@ const _watchdog = setTimeout(() => { console.log('\n§W-CPE-REVEAL-PULLOUT TIMEO
       'EDITOR\'S OWN live plan — the exact plan Preview flies, not a freshly-built one',
       previewReplanTest.tP > previewReplanTest.tO && previewReplanTest.tV > previewReplanTest.tP,
       'tO=' + previewReplanTest.tO.toFixed(3) + ' tP=' + previewReplanTest.tP.toFixed(3) + ' tV=' + previewReplanTest.tV.toFixed(3));
+  }
+
+  // ── W-PULLOUT-DISC-ORDER (§CPE_DISCIPLINE_REVEAL_ORDER, 2026-08-16): the tail parade's discipline
+  // order must match a HAND-COMPUTED sort of the same fixture DB — ascending AVG(bbox_x*bbox_y*
+  // bbox_z) per discipline, with the literal 'MEP' code forced last regardless of its own measured
+  // size. Recomputed independently here (not just re-reading A.cpeRevealDiscsPresent's own output)
+  // so this is a real numeric proof, not a tautology. ──
+  const discOrderTest = await pg.evaluate(() => {
+    const A = window.APP;
+    const discs = A.cpeRevealDiscsPresent ? A.cpeRevealDiscsPresent() : [];
+    if (!discs.length) return { ok: false, reason: 'no non-ARC/STR discipline present in this fixture' };
+    const inList = discs.map(d => "'" + d.replace(/'/g, "''") + "'").join(',');
+    const rows = A.dbQuery('SELECT m.discipline, AVG(t.bbox_x * t.bbox_y * t.bbox_z) FROM elements_meta m ' +
+      'JOIN element_transforms t ON m.guid = t.guid WHERE m.discipline IN (' + inList + ') ' +
+      'AND t.bbox_x IS NOT NULL AND t.bbox_x > 0 GROUP BY m.discipline');
+    const avgVol = {}; (rows || []).forEach(r => { avgVol[r[0]] = +r[1]; });
+    const expected = discs.slice().sort((a, b) => {
+      if (a === 'MEP' && b !== 'MEP') return 1;
+      if (b === 'MEP' && a !== 'MEP') return -1;
+      const va = avgVol[a], vb = avgVol[b];
+      if (va == null && vb == null) return 0;
+      if (va == null) return 1;
+      if (vb == null) return -1;
+      return va - vb;
+    });
+    return { ok: true, actual: discs, expected, avgVol, hasMep: discs.indexOf('MEP') !== -1 };
+  });
+  chk('disc-order probe ran', discOrderTest.ok, discOrderTest.reason || '');
+  if (discOrderTest.ok) {
+    chk('A.cpeRevealDiscsPresent() order === independently hand-computed AVG(bbox volume) ascending sort',
+      JSON.stringify(discOrderTest.actual) === JSON.stringify(discOrderTest.expected),
+      'actual=' + JSON.stringify(discOrderTest.actual) + ' expected=' + JSON.stringify(discOrderTest.expected) +
+      ' avgVol=' + JSON.stringify(discOrderTest.avgVol));
+    if (discOrderTest.hasMep) {
+      chk('MEP is the LAST discipline in the order, regardless of its own measured size',
+        discOrderTest.actual[discOrderTest.actual.length - 1] === 'MEP', 'got=' + JSON.stringify(discOrderTest.actual));
+    } else {
+      console.log('  (skipped MEP-last check — fixture building has no MEP-coded elements, only sub-disciplines)');
+    }
+  }
+  // The sort (and its log line) only runs when >1 discipline is present — a single-discipline
+  // fixture correctly skips both (no ordering decision to make or log), so this check is gated the
+  // same way the fixture-dependent checks above are, not a fixed expectation.
+  if (discOrderTest.ok && discOrderTest.actual.length > 1) {
+    const orderLog = logs.filter(l => l.indexOf('§CPE_REVEAL_DISC_ORDER') !== -1);
+    chk('§CPE_REVEAL_DISC_ORDER logged with real avg-volume numbers per discipline',
+      orderLog.length > 0, orderLog.slice(-1)[0] || 'not found');
+  } else {
+    console.log('  (skipped §CPE_REVEAL_DISC_ORDER log check — fixture has <= 1 discipline, sort is a correct no-op)');
   }
 
   chk('zero pageerrors through the whole run', errs.length === 0, errs.join(' | '));


### PR DESCRIPTION
## Summary
- Replaces the deliberate teleport cut between the pull-out beat and round 2's forward lap with a new `_flyBackPose` sub-beat: a fast eased retrace of the same walked path at `CINEMA_PULLBACK_MPS`, position/gaze-continuous on both new seams. Fixes the user report on a live Hospital bake ("cuts to it abruptly instead of smoothly").
- `A.cpeRevealDiscsPresent` now sorts the tail parade ascending by real average element bbox volume (`element_transforms.bbox_x/y/z`), with the literal `MEP` discipline code forced last. Degrades to the original unordered list if `A.dbQuery` is unavailable.
- The tail parade's discipline-to-discipline transitions get a brief overlap window (`CPE_REVEAL_FADE_SEC=0.4s`) instead of an instant hard swap — `filterDiscs` has no per-element opacity channel (Instanced/BatchedMesh share one material per batch), so this is documented as the honest approximation, not a literal fade.

Spec: `bim-compiler` repo, `prompts/CINEMA_DISCIPLINE_REVEAL.md`, 2026-08-16 dated section.

## Test plan
- [x] `node witness_cpe_reveal_pullout.js` — 60/60 PASS (extended, not new — the old "tP -> tV is a real CUT" assertion replaced with its opposite: both new seams now continuous, <5cm position / <2deg gaze on the real HHS_Office_Federated fixture)
- [x] `node witness_cpe_reveal_panel.js` — 7/7 PASS (regression, unaffected)
- [x] `node witness_cpe_room_title.js` — 11/11 PASS (regression, unaffected)
- [x] `node --check` on all 3 edited JS files
- [ ] Known gap (named in the spec, not blocking): the git-tracked fixture used has only ONE non-ARC/STR discipline (MEP), so the sort/fade paths correctly no-op/degrade on it but aren't exercised end-to-end against a real multi-discipline building (Hospital is OCI-distributed, not pulled into this worktree). Follow-on: re-run this witness against a multi-discipline building once available.

🤖 Generated with [Claude Code](https://claude.com/claude-code)