### PR TITLE
fix(4d): §CJP_DAY_ROUNDING_TOL — fleet floating 265 -> 133 (-49.8%)

### DIFF
--- a/scripts/probe_captured_floating.js
+++ b/scripts/probe_captured_floating.js
@@ -777,6 +777,43 @@ async function main() {
       ' inWindow=' + inW8 + ' outWindow=' + outW8);
     console.log('§EXP8_FINAL_BYCLASS ' + JSON.stringify(final8.byClass));
 
+    // §CJP_DECOMP_EXP8 (2026-08-16, thread 2 of §STOREY_ORDER_REPORT's handoff — distinct from the
+    // older §CJP_DECOMP block above, which runs on the superseded EXP1 raw-fed pipeline, not EXP8)
+    // — per-TASK breakdown of the remaining WINDOW_BLOCKED population on the FINAL
+    // (post-_cjpJudgeParity) cap8 state, reusing final8's own contact graph (same clone order, zero
+    // extra scan). For each still-floating element, names the exact task window it's blocked against
+    // and the gap (days by which pushing it to its real first-contact would overrun that task's
+    // authored end) — the number a coverage-rounding or per-task end-nudge fix would need to close.
+    {
+      const G8 = final8.G;
+      const byTask = {};
+      let noWin = 0;
+      for (let i = 0; i < cap8.length; i++) {
+        const list = G8.contacts[i]; if (!list) continue;
+        const T = cap8[i];
+        let first = Infinity;
+        for (const k of list) { const s = cap8[k].s; if (s < first) first = s; }
+        if (first <= T.s + 1) continue; // not floating
+        const w = taskWin7[T.task]; if (!w) { noWin++; continue; }
+        const dur = Math.max(60000, T.e - T.s);
+        const gapDays = ((first + dur) - w.e) / DAY5;
+        const g = byTask[T.task] || (byTask[T.task] = { n: 0, sumGap: 0, maxGap: -Infinity, cls: {} });
+        g.n++; g.sumGap += gapDays; if (gapDays > g.maxGap) g.maxGap = gapDays;
+        g.cls[T.cls] = (g.cls[T.cls] || 0) + 1;
+      }
+      const rows = Object.entries(byTask).map(function (e) {
+        const t = e[0], g = e[1], w = taskWin7[t];
+        return { task: t, n: g.n, avgGapDays: (g.sumGap / g.n), maxGapDays: g.maxGap,
+          winDays: Math.round((w.e - w.s) / DAY5), cls: g.cls };
+      }).sort(function (a, b) { return b.n - a.n; });
+      const totalN = rows.reduce(function (a, r) { return a + r.n; }, 0);
+      console.log('§CJP_DECOMP_EXP8 n_tasks=' + rows.length + ' total=' + totalN + ' noWindow=' + noWin);
+      rows.slice(0, 15).forEach(function (r) {
+        console.log('§CJP_DECOMP_EXP8_TASK ' + r.task + ' n=' + r.n + ' avgGapDays=' + r.avgGapDays.toFixed(1) +
+          ' maxGapDays=' + r.maxGapDays.toFixed(1) + ' winDays=' + r.winDays + ' cls=' + JSON.stringify(r.cls));
+      });
+    }
+
     // §STOREY_ORDER_REPORT (2026-08-16) FINAL — same math as the RAW call above, run on the
     // FINAL overlay times (post-_cjpJudgeParity cap8, the EXP8 winner). Comparing RAW vs FINAL
     // isolates whether §4D_BAND_MONOTONIC's ladder survives the remap/repair/window/parity chain.

--- a/viewer/tests/witness_crosstask_judge_parity.js
+++ b/viewer/tests/witness_crosstask_judge_parity.js
@@ -16,9 +16,15 @@
 //   W-CJP-2  THE BAR: on a real building schedule with judge-rule floating present, the pass
 //            strictly reduces it (numbers per building live in probe_captured_floating.js §EXP4 —
 //            measured 2026-08-16: 3090 -> 656 across the 7 buildings).
