### PR TITLE
feat(4d): §S6_CREW_PASS — crew-aware CPM forward pass, §CREW_FEASIBILITY 6/7 FAIL → 0/7

### DIFF
--- a/scripts/probe_cpm_display_path.js
+++ b/scripts/probe_cpm_display_path.js
@@ -72,12 +72,37 @@ async function runBuilding(SQL, RATES, name) {
     const st = schedule[el.guid]; if (!st) return null;
     return { guid: el.guid, cls: el.cls, seq: el.seq, phase: el.phase, storey: el.storey,
              x0: el.x0, x1: el.x1, y0: el.y0, y1: el.y1, bz: el.bz, tz: el.tz,
-             s: st.start, e: st.end };
+             s: st.start, e: st.end, resource: el.resource };   // §S6_CREW_PASS
   }).filter(Boolean);
   console.log('§CPMDP_BUILDING ' + name + ' n=' + items.length);
-  const res = CpmSchedule.run(items);
+  const res = CpmSchedule.run(items, { maxCrews });
   if (!res.ok) throw new Error('CPM failed');
   items.forEach((o, i) => { o.s = res.solution.times[i].s; o.e = res.solution.times[i].e; });
+
+  // §CREW_FEASIBILITY (4D_GANTT_TM_REFACTOR.md §S6 acceptance 1) on the CPM-authored schedule this
+  // display path plays: per resource, integrated over-cap exposure must stay within the 1-day
+  // rounding quantum.
+  let crewViol = 0;
+  {
+    const byRes = {};
+    items.forEach(o => { (byRes[o.resource] = byRes[o.resource] || []).push(o); });
+    const detail = [];
+    Object.keys(byRes).sort().forEach(function (r) {
+      const cap = maxCrews[r] || 3;   // schedule_gate.js MAX_CREWS_DEFAULT, mirrored
+      const ev = [];
+      byRes[r].forEach(o => { ev.push([o.s, 1]); ev.push([o.e, -1]); });
+      ev.sort((a, b) => a[0] - b[0] || a[1] - b[1]);
+      let cur = 0, mx = 0, overMs = 0, lastT = null;
+      for (const [t, d] of ev) {
+        if (cur > cap && lastT != null) overMs += t - lastT;
+        lastT = t; cur += d; if (cur > mx) mx = cur;
+      }
+      if (overMs > 86400000) { crewViol++; detail.push(r + ' cap=' + cap + ' maxConc=' + mx + ' overDays=' + (overMs / 86400000).toFixed(1)); }
+    });
+    console.log('§CREW_FEASIBILITY_CPMDP violations=' + crewViol +
+      (detail.length ? ' detail=' + JSON.stringify(detail.slice(0, 8)) : '') +
+      ' ' + (crewViol === 0 ? 'PASS' : 'FAIL'));
+  }
 
   // §ZONE_DISPLAY_AUTHORING with the CPM display schedule: deriveZones + day-rounded windows
   // (materializeZones' own construction, verbatim from probe_captured_floating.js).
@@ -161,10 +186,11 @@ async function runBuilding(SQL, RATES, name) {
     ' outlierOutside=' + outlierOutside + '/' + clamped + ' nonOutlierOutside=' + otherOut +
     ' (bar: outside <= Tukey-outlier count; nonOutlier outside must be 0)');
 
-  const pass = final.midair === 0 && otherOut === 0;
-  console.log('§CPMDP_ACCEPT ' + name + ' finalFloating=' + final.midair + ' nonOutlierOutside=' + otherOut + ' ' + (pass ? 'PASS' : 'FAIL'));
+  const pass = final.midair === 0 && otherOut === 0 && crewViol === 0;
+  console.log('§CPMDP_ACCEPT ' + name + ' finalFloating=' + final.midair + ' nonOutlierOutside=' + otherOut +
+    ' crewFeasViolations=' + crewViol + ' ' + (pass ? 'PASS' : 'FAIL'));
   return { name, final: final.midair, pre: preRescale.midair, post: postRescale.midair,
-           outlierOutside, otherOut };
+           outlierOutside, otherOut, crewViol };
 }
 
 async function main() {
@@ -176,9 +202,10 @@ async function main() {
   const out = [];
   for (const name of FLEET) out.push(await runBuilding(SQL, RATES, name));
   let fails = 0;
-  out.forEach(r => { if (r.final !== 0 || r.otherOut !== 0) fails++; });
+  out.forEach(r => { if (r.final !== 0 || r.otherOut !== 0 || r.crewViol !== 0) fails++; });
   console.log('§CPMDP_FLEET ' + JSON.stringify(out.map(r => [r.name, 'pre=' + r.pre, 'post=' + r.post,
-    'final=' + r.final, 'outlierOutside=' + r.outlierOutside, 'otherOut=' + r.otherOut])));
+    'final=' + r.final, 'outlierOutside=' + r.outlierOutside, 'otherOut=' + r.otherOut,
+    'crewViol=' + r.crewViol])));
   console.log('§CPMDP_FLEET_VERDICT buildings=' + out.length + ' fails=' + fails + ' ' + (fails === 0 ? 'PASS' : 'FAIL'));
   process.exit(fails === 0 ? 0 : 1);
 }

