### PR TITLE
fix(4d): §S2_TUKEY_ENVELOPE — task bars = classification-free robust envelope, not straggler min/max

### DIFF
--- a/scripts/probe_cpm_display_path.js
+++ b/scripts/probe_cpm_display_path.js
@@ -81,29 +81,36 @@ async function runBuilding(SQL, RATES, name) {
 
   // §ZONE_DISPLAY_AUTHORING with the CPM display schedule: deriveZones + day-rounded windows
   // (materializeZones' own construction, verbatim from probe_captured_floating.js).
-  // §ZONE_WINDOW_DAGWINS_CLIP mirror: straggler times clamped into their group's non-straggler
-  // envelope for WINDOW AUTHORING ONLY (the played items keep true physics times).
-  const stragOf = res.graph.stragglerOf;
-  const envByG = {};
+  // §ZONE_WINDOW_DAGWINS_CLIP mirror (M2, 4D_GANTT_TM_REFACTOR.md) — Tukey-fenced robust envelope
+  // over ALL members' times (classification-free), mirroring time_machine.js's own _tmDisplayRemap
+  // formula verbatim. Percentile convention: sorted[Math.floor(n*p)] (matches storeyOrderReport).
   const gkOf = o => (o.phase || '_UNPHASED') + '||' + ScheduleGate.collapsePhase(o.storey);
-  items.forEach((o, i) => {
-    if (stragOf[i]) return;
-    const k = gkOf(o), e2 = envByG[k] || (envByG[k] = { min: Infinity, max: -Infinity });
-    if (o.s < e2.min) e2.min = o.s;
-    if (o.e > e2.max) e2.max = o.e;
+  const groupsByG = {};
+  items.forEach(o => {
+    const k = gkOf(o), g = groupsByG[k] || (groupsByG[k] = { starts: [], ends: [] });
+    g.starts.push(o.s); g.ends.push(o.e);
+  });
+  function tukeyBound(arr, lowSide) {
+    const s = arr.slice().sort((a, b) => a - b);
+    const n = s.length, q1 = s[Math.floor(n * 0.25)], q3 = s[Math.floor(n * 0.75)], iqr = q3 - q1;
+    return lowSide ? Math.max(s[0], q1 - 1.5 * iqr) : Math.min(s[n - 1], q3 + 1.5 * iqr);
+  }
+  const barByG = {};
+  Object.keys(groupsByG).forEach(k => {
+    const g = groupsByG[k], lo = tukeyBound(g.starts, true), hi = tukeyBound(g.ends, false);
+    barByG[k] = { lo, hi: Math.max(hi, lo) };
   });
   const dispSchedule = {};
   let clamped = 0;
-  items.forEach((o, i) => {
+  const outlierGuid = {};
+  items.forEach(o => {
+    const b = barByG[gkOf(o)];
     let st = o.s, en = o.e;
-    if (stragOf[i]) {
-      const e2 = envByG[gkOf(o)];
-      if (e2 && e2.max > e2.min) {
-        st = Math.min(Math.max(st, e2.min), e2.max);
-        en = Math.min(Math.max(en, e2.min), e2.max);
-        if (en <= st) { st = Math.max(e2.min, e2.max - 60000); en = e2.max; }
-        clamped++;
-      }
+    if (b) {
+      let nst = Math.min(Math.max(st, b.lo), b.hi), nen = Math.min(Math.max(en, b.lo), b.hi);
+      if (nen <= nst) { nst = Math.max(b.lo, b.hi - 60000); nen = b.hi; }
+      if (nst !== st || nen !== en) { clamped++; outlierGuid[o.guid] = 1; }
+      st = nst; en = nen;
     }
     dispSchedule[o.guid] = { start: st, end: en };
   });
@@ -138,25 +145,26 @@ async function runBuilding(SQL, RATES, name) {
   console.log('§CPMDP_FINAL floating=' + final.midair + ' windowBlocked=' + cjp.windowBlocked +
     ' cjpPushed=' + cjp.pushed + ' byClass=' + JSON.stringify(final.byClass));
 
-  // Window fidelity of the played timeline vs its own authored windows. A dag-wins straggler
-  // legitimately rides OUTSIDE its bar (§ZONE_WINDOW_DAGWINS_CLIP — counted, never hidden);
-  // any NON-straggler outside its window is a real defect and must be 0.
-  const stragGuid = {};
-  items.forEach((o, i) => { if (stragOf[i]) stragGuid[o.guid] = 1; });
-  let inWin = 0, stragOut = 0, otherOut = 0;
+  // Window fidelity of the played timeline vs its own authored windows. A Tukey outlier
+  // legitimately rides OUTSIDE its bar (§ZONE_WINDOW_DAGWINS_CLIP M2 — counted, never hidden);
+  // the hard bar (4D_GANTT_TM_REFACTOR.md §STAGES S2): elements outside their bar <= the
+  // Tukey-outlier count. Set-membership check (stricter, implies the count bar): any element
+  // outside its window that was NOT flagged an outlier during fencing is a real defect, must be 0.
+  let inWin = 0, outlierOutside = 0, otherOut = 0;
   rescaled.forEach(function (o) {
     const w = taskWin[o.task]; if (!w) return;
     if (o.s >= w.s && o.e <= w.e) inWin++;
-    else if (stragGuid[o.guid]) stragOut++;
+    else if (outlierGuid[o.guid]) outlierOutside++;
     else otherOut++;
   });
-  console.log('§CPMDP_WINDOW_FIDELITY inWindow=' + inWin + '/' + (inWin + stragOut + otherOut) +
-    ' stragglerOutside=' + stragOut + ' nonStragglerOutside=' + otherOut + ' (bar: nonStraggler must be 0)');
+  console.log('§CPMDP_WINDOW_FIDELITY inWindow=' + inWin + '/' + (inWin + outlierOutside + otherOut) +
+    ' outlierOutside=' + outlierOutside + '/' + clamped + ' nonOutlierOutside=' + otherOut +
+    ' (bar: outside <= Tukey-outlier count; nonOutlier outside must be 0)');
 
   const pass = final.midair === 0 && otherOut === 0;
-  console.log('§CPMDP_ACCEPT ' + name + ' finalFloating=' + final.midair + ' nonStragglerOutside=' + otherOut + ' ' + (pass ? 'PASS' : 'FAIL'));
+  console.log('§CPMDP_ACCEPT ' + name + ' finalFloating=' + final.midair + ' nonOutlierOutside=' + otherOut + ' ' + (pass ? 'PASS' : 'FAIL'));
   return { name, final: final.midair, pre: preRescale.midair, post: postRescale.midair,
-           stragOut, otherOut };
+           outlierOutside, otherOut };
 }
 
 async function main() {
@@ -170,7 +178,7 @@ async function main() {
   let fails = 0;
   out.forEach(r => { if (r.final !== 0 || r.otherOut !== 0) fails++; });
   console.log('§CPMDP_FLEET ' + JSON.stringify(out.map(r => [r.name, 'pre=' + r.pre, 'post=' + r.post,
-    'final=' + r.final, 'stragOut=' + r.stragOut, 'otherOut=' + r.otherOut])));
+    'final=' + r.final, 'outlierOutside=' + r.outlierOutside, 'otherOut=' + r.otherOut])));
   console.log('§CPMDP_FLEET_VERDICT buildings=' + out.length + ' fails=' + fails + ' ' + (fails === 0 ? 'PASS' : 'FAIL'));
   process.exit(fails === 0 ? 0 : 1);
 }

--- a/viewer/time_machine.js
+++ b/viewer/time_machine.js
@@ -4612,47 +4612,55 @@
         cls: el.cls, seq: el.seq, phase: el.phase, storey: el.storey });
     });
     if (!items.length) return null;
