### PR TITLE
fix(4d): §ZONE_WINDOW_DAGWINS_CLIP — readable task bars, epoch-safe reuse, no re-spacing

### DIFF
--- a/scripts/probe_cpm_display_path.js
+++ b/scripts/probe_cpm_display_path.js
@@ -81,8 +81,33 @@ async function runBuilding(SQL, RATES, name) {
 
   // §ZONE_DISPLAY_AUTHORING with the CPM display schedule: deriveZones + day-rounded windows
   // (materializeZones' own construction, verbatim from probe_captured_floating.js).
+  // §ZONE_WINDOW_DAGWINS_CLIP mirror: straggler times clamped into their group's non-straggler
+  // envelope for WINDOW AUTHORING ONLY (the played items keep true physics times).
+  const stragOf = res.graph.stragglerOf;
+  const envByG = {};
+  const gkOf = o => (o.phase || '_UNPHASED') + '||' + ScheduleGate.collapsePhase(o.storey);
+  items.forEach((o, i) => {
+    if (stragOf[i]) return;
+    const k = gkOf(o), e2 = envByG[k] || (envByG[k] = { min: Infinity, max: -Infinity });
+    if (o.s < e2.min) e2.min = o.s;
+    if (o.e > e2.max) e2.max = o.e;
+  });
   const dispSchedule = {};
-  items.forEach(o => dispSchedule[o.guid] = { start: o.s, end: o.e });
+  let clamped = 0;
+  items.forEach((o, i) => {
+    let st = o.s, en = o.e;
+    if (stragOf[i]) {
+      const e2 = envByG[gkOf(o)];
+      if (e2 && e2.max > e2.min) {
+        st = Math.min(Math.max(st, e2.min), e2.max);
+        en = Math.min(Math.max(en, e2.min), e2.max);
+        if (en <= st) { st = Math.max(e2.min, e2.max - 60000); en = e2.max; }
+        clamped++;
+      }
+    }
+    dispSchedule[o.guid] = { start: st, end: en };
+  });
+  console.log('§CPMDP_DAGWINS_CLIP clamped=' + clamped);
   const rolled = ScheduleGate.deriveZones(elements, dispSchedule);
   const minStart = Math.min.apply(null, rolled.zones.map(z => z.start));
   const taskWin = {}, guidTask = {};
@@ -102,9 +127,10 @@ async function runBuilding(SQL, RATES, name) {
   const preRescale = floatingCensus(scheduled.map(o => Object.assign({}, o)));
   console.log('§CPMDP_PRE_RESCALE floating=' + preRescale.midair + ' orphans=' + preRescale.orphans);
 
-  // _cap overlay: rescale into the (self-derived) windows, §OG skip (display-authored), judge parity.
+  // _cap overlay, display-authored path: §CAP_RESCALE_SKIP (windows are views — no reconcile),
+  // §OG skip, judge parity only.
   const rescaled = scheduled.map(o => Object.assign({}, o));
-  applyCapWindowRescale(rescaled, taskWin);
+  console.log('§CAP_RESCALE_SKIP mirror (display-authored)');
   const postRescale = floatingCensus(rescaled.map(o => Object.assign({}, o)));
   console.log('§CPMDP_POST_RESCALE floating=' + postRescale.midair + ' byClass=' + JSON.stringify(postRescale.byClass));
   const cjp = _cjpJudgeParity(rescaled, taskWin);
@@ -112,19 +138,25 @@ async function runBuilding(SQL, RATES, name) {
   console.log('§CPMDP_FINAL floating=' + final.midair + ' windowBlocked=' + cjp.windowBlocked +
     ' cjpPushed=' + cjp.pushed + ' byClass=' + JSON.stringify(final.byClass));
 
-  // Window fidelity of the played timeline vs its own authored windows (the needle-vs-appearance bar).
-  let inWin = 0, outWin = 0;
+  // Window fidelity of the played timeline vs its own authored windows. A dag-wins straggler
+  // legitimately rides OUTSIDE its bar (§ZONE_WINDOW_DAGWINS_CLIP — counted, never hidden);
+  // any NON-straggler outside its window is a real defect and must be 0.
+  const stragGuid = {};
+  items.forEach((o, i) => { if (stragOf[i]) stragGuid[o.guid] = 1; });
+  let inWin = 0, stragOut = 0, otherOut = 0;
   rescaled.forEach(function (o) {
     const w = taskWin[o.task]; if (!w) return;
-    if (o.s >= w.s && o.e <= w.e) inWin++; else outWin++;
+    if (o.s >= w.s && o.e <= w.e) inWin++;
+    else if (stragGuid[o.guid]) stragOut++;
+    else otherOut++;
   });
-  console.log('§CPMDP_WINDOW_FIDELITY inWindow=' + inWin + '/' + (inWin + outWin) +
-    ' pct=' + (100 * inWin / Math.max(1, inWin + outWin)).toFixed(2));
+  console.log('§CPMDP_WINDOW_FIDELITY inWindow=' + inWin + '/' + (inWin + stragOut + otherOut) +
+    ' stragglerOutside=' + stragOut + ' nonStragglerOutside=' + otherOut + ' (bar: nonStraggler must be 0)');
 
-  const pass = final.midair === 0;
-  console.log('§CPMDP_ACCEPT ' + name + ' finalFloating=' + final.midair + ' ' + (pass ? 'PASS' : 'FAIL'));
+  const pass = final.midair === 0 && otherOut === 0;
+  console.log('§CPMDP_ACCEPT ' + name + ' finalFloating=' + final.midair + ' nonStragglerOutside=' + otherOut + ' ' + (pass ? 'PASS' : 'FAIL'));
   return { name, final: final.midair, pre: preRescale.midair, post: postRescale.midair,
-           fidelity: (100 * inWin / Math.max(1, inWin + outWin)).toFixed(2) };
+           stragOut, otherOut };
 }
 
 async function main() {
@@ -136,9 +168,9 @@ async function main() {
   const out = [];
   for (const name of FLEET) out.push(await runBuilding(SQL, RATES, name));
   let fails = 0;
-  out.forEach(r => { if (r.final !== 0) fails++; });
+  out.forEach(r => { if (r.final !== 0 || r.otherOut !== 0) fails++; });
   console.log('§CPMDP_FLEET ' + JSON.stringify(out.map(r => [r.name, 'pre=' + r.pre, 'post=' + r.post,
-    'final=' + r.final, 'fid=' + r.fidelity + '%'])));
+    'final=' + r.final, 'stragOut=' + r.stragOut, 'otherOut=' + r.otherOut])));
   console.log('§CPMDP_FLEET_VERDICT buildings=' + out.length + ' fails=' + fails + ' ' + (fails === 0 ? 'PASS' : 'FAIL'));
   process.exit(fails === 0 ? 0 : 1);
 }