--- a/scripts/probe_cpm_schedule.js
+++ b/scripts/probe_cpm_schedule.js
@@ -116,7 +116,7 @@ async function runBuilding(SQL, RATES, name) {
     const st = schedule[el.guid]; if (!st) return null;
     return { guid: el.guid, cls: el.cls, seq: el.seq, phase: el.phase, storey: el.storey,
              x0: el.x0, x1: el.x1, y0: el.y0, y1: el.y1, bz: el.bz, tz: el.tz,
-             s: st.start, e: st.end };
+             s: st.start, e: st.end, resource: el.resource };   // §S6_CREW_PASS
   }).filter(Boolean);
   console.log('§CPM_BUILDING ' + name + ' n=' + items.length);
 
@@ -138,12 +138,73 @@ async function runBuilding(SQL, RATES, name) {
   console.log('§CPM_RAW_FLOATING midair=' + rawCensus.midair + ' structural=' + structuralCount(rawCensus.byClass) +
     ' orphans=' + rawCensus.orphans);
 
-  // THE CPM PASS.
-  const res = CpmSchedule.run(items);
+  // THE CPM PASS (§S6_CREW_PASS: same per-resource caps computeSchedule ran on).
+  const res = CpmSchedule.run(items, { maxCrews });
   if (!res.ok) throw new Error('CPM run failed: ' + res.error);
   const cpmItems = items.map(function (o, i) {
     return Object.assign({}, o, { s: res.solution.times[i].s, e: res.solution.times[i].e });
   });
+
+  // §CREW_FEASIBILITY (4D_GANTT_TM_REFACTOR.md §S2_REVIEW_VERDICT S6 acceptance 1) — the invariant
+  // the tail compression broke: per resource, concurrently-running elements must not exceed
+  // max_crews. Tolerance = the day-rounding quantum: a resource only VIOLATES when its integrated
+  // over-cap exposure exceeds one day (boundary/SCC-equality overlaps inside a day are absorbed).
+  // Printed for RAW and CPM so the before/after is in the same log.
+  function crewFeasibility(list, label) {
+    const byRes = {};
+    list.forEach(o => { (byRes[o.resource] = byRes[o.resource] || []).push(o); });
+    let violations = 0; const detail = [];
+    Object.keys(byRes).sort().forEach(function (r) {
+      const cap = maxCrews[r] || 3;   // schedule_gate.js MAX_CREWS_DEFAULT, mirrored
+      const ev = [];
+      byRes[r].forEach(o => { ev.push([o.s, 1]); ev.push([o.e, -1]); });
+      ev.sort((a, b) => a[0] - b[0] || a[1] - b[1]);   // half-open: ends before starts at same t
+      let cur = 0, mx = 0, overMs = 0, lastT = null;
+      for (const [t, d] of ev) {
+        if (cur > cap && lastT != null) overMs += t - lastT;
+        lastT = t; cur += d; if (cur > mx) mx = cur;
+      }
+      if (overMs > DAY_MS) { violations++; detail.push(r + ' cap=' + cap + ' maxConc=' + mx + ' overDays=' + (overMs / DAY_MS).toFixed(1)); }
+    });
+    console.log('§CREW_FEASIBILITY_' + label + ' resources=' + Object.keys(byRes).length +
+      ' violations=' + violations + (detail.length ? ' detail=' + JSON.stringify(detail.slice(0, 8)) : '') +
+      ' ' + (violations === 0 ? 'PASS' : 'FAIL'));
+    return violations;
+  }
+  crewFeasibility(items, 'RAW');
+  const crewViol = crewFeasibility(cpmItems, 'CPM');
+
+  // §CREW_SPREAD_FLOOR (S6 acceptance 2) — a large task-group's span must be at least its own
+  // crew-arithmetic floor: max over its resources of (Σ crew-leveled duration ÷ that resource's
+  // cap). Computed from the data, not assumed; tolerance 1 day (the rounding quantum).
+  {
+    const byGrp = {};
+    cpmItems.forEach(function (o) {
+      if (!o.storey) return;
+      const k = (o.phase || '_UNPHASED') + '||' + ScheduleGate.collapsePhase(o.storey);
+      const g = byGrp[k] || (byGrp[k] = { s: Infinity, e: -Infinity, n: 0, durByRes: {} });
+      if (o.s < g.s) g.s = o.s;
+      if (o.e > g.e) g.e = o.e;
+      g.n++;
+      g.durByRes[o.resource] = (g.durByRes[o.resource] || 0) + Math.max(0, o.e - o.s);
+    });
+    let floorViol = 0; const fDetail = [];
+    Object.keys(byGrp).forEach(function (k) {
+      const g = byGrp[k]; if (g.n < 1000) return;
+      let floorMs = 0, floorRes = null;
+      Object.keys(g.durByRes).forEach(function (r) {
+        const f = g.durByRes[r] / (maxCrews[r] || 3);
+        if (f > floorMs) { floorMs = f; floorRes = r; }
+      });
+      const spanMs = g.e - g.s;
+      const ok = spanMs >= floorMs - DAY_MS;
+      if (!ok) floorViol++;
+      fDetail.push(k + ' n=' + g.n + ' span=' + (spanMs / DAY_MS).toFixed(1) + 'd floor=' +
+        (floorMs / DAY_MS).toFixed(1) + 'd(' + floorRes + ') ' + (ok ? 'ok' : 'VIOL'));
+    });
+    console.log('§CREW_SPREAD_FLOOR groups(n>=1000)=' + fDetail.length + ' violations=' + floorViol +
+      ' ' + JSON.stringify(fDetail) + ' ' + (floorViol === 0 ? 'PASS' : 'FAIL'));
+  }
 
   // §CPM_FLOATING — the judge on CPM output.
   const census = floatingCensus(cpmItems);
@@ -255,11 +316,13 @@ async function runBuilding(SQL, RATES, name) {
     ' build=' + res.ms.build + ' solve=' + res.ms.solve + ') tierAuditRegateMs=' + (tR1 - tR0) +
     ' regatePushed=' + reg.pushed + ' speedup=' + ((tR1 - tR0) / Math.max(1, res.ms.total)).toFixed(2) + 'x');
 
-  const pass = census.midair === 0 && storeyRes.violations === 0;
+  const pass = census.midair === 0 && storeyRes.violations === 0 && crewViol === 0;
   console.log('§CPM_ACCEPT ' + name + ' floating=' + census.midair + ' structural=' + structural +
     ' storeyViolations=' + storeyRes.violations + '/' + (storeyRes.storeys - 1) +
+    ' crewFeasViolations=' + crewViol +
     ' cycleDrops=' + JSON.stringify(res.solution.drops) + ' ' + (pass ? 'PASS' : 'FAIL'));
   return { name, midair: census.midair, structural, storeyViolations: storeyRes.violations,
+           crewViol,
            rawMidair: rawCensus.midair, cpmMs: res.ms.total, regateMs: tR1 - tR0, parity: mismatch === 0 };
 }
 