-    var _dtRes = _displayTimeline(items);   // §CPM_DISPLAY: same single source as the kernel_ops write path
+    _displayTimeline(items);   // §CPM_DISPLAY: same single source as the kernel_ops write path (times only)
     var out = {};
-    // §ZONE_WINDOW_DAGWINS_CLIP (2026-08-16, bim-compiler prompts/4D_SCHEDULE_ARCHITECTURE_REDESIGN.md
-    // — user live report: "the schedule looks gibberish", measured: every Hospital task bar ran to
-    // project end because each (phase, level) group's min/max envelope was smeared by its dag-wins
-    // stragglers, 11,215/63,415 physics-forced-late elements). For WINDOW AUTHORING ONLY, a
-    // straggler's time is clamped into its group's non-straggler envelope, so the bar shows the
-    // group's own coherent block — the shipped pre-CPM semantics exactly (`_tier1Extents` always
-    // excluded `_t1Straggler` from serialization extents). The movie/ops keep TRUE physics times:
-    // a straggler appears after its bar, §TIER_DAG_WINS doctrine — counted, never hidden.
-    var _strag = _dtRes && _dtRes.strag;
-    if (_strag) {
-      var _SGw = (typeof ScheduleGate !== 'undefined') ? ScheduleGate : null;
-      var _env = {}, _gkOf = function (it) {
-        return (it.phase || '_UNPHASED') + '||' + (_SGw && _SGw.collapsePhase ? _SGw.collapsePhase(it.storey) : (it.storey || ''));
-      };
-      items.forEach(function (it) {
-        if (_strag[it.guid]) return;
-        var k = _gkOf(it), e2 = _env[k] || (_env[k] = { min: Infinity, max: -Infinity });
-        if (it.s < e2.min) e2.min = it.s;
-        if (it.e > e2.max) e2.max = it.e;
-      });
-      var _clamped = 0;
-      items.forEach(function (it) {
-        var st = it.s, en = it.e;
-        if (_strag[it.guid]) {
-          var e2 = _env[_gkOf(it)];
-          if (e2 && e2.max > e2.min) {
-            st = Math.min(Math.max(st, e2.min), e2.max);
-            en = Math.min(Math.max(en, e2.min), e2.max);
-            if (en <= st) { st = Math.max(e2.min, e2.max - 60000); en = e2.max; }
-            _clamped++;
-          }
-        }
-        out[it.guid] = { start: st, end: en };
-      });
-      console.log('§ZONE_WINDOW_DAGWINS_CLIP clamped=' + _clamped +
-        ' (straggler times clamped into their group envelope for WINDOW AUTHORING ONLY — ops/movie keep true physics times)');
-    } else {
-      items.forEach(function (it) { out[it.guid] = { start: it.s, end: it.e }; });
+    // §ZONE_WINDOW_DAGWINS_CLIP (2026-08-16, bim-compiler prompts/4D_GANTT_TM_REFACTOR.md §MODEL M2 —
+    // superseded the min/max-over-non-stragglers formula this tag originally shipped with; tag kept,
+    // formula changed per M2's own instruction). A TASK BAR is the ROBUST ENVELOPE of ALL its
+    // members' true times — Tukey fences (Q1-1.5*IQR .. Q3+1.5*IQR, clamped to actual min/max) over
+    // member starts (low fence) and ends (high fence), the same outlier-statistic family as the
+    // shipped per-task median-based §GANTT_GAP_CLAMP. CLASSIFICATION-FREE (no straggler graph lookup
+    // needed) — right on BOTH Hospital-shaped (late-tail) and Terminal-shaped (straggler-mass)
+    // buildings, where a fixed classification undercounted/overcounted depending on shape. For WINDOW
+    // AUTHORING ONLY, every member's time is clamped into its group's fence so the bar shows the
+    // group's own coherent mass; a genuine outlier still rides outside the resulting bar (never
+    // hidden — §TIER_DAG_WINS doctrine unchanged) — deriveZones takes a plain min(start)/max(end)
+    // over what this function returns, so clamping IS the mechanism that shapes the bar. The
+    // movie/ops keep TRUE physics times (this map is window-authoring-only, per §ZONE_DISPLAY_AUTHORING
+    // above — never fed back into `items`). Percentile convention matches storeyOrderReport /
+    // §GANTT_GAP_CLAMP: sorted[Math.floor(n*p)], no interpolation.
+    var _SGw = (typeof ScheduleGate !== 'undefined') ? ScheduleGate : null;
+    var _gkOf = function (it) {
+      return (it.phase || '_UNPHASED') + '||' + (_SGw && _SGw.collapsePhase ? _SGw.collapsePhase(it.storey) : (it.storey || ''));
+    };
+    var _groups = {};
+    items.forEach(function (it) {
+      var k = _gkOf(it), g = _groups[k] || (_groups[k] = { starts: [], ends: [] });
+      g.starts.push(it.s); g.ends.push(it.e);
+    });
+    function _tukeyBound(arr, lowSide) {
+      var s = arr.slice().sort(function (a, b) { return a - b; });
+      var n = s.length, q1 = s[Math.floor(n * 0.25)], q3 = s[Math.floor(n * 0.75)], iqr = q3 - q1;
+      return lowSide ? Math.max(s[0], q1 - 1.5 * iqr) : Math.min(s[n - 1], q3 + 1.5 * iqr);
     }
+    var _bar = {};
+    Object.keys(_groups).forEach(function (k) {
+      var g = _groups[k], lo = _tukeyBound(g.starts, true), hi = _tukeyBound(g.ends, false);
+      _bar[k] = { lo: lo, hi: Math.max(hi, lo) };   // degenerate-group safety (n=1, zero IQR)
+    });
+    var _clamped = 0;
+    items.forEach(function (it) {
+      var b = _bar[_gkOf(it)], st = it.s, en = it.e;
+      if (b) {
+        var nst = Math.min(Math.max(st, b.lo), b.hi), nen = Math.min(Math.max(en, b.lo), b.hi);
+        if (nen <= nst) { nst = Math.max(b.lo, b.hi - 60000); nen = b.hi; }
+        if (nst !== st || nen !== en) _clamped++;
+        st = nst; en = nen;
+      }
+      out[it.guid] = { start: st, end: en };
+    });
+    console.log('§ZONE_WINDOW_DAGWINS_CLIP clamped=' + _clamped +
+      ' (Tukey-fenced group envelope, classification-free, for WINDOW AUTHORING ONLY — ops/movie keep true physics times)');
     return out;
   }
 


