### PR TITLE
chore(4d): §S5_CLOSEOUT — cache version bump, witness confirmation, live-deploy verification

### DIFF
--- a/viewer/sw.js
+++ b/viewer/sw.js
@@ -8,7 +8,15 @@
 // Cache-first for heavy assets (.wasm, images). DB files skip SW (IndexedDB handles them).
 //
 // DEPLOY: bump CACHE_VERSION on every OCI upload. Old caches are purged on activate.
-const CACHE_VERSION = 'v1047';   // bump on each deploy; per-change detail is the git commit message.
+const CACHE_VERSION = 'v1048';   // bump on each deploy; per-change detail is the git commit message.
+// v1048 (2026-08-16) bim-compiler prompts/4D_GANTT_TM_REFACTOR.md S1-S4 closeout: §S1_BAND_RANK
+// (cpm_schedule.js buildGraph — E4 storey hammocks + straggler group-key use 3m z-bands, not
+// per-storey-name rank, PR #1401); §S2_TUKEY_ENVELOPE (time_machine.js _tmDisplayRemap — task bars
+// are a classification-free Tukey-fenced robust envelope over ALL group members' true times,
+// replacing the straggler-classification min/max clip, PR #1402); §S4_RAW_SCHEDULE_REUSE
+// (time_machine.js injectGantt skips a redundant computeSchedule call when materializeZones already
+// computed it, PR #1404). _GANTT_CACHE_VERSION 29->30 — any building already materialized under the
+// old E4/bar-shape formulas will regenerate on next activation rather than replay stale schedules.
 // v1047 (2026-08-16) §ZONE_WINDOW_DAGWINS_CLIP: task bars = non-straggler envelopes (user:
 // "schedule looks gibberish" — every Hospital bar ran to project end, smeared by 11,215 dag-wins
 // stragglers); §CAP_RESCALE_SKIP: display-authored windows never re-spaced (views, not a second

--- a/viewer/time_machine.js
+++ b/viewer/time_machine.js
@@ -8216,7 +8216,7 @@
   // huts going first before the walls" AFTER a hard reset, because §GANTT_CACHE_HIT served a
   // gantt:v4 entry generated under the old ordering. A hard reset cannot clear it — the entry is in
   // IndexedDB, not the HTTP cache. This bump is that fix's second half.
-  var _GANTT_CACHE_VERSION = 29;   // §ZONE_WINDOW_DAGWINS_CLIP + §CAP_RESCALE_SKIP + §CPM_DISPLAY_EPOCH
+  var _GANTT_CACHE_VERSION = 30;   // §S1_BAND_RANK + §S2_TUKEY_ENVELOPE + §S4_RAW_SCHEDULE_REUSE (4D_GANTT_TM_REFACTOR.md)
   // was 28:   // §CPM_DISPLAY (2026-08-16): display timeline authored by the one-DAG CPM pass
   // was 27:   // §ZONE_DISPLAY_AUTHORING (2026-08-16): task windows authored from
                                    // the DISPLAY timeline + strict-bar sweep skipped on that path —


### PR DESCRIPTION
## Summary
Closeout for `prompts/4D_GANTT_TM_REFACTOR.md` §STAGES S5 (bim-compiler). Bumps `_GANTT_CACHE_VERSION` 29→30 and `sw.js` `CACHE_VERSION` v1047→v1048 to catch up S1/S2/S4's schedule-generation-behavior changes (none of those PRs bumped it — a process gap this session found: `gate_4d.sh`'s own `§CACHE_VERSION_GUARD` was run BEFORE each commit against working-tree-only diffs, which its git-diff-based check cannot see, so it never actually caught the miss it exists to catch).

## Witnesses — all 4 named in S5's acceptance, green
```
witness_zone_display_authoring: §ZDA_WITNESS_SUMMARY pass=16 fail=0
witness_crosstask_judge_parity: §CJP_WITNESS_SUMMARY pass=20 fail=0
witness_midair_zero:            PASS via gate_4d.sh (§MIDAIR_ZERO_SUMMARY pass=39 fail=0)
witness_tier_serial_display:    PASS via gate_4d.sh (§TIER_SERIAL_SUMMARY pass=57 fail=0)
```
No witness assertion needed updating — none of M1/M2/M3's metric-meaning changes broke a locked baseline.

## gate_4d.sh — run AFTER commit this time (properly exercises §CACHE_VERSION_GUARD)
```
§GATE_4D_RESULT pass=8 fail=0 missing=1
§CACHE_VERSION_GUARD PASS gating_changed=0 version_bumped=1
```
(the 1 MISS — `witness_arch_area_weight` — is pre-existing on clean origin/main, confirmed unrelated to this lane in every prior stage's own run)

## Final fleet confirmation (no new regressions vs S1-S4's documented state)
```
probe_cpm_schedule.js:      floating=0/7, structural=0/7 on ALL 7 (storeyViol fails=3 is the
                             already-documented S1 federated-ladder residual, byte-identical numbers)
probe_cpm_display_path.js:  §CPMDP_FLEET_VERDICT buildings=7 fails=0 PASS
```

## Live-deploy verification — genuine, not just curl
Curled the live GitHub Pages payload AND ran a real headless browser session against the deployed `https://red1oon.github.io/bim-ootb/viewer/viewer.html` with a real Hospital DB:
```
[live] §CPM_RUN n=63415 ... stragglers=11215 ... makespanDays=388.4   <- S1's band-rank cpm_schedule.js, live
[live] §ZONE_WINDOW_DAGWINS_CLIP clamped=6230 (Tukey-fenced group envelope, classification-free...)  <- S2, live
[live] §S4_RAW_SCHEDULE_REUSE hits=63415 misses=0 — skipped a second computeSchedule call            <- S4, live
[live] §TIME_MACHINE ON — 63415 ops, 74 days, ...
LIVE_TM_ACTIVATED=true
```
All 4 prior PRs (#1401-#1404) triggered successful `deploy-pages.yml` runs (confirmed via `gh run list`).

## Docs
- `prompts/4D_SCHEDULE_ARCHITECTURE_REDESIGN.md`: `§ZONE_WINDOW_DAGWINS_CLIP`'s original min/max-over-non-stragglers formula description marked ⛔ RETIRED, pointing to S2's Tukey-fence successor (tag kept, formula changed, per that spec's own M2 instruction). The "TM activation ≈20s, not fixed" note updated with S4's measured outcome.
- `PROGRESS.md`: one-liner added.
- `prompts/4D_GANTT_TM_REFACTOR.md`: dated §S5 section (this PR).

## Test plan
- [x] All 4 S5-named witnesses green (16/16, 20/20, 39/39, 57/57)
- [x] `gate_4d.sh` pass=8 fail=0 missing=1 (pre-existing), `§CACHE_VERSION_GUARD` PASS
- [x] Fleet probes — no new regressions vs S1-S4's documented state
- [x] Live-deploy verification — real browser session against the deployed site, all 3 shipped stages' § log signatures confirmed live

🤖 Generated with [Claude Code](https://claude.com/claude-code)