--- a/viewer/sw.js
+++ b/viewer/sw.js
@@ -8,7 +8,12 @@
 // Cache-first for heavy assets (.wasm, images). DB files skip SW (IndexedDB handles them).
 //
 // DEPLOY: bump CACHE_VERSION on every OCI upload. Old caches are purged on activate.
-const CACHE_VERSION = 'v1046';   // bump on each deploy; per-change detail is the git commit message.
+const CACHE_VERSION = 'v1047';   // bump on each deploy; per-change detail is the git commit message.
+// v1047 (2026-08-16) §ZONE_WINDOW_DAGWINS_CLIP: task bars = non-straggler envelopes (user:
+// "schedule looks gibberish" — every Hospital bar ran to project end, smeared by 11,215 dag-wins
+// stragglers); §CAP_RESCALE_SKIP: display-authored windows never re-spaced (views, not a second
+// schedule); §CPM_DISPLAY_EPOCH: one-truth reuse rigid-shifts the cached timeline onto the
+// requester's epoch (was landing uncovered ops in 1970). _GANTT_CACHE_VERSION 28->29.
 // v1046 (2026-08-16) §CPM_DISPLAY: time_machine.js display timeline authored by cpm_schedule.js
 // one-DAG forward pass (support/host/discipline/storey edges, SCC-condensed) at BOTH consumers
 // (kernel_ops write + materializeZones displayRemap) — floating 0 by construction, ?cpm4d=0 reverts.