-//   W-CJP-3  WINDOW SAFETY (the anti-desync contract): every element the pass MOVES ends fully
-//            inside its own task's authored window, and the per-building in/out-window counts are
-//            byte-identical before vs after — the pass can never manufacture a Gantt desync.
+//   W-CJP-3  WINDOW SAFETY (the anti-desync contract): every element the pass MOVES ends inside its
+//            own task's authored window, WITHIN ONE DAY (§CJP_DAY_ROUNDING_TOL, 2026-08-16 —
+//            the window's own end is itself rounded to a whole day by materializeZones, so a push
+//            landing inside that same calendar day is not a desync, it's honouring the window's own
+//            rounding). MEASURED: this closed 90% of Clinic's residual floating (91->9) and the
+//            fleet total 265->133 (-49.8%), zero regressions on any of the 7 buildings — see
+//            probe_captured_floating.js §CJP_DECOMP_EXP8. Never more than one day, ever — the
+//            2026-08-13 unbounded _midairRepair swap was REJECTED for 100-300d desync; this is
+//            bounded by construction to the window's own rounding quantum, not an open-ended push.
 //   W-CJP-4  MONOTONE: zero elements start EARLIER after the pass (§TIER_SERIAL W-TS-3's property).
 //   W-CJP-5  JUDGE UNTOUCHED: orphans/grounded counts byte-identical — the pass repairs against
 //            the judge, it never weakens the judge.
@@ -91,30 +97,40 @@ function mk(guid, s, e, bz, tz, task) {
   return { guid, s: s * DAY, e: e * DAY, bz, tz, x0: 0, x1: 2, y0: 0, y1: 2, cls: 'IfcSlab', seq: 5, task };
 }
 {
-  // carrier C (day 10) with three dependents resting on it, each floating (start day 0):
+  // carrier C (day 10) with five dependents resting on it, each floating (start day 0):
   //   R in a window wide enough to absorb the push        -> must land exactly on C.s
   //   B in a window that ends before C.s + dur            -> WINDOW_BLOCKED, byte-identical
   //   O already outside its own window                    -> byte-identical
+  //   T in a window whose overrun is INSIDE the 1-day §CJP_DAY_ROUNDING_TOL -> gets pushed anyway
+  //   X in a window whose overrun EXCEEDS the 1-day tolerance             -> still WINDOW_BLOCKED
   const C = mk('C', 10, 11, 0, 3, 'TC');
   const R = mk('R', 0, 1, 3, 4, 'TR');
   const B = mk('B', 0, 1, 3, 4, 'TB'); B.x0 = 10; B.x1 = 12; C.x1 = 12; // widen C to touch B too
   const O = mk('O', 0, 1, 3, 4, 'TO'); O.y0 = 10; O.y1 = 12; C.y1 = 12; // widen C to touch O too
+  const T = mk('T', 0, 1, 3, 4, 'TT'); T.x0 = 20; T.x1 = 22; C.x1 = 22; // widen C to touch T too
+  const X = mk('X', 0, 1, 3, 4, 'TX'); X.y0 = 20; X.y1 = 22; C.y1 = 22; // widen C to touch X too
   const taskWin = {
     TC: { s: 0, e: 100 * DAY },
     TR: { s: 0, e: 100 * DAY },
     TB: { s: 0, e: 5 * DAY },
-    TO: { s: 5 * DAY, e: 100 * DAY }   // O.s=0 sits BEFORE its window -> already-out
+    TO: { s: 5 * DAY, e: 100 * DAY },  // O.s=0 sits BEFORE its window -> already-out
+    TT: { s: 0, e: 10.5 * DAY },       // push would end at day 11, overrun 0.5d < 1d tol -> pushed
+    TX: { s: 0, e: 8 * DAY }           // push would end at day 11, overrun 3d > 1d tol -> blocked
   };
-  const items = [C, R, B, O];
+  const items = [C, R, B, O, T, X];
   const before = census(items.map(o => Object.assign({}, o)));
   const r = _cjpJudgeParity(items, taskWin);
-  assert(r.pushed >= 1, 'pass pushed at least the reachable violation (pushed=' + r.pushed + ')');
+  assert(r.pushed >= 2, 'pass pushed at least the reachable + in-tolerance violations (pushed=' + r.pushed + ')');
   assert(R.s === C.s && R.e === R.s + 1 * DAY, 'reachable dependent lands exactly on first-contact start, duration preserved');
   assert(B.s === 0 && B.e === 1 * DAY, 'WINDOW_BLOCKED dependent left byte-identical (honest floating)');
   assert(O.s === 0 && O.e === 1 * DAY, 'already-out-of-window element left byte-identical');
   assert(C.s === 10 * DAY, 'carrier itself never moved');
+  assert(T.s === C.s && T.e === T.s + 1 * DAY, '§CJP_DAY_ROUNDING_TOL: in-tolerance overrun (0.5d) IS pushed, lands on first-contact start');
+  assert(T.e - taskWin.TT.e === 0.5 * DAY, 'in-tolerance push overruns its window by exactly the real 0.5d gap (never more)');
+  assert(X.s === 0 && X.e === 1 * DAY, 'over-tolerance overrun (3d > 1d) still WINDOW_BLOCKED, byte-identical');
   const after = census(items.map(o => Object.assign({}, o)));
-  assert(before.midair === 3 && after.midair === 2, 'census: 3 floating before, exactly the reachable one repaired (after=' + after.midair + ')');
+  assert(before.midair === 5 && after.midair === 3,
+    'census: 5 floating before, reachable + in-tolerance repaired, B/O/X honestly remain (after=' + after.midair + ')');
 }
 
 // ── W-CJP-2..5: real buildings, full generative schedule + real task windows ──────────────────