@@ -273,9 +336,10 @@ async function main() {
   for (const name of FLEET) out.push(await runBuilding(SQL, RATES, name));
   let fails = 0;
   console.log('§CPM_FLEET ' + JSON.stringify(out.map(function (r) {
-    if (r.midair !== 0 || r.storeyViolations !== 0 || !r.parity) fails++;
+    if (r.midair !== 0 || r.storeyViolations !== 0 || !r.parity || r.crewViol !== 0) fails++;
     return [r.name, 'raw=' + r.rawMidair, 'cpm=' + r.midair, 'str=' + r.structural,
-            'storeyViol=' + r.storeyViolations, 'cpmMs=' + r.cpmMs, 'regateMs=' + r.regateMs];
+            'storeyViol=' + r.storeyViolations, 'crewViol=' + r.crewViol,
+            'cpmMs=' + r.cpmMs, 'regateMs=' + r.regateMs];
   })));
   console.log('§CPM_FLEET_VERDICT buildings=' + out.length + ' fails=' + fails + ' ' + (fails === 0 ? 'PASS' : 'FAIL'));
   process.exit(fails === 0 ? 0 : 1);

--- a/viewer/cpm_schedule.js
+++ b/viewer/cpm_schedule.js
@@ -331,11 +331,31 @@
     return { comp: comp, sizes: sizes };
   }
 