### PR DESCRIPTION
## Summary
Implements `prompts/4D_GANTT_TM_REFACTOR.md` §MODEL M2 + §STAGES S2 (bim-compiler). Replaces `_tmDisplayRemap`'s straggler-classification-based clip with a **Tukey-fenced robust envelope** (Q1-1.5·IQR .. Q3+1.5·IQR, clamped to actual min/max) computed over **ALL** group members' true start/end times — classification-free, no `graph.stragglerOf` lookup needed. Same outlier-statistic family as the shipped per-task median-based `§GANTT_GAP_CLAMP`. Mirrored verbatim in `scripts/probe_cpm_display_path.js` per the spec's own instruction; outside-window accounting renamed `stragglerOutside` → `outlierOutside`.

## Evidence (read the log, not the exit code)

**`node scripts/probe_cpm_display_path.js` — fleet, all 7 buildings:**
```
§CPMDP_FLEET_VERDICT buildings=7 fails=0 PASS
floating=0 and nonOutlierOutside=0 on all 7 (the hard bar)
```
Outlier populations are far SMALLER than the old straggler-classification population:
```
Terminal:  clamped=1186  (was stragglerOutside=9576)
Duplex:    clamped=61    (was stragglerOutside=168)
LTU:       clamped=7247  (was stragglerOutside=17348)
```