--- a/viewer/tests/witness_midair_zero.js
+++ b/viewer/tests/witness_midair_zero.js
@@ -115,7 +115,7 @@ console.log('§MIDAIR_SLICE _midairRepairDefs=' + _mrCount + ' slicing #' + (_mr
 // so neither the seam call nor the legacy repair pair can silently drop out.
 assert(/_displayTimeline\(_twItems\)/.test(tmSrc),
   'W-MZ-5a kernel_ops path calls _displayTimeline (the single display-timeline source)');
-assert(/function _displayTimeline\(items\) \{[\s\S]{0,2600}_twoTierRemap\(items\);[\s\S]{0,200}_midairRepair\(items\)/.test(tmSrc),
+assert(/function _displayTimeline\(items\) \{[\s\S]{0,6000}_twoTierRemap\(items\);[\s\S]{0,200}_midairRepair\(items\)/.test(tmSrc),
   'W-MZ-5b _displayTimeline legacy branch still runs _twoTierRemap then _midairRepair (a defined-but-uncalled repair is a silent no-op)');
 // W-MZ-6 — the LOCK gate must judge by the same rule the generator enforces, or a planner's drag
 // re-creates exactly the hangings the generated film has none of and the lock is still granted.

--- a/viewer/tests/witness_zone_display_authoring.js
+++ b/viewer/tests/witness_zone_display_authoring.js
@@ -198,13 +198,16 @@ async function main() {
       CpmSchedule: require(path.join(__dirname, '..', 'cpm_schedule.js')) };
     vm.createContext(cpmSandbox);
     vm.runInContext(sliced.replace('var _CPM_DISPLAY = false;', 'var _CPM_DISPLAY = true;') +
-      '\nthis.__remapHook = _tmDisplayRemap; this.__cg = _contactGraph;', cpmSandbox);
-    const cpmDisp = cpmSandbox.__remapHook(elements, rawSched);
+      '\nthis.__remapHook = _tmDisplayRemap; this.__cg = _contactGraph; this.__dt = _displayTimeline;', cpmSandbox);
+    // judge the OPS timeline (what the movie plays) — the hook's map is the WINDOW view, which
+    // deliberately clamps dag-wins stragglers (§ZONE_WINDOW_DAGWINS_CLIP) and is not the schedule
     const cpmItems = elements.map(el => {
-      const st = cpmDisp[el.guid]; if (!st) return null;
+      const st = rawSched[el.guid]; if (!st) return null;
       return { guid: el.guid, s: st.start, e: st.end, bz: el.bz, tz: el.tz,
-        x0: el.x0, x1: el.x1, y0: el.y0, y1: el.y1, cls: el.cls, seq: el.seq };
+        x0: el.x0, x1: el.x1, y0: el.y0, y1: el.y1, cls: el.cls, seq: el.seq,
+        phase: el.phase, storey: el.storey };
     }).filter(Boolean);
+    cpmSandbox.__dt(cpmItems);
     const cpmFloat = census(cpmItems);
     console.log = ql;
     console.log('  §ZDA_CPM_DISPLAY ' + B + ' midair=' + cpmFloat + ' (legacy display path above: ' + nextFloat + ')');

--- a/viewer/time_machine.js
+++ b/viewer/time_machine.js
@@ -4533,15 +4533,28 @@
       var _rh = 0, _rm = 0, _ri;
       for (_ri = 0; _ri < items.length; _ri++) { if (_cache.map[items[_ri].guid]) _rh++; else _rm++; }
       if (_rh > 0 && _rh >= 0.999 * (_rh + _rm)) {
+        // §CPM_DISPLAY_EPOCH: the two consumers anchor computeSchedule differently (the hook at 0,
+        // the seam at baseMs/_cap.base) — a verbatim replay would land ops in the wrong epoch
+        // (1970 for any uncovered element). Rigid-shift the cached timeline so its earliest start
+        // lands on the requester's own earliest RAW start: relative structure (the schedule) is
+        // untouched, only the calendar anchor moves.
+        var _reqMin = Infinity;
+        for (_ri = 0; _ri < items.length; _ri++) if (items[_ri].s < _reqMin) _reqMin = items[_ri].s;
+        var _delta = (isFinite(_reqMin) && isFinite(_cache.minS)) ? (_reqMin - _cache.minS) : 0;
+        var _rstrag = {};
         for (_ri = 0; _ri < items.length; _ri++) {
           var _rc = _cache.map[items[_ri].guid];
-          if (_rc) { items[_ri].s = _rc.start; items[_ri].e = _rc.end; }
+          if (_rc) {
+            items[_ri].s = _rc.start + _delta; items[_ri].e = _rc.end + _delta;
+            if (_rc.str) _rstrag[items[_ri].guid] = 1;
+          }
         }
         _displayTimeline._last = null;
         var _raud = _midairAudit(items);
         console.log('§CPM_DISPLAY_REUSE hits=' + _rh + ' misses=' + _rm + ' midair=' + _raud.midair +
+          ' epochShiftDays=' + (_delta / 86400000).toFixed(1) +
           ' — this consumer replays the SAME timeline its partner authored (one truth, no second recipe)');
-        return { cpm: 'reuse', midair: _raud.midair, stats: null };
+        return { cpm: 'reuse', midair: _raud.midair, stats: null, strag: _rstrag };
       }
     }
     if (_CPM_DISPLAY && typeof CpmSchedule !== 'undefined' && CpmSchedule.run) {
@@ -4549,17 +4562,19 @@
       if (r && r.ok) {
         for (var i = 0; i < items.length; i++) { items[i].s = r.solution.times[i].s; items[i].e = r.solution.times[i].e; }
         var aud = _midairAudit(items);
-        _displayTimelineRemember(items);
+        _displayTimelineRemember(items, r.graph.stragglerOf);
         console.log('§CPM_DISPLAY on — one-DAG schedule authored the display timeline' +
           ' midair=' + aud.midair + ' orphans=' + aud.orphans +
           ' stragglers=' + r.graph.counts.stragglers + ' (0 midair = nothing appears before what it touches)');
-        return { cpm: true, midair: aud.midair, stats: r };
+        var _cstrag = {};
+        for (var _ci = 0; _ci < items.length; _ci++) if (r.graph.stragglerOf[_ci]) _cstrag[items[_ci].guid] = 1;
+        return { cpm: true, midair: aud.midair, stats: r, strag: _cstrag };
       }
       console.warn('§CPM_DISPLAY_FALLBACK CpmSchedule.run failed — legacy repair chain used');
     }
     var tw = _twoTierRemap(items);
     _midairRepair(items);
-    _displayTimelineRemember(items);
+    _displayTimelineRemember(items, null);
     return { cpm: false, stats: tw };
   }
   // §CPM_DISPLAY_ONE_TRUTH: the LAST computed display timeline, guid-keyed. materializeZones'
@@ -4569,10 +4584,13 @@
   // (measured live on Terminal, 2026-08-16: makespan 151.2d vs 121.2d, 36/72 task windows
   // duration-mismatched, §CROSSTASK_JUDGE_PARITY floating 9). Coverage is the fingerprint — a
   // different building's guids simply miss and fall through to the compute path.
-  function _displayTimelineRemember(items) {
-    var map = {};
-    for (var i = 0; i < items.length; i++) map[items[i].guid] = { start: items[i].s, end: items[i].e };
-    _displayTimeline._last = { map: map, n: items.length };
+  function _displayTimelineRemember(items, stragglerOf) {
+    var map = {}, minS = Infinity;
+    for (var i = 0; i < items.length; i++) {
+      map[items[i].guid] = { start: items[i].s, end: items[i].e, str: stragglerOf ? stragglerOf[i] : 0 };
+      if (items[i].s < minS) minS = items[i].s;
+    }
+    _displayTimeline._last = { map: map, n: items.length, minS: minS };
   }
 
   // §ZONE_DISPLAY_AUTHORING (2026-08-16, bim-compiler prompts/4D_SCHEDULE_PERFECTION.md
@@ -4594,9 +4612,47 @@
         cls: el.cls, seq: el.seq, phase: el.phase, storey: el.storey });
     });
     if (!items.length) return null;
