### PR TITLE
test(4d): §S3_LAYER_BUILDUP — M3 monotone-band-median metric added to probe_gantt_stagger.js

### DIFF
--- a/scripts/probe_gantt_stagger.js
+++ b/scripts/probe_gantt_stagger.js
@@ -75,6 +75,52 @@ async function main() {
     ' overlapDaysSum=' + overlapDaysSum.toFixed(0) +
     ' parallelism=' + (sumSpan / Math.max(1, total)).toFixed(2) + 'x totalDays=' + total.toFixed(0) +
     ' tasks=' + tasks.length);
+
+  // §LAYER_BUILDUP (M3, bim-compiler prompts/4D_GANTT_TM_REFACTOR.md §MODEL M3 + §STAGES S3) — the
+  // user's "uniform layer by layer build up" complaint, as a number: OPS, not tasks. Query
+  // kernel_ops ELEMENT_PLACE (the movie's own true physics times — M3: playback does not change)
+  // joined to each element's real Z, banded into the same 3m z-band quantum M1's bandRank uses
+  // (floor(centerZ/3m), the shipped §GANTT banding precedent). Acceptance: per band, the MEDIAN op
+  // start must be monotone non-decreasing with band rank, tolerance 1 day (the window rounding
+  // quantum) — violations must be 0 on Terminal AND Hospital.
+  const opRows = await page.evaluate(() => {
+    const r = window.APP.db.exec(
+      "SELECT k.timestamp, COALESCE(t.center_z, 0) as cz " +
+      "FROM kernel_ops k JOIN elements_meta m ON m.guid = k.output_guid " +
+      "LEFT JOIN element_transforms t ON t.guid = m.guid " +
+      "WHERE k.op_type='ELEMENT_PLACE' AND (k.undone IS NULL OR k.undone=0)");
+    return r.length ? r[0].values : [];
+  });
+  if (opRows.length) {
+    const opT0 = Math.min(...opRows.map(r => r[0]));
+    const bandsOf = {};
+    opRows.forEach(r => {
+      const band = Math.floor(r[1] / 3);
+      (bandsOf[band] = bandsOf[band] || []).push((r[0] - opT0) / D);
+    });
+    const bandKeys = Object.keys(bandsOf).map(Number).sort((a, b) => a - b);
+    const medians = bandKeys.map(b => {
+      const arr = bandsOf[b].slice().sort((a, c) => a - c);
+      return { band: b, n: arr.length, median: arr[Math.floor(arr.length * 0.5)] };
+    });
+    let layerViol = 0, layerDetail = [];
+    for (let i = 1; i < medians.length; i++) {
+      if (medians[i].median < medians[i - 1].median - 1) {   // 1-day tolerance, §MODEL M3
+        layerViol++;
+        if (layerDetail.length < 10) layerDetail.push('band' + medians[i - 1].band + '(n=' + medians[i - 1].n +
+          ',med=' + medians[i - 1].median.toFixed(1) + 'd)>band' + medians[i].band + '(n=' + medians[i].n +
+          ',med=' + medians[i].median.toFixed(1) + 'd)');
+      }
+    }
+    console.log('§LAYER_BUILDUP_TABLE ' + JSON.stringify(medians.map(m => [m.band, m.n, m.median.toFixed(1)])));
+    console.log('§LAYER_BUILDUP MODE=' + (MODE ? 'legacy' : 'cpm') + ' BLD=' + BLD +
+      ' violations=' + layerViol + '/' + (medians.length - 1) + ' bands=' + medians.length + ' ops=' + opRows.length +
+      (layerDetail.length ? ' detail=' + JSON.stringify(layerDetail) : '') +
+      ' ' + (layerViol === 0 ? 'PASS' : 'FAIL'));
+  } else {
+    console.log('§LAYER_BUILDUP_SKIP no ELEMENT_PLACE ops found in kernel_ops');
+  }
+
   await browser.close(); server.kill(); process.exit(0);
 }
 main().catch(e => { console.error('ERR ' + (e && e.stack || e)); process.exit(2); });


### PR DESCRIPTION
## Summary
Implements `prompts/4D_GANTT_TM_REFACTOR.md` §MODEL M3 + §STAGES S3 (bim-compiler). Adds the "uniform layer by layer build up" acceptance metric to `scripts/probe_gantt_stagger.js` as a NUMBER, not a screenshot: queries `kernel_ops` `ELEMENT_PLACE` (the movie's own true physics op times — M3: playback does not change) joined to each element's real Z, banded into the same 3m z-band quantum M1's `bandRank` uses (`floor(centerZ/3m)`). Per band, checks the MEDIAN op start is monotone non-decreasing with band rank, tolerance 1 day.

## Evidence (real viewer, both buildings named in S3's acceptance)
```
Terminal: §LAYER_BUILDUP violations=0/12 bands=13 ops=48428 PASS
Hospital: §LAYER_BUILDUP violations=1/14 bands=15 ops=63415 FAIL
  detail: band54(n=116,med=364.7d) > band55(n=1644,med=61.6d)
```

**Terminal fully meets S3's acceptance bar.** This is also directly relevant to the S2 review checkpoint (`#1402`): despite S2's finding that Terminal's Roof-Level Superstructure population compresses into a <1-day bar near the schedule's tail, the CROSS-band median order is still strictly monotone (bands -6→9 all non-decreasing) — supporting the "physics-true consequence" reading of that finding rather than a bug.

**Hospital's single violation, root-caused (not invented):** direct query against `elements_meta`/`element_transforms` confirms both band54 (z 162-165m) and band55 (z 165-168m) are the **same real named storey** ("Level 1"), which is taller than the 3m band quantum — so the banding scheme slices one physical storey into two z-bands. band54 is dominated by `IfcFooting` (n=553 in that slice); band55 is dominated by later-phase elements (proxies, pipes, walls, doors). Comparing their medians across this band boundary measures **intra-storey multi-phase timing spread** (a Substructure/Tier-1 element vs later-tier elements of the SAME floor), not a real inter-floor sequencing violation. Not fixed here — a phase-aware banding or same-storey-exclusion mechanism isn't in §MODEL M3's literal text, and adding one now would be inventing a mechanism the spec didn't derive.

## Test plan
- [x] `BLD=Terminal_extracted node scripts/probe_gantt_stagger.js` — `§LAYER_BUILDUP violations=0/12 PASS`
- [x] `BLD=Hospital_extracted node scripts/probe_gantt_stagger.js` — `§LAYER_BUILDUP violations=1/14 FAIL`, root cause traced and documented (same-storey band-boundary artifact)
- [x] No shipped `viewer/*.js` touched — probe-only change, zero production risk

🤖 Generated with [Claude Code](https://claude.com/claude-code)
