### PR TITLE
test(4d): probe_gantt_stagger.js — headless per-task window dump + stagger metrics, any building, both engines

### DIFF
--- a/scripts/probe_gantt_stagger.js
+++ b/scripts/probe_gantt_stagger.js
@@ -1,0 +1,80 @@
+#!/usr/bin/env node
+// probe_gantt_stagger.js — quantify Gantt "stagger" for any building, BOTH engines (CPM4D=0 legacy):
+// dump all authored task windows, compute (a) within-level phase order violations, (b) per-phase
+// level cascade overlap, (c) global parallelism. Numbers, not looks.
+'use strict';
+const { spawn } = require('child_process');
+const puppeteer = require(process.env.PUPPETEER || 'puppeteer');
+const PORT = 8125;
+const MODE = process.env.CPM4D === '0' ? '&cpm4d=0' : '';
+const BLD = process.env.BLD || 'Terminal_extracted';
+const URL = `http://localhost:${PORT}/viewer/viewer.html?db=/buildings/${BLD}.db${MODE}`;
+
+async function main() {
+  const server = spawn('python3', ['-m', 'http.server', String(PORT), '--directory', process.env.SERVE_ROOT || '/tmp/cpm-serve'], { stdio: 'ignore' });
+  await new Promise(r => setTimeout(r, 1500));
+  const browser = await puppeteer.launch({ headless: 'new',
+    args: ['--no-sandbox', '--disable-dev-shm-usage', '--use-angle=swiftshader', '--enable-unsafe-swiftshader'] });
+  const page = await browser.newPage();
+  const lines = [];
+  page.on('console', m => { const t = m.text(); if (t.indexOf('§') >= 0) lines.push(t); });
+  await page.goto(URL, { waitUntil: 'domcontentloaded', timeout: 60000 });
+  await page.waitForFunction(() => typeof window.toggleTimeMachine === 'function', { timeout: 180000 });
+  await page.waitForFunction(() => window.APP && window.APP.db, { timeout: 240000 }).catch(() => {});
+  await new Promise(r => setTimeout(r, 15000));
+  await page.evaluate(() => window.toggleTimeMachine());
+  const deadline = Date.now() + 300000;
+  while (Date.now() < deadline) {
+    if (lines.some(l => l.indexOf('§TIME_MACHINE ON') >= 0)) break;
+    await new Promise(r => setTimeout(r, 2000));
+  }
+  const rows = await page.evaluate(() => {
+    const r = window.APP.db.exec("SELECT t.task_id, t.schedule_start, t.schedule_finish, COUNT(te.guid) " +
+      "FROM tasks t LEFT JOIN task_elements te ON te.task_id=t.task_id " +
+      "WHERE t.schedule_id='SCH_AUTHORED' AND (t.is_summary IS NULL OR t.is_summary=0) " +
+      "GROUP BY t.task_id ORDER BY t.schedule_start");
+    return r.length ? r[0].values : [];
+  });
+  console.log('MODE=' + (MODE ? 'legacy' : 'cpm') + ' BLD=' + BLD);
+  const D = 86400000, parse = s => new Date(s).getTime();
+  const t0 = Math.min(...rows.map(r => parse(r[1])));
+  const tasks = rows.map(r => {
+    const m = String(r[0]).match(/^TASK_(.+)_([^_]*Level[^_]*|.+)$/);
+    return { id: r[0], s: (parse(r[1]) - t0) / D, e: (parse(r[2]) - t0) / D, n: r[3] };
+  });
+  tasks.forEach(t => console.log('TASK ' + t.id + ' s=' + t.s.toFixed(0) + ' e=' + t.e.toFixed(0) + ' n=' + t.n));
+  // stagger metrics from task ids: TASK_<phase>_<storey>, phase in known set
+  const PH = ['Substructure', 'Superstructure', 'Architecture', 'MEP_Rough_in', 'MEP_Final', 'Finishes'];
+  const per = {};
+  tasks.forEach(t => {
+    for (const p of PH) {
+      if (t.id.startsWith('TASK_' + p + '_')) {
+        const st = t.id.slice(('TASK_' + p + '_').length);
+        (per[st] = per[st] || {})[p] = t;
+        break;
+      }
+    }
+  });
+  let phasePairs = 0, phaseOverlapPairs = 0, overlapDaysSum = 0;
+  Object.keys(per).forEach(st => {
+    const g = per[st];
+    for (let i = 0; i + 1 < PH.length; i++) {
+      for (let j = i + 1; j < PH.length; j++) {
+        const a = g[PH[i]], b = g[PH[j]];
+        if (!a || !b) continue;
+        phasePairs++;
+        const ov = Math.min(a.e, b.e) - Math.max(a.s, b.s);
+        if (ov > 1) { phaseOverlapPairs++; overlapDaysSum += ov; }
+      }
+    }
+  });
+  const spans = tasks.map(t => t.e - t.s);
+  const total = Math.max(...tasks.map(t => t.e));
+  const sumSpan = spans.reduce((a, b) => a + b, 0);
+  console.log('METRIC withinLevelPhasePairs=' + phasePairs + ' overlapping=' + phaseOverlapPairs +
+    ' overlapDaysSum=' + overlapDaysSum.toFixed(0) +
+    ' parallelism=' + (sumSpan / Math.max(1, total)).toFixed(2) + 'x totalDays=' + total.toFixed(0) +
+    ' tasks=' + tasks.length);
+  await browser.close(); server.kill(); process.exit(0);
+}
+main().catch(e => { console.error('ERR ' + (e && e.stack || e)); process.exit(2); });


### PR DESCRIPTION
Harness for prompts/4D_GANTT_TM_REFACTOR.md (bim-compiler): dumps every authored task's
[start,end,n] from the real viewer's DB after TM activation and computes within-level phase
overlap + parallelism. Found the 'many stacked equi-shaped bars' signature on Terminal:
49/72 tasks as 1-2-day bars all at day 149-150 (Superstructure_05: 10,355 elements in a 1-day
bar). ENV: BLD=<name> CPM4D=0 SERVE_ROOT=<dir> PUPPETEER=<path>.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