-  // solve(items, graph) — SCC condensation + ONE forward pass. Returns per-element {s,e} + stats.
-  function solve(items, graph) {
+  // solve(items, graph, opts) — SCC condensation + ONE crew-aware forward pass (serial
+  // schedule-generation scheme). Returns per-element {s,e} + stats.
+  //
+  // §S6_CREW_PASS (bim-compiler prompts/4D_GANTT_TM_REFACTOR.md §S2_REVIEW_VERDICT S6): E5's TIMES
+  // stop being the lower bound. They were computed by computeSchedule at RAW dates — once the
+  // precedence gates displace work (Terminal roof: 10,950 elements moved from day ~37 to day ~130),
+  // nothing re-enforced "this trade has N crews" at the new date, so the tail built at effectively
+  // infinite crew capacity (10,950 starts inside 0.4 days, §CREW_FEASIBILITY massively violated).
+  // The fix: the SAME greedy crew-slot allocator computeSchedule already runs (schedule_gate.js
+  // §CREW-CAP — per-resource slot array, claim-earliest-slot, cap = maxCrews[resource] with the
+  // same MAX_CREWS_DEFAULT=3 fallback) claims slots INSIDE this topological pass. Ready components
+  // come off a priority queue keyed (earliest precedence-feasible time, bz, guid — deterministic);
+  // finalizing an element sets start = max(precedence bound, earliest slot of its resource pool),
+  // then advances the claimed slot by the element's real crew-leveled duration (e-s, still
+  // computeSchedule's own — durations stay E5's, only its TIMES retire). Delays only, so every
+  // edge lower bound stays satisfied — floating-0 by construction is preserved. O((V+E)·log V).
+  // Contracted pure-physics SCCs keep ONE shared start (the judge's own equality contract): each
+  // member reserves its own slot, the shared start is the latest reservation, and a member that
+  // finds its pool exhausted by its own SCC is counted in drops.crewOverCapScc — never hidden.
+  function solve(items, graph, opts) {
+    var maxCrews = opts && opts.maxCrews;
     var n = graph.nElements, total = graph.nNodes, out = graph.out;
     var i, u, k, e, os;
-    var drops = { e3: 0, e4: 0, member: 0, contractedSccs: 0, contractedNodes: 0, fsViolInScc: 0 };
+    var drops = { e3: 0, e4: 0, member: 0, contractedSccs: 0, contractedNodes: 0, fsViolInScc: 0,
+                  crewOverCapScc: 0 };
 
     // Round 1 — cycles containing tidiness edges (E3/E4 hammocks + milestone membership) lose
     // exactly those edges inside the cycle; physics edges are never dropped here.
@@ -362,18 +382,49 @@
       if (scc.sizes[i] > 1) { drops.contractedSccs++; drops.contractedNodes += scc.sizes[i]; }
     }
 
-    // Kahn over the CONDENSATION: every node of a component shares one earliest-start (an SS
-    // physics edge inside it holds with equality — the judge's own tolerance accepts that; FS
-    // edges inside it are the counted cost of the break, never hidden).
+    // Crew-aware Kahn over the CONDENSATION (§S6_CREW_PASS): every node of a component shares one
+    // earliest-start (an SS physics edge inside it holds with equality — the judge's own tolerance
+    // accepts that; FS edges inside it are the counted cost of the break, never hidden). The base
+    // epoch is the raw schedule's own earliest start (extracted, not invented) — E5's per-element
+    // TIMES no longer seed ES.
+    var base = Infinity;
+    for (i = 0; i < n; i++) if (items[i].s < base) base = items[i].s;
+    if (!isFinite(base)) base = 0;
     var ES = new Float64Array(total), DUR = new Float64Array(total);
-    for (i = 0; i < n; i++) { ES[i] = items[i].s; DUR[i] = Math.max(0, items[i].e - items[i].s); }
+    for (i = 0; i < total; i++) ES[i] = base;
+    for (i = 0; i < n; i++) DUR[i] = Math.max(0, items[i].e - items[i].s);
+    // Crew pools — same shape, same claim-earliest-slot rule, same default as schedule_gate.js's
+    // own claimCrew (§CREW-CAP: MAX_CREWS_DEFAULT = 3; an element without a resource pools under
+    // the same single 'undefined' key computeSchedule uses).
+    function crewCapFor(resource) {
+      if (typeof maxCrews === 'number') return maxCrews;
+      if (maxCrews && maxCrews[resource]) return maxCrews[resource];
+      return 3;   // schedule_gate.js MAX_CREWS_DEFAULT, mirrored not invented
+    }
+    var crews = {};
+    function poolOf(resource) {
+      return crews[resource] || (crews[resource] = new Array(crewCapFor(resource)).fill(base));
+    }
     var compES = new Float64Array(nComp);
+    for (i = 0; i < nComp; i++) compES[i] = base;
     var compNodes = new Array(nComp);
     for (u = 0; u < total; u++) {
       var c = comp[u];
       (compNodes[c] || (compNodes[c] = [])).push(u);
-      if (ES[u] > compES[c]) compES[c] = ES[u];
     }
+    // Deterministic priority key per component: (compES at readiness, min member bz, min member
+    // guid, comp id). Milestone-only components sort FIRST at equal time (bz -Infinity): they are
+    // dur-0 gates with no crew claim, and releasing them eagerly keeps the ready set maximal so
+    // slots go to the lowest precedence-feasible WORK first.
+    var compBz = new Float64Array(nComp), compGuid = new Array(nComp);
+    for (i = 0; i < nComp; i++) { compBz[i] = Infinity; compGuid[i] = null; }
+    for (u = 0; u < n; u++) {
+      var cb = comp[u];
+      if (items[u].bz < compBz[cb]) compBz[cb] = items[u].bz;
+      var g0 = String(items[u].guid);
+      if (compGuid[cb] === null || g0 < compGuid[cb]) compGuid[cb] = g0;
+    }
+    for (i = 0; i < nComp; i++) if (compGuid[i] === null) { compBz[i] = -Infinity; compGuid[i] = ''; }
     var indeg = new Int32Array(nComp);
     for (u = 0; u < total; u++) {
       os = out[u]; if (!os) continue;
@@ -382,16 +433,94 @@
         if (!e.dropped && comp[e.to] !== comp[u]) indeg[comp[e.to]]++;
       }
     }