-    _displayTimeline(items);   // §CPM_DISPLAY: same single source as the kernel_ops write path
+    var _dtRes = _displayTimeline(items);   // §CPM_DISPLAY: same single source as the kernel_ops write path
     var out = {};
-    items.forEach(function (it) { out[it.guid] = { start: it.s, end: it.e }; });
+    // §ZONE_WINDOW_DAGWINS_CLIP (2026-08-16, bim-compiler prompts/4D_SCHEDULE_ARCHITECTURE_REDESIGN.md
+    // — user live report: "the schedule looks gibberish", measured: every Hospital task bar ran to
+    // project end because each (phase, level) group's min/max envelope was smeared by its dag-wins
+    // stragglers, 11,215/63,415 physics-forced-late elements). For WINDOW AUTHORING ONLY, a
+    // straggler's time is clamped into its group's non-straggler envelope, so the bar shows the
+    // group's own coherent block — the shipped pre-CPM semantics exactly (`_tier1Extents` always
+    // excluded `_t1Straggler` from serialization extents). The movie/ops keep TRUE physics times:
+    // a straggler appears after its bar, §TIER_DAG_WINS doctrine — counted, never hidden.
+    var _strag = _dtRes && _dtRes.strag;
+    if (_strag) {
+      var _SGw = (typeof ScheduleGate !== 'undefined') ? ScheduleGate : null;
+      var _env = {}, _gkOf = function (it) {
+        return (it.phase || '_UNPHASED') + '||' + (_SGw && _SGw.collapsePhase ? _SGw.collapsePhase(it.storey) : (it.storey || ''));
+      };
+      items.forEach(function (it) {
+        if (_strag[it.guid]) return;
+        var k = _gkOf(it), e2 = _env[k] || (_env[k] = { min: Infinity, max: -Infinity });
+        if (it.s < e2.min) e2.min = it.s;
+        if (it.e > e2.max) e2.max = it.e;
+      });
+      var _clamped = 0;
+      items.forEach(function (it) {
+        var st = it.s, en = it.e;
+        if (_strag[it.guid]) {
+          var e2 = _env[_gkOf(it)];
+          if (e2 && e2.max > e2.min) {
+            st = Math.min(Math.max(st, e2.min), e2.max);
+            en = Math.min(Math.max(en, e2.min), e2.max);
+            if (en <= st) { st = Math.max(e2.min, e2.max - 60000); en = e2.max; }
+            _clamped++;
+          }
+        }
+        out[it.guid] = { start: st, end: en };
+      });
+      console.log('§ZONE_WINDOW_DAGWINS_CLIP clamped=' + _clamped +
+        ' (straggler times clamped into their group envelope for WINDOW AUTHORING ONLY — ops/movie keep true physics times)');
+    } else {
+      items.forEach(function (it) { out[it.guid] = { start: it.s, end: it.e }; });
+    }
     return out;
   }
 