**`bash scripts/gate_4d.sh` (bim-compiler):**
```
§GATE_4D_RESULT pass=7 fail=0 missing=1
```
(same pre-existing MISS as S1 — `witness_arch_area_weight`, not caused by this stage)

**Hospital's ground-level cascade preserved** (live `probe_gantt_stagger.js`):
```
TASK_Substructure_Level_1  s=0 e=3
TASK_Superstructure_Level_1  s=1 e=387
TASK_Architecture_Level_1  s=6 e=386
```

## NOT met: Terminal's "equi-shape cluster gone" acceptance criterion

Live stagger probe, Terminal, before vs after this stage:

| metric | pre-S2 (S1 only) | post-S2 |
|---|---|---|
| tasks with n≥1,000 in a bar <2 days | 5 | 4 |
| tasks sharing exact same start day | 18/72 = 25.0% | 20/72 = 27.8% |
| tasks within ±1d of that day | 36/72 = 50.0% | 38/72 = 52.8% |

Essentially unchanged — on the clustering metric, marginally worse.

**Root-caused, not invented — checked RAW crew-leveled vs CPM-solved times directly** for Terminal's Roof-Level Superstructure population (n=10,950):
```
RAW (computeSchedule, LOCKED/untouched):  startDay p25=36.0 p50=37.9 p75=39.7  (spread ~13 days)
CPM (this lane's own solve(), post-S1):   startDay p25=130.0 p50=130.4 p75=130.4 (spread ~0.4 days)
                                            makespanDays=130.6 — i.e. compressed to the project's tail
```
**The compression is introduced by the CPM forward pass itself** (full precedence honored, `floating=0` verified independently) — NOT by `computeSchedule` (locked, untouched, confirmed spread) and NOT by this stage's window-authoring formula (S2 only reshapes which times feed `deriveZones`'s `min()`/`max()` — it cannot widen a bar whose true CPM-solved population is already this tight). Same pattern reproduces on Hospital's upper levels: `TASK_Architecture_Level_3` n=4423 in a 1-day bar, `Level_4` n=4436 in a 1-day bar, `Level_5` n=3537 in a 1-day bar.

