### PR TITLE
fix(4d): §S1_BAND_RANK — E4 storey hammocks + straggler group-key use 3m z-bands, not storey names

### DIFF
--- a/viewer/cpm_schedule.js
+++ b/viewer/cpm_schedule.js
@@ -145,14 +145,29 @@
       if (L) { var a = lvlAgg[L] || (lvlAgg[L] = { sum: 0, c: 0 }); a.sum += items[i].bz; a.c++; }
     }
     var levels = Object.keys(lvlAgg).sort(function (a, b) { return lvlAgg[a].sum / lvlAgg[a].c - lvlAgg[b].sum / lvlAgg[b].c; });
-    var lvlRank = {}; levels.forEach(function (L, r) { lvlRank[L] = r; });
 
-    // Group key = lexicographic (levelRank, phaseRank) as one int; phaseRank = Tier-1 chain index,
-    // Tier-2 = 3. Every hammock gate points to a strictly LARGER key than its own.
+    // M1 (4D_GANTT_TM_REFACTOR.md) — a LEVEL, to the gates, is a physical 3-metre z-band, not a
+    // storey name. Precedent: the shipped §GANTT banding (time_machine.js `band: Math.floor(cz/3)`)
+    // and §4D_BAND_MONOTONIC's own band-rank gate — same quantum, reused here, not invented.
+    // bandOfLevel = floor(meanZ/3m); bandRank = dense rank of the distinct band values PRESENT
+    // (ascending), so federated pseudo-levels sharing one physical storey (Terminal's Kedai/Jalan/
+    // Tanah cluster) collapse onto the SAME bandRank and are never chained to each other by E4.
+    var bandOfLevel = {};
+    levels.forEach(function (L) { bandOfLevel[L] = Math.floor((lvlAgg[L].sum / lvlAgg[L].c) / 3); });
+    var bandValues = [];
+    levels.forEach(function (L) { if (bandValues.indexOf(bandOfLevel[L]) < 0) bandValues.push(bandOfLevel[L]); });
+    bandValues.sort(function (a, b) { return a - b; });
+    var bandRankOfBand = {}; bandValues.forEach(function (b, r) { bandRankOfBand[b] = r; });
+    var bandRank = {}; levels.forEach(function (L) { bandRank[L] = bandRankOfBand[bandOfLevel[L]]; });
+
+    // Group key = lexicographic (bandRank, phaseRank) as one int; phaseRank = Tier-1 chain index,
+    // Tier-2 = 3. Every hammock gate points to a strictly LARGER key than its own. bandRank (not
+    // per-name lvlRank) is the M1 straggler group-key so cross-ladder ancestry inside one physical
+    // band stops manufacturing false stragglers.
     function phaseRank(P) { var t = TIER1_ORDER.indexOf(P); return t >= 0 ? t : 3; }
     function groupKeyOf(i2) {
       if (!lvlOf[i2]) return -1;
-      return lvlRank[lvlOf[i2]] * 8 + phaseRank(items[i2].phase || '_UNPHASED');
+      return bandRank[lvlOf[i2]] * 8 + phaseRank(items[i2].phase || '_UNPHASED');
     }
 
     // §CPM_STRAGGLER_MEMBERSHIP propagation: maxAncKey over the PHYSICS-ONLY condensation
@@ -245,17 +260,31 @@
       });
     });
 