-    var q = [], head = 0, processed = 0;
-    for (i = 0; i < nComp; i++) if (!indeg[i]) q.push(i);
-    while (head < q.length) {
-      var cu = q[head++]; processed++;
+    // Binary min-heap of ready components. compES is FINAL at push time (indeg 0 = every
+    // predecessor finalized), so the key never moves while queued.
+    var heap = [];
+    function heapLess(a, b) {
+      if (compES[a] !== compES[b]) return compES[a] < compES[b];
+      if (compBz[a] !== compBz[b]) return compBz[a] < compBz[b];
+      if (compGuid[a] !== compGuid[b]) return compGuid[a] < compGuid[b];
+      return a < b;
+    }
+    function heapPush(v) {
+      heap.push(v);
+      var ci = heap.length - 1;
+      while (ci > 0) {
+        var pi = (ci - 1) >> 1;
+        if (heapLess(heap[ci], heap[pi])) { var t = heap[ci]; heap[ci] = heap[pi]; heap[pi] = t; ci = pi; }
+        else break;
+      }
+    }
+    function heapPop() {
+      var top = heap[0], last = heap.pop();
+      if (heap.length) {
+        heap[0] = last;
+        var ci = 0;
+        for (;;) {
+          var l = 2 * ci + 1, r = l + 1, m = ci;
+          if (l < heap.length && heapLess(heap[l], heap[m])) m = l;
+          if (r < heap.length && heapLess(heap[r], heap[m])) m = r;
+          if (m === ci) break;
+          var t2 = heap[ci]; heap[ci] = heap[m]; heap[m] = t2; ci = m;
+        }
+      }
+      return top;
+    }
+    var processed = 0;
+    for (i = 0; i < nComp; i++) if (!indeg[i]) heapPush(i);
+    function memberOrder(a, b) {   // deterministic within-component claim order
+      if (items[a].bz !== items[b].bz) return items[a].bz - items[b].bz;
+      var ga = String(items[a].guid), gb = String(items[b].guid);
+      return ga < gb ? -1 : (ga > gb ? 1 : 0);
+    }
+    while (heap.length) {
+      var cu = heapPop(); processed++;
       var members = compNodes[cu], contracted = members.length > 1;
       var es = compES[cu];
-      for (k = 0; k < members.length; k++) {
-        u = members[k];
+      if (!contracted) {
+        u = members[0];
+        if (u < n) {   // element: claim a crew slot; milestone: pure gate, no claim
+          var pool1 = poolOf(items[u].resource), idx1 = 0;
+          for (k = 1; k < pool1.length; k++) if (pool1[k] < pool1[idx1]) idx1 = k;
+          es = Math.max(es, pool1[idx1]);
+          pool1[idx1] = es + DUR[u];
+        }
         ES[u] = es;
-        if (contracted) {
+      } else {
+        // Contracted pure-physics SCC (element-only by construction — round 1 dropped every
+        // tidiness edge inside cycles): reserve one slot per member, shared start = the latest
+        // reservation, then commit every slot to sharedStart + that member's duration.
+        var mem = members.slice().sort(memberOrder);
+        var picks = [], usedByPool = {};
+        for (k = 0; k < mem.length; k++) {
+          u = mem[k];
+          var r1 = items[u].resource, pool2 = poolOf(r1);
+          var used = usedByPool[r1] || (usedByPool[r1] = {});
+          var idx2 = -1;
+          for (var si = 0; si < pool2.length; si++)
+            if (!used[si] && (idx2 < 0 || pool2[si] < pool2[idx2])) idx2 = si;
+          if (idx2 < 0) {
+            // pool exhausted by this SCC alone — cap physically cannot hold under the shared-start
+            // contract; reuse the earliest slot and COUNT it (never hidden)
+            drops.crewOverCapScc++;
+            idx2 = 0;
+            for (si = 1; si < pool2.length; si++) if (pool2[si] < pool2[idx2]) idx2 = si;
+            picks.push({ u: u, r: r1, idx: idx2, reuse: true });
+          } else {
+            used[idx2] = 1;
+            if (pool2[idx2] > es) es = pool2[idx2];
+            picks.push({ u: u, r: r1, idx: idx2 });
+          }
+        }
+        for (k = 0; k < picks.length; k++) {
+          var p1 = picks[k], pool3 = poolOf(p1.r);
+          var end1 = es + DUR[p1.u];
+          if (end1 > pool3[p1.idx]) pool3[p1.idx] = end1;
+          ES[p1.u] = es;
+        }
+        for (k = 0; k < members.length; k++) {
+          u = members[k];
+          if (u >= n) ES[u] = es;   // defensive: no milestone survives in a round-2 SCC
           // count internal FS violations honestly (S finishes after T starts, same instant)
           os = out[u];
           if (os) for (var k2 = 0; k2 < os.length; k2++) {
@@ -409,7 +538,7 @@
           var b = e.kind === FS ? ef : ES[u];
           if (b > ES[e.to]) ES[e.to] = b;
           if (ES[e.to] > compES[cv]) compES[cv] = ES[e.to];
-          if (--indeg[cv] === 0) q.push(cv);
+          if (--indeg[cv] === 0) heapPush(cv);
         }
       }
     }
@@ -424,15 +553,17 @@
              makespanDays: (makespanE - makespanS) / 86400000 };
   }
 
-  // run(items) — contact graph + build + solve, with per-phase §CPM timing stats.
-  function run(items) {
+  // run(items, opts) — contact graph + build + solve, with per-phase §CPM timing stats.
+  // opts.maxCrews: per-resource crew caps ({resource: N} or a uniform number) for §S6_CREW_PASS —
+  // same lookup shape computeSchedule takes (LABOR_RATES[r].max_crews_fixed ?? max_crews).
+  function run(items, opts) {
     var t0 = Date.now();
     var G = contactGraph(items);
     var t1 = Date.now();
     if (!G.ok) return { ok: false, error: 'ScheduleGate not loaded' };
     var graph = buildGraph(items, G);
     var t2 = Date.now();
-    var sol = solve(items, graph);
+    var sol = solve(items, graph, opts);
     var t3 = Date.now();
     console.log('§CPM_RUN n=' + items.length + ' nodes=' + graph.nNodes +
       ' edges={E1:' + graph.counts.e1 + ',E2host:' + graph.counts.e2h + ',E2open:' + graph.counts.e2o +
@@ -441,6 +572,7 @@
       ' cycleDrops={E3:' + sol.drops.e3 + ',E4:' + sol.drops.e4 + ',member:' + sol.drops.member +
       ',contractedSccs:' + sol.drops.contractedSccs + ',contractedNodes:' + sol.drops.contractedNodes +
       ',fsViolInScc:' + sol.drops.fsViolInScc + '}' +
+      ' crewOverCapScc=' + sol.drops.crewOverCapScc +
       ' makespanDays=' + sol.makespanDays.toFixed(1) +
       ' ms={contact:' + (t1 - t0) + ',build:' + (t2 - t1) + ',solve:' + (t3 - t2) + ',total:' + (t3 - t0) + '}');
     return { ok: true, G: G, graph: graph, solution: sol,

--- a/viewer/sw.js
+++ b/viewer/sw.js
@@ -8,7 +8,7 @@
 // Cache-first for heavy assets (.wasm, images). DB files skip SW (IndexedDB handles them).
 //
 // DEPLOY: bump CACHE_VERSION on every OCI upload. Old caches are purged on activate.
-const CACHE_VERSION = 'v1048';   // bump on each deploy; per-change detail is the git commit message.
+const CACHE_VERSION = 'v1049';   // bump on each deploy; per-change detail is the git commit message.
 // v1048 (2026-08-16) bim-compiler prompts/4D_GANTT_TM_REFACTOR.md S1-S4 closeout: §S1_BAND_RANK
 // (cpm_schedule.js buildGraph — E4 storey hammocks + straggler group-key use 3m z-bands, not
 // per-storey-name rank, PR #1401); §S2_TUKEY_ENVELOPE (time_machine.js _tmDisplayRemap — task bars

--- a/viewer/time_machine.js
+++ b/viewer/time_machine.js
@@ -4558,7 +4558,17 @@
       }
     }
     if (_CPM_DISPLAY && typeof CpmSchedule !== 'undefined' && CpmSchedule.run) {
-      var r = CpmSchedule.run(items);
+      // §S6_CREW_PASS (4D_GANTT_TM_REFACTOR.md §S2_REVIEW_VERDICT S6): hand the solve the SAME
+      // per-resource crew caps computeSchedule runs on (max_crews_fixed wins over max_crews —
+      // injectGantt's own §CREW_DEMAND rule), so precedence-displaced work is re-paced by real
+      // crew capacity in-pass instead of landing simultaneously at the schedule tail.
+      var _dtLR = (typeof window !== 'undefined' && window.LABOR_RATES) || {};
+      var _dtMaxCrews = {};
+      for (var _dtR in _dtLR) {
+        if (_dtLR[_dtR].max_crews_fixed != null) _dtMaxCrews[_dtR] = _dtLR[_dtR].max_crews_fixed;
+        else if (_dtLR[_dtR].max_crews) _dtMaxCrews[_dtR] = _dtLR[_dtR].max_crews;
+      }
+      var r = CpmSchedule.run(items, { maxCrews: _dtMaxCrews });
       if (r && r.ok) {
         for (var i = 0; i < items.length; i++) { items[i].s = r.solution.times[i].s; items[i].e = r.solution.times[i].e; }
         var aud = _midairAudit(items);
@@ -4628,7 +4638,8 @@
       var st = schedule[el.guid]; if (!st) return;
       items.push({ guid: el.guid, s: st.start, e: st.end, bz: el.base_z, tz: el.top_z,
         x0: el.x0, x1: el.x1, y0: el.y0, y1: el.y1,
-        cls: el.cls, seq: el.seq, phase: el.phase, storey: el.storey });
+        cls: el.cls, seq: el.seq, phase: el.phase, storey: el.storey,
+        resource: el.resource });   // §S6_CREW_PASS: the solve's in-pass crew pools key on this
     });
     if (!items.length) return null;
     _displayTimeline(items);   // §CPM_DISPLAY: same single source as the kernel_ops write path (times only)
@@ -5642,7 +5653,8 @@
       return { guid: el.guid, s: _ts ? _ts.start : baseMs, e: _ts ? _ts.end : baseMs + 60000,
         bz: el.base_z, tz: el.top_z, x0: el.x0, x1: el.x1, y0: el.y0, y1: el.y1,
         cls: el.cls, seq: el.seq, phase: el.phase,
-        storey: el.storey };   // §TIER_SERIAL_BY_ZONE: the §ZONE_INDEX band, already median-Z repaired
+        storey: el.storey,   // §TIER_SERIAL_BY_ZONE: the §ZONE_INDEX band, already median-Z repaired
+        resource: el.resource };   // §S6_CREW_PASS: the solve's in-pass crew pools key on this
     });
     var _twStats = _displayTimeline(_twItems).stats;   // §CPM_DISPLAY (or legacy §TIER_SERIAL+§MIDAIR_REPAIR via ?cpm4d=0)
     _s4Mark('displayTimeline');