@@ -5685,8 +5741,9 @@
     }
     console.log('§GANTT injected=' + count + ' dbElements=' + totalDbElements +
       ' sceneMeshGUIDs=' + sceneGuids +
-      ', bands=' + storeyNames.length + ', ' + projectDays + ' days, scale=' + scaleFactor.toFixed(2) +
-      ', start=' + startDate.toLocaleDateString() + ' end=' + endDate.toLocaleDateString());
+      ', bands=' + storeyNames.length + ', serialClockDays=' + projectDays + ', scale=' + scaleFactor.toFixed(2) +
+      ', anchor=' + new Date(baseMs).toLocaleDateString() + ' end=' + endDate.toLocaleDateString() +
+      ' (anchor=real ops epoch; serialClockDays sizes the degenerate-project floor, not the axis)');
 
     // ── T3 §3.1/§3.3: overlay captured task names + the captured project window onto covered
     // elements. The generative pass above already laid every element on the real-start epoch
@@ -5819,7 +5876,24 @@
       // not a new correctness class.
       // §ZONE_DISPLAY_AUTHORING (2026-08-16): extracted into the named _capWindowRescale so
       // witnesses/probes can slice the SHIPPED rescale instead of maintaining copies — body verbatim.
-      _capWindowRescale(_allScheduled, _cap.win);
+      // §CAP_RESCALE_SKIP (2026-08-16, bim-compiler prompts/4D_SCHEDULE_ARCHITECTURE_REDESIGN.md
+      // §ZONE_WINDOW_DAGWINS_CLIP follow-through): a display-authored schedule's windows are VIEWS
+      // of these very element times — there is nothing to reconcile, and every reconciliation
+      // attempt measurably damaged the contact order (gap-clamp: 4,712 manufactured violations;
+      // even a rigid per-task shift: 537). Same DB flag §OG_SWEEP_SKIP already keys on, computed
+      // once here for both. Bar EDITS are not lost: the Gantt edit machinery mutates element times
+      // directly (witness_gantt_edit_lock / witness_gantt_group_move) — this load-path rescale was
+      // only ever for imported/captured windows, which keep it below.
+      var _capDisplayAuthored = false;
+      try {
+        var _daR0 = db.exec('SELECT 1 FROM schedules WHERE display_authored=1 LIMIT 1');
+        _capDisplayAuthored = !!(_daR0.length && _daR0[0].values.length);
+      } catch (e0) { /* legacy DB without the column — rescale stays */ }
+      if (_capDisplayAuthored) {
+        console.log('§CAP_RESCALE_SKIP display-authored windows are views of these element times — nothing to reconcile');
+      } else {
+        _capWindowRescale(_allScheduled, _cap.win);
+      }
       function _capWindowRescale(_allScheduled, _win) {
       var _GANTT_GAP_CLAMP_K = 500;
       var _taskItems = {}, _taskSpan = {};
@@ -5850,18 +5924,19 @@
         var arr = _taskItems[tid];
         var w = _win[tid];
         var sp = _taskSpan[tid];
-        // tolerance = 2 days: a display-authored window is the floor(start)/ceil(end) DAY
-        // ENVELOPE of these times (§ZONE_ENVELOPE_DAYS), so its duration legitimately exceeds the
-        // element span by up to one day at each edge — the quantum is the window's own rounding,
-        // never a tuned constant.
-        if (w && Math.abs((w.e - w.s) - (sp.max - sp.min)) <= 2 * _identD) {
+        // identity = the window is the HEAD of its own element span: same start within the 2-day
+        // floor/ceil quantum (§ZONE_ENVELOPE_DAYS), and no wider than the span needs. The span may
+        // legitimately OVERHANG the window (§ZONE_WINDOW_DAGWINS_CLIP: a dag-wins straggler rides
+        // OUTSIDE its bar and is never squeezed back in — squeezing is what manufactured 4,712
+        // violations from a 0-floating timeline). Identity tasks take a RIGID SHIFT only (<=2d
+        // day-rounding), order and spacing byte-exact. A bar a planner moved (start off by >2d) or
+        // widened past its own span still takes the full rescale below.
+        // action for an identity task: NOTHING — replay verbatim. Even a rigid per-task shift is
+        // poison here (measured: sub-2-day differential shifts across tasks broke 537 cross-task
+        // contact pairs, 34 of them unrepairable because a straggler sits outside its own window).
+        // The window is a floor/ceil VIEW of these exact times; there is nothing to move.
+        if (w && Math.abs(w.s - sp.min) <= 2 * _identD && (w.e - w.s) <= (sp.max - sp.min) + 2 * _identD) {
           _identSkipped++;
-          var _af = (w.e - w.s) / Math.max(1, sp.max - sp.min);
-          for (var _ai = 0; _ai < arr.length; _ai++) {
-            var _it = arr[_ai], _dur = Math.max(0, _it.e - _it.s);
-            _it.s = w.s + Math.floor((_it.s - sp.min) * _af);
-            _it.e = _it.s + Math.max(60000, Math.floor(_dur * _af));
-          }
           return;
         }
         _identRescaled++;
@@ -5902,7 +5977,7 @@
           item.e = item.s + scaledDur;       // never zero/negative duration (floor already >=60000)
         }
       });