This is neither S1's target (band-rank E4/grouping — already shipped, #1401) nor S2's target (bar-width formula — this PR) — it's a property of the CPM graph's own precedence structure (E1 support chains + E3/E4 hammocks combined, all LOCKED core per this lane's §LOCKED section except S1's one named change). Since `floating=0` and judge-parity hold throughout, this may be an accurate reflection of Terminal's true construction sequence once full physics precedence is honored (a fast, thousands-of-small-elements roof population that genuinely can't start until nearly everything below it completes) — or it may indicate an overly-aggressive edge somewhere in the combined graph. **This is squarely the "Fable/Opus review checkpoint" `§DISPATCH` rule 4 names for after S2** — full stagger dumps below for that review.

<details>
<summary>Terminal stagger dump — BEFORE this stage (S1 only, `probe_gantt_stagger.js`)</summary>

```
TASK TASK_Substructure_GROUND_FLOOR_LEVEL s=0 e=144 n=236
TASK TASK_Superstructure_Aras_Tanah s=0 e=48 n=78
TASK TASK_Superstructure_GROUND_FLOOR_LEVEL s=0 e=3 n=266
TASK TASK_MEP_Rough_in_GROUND_FLOOR_LEVEL s=23 e=48 n=722
TASK TASK_Architecture_Aras_Jalan s=47 e=48 n=32
TASK TASK_Architecture_Aras_Kedai s=47 e=151 n=49
TASK TASK_Architecture_Aras_Tanah s=47 e=130 n=455
TASK TASK_Architecture_GROUND_FLOOR_LEVEL s=47 e=131 n=4
TASK TASK_Architecture_Level_Kedai s=47 e=143 n=21
TASK TASK_MEP_Rough_in_Aras_Jalan s=47 e=144 n=9
TASK TASK_Superstructure_02_FIRST_FLOOR_LEVEL s=47 e=144 n=199
TASK TASK_Superstructure_Aras_Kedai s=47 e=48 n=2
TASK TASK_Superstructure_Ground_Lev s=47 e=151 n=23
TASK TASK_Superstructure_Level_01 s=47 e=48 n=28
TASK TASK_Architecture_Level_01 s=129 e=131 n=15
TASK TASK_MEP_Final_00_Aras_Asas s=129 e=150 n=4
TASK TASK_MEP_Final_GROUND_FLOOR_LEVEL s=129 e=144 n=66
TASK TASK_MEP_Rough_in_Aras_Tanah s=129 e=144 n=2897
TASK TASK_MEP_Rough_in_Ground_Lev s=129 e=130 n=12
TASK TASK_MEP_Final_Aras_Kedai s=130 e=151 n=24
TASK TASK_MEP_Final_Level_Kedai s=131 e=151 n=193
TASK TASK_MEP_Final_Aras_Tanah s=132 e=150 n=541
TASK TASK_Finishes_Aras_Tanah s=133 e=150 n=215
TASK TASK_Architecture_02_FIRST_FLOOR_LEVEL s=143 e=144 n=5
TASK TASK_Architecture_Aras_01 s=143 e=144 n=296
TASK TASK_Architecture_Aras_02 s=143 e=150 n=235
TASK TASK_Architecture_Level_02 s=143 e=144 n=8
TASK TASK_Architecture_Level_03 s=143 e=150 n=4
TASK TASK_MEP_Final_Aras_Jalan s=143 e=151 n=4
TASK TASK_MEP_Rough_in_02_FIRST_FLOOR_LEVEL s=143 e=144 n=167
TASK TASK_MEP_Rough_in_Aras_01 s=143 e=150 n=1617
TASK TASK_Superstructure_03_SECOND_FLOOR_LEVEL s=143 e=150 n=208
TASK TASK_Superstructure_Aras_01 s=143 e=144 n=49
TASK TASK_Superstructure_Aras_02 s=143 e=144 n=43
TASK TASK_Superstructure_Level_02 s=143 e=144 n=28
TASK TASK_Superstructure_Level_03 s=143 e=144 n=13
TASK TASK_Architecture_03_SECOND_FLOOR_LEVEL s=149 e=150 n=2
TASK TASK_Architecture_04_THIRD_FLOOR_LEVEL s=149 e=150 n=5
TASK TASK_Architecture_Level_04 s=149 e=150 n=6
TASK TASK_Finishes_Aras_01 s=149 e=150 n=18
TASK TASK_Finishes_Aras_02 s=149 e=150 n=18
TASK TASK_MEP_Final_02_FIRST_FLOOR_LEVEL s=149 e=151 n=17
TASK TASK_MEP_Final_03_SECOND_FLOOR_LEVEL s=149 e=150 n=18
TASK TASK_MEP_Final_Aras_01 s=149 e=150 n=325
TASK TASK_MEP_Final_Aras_02 s=149 e=150 n=366
TASK TASK_MEP_Final_Level_01 s=149 e=150 n=115
TASK TASK_MEP_Final_Level_02 s=149 e=150 n=178
TASK TASK_MEP_Final_Level_03 s=149 e=150 n=152
TASK TASK_MEP_Rough_in_03_SECOND_FLOOR_LEVEL s=149 e=150 n=253
TASK TASK_MEP_Rough_in_Aras_02 s=149 e=151 n=2105
TASK TASK_Superstructure_04_THIRD_FLOOR_LEVEL s=149 e=150 n=313
TASK TASK_Superstructure_05_FOURTH_FLOOR_LEVEL_OBSERVATORY_DECK s=149 e=150 n=10355
TASK TASK_Superstructure_Aras_03 s=149 e=151 n=3494
TASK TASK_Superstructure_Level_04 s=149 e=150 n=6172
TASK TASK_Architecture_Aras_03 s=150 e=151 n=60
TASK TASK_Architecture_Aras_04 s=150 e=151 n=55
TASK TASK_Architecture_Aras_Bumbung s=150 e=151 n=7
TASK TASK_Finishes_Aras_03 s=150 e=151 n=3
TASK TASK_Finishes_Aras_04 s=150 e=151 n=4
TASK TASK_MEP_Final_04_THIRD_FLOOR_LEVEL s=150 e=151 n=1
TASK TASK_MEP_Final_Aras_03 s=150 e=151 n=210
TASK TASK_MEP_Final_Aras_04 s=150 e=151 n=111
TASK TASK_MEP_Final_Aras_Bumbung s=150 e=151 n=29
TASK TASK_MEP_Final_Level_04 s=150 e=151 n=19
TASK TASK_MEP_Rough_in_04_THIRD_FLOOR_LEVEL s=150 e=151 n=179
TASK TASK_MEP_Rough_in_Aras_03 s=150 e=151 n=1287
TASK TASK_MEP_Rough_in_Aras_04 s=150 e=151 n=227
TASK TASK_MEP_Rough_in_Aras_Bumbung s=150 e=151 n=2
TASK TASK_Superstructure_06_ROOF_LEVEL s=150 e=151 n=11004
TASK TASK_Superstructure_07_BEAM_LEVEL_OBSERVATORY s=150 e=151 n=2542
TASK TASK_Superstructure_Aras_04 s=150 e=151 n=3
TASK TASK_Superstructure_Aras_Bumbung s=150 e=151 n=5
```
```
METRIC withinLevelPhasePairs=104 overlapping=10 overlapDaysSum=202 parallelism=7.29x totalDays=151 tasks=72
```
</details>