-    // E4 — storey hammocks per phase: M(P, level k) -> elements of (P, next level where P present).
+    // E4 — storey hammocks per phase, band-to-band (M1, THE MISSING/CORRECTED EDGE): every M(L,P)
+    // with L in band b -> elements of (P, L') for every L' in the next PRESENT band. Levels sharing
+    // one band are parallel sub-buildings (e.g. Terminal's Kedai shop block vs the main hall) and
+    // are NEVER chained to each other — only band-to-band edges exist.
     var phases = {};
     Object.keys(groups).forEach(function (key) {
       var cut = key.indexOf('||');
       (phases[key.slice(cut + 2)] = phases[key.slice(cut + 2)] || []).push(key.slice(0, cut));
     });
     Object.keys(phases).forEach(function (P) {
-      var ls = phases[P].sort(function (a, b) { return lvlRank[a] - lvlRank[b]; });
-      for (var p = 0; p + 1 < ls.length; p++) {
-        var m = milestone(ls[p], P), succ = groups[ls[p + 1] + '||' + P];
-        for (var k = 0; k < succ.length; k++) addEdge(m, succ[k], FS, 4, 'e4');
+      var byBand = {};
+      phases[P].forEach(function (L) {
+        var br = bandRank[L];
+        (byBand[br] = byBand[br] || []).push(L);
+      });
+      var bandRanksPresent = Object.keys(byBand).map(Number).sort(function (a, b) { return a - b; });
+      for (var p = 0; p + 1 < bandRanksPresent.length; p++) {
+        var fromLevels = byBand[bandRanksPresent[p]], toLevels = byBand[bandRanksPresent[p + 1]];
+        fromLevels.forEach(function (L) {
+          var m = milestone(L, P);
+          toLevels.forEach(function (L2) {
+            var succ = groups[L2 + '||' + P];
+            for (var k = 0; k < succ.length; k++) addEdge(m, succ[k], FS, 4, 'e4');
+          });
+        });
       }
     });
 


### PR DESCRIPTION
## Summary
Implements `prompts/4D_GANTT_TM_REFACTOR.md` §MODEL M1 + §STAGES S1 (bim-compiler). `cpm_schedule.js`'s `buildGraph()` replaces per-storey-name `lvlRank` with `bandRank` (dense rank of `floor(meanZ/3m)`, same quantum as the shipped `§GANTT` banding / `§4D_BAND_MONOTONIC`) in two places:
- **groupKeyOf** (straggler classification) — federated pseudo-levels sharing one physical floor (Terminal's Kedai/Jalan/Tanah cluster, JKR's Ground-Floor-name triplets) now share one bandRank instead of arbitrary name-tie-broken distinct ranks.
- **E4 storey hammocks** — chain band *b*'s milestones → band *b+1*'s elements (next PRESENT band), for every level pair in that band, instead of chaining named levels 1:1 regardless of z-proximity. Levels sharing a band are parallel sub-buildings, never chained to each other.

## Evidence (read the log, not the exit code)

**`node scripts/probe_cpm_schedule.js` — fleet, all 7 buildings:**
```
§CPM_FLOATING midair=0 structural=0   (all 7 buildings, unchanged)
§CPM_GATE_CHECK elementEdgeViolations=0 PASS   (all 7)
§CPM_PARITY ... elementMismatch=0 ... PASS   (all 7, unaffected — E1/E2 physics untouched)
cycleDrops e3=0 e4=0 member=0   (all 7, no new cycle class; contractedSccs identical to baseline)
```

**`node scripts/probe_cpm_display_path.js` — 7/7 PASS:**
```
§CPMDP_FLEET_VERDICT buildings=7 fails=0 PASS
nonStragglerOutside=0 on all 7 (the hard bar)
```

**`VIEWER_DIR=<worktree>/viewer BLD_DIR=~/bim-ootb/buildings bash scripts/gate_4d.sh` (bim-compiler):**
```
§GATE_4D_RESULT pass=7 fail=0 missing=1
```
(the one MISS — `witness_arch_area_weight`, "not in this revision" — is pre-existing on clean origin/main, not caused by this change)

## Mixed result on the softer, non-gating metrics (measured, not hidden)
- Terminal `§CPM_RUN` stragglers rose **9,678 → 13,084** — the spec predicted a material drop from a differently-measured 14,129 baseline; the actual direction on this harness's own number went the other way.
- `§CPM_STOREY_PHASE` violations: **Clinic 0→2 (worse), JKR 3→4 (worse)**, HHS 1→0 (better), LTU 8→7 (better), Duplex/Hospital/Terminal unchanged count.

Traced mechanism (not a bug): band-collapsing removes arbitrary per-name separation between same-floor federated pseudo-levels. This correctly exposes intra-floor phase-order dag-wins as stragglers that per-name `lvlRank` ties previously hid — consistent with the project's own `§TIER_DAG_WINS` doctrine ("physics beats phase tidiness … counted, never hidden"), not a regression in the hard sense. None of `§DISPATCH`'s 5 explicit STOP triggers fired (floating / gate-check / new cycle class / invented constant / witness-baseline surprise all clean), so per this project's WORK-TO-ZERO discipline this proceeds to S2 rather than blocking — S2's own acceptance (bar-shape readability, the actual user symptom) is the real test of whether this stage's model change is right. Full numbers logged in `bim-compiler prompts/4D_GANTT_TM_REFACTOR.md` dated 2026-08-16 §S1 section.

## Test plan
- [x] `node scripts/probe_cpm_schedule.js` — floating 0/7, gate-check 0/7, parity 7/7, cycleDrops 0/7
- [x] `node scripts/probe_cpm_display_path.js` — 7/7 PASS
- [x] `bash scripts/gate_4d.sh` (bim-compiler) — pass=7 fail=0 missing=1 (pre-existing)

🤖 Generated with [Claude Code](https://claude.com/claude-code)