@@ -8216,7 +8228,7 @@
   // huts going first before the walls" AFTER a hard reset, because §GANTT_CACHE_HIT served a
   // gantt:v4 entry generated under the old ordering. A hard reset cannot clear it — the entry is in
   // IndexedDB, not the HTTP cache. This bump is that fix's second half.
-  var _GANTT_CACHE_VERSION = 30;   // §S1_BAND_RANK + §S2_TUKEY_ENVELOPE + §S4_RAW_SCHEDULE_REUSE (4D_GANTT_TM_REFACTOR.md)
+  var _GANTT_CACHE_VERSION = 31;   // §S6_CREW_PASS (4D_GANTT_TM_REFACTOR.md) — crew-aware forward pass reshapes every schedule
   // was 28:   // §CPM_DISPLAY (2026-08-16): display timeline authored by the one-DAG CPM pass
   // was 27:   // §ZONE_DISPLAY_AUTHORING (2026-08-16): task windows authored from
                                    // the DISPLAY timeline + strict-bar sweep skipped on that path —


### PR DESCRIPTION
Implementing `bim-compiler prompts/4D_GANTT_TM_REFACTOR.md §S2_REVIEW_VERDICT S6` — the crew-aware forward pass (serial schedule-generation scheme). This is the first stage to touch the solve's semantics; per the spec, the before/after stagger dumps and §CREW_FEASIBILITY numbers are posted here for the review checkpoint BEFORE merge.