<details>
<summary>Terminal stagger dump — AFTER this stage (S1+S2, `probe_gantt_stagger.js`)</summary>

```
TASK TASK_Substructure_GROUND_FLOOR_LEVEL s=0 e=117 n=236
TASK TASK_MEP_Rough_in_GROUND_FLOOR_LEVEL s=23 e=151 n=722
TASK TASK_Architecture_Aras_Kedai s=47 e=48 n=49
TASK TASK_Architecture_Aras_Tanah s=47 e=151 n=455
TASK TASK_Architecture_GROUND_FLOOR_LEVEL s=47 e=131 n=4
TASK TASK_Architecture_Level_Kedai s=47 e=143 n=21
TASK TASK_MEP_Rough_in_Aras_Jalan s=47 e=144 n=9
TASK TASK_Superstructure_02_FIRST_FLOOR_LEVEL s=47 e=151 n=199
TASK TASK_Superstructure_Aras_Kedai s=47 e=48 n=2
TASK TASK_Superstructure_Aras_Tanah s=47 e=48 n=78
TASK TASK_Superstructure_GROUND_FLOOR_LEVEL s=47 e=48 n=266
TASK TASK_Superstructure_Ground_Lev s=47 e=48 n=23
TASK TASK_Superstructure_Level_01 s=47 e=151 n=28
TASK TASK_Architecture_Aras_Jalan s=129 e=151 n=32
TASK TASK_Architecture_Level_01 s=129 e=131 n=15
TASK TASK_MEP_Final_00_Aras_Asas s=129 e=150 n=4
TASK TASK_MEP_Final_GROUND_FLOOR_LEVEL s=129 e=144 n=66
TASK TASK_MEP_Rough_in_Aras_Tanah s=129 e=151 n=2897
TASK TASK_MEP_Rough_in_Ground_Lev s=129 e=130 n=12
TASK TASK_MEP_Final_Aras_Kedai s=130 e=151 n=24
TASK TASK_MEP_Final_Level_Kedai s=131 e=151 n=193
TASK TASK_MEP_Final_Aras_Tanah s=132 e=151 n=541
TASK TASK_Finishes_Aras_Tanah s=142 e=151 n=215
TASK TASK_Architecture_02_FIRST_FLOOR_LEVEL s=143 e=151 n=5
TASK TASK_Architecture_Aras_01 s=143 e=151 n=296
TASK TASK_Architecture_Aras_02 s=143 e=151 n=235
TASK TASK_Architecture_Level_02 s=143 e=151 n=8
TASK TASK_MEP_Rough_in_02_FIRST_FLOOR_LEVEL s=143 e=151 n=167
TASK TASK_MEP_Rough_in_Aras_01 s=143 e=151 n=1617
TASK TASK_Superstructure_03_SECOND_FLOOR_LEVEL s=143 e=151 n=208
TASK TASK_Superstructure_Aras_01 s=143 e=144 n=49
TASK TASK_Superstructure_Aras_02 s=143 e=144 n=43
TASK TASK_Superstructure_Level_02 s=143 e=151 n=28
TASK TASK_Superstructure_Level_03 s=143 e=151 n=13
TASK TASK_Architecture_03_SECOND_FLOOR_LEVEL s=149 e=151 n=2
TASK TASK_Architecture_04_THIRD_FLOOR_LEVEL s=149 e=151 n=5
TASK TASK_Architecture_Level_03 s=149 e=151 n=4
TASK TASK_Finishes_Aras_01 s=149 e=150 n=18
TASK TASK_Finishes_Aras_02 s=149 e=150 n=18
TASK TASK_MEP_Final_02_FIRST_FLOOR_LEVEL s=149 e=150 n=17
TASK TASK_MEP_Final_03_SECOND_FLOOR_LEVEL s=149 e=150 n=18
TASK TASK_MEP_Final_Aras_01 s=149 e=150 n=325
TASK TASK_MEP_Final_Aras_02 s=149 e=150 n=366
TASK TASK_MEP_Final_Level_01 s=149 e=150 n=115
TASK TASK_MEP_Final_Level_02 s=149 e=150 n=178
TASK TASK_MEP_Final_Level_03 s=149 e=151 n=152
TASK TASK_MEP_Rough_in_03_SECOND_FLOOR_LEVEL s=149 e=150 n=253
TASK TASK_MEP_Rough_in_Aras_02 s=149 e=150 n=2105
TASK TASK_Superstructure_04_THIRD_FLOOR_LEVEL s=149 e=151 n=313
TASK TASK_Superstructure_05_FOURTH_FLOOR_LEVEL_OBSERVATORY_DECK s=149 e=151 n=10355
TASK TASK_Superstructure_Aras_03 s=149 e=151 n=3494
TASK TASK_Superstructure_Level_04 s=149 e=151 n=6172
TASK TASK_Architecture_Aras_03 s=150 e=151 n=60
TASK TASK_Architecture_Aras_04 s=150 e=151 n=55
TASK TASK_Architecture_Aras_Bumbung s=150 e=151 n=7
TASK TASK_Architecture_Level_04 s=150 e=151 n=6
TASK TASK_Finishes_Aras_03 s=150 e=151 n=3
TASK TASK_Finishes_Aras_04 s=150 e=151 n=4
TASK TASK_MEP_Final_04_THIRD_FLOOR_LEVEL s=150 e=151 n=1
TASK TASK_MEP_Final_Aras_03 s=150 e=151 n=210
TASK TASK_MEP_Final_Aras_04 s=150 e=151 n=111
TASK TASK_MEP_Final_Aras_Bumbung s=150 e=151 n=29
TASK TASK_MEP_Final_Aras_Jalan s=150 e=151 n=4
TASK TASK_MEP_Final_Level_04 s=150 e=151 n=19
TASK TASK_MEP_Rough_in_04_THIRD_FLOOR_LEVEL s=150 e=151 n=179
TASK TASK_MEP_Rough_in_Aras_03 s=150 e=151 n=1287
TASK TASK_MEP_Rough_in_Aras_04 s=150 e=151 n=227
TASK TASK_MEP_Rough_in_Aras_Bumbung s=150 e=151 n=2
TASK TASK_Superstructure_06_ROOF_LEVEL s=150 e=151 n=11004
TASK TASK_Superstructure_07_BEAM_LEVEL_OBSERVATORY s=150 e=151 n=2542
TASK TASK_Superstructure_Aras_04 s=150 e=151 n=3
TASK TASK_Superstructure_Aras_Bumbung s=150 e=151 n=5
```
```
METRIC withinLevelPhasePairs=104 overlapping=24 overlapDaysSum=431 parallelism=7.36x totalDays=151 tasks=72
```
</details>

## Test plan
- [x] `node scripts/probe_cpm_display_path.js` — 7/7 PASS, floating=0, nonOutlierOutside=0
- [x] `bash scripts/gate_4d.sh` (bim-compiler) — pass=7 fail=0 missing=1 (pre-existing)
- [x] Hospital ground-level cascade order preserved (live probe)
- [x] Terminal equi-shape criterion — NOT met, root cause traced to CPM solve() precedence (out of S1/S2 scope), flagged for review checkpoint per `§DISPATCH` rule 4

🤖 Generated with [Claude Code](https://claude.com/claude-code)