@@ -170,17 +186,24 @@ async function main() {
       ' pushed=' + r.pushed + ' inWindow ' + winBefore.inW + '->' + winAfter.inW);
     assert(before.midair === 0 || after.midair < before.midair,
       'W-CJP-2 floating strictly reduced (' + before.midair + ' -> ' + after.midair + ')');
-    let movedOut = 0, earlier = 0;
+    // §CJP_DAY_ROUNDING_TOL (2026-08-16): a moved element may now end up to ONE DAY past its
+    // window's own (already day-rounded) end — desyncOut counts anything WORSE than that, the real
+    // anti-desync bar. movedPastWindow (informational) reports how many pushes used the tolerance.
+    const DAY_TOL = DAY;
+    let desyncOut = 0, movedPastWindow = 0, earlier = 0;
     items.forEach(o => {
       if (o.s < sBefore[o.guid]) earlier++;
       if (o.s !== sBefore[o.guid]) {
         const w = taskWin[o.task];
-        if (!w || o.s < w.s || o.e > w.e) movedOut++;
+        if (!w || o.s < w.s || o.e > w.e + DAY_TOL) desyncOut++;
+        else if (o.e > w.e) movedPastWindow++;
       }
     });
-    assert(movedOut === 0, 'W-CJP-3a every moved element ends fully inside its own task window (movedOut=' + movedOut + ')');
-    assert(winBefore.inW === winAfter.inW && winBefore.outW === winAfter.outW,
-      'W-CJP-3b in/out-window counts byte-identical (' + winBefore.inW + '/' + winBefore.outW + ')');
+    assert(desyncOut === 0,
+      'W-CJP-3a every moved element ends within its window + 1-day rounding tolerance (desyncOut=' + desyncOut + ')');
+    assert(winAfter.outW - winBefore.outW === movedPastWindow,
+      'W-CJP-3b in/out-window count delta matches exactly the tolerance-zone pushes (' +
+      winBefore.outW + '->' + winAfter.outW + ', movedPastWindow=' + movedPastWindow + ')');
     assert(earlier === 0, 'W-CJP-4 monotone — zero elements start earlier (earlier=' + earlier + ')');
     assert(before.orphans === after.orphans && before.grounded === after.grounded,
       'W-CJP-5 judge untouched — orphans/grounded byte-identical (' + after.orphans + '/' + after.grounded + ')');

--- a/viewer/time_machine.js
+++ b/viewer/time_machine.js
@@ -4447,7 +4447,20 @@
   // termination argument as _midairRepair's own. MEASURED (probe_captured_floating.js §EXP4, all 7
   // buildings, 2026-08-16): floating 3090 -> 656 (-78.8%), window fidelity byte-identical on every
   // building, orphans/grounded untouched (the judge itself is never modified here).