## What changed
- `viewer/cpm_schedule.js` `solve()`: E5's TIMES retire as the lower bound (computed at RAW dates, they could not re-enforce crew capacity once precedence displaced work). The pass now claims the SAME per-resource crew slots `computeSchedule`'s own allocator uses (claim-earliest-slot, `max_crews_fixed ?? max_crews`, `MAX_CREWS_DEFAULT=3` mirrored), from a deterministic priority queue keyed (precedence-feasible time, bz, guid). Delays only → floating-0 by construction preserved. Contracted pure-physics SCCs keep ONE shared start (judge equality contract); a member whose pool is exhausted by its own SCC is counted in `crewOverCapScc`, never hidden.
- `viewer/time_machine.js`: `resource` plumbed on both `_displayTimeline` item builders (`_twItems` + the `_tmDisplayRemap` hook); the CPM call passes the LABOR_RATES crew-cap lookup. `_GANTT_CACHE_VERSION` 30→31, `sw.js` v1048→v1049 (bumped WITH the change, per the S5 process note).
- `scripts/probe_cpm_schedule.js` / `probe_cpm_display_path.js`: `resource` plumbed; NEW fleet gates `§CREW_FEASIBILITY` (per-resource concurrency ≤ cap, tolerance = 1-day quantum) and `§CREW_SPREAD_FLOOR` (group span ≥ Σdur/cap, groups n≥1000).