-      console.log('§CAP_RESCALE_IDENTITY tasks=' + _identSkipped + '/' + (_identSkipped + _identRescaled) + ' affine-rebased shape-exact (window duration==own envelope duration); reSpaced=' + _identRescaled);
+      console.log('§CAP_RESCALE_IDENTITY tasks=' + _identSkipped + '/' + (_identSkipped + _identRescaled) + ' replayed verbatim (window==head of own span within day rounding); reSpaced=' + _identRescaled);
       }
       // §ZONE_DISPLAY_AUTHORING (2026-08-16): when the task windows were authored FROM the display
       // timeline (schedules.display_authored=1, written by materializeZones' displayRemap path),
@@ -8077,7 +8152,8 @@
   // huts going first before the walls" AFTER a hard reset, because §GANTT_CACHE_HIT served a
   // gantt:v4 entry generated under the old ordering. A hard reset cannot clear it — the entry is in
   // IndexedDB, not the HTTP cache. This bump is that fix's second half.
-  var _GANTT_CACHE_VERSION = 28;   // §CPM_DISPLAY (2026-08-16): display timeline authored by the one-DAG CPM pass
+  var _GANTT_CACHE_VERSION = 29;   // §ZONE_WINDOW_DAGWINS_CLIP + §CAP_RESCALE_SKIP + §CPM_DISPLAY_EPOCH
+  // was 28:   // §CPM_DISPLAY (2026-08-16): display timeline authored by the one-DAG CPM pass
   // was 27:   // §ZONE_DISPLAY_AUTHORING (2026-08-16): task windows authored from
                                    // the DISPLAY timeline + strict-bar sweep skipped on that path —
                                    // one schedule for movie and Gantt. Bump re-materializes stale