+  // §CJP_DAY_ROUNDING_TOL (2026-08-16, bim-compiler prompts/4D_SCHEDULE_PERFECTION.md thread 2,
+  // §CJP_DECOMP_EXP8 measurement) — a task window's own end (taskWin[t].e) is ALREADY rounded to a
+  // whole day (materializeZones: `Math.round((z.end-minStart)/86400000)`), but the WINDOW_BLOCKED
+  // check below compared it against an element's exact-millisecond real end with zero tolerance.
+  // MEASURED per-task decomposition on 3 buildings: Clinic 82/91 (90%) of its residual floating had
+  // avgGapDays <1 (TASK_Substructure_First_Floor alone: n=38, avgGapDays=0.1, on a 4-day window) —
+  // a sub-day rounding artifact against the window's own quantum, not a real authoring conflict.
+  // Fix: the window's rounded end already means "through the end of that calendar day" — allow a
+  // push whose result lands within that same day, exactly the quantum the window itself was rounded
+  // to (not an invented fudge factor). Genuinely-undersized windows (gaps of many days, e.g.
+  // Hospital's TASK_Superstructure_Level_2, avgGapDays=52 on an 11-day window) are UNCHANGED — still
+  // correctly WINDOW_BLOCKED, one day of slack cannot paper over a real conflict.
   function _cjpJudgeParity(items, taskWin) {
+    var _CJP_DAY_TOL = 86400000;
     var _t0 = (typeof performance !== 'undefined' && performance.now) ? performance.now() : Date.now();
     var G = _contactGraph(items);
     if (!G.ok) return { pushed: 0, sweeps: 0 };
@@ -4463,7 +4476,7 @@
         var w = taskWin && taskWin[T.task]; if (!w) continue;
         if (T.s < w.s || T.e > w.e) continue;              // already out of window — never worsen
         var dur = Math.max(60000, T.e - T.s);
-        if (first + dur > w.e) continue;                   // WINDOW_BLOCKED — honest floating
+        if (first + dur > w.e + _CJP_DAY_TOL) continue;     // WINDOW_BLOCKED — honest floating
         var d = first - T.s;
         T.s = first; T.e = T.s + dur;
         pushed++; moved++; if (d > maxShift) maxShift = d;
@@ -4481,7 +4494,7 @@
       if (cf > Tc.s + 1) {
         floating++;
         var cw = taskWin && taskWin[Tc.task];
-        if (cw && cf + Math.max(60000, Tc.e - Tc.s) > cw.e) blocked++;
+        if (cw && cf + Math.max(60000, Tc.e - Tc.s) > cw.e + _CJP_DAY_TOL) blocked++;
       }
     }
     console.log('§CROSSTASK_JUDGE_PARITY pushed=' + pushed + ' sweeps=' + sweeps +


### PR DESCRIPTION
## Summary
- Thread 2 of `bim-compiler/prompts/4D_SCHEDULE_PERFECTION.md` §STOREY_ORDER_REPORT handoff: the "remaining 265" residual floating chase.
- New probe instrumentation (`§CJP_DECOMP_EXP8` in `probe_captured_floating.js`) decomposed the residual by task, revealing most of it is a **sub-day rounding artifact**: a task window's end is already rounded to a whole day (`materializeZones`), but `_cjpJudgeParity`'s `WINDOW_BLOCKED` check compared it against an element's exact-millisecond real end with zero tolerance. Clinic alone: 90% of its 91 residual (82 elements) had this exact shape — one task group of 38 footings sat at `avgGapDays=0.1` on a 4-day window.
- Fix (`viewer/time_machine.js`, `_cjpJudgeParity`): allow a push whose result lands within **one day** past the window's rounded end (`§CJP_DAY_ROUNDING_TOL`, exactly the window's own rounding quantum — not an invented number). Genuinely undersized windows (gaps of many days, e.g. Hospital's `TASK_Superstructure_Level_2`, 52-day gap on an 11-day window) are unaffected, still correctly `WINDOW_BLOCKED`.

## Fleet measurement (probe_captured_floating.js §EXP8_FINAL, all 7 buildings, zero regressions)
| Building | Before | After | Δ |
|---|---|---|---|
| Terminal | 27 | 18 | -9 |
| Hospital | 63 | 51 | -12 |
| Duplex | 3 | **0** | -3 (closed) |
| HHS_Office_Federated | 11 | **0** | -11 (closed) |
| Clinic | 91 | 9 | -82 |
| LTU_AHouse | 43 | 30 | -13 |
| JKR | 27 | 25 | -2 |
| **Total** | **265** | **133** | **-132 (-49.8%)** |

## Test plan
- [x] `node -c viewer/time_machine.js` — syntax OK
- [x] `viewer/tests/witness_crosstask_judge_parity.js` updated for the new bounded contract — W-CJP-3's old "in/out-window counts byte-identical" claim replaced with a bounded-desync claim (never more than 1 day past window, per-element checked), matching the trade-off pattern `§TIER2_PER_ELEMENT_CLAMP` already established elsewhere in this file. New synthetic cases test the tolerance boundary directly (0.5d overrun IS pushed, 3d overrun stays blocked).
- [x] Ran on Duplex/HHS/Clinic/Hospital/Terminal/JKR: **30/30 + 20/20 assertions pass**
- [x] Ran the full fleet floating census via the probe (table above) — read from logs, not eyeballed

🤖 Generated with [Claude Code](https://claude.com/claude-code)