## §CREW_FEASIBILITY — the invariant the compression broke (acceptance 1)
BEFORE (old solve): RAW schedule 0 violations on all 7 (computeSchedule enforces crews); CPM output violated on **6/7 buildings** — worst:
```
Terminal:  STEEL_ERECTOR cap=3 maxConc=14417 · PLUMBER cap=2 maxConc=1966 · HVAC_TECH cap=2 maxConc=516
Hospital:  PLUMBER cap=2 maxConc=10657 · HVAC_TECH cap=2 maxConc=3156 · STEEL_ERECTOR cap=3 maxConc=619
LTU:       PLUMBER cap=2 maxConc=15294 overDays=30.3 (+5 more resources)
```
AFTER: **0 violations, all 7 buildings**, both probes (`§CREW_FEASIBILITY_CPM` + `§CREW_FEASIBILITY_CPMDP` all PASS).

## §CREW_SPREAD_FLOOR — Terminal roof arithmetic (acceptance 2)
BEFORE: `Superstructure||06 ROOF LEVEL n=10950 span=0.5d floor=7.6d VIOL` (+16 more groups fleet-wide).
AFTER: **0 violations fleet-wide** — roof span 11.1d ≥ 7.6d floor; every n≥1000 group ≥ its own crew floor.

## Hard gates (acceptance 3)
```
§CPM_FLOATING midair=0 structural=0     ALL 7   (unchanged)
§CPM_GATE_CHECK elementEdgeViolations=0 ALL 7
§CPM_PARITY elementMismatch=0           ALL 7
cycleDrops {e3:0,e4:0,member:0}         ALL 7   contractedSccs/Nodes identical to baseline
§CPMDP_FLEET_VERDICT buildings=7 fails=0 PASS   (nonOutlierOutside=0 all 7)
gate_4d.sh: §GATE_4D_RESULT pass=8 fail=0 missing=1 (same pre-existing witness_arch_area_weight MISS)
             §CACHE_VERSION_GUARD PASS gating_changed=0 version_bumped=1 (run AFTER commit)
witness_zone_display_authoring pass=16 fail=0 · witness_crosstask_judge_parity pass=20 fail=0
   (no assertion updates needed anywhere)
§LAYER_BUILDUP (S3 metric, live headless viewer): Terminal 0/12 PASS (unchanged);
   Hospital 1/14 — the SAME pre-S6 band54>band55 same-storey artifact, not worse
   (medians moved 364.7→60.7 / 61.6→18.1 but the boundary-slice artifact persists as predicted)
```

## Stagger — the user's symptom, before → after (acceptance 4)
Live headless viewer (`probe_gantt_stagger.js`), real DBs:
```
                                    Terminal        Hospital
tasks n≥1000 in a bar <2 days:      4  → 0          8  → 0
tasks sharing one exact start day:  20/72 → 9/72    11/35 → 3/35
tasks within ±1d of that day:       38/72 → 17/72   16/35 → 3/35
cluster location:                   day 150 (tail)  day 385 (tail)
                                    → day 1 (start) → day 10 (early)
totalDays:                          151 → 106       388 → 329
parallelism:                        7.36x → 20.5x   6.36x → 6.71x
```
The residual same-start group sits at PROJECT START (many trades legitimately begin early), not stacked at the tail — the "stack hell" shape is gone.

**Makespan note (recorded, not capped):** the spec predicted growth; makespans SHRANK instead (Terminal 130.6→100.2d engine-side). The prediction assumed E5's raw floors stayed; with E5 times retired (the spec's own instruction), in-pass slots pace work in topological priority order — more efficient than the raw z-order allocator, while feasibility now holds. Both directions of the crew constraint are now proven (no over-cap concurrency; every big group ≥ its crew floor), so the shorter makespan is the honest schedule, not a compression artifact.

**Soft-metric drift (reported, not hidden):** `§CPM_STOREY` LEVEL-granularity violations move 3→5 buildings (Duplex 0→1, Clinic 0→1, JKR 2→7, Terminal 4→5, LTU 4→6; HHS/Hospital stay 0). Detail rows are dominated by federated name-soup pairs (same physical floor, different storey names — `VÅNING 1` vs `VÅN 1`, `01 Ground Level Floor` vs `01 Ground Floor Level`) whose p50s were indistinguishable when everything compressed at the tail and now separate visibly under honest spreading — the S1 federated-ladder residual made more VISIBLE, not a new inversion class. The per-band physics metric (`§LAYER_BUILDUP`, ops not names) is unchanged on both live buildings.

Full logs: probe runs archived in the session scratchpad; dated §S6 section lands in `4D_GANTT_TM_REFACTOR.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