--- a/viewer/viewer.html
+++ b/viewer/viewer.html
@@ -933,9 +933,9 @@ html.bim-embedded, html.bim-embedded body { background: #0b0b0b; }
 <script src="precision_cam.js?v=8" onerror="console.warn('§LOAD_FAIL precision_cam.js')"></script>
 <script src="schedule_gate.js?v=3" onerror="console.warn('§LOAD_FAIL schedule_gate.js')"></script>
 <script src="cpm_schedule.js?v=1" onerror="console.warn('§LOAD_FAIL cpm_schedule.js')"></script>
-<script src="time_machine.js?v=70" onerror="console.warn('§LOAD_FAIL time_machine.js')"></script>
+<script src="time_machine.js?v=71" onerror="console.warn('§LOAD_FAIL time_machine.js')"></script>
 <script src="dlod_nav.js?v=2" onerror="console.warn('§LOAD_FAIL dlod_nav.js')"></script>
-<script src="schedule_author.js?v=13" onerror="console.warn('§LOAD_FAIL schedule_author.js')"></script>
+<script src="schedule_author.js?v=14" onerror="console.warn('§LOAD_FAIL schedule_author.js')"></script>
 <script src="schedule_sync.js?v=3" onerror="console.warn('§LOAD_FAIL schedule_sync.js')"></script>
 <script src="schedule_author_ui.js?v=9" onerror="console.warn('§LOAD_FAIL schedule_author_ui.js')"></script>
 <script src="error_reporter.js?v=1" onerror="console.warn('§LOAD_FAIL error_reporter.js')"></script>


### PR DESCRIPTION
Follow-through on #1398 after the user's live report: *"setting up 4D during Time Machine is eating up lots of mem resources, hangs a bit, and the schedule looks gibberish."*

## Root cause (measured, headless Hospital in the real viewer)
Every task bar ran 2026-08-16 → 2027-09-07 — full project width — because derived windows were min/max envelopes smeared by each group's **dag-wins stragglers** (11,215/63,415 physics-forced-late elements). That wall of full-width bars is the "gibberish".

## Fixes
- **§ZONE_WINDOW_DAGWINS_CLIP** — window authoring clamps straggler times into their group's non-straggler envelope (the shipped pre-CPM semantics: `_tier1Extents` always excluded `_t1Straggler`). Ops/movie keep true physics times; a straggler rides outside its bar — counted, never hidden.
- **§CAP_RESCALE_SKIP** — display-authored windows are views of these element times: the load-path rescale is skipped outright (gap-clamp manufactured 4,712 violations from a 0-floating timeline; even a rigid per-task shift broke 537 cross-task pairs — both measured). Bar edits still land via the Gantt edit machinery (mutates element times directly). Imported/captured schedules keep the rescale.
- **§CPM_DISPLAY_EPOCH** — one-truth reuse rigid-shifts the cached timeline onto the requester's epoch (measured live: `epochShiftDays=20672.7` — uncovered ops were landing in 1970).
- `§GANTT injected` line now prints the real ops anchor instead of the serial-clock cosmetic start (was `start=2/22/2023, 1271 days` on a 388-day schedule).

## Measured
| bar | result |
|---|---|
| fleet display-path probe | **7/7 PASS** — floating 0, nonStragglerOutside 0 on every building |
| live headless Hospital | task cascade Substructure Aug 16–18 → Superstructure Aug 17–23 → Architecture Aug 22–Oct 17…; §CJP pushed=0, floating=0/63,415 |
| gate_4d.sh | 7/7 |
| witness_zone_display_authoring | 16/16 (W-ZDA-6 now judges the ops timeline, not the window view) |
| witness_midair_zero | 39/39 |

Hang/memory: activation is ~20s on Hospital, 7.2s of it the pre-existing chunked kernel_ops write loop (§WRITE_LOOP_TIMING) — unchanged here, named for a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)