### PR TITLE
fix(4d): §S7_OUTLIER_DELTA — Gantt drag collapsed 437 + inverted 217 outlier ops per gesture, now 0/0

### DIFF
--- a/scripts/probe_gantt_drag_outliers.js
+++ b/scripts/probe_gantt_drag_outliers.js
@@ -1,0 +1,79 @@
+#!/usr/bin/env node
+// probe_gantt_drag_outliers.js — Implementing bim-compiler prompts/4D_GANTT_TM_REFACTOR.md §S7
+// step 1 (measure, don't assume): drive the REAL commitGanttDrag path headless (window.__tmGanttDrag
+// test hook) on a large-outlier task and read §RETIME_OUTLIER_AUDIT — how many of the task's ops sat
+// outside its OLD drawn window (M2 Tukey outliers) and what duration _retimeSpan hands them back.
+// A move (+5d) and a resizeR (-30%) are both committed, each on a fresh page load so the second
+// gesture never operates on the first one's already-retimed ops. Read the log after every run.
+'use strict';
+const { spawn } = require('child_process');
+const puppeteer = require(process.env.PUPPETEER || 'puppeteer');
+const PORT = 8126;
+const BLD = process.env.BLD || 'Terminal_extracted';
+const URL = `http://localhost:${PORT}/viewer/viewer.html?db=/buildings/${BLD}.db`;
+
+async function gesture(browser, label, pick, drag) {
+  const page = await browser.newPage();
+  const lines = [];
+  page.on('console', m => { const t = m.text(); if (t.indexOf('§') >= 0) lines.push(t); });
+  page.on('pageerror', e => console.log('[pageerror] ' + String(e).slice(0, 300)));
+  await page.goto(URL, { waitUntil: 'domcontentloaded', timeout: 60000 });
+  await page.waitForFunction(() => typeof window.toggleTimeMachine === 'function', { timeout: 180000 });
+  await page.waitForFunction(() => window.APP && window.APP.db, { timeout: 240000 }).catch(() => {});
+  await new Promise(r => setTimeout(r, 15000));
+  await page.evaluate(() => window.toggleTimeMachine());
+  const deadline = Date.now() + 300000;
+  while (Date.now() < deadline) {
+    if (lines.some(l => l.indexOf('§TIME_MACHINE ON') >= 0)) break;
+    await new Promise(r => setTimeout(r, 200));
+  }
+  // open the Gantt drawer — _ganttTasks is computed by drawGanttMini, which only runs visible
+  await page.evaluate(() => {
+    const btn = document.getElementById('tm-gantt');
+    if (btn) btn.dispatchEvent(new PointerEvent('pointerup', { bubbles: true }));
+  });
+  await new Promise(r => setTimeout(r, 4000));
+  const diag = await page.evaluate(() => ({
+    tm: typeof window.toggleTimeMachine, bars: typeof window.__tmGanttWindows,
+    drag: typeof window.__tmGanttDrag, zone: typeof window.__tmZoneProbe,
+    loadFail: (window.__loadFails || null) }));
+  console.log('DIAG ' + JSON.stringify(diag));
+  lines.filter(l => /LOAD_FAIL/.test(l)).forEach(l => console.log('[loadfail] ' + l));
+  const bars = await page.evaluate(() => window.__tmGanttWindows ? window.__tmGanttWindows() : null);
+  if (!bars) { console.log('ERR __tmGanttBars missing'); await page.close(); return; }
+  const bar = pick(bars);
+  if (!bar) {
+    console.log('ERR no matching bar — bars dump follows (' + bars.length + ')');
+    bars.slice(0, 40).forEach(b => console.log('  BAR taskId=' + b.taskId + ' phase=' + b.phase +
+      ' storey=' + b.storey + ' n=' + b.n));
+    await page.close(); return;
+  }
+  console.log('GESTURE ' + label + ' task=' + bar.taskId + ' n=' + bar.n +
+    ' window=[' + new Date(bar.startTs).toISOString().slice(0, 10) + '..' +
+    new Date(bar.endTs).toISOString().slice(0, 10) + ']');
+  const before = lines.length;
+  const okDrag = await page.evaluate((tid, mode, dd) => window.__tmGanttDrag(tid, mode, dd),
+    bar.taskId, drag.mode, drag.deltaDays(bar));
+  await new Promise(r => setTimeout(r, 2000));
+  console.log('DRAG ok=' + okDrag + ' mode=' + drag.mode);
+  lines.slice(before).filter(l => /§(GANTT_RETIME|RETIME_OUTLIER_AUDIT|GANTT_DRAG)/.test(l))
+    .forEach(l => console.log('[drag] ' + l));
+  await page.close();
+}
+
+async function main() {
+  const server = spawn('python3', ['-m', 'http.server', String(PORT), '--directory',
+    process.env.SERVE_ROOT || '/tmp/s7-serve'], { stdio: 'ignore' });
+  await new Promise(r => setTimeout(r, 1500));
+  const browser = await puppeteer.launch({ headless: 'new',
+    args: ['--no-sandbox', '--disable-dev-shm-usage', '--use-angle=swiftshader', '--enable-unsafe-swiftshader'] });
+  // the S2/S6 lane's named large-outlier population: biggest Superstructure task
+  const pickBig = bars => bars.filter(b => b.taskId && /Superstructure/.test(b.taskId))
+    .sort((a, b) => b.n - a.n)[0];
+  await gesture(browser, 'MOVE+5d', pickBig, { mode: 'move', deltaDays: () => 5 });
+  await gesture(browser, 'RESIZE-30pct', pickBig, {
+    mode: 'resizeR',
+    deltaDays: bar => -Math.max(1, Math.round(0.3 * (bar.endTs - bar.startTs) / 86400000)) });
+  await browser.close(); server.kill(); process.exit(0);
+}
+main().catch(e => { console.error('ERR ' + (e && e.stack || e)); process.exit(2); });

--- a/viewer/sw.js
+++ b/viewer/sw.js
@@ -8,7 +8,7 @@
 // Cache-first for heavy assets (.wasm, images). DB files skip SW (IndexedDB handles them).
 //
 // DEPLOY: bump CACHE_VERSION on every OCI upload. Old caches are purged on activate.
-const CACHE_VERSION = 'v1049';   // bump on each deploy; per-change detail is the git commit message.
+const CACHE_VERSION = 'v1050';   // bump on each deploy; per-change detail is the git commit message.
 // v1048 (2026-08-16) bim-compiler prompts/4D_GANTT_TM_REFACTOR.md S1-S4 closeout: §S1_BAND_RANK
 // (cpm_schedule.js buildGraph — E4 storey hammocks + straggler group-key use 3m z-bands, not
 // per-storey-name rank, PR #1401); §S2_TUKEY_ENVELOPE (time_machine.js _tmDisplayRemap — task bars

--- a/viewer/time_machine.js
+++ b/viewer/time_machine.js
@@ -6943,6 +6943,18 @@
   // out of THIS source and test the shipped function rather than a hand-copied duplicate (the copy
   // problem this codebase already paid for three times with the support predicate).
   function _retimeSpan(opS, opE, oS, oE, nS, nE) {
+    // §S7_OUTLIER_DELTA (4D_GANTT_TM_REFACTOR.md §S7, measured live 2026-08-16: Terminal roof task
+    // n=11,004 had 440 ops outside its drawn bar; a drag collapsed 437 to the 60s floor and
+    // INVERTED 217 — end before start by up to -3.6h — because the affine map below assumes
+    // containment and extrapolates-then-clamps an outsider). An op outside the OLD window is a
+    // dag-wins Tukey outlier the bar deliberately excludes (M2: "counted, never hidden") — the
+    // edit-side rule is the same doctrine: never squeeze it into the window. It gets the window's
+    // uniform START delta with its TRUE duration preserved (a move shifts it with the task; a
+    // right-edge resize leaves it untouched, since nS==oS ⇒ delta 0).
+    if (opS < oS - 1 || opE > oE + 1) {
+      var ds = nS - oS;
+      return { s: Math.round(opS + ds), e: Math.round(opE + ds) };
+    }
     var oSpan = Math.max(1, oE - oS), nSpan = Math.max(1, nE - nS);
     var s = Math.round(nS + ((opS - oS) / oSpan) * nSpan);
     var e = Math.round(nS + ((opE - oS) / oSpan) * nSpan);
@@ -6958,6 +6970,11 @@
     var opByGuid = {}, i;
     for (i = 0; i < _ops.length; i++) if (_ops[i].output_guid) opByGuid[_ops[i].output_guid] = _ops[i];
     var rows = 0, t0 = (window.performance || Date).now();
+    // §RETIME_OUTLIER_AUDIT (4D_GANTT_TM_REFACTOR.md §S7 step 1 — measure, don't assume): count,
+    // per commit, the ops whose TRUE times sit outside their task's OLD drawn window (the Tukey
+    // outliers M2 deliberately leaves riding outside the bar) and what duration _retimeSpan hands
+    // each one back. collapsed = duration crushed to the 60s floor; inverted = end before start.
+    var audOutside = 0, audCollapsed = 0, audInverted = 0, audMinDur = Infinity, audMaxDur = -Infinity;
     db.run('BEGIN');
     moved.forEach(function (m) {
       var bar = barsByTask[m.id]; if (!bar || !bar.guids || !bar.guids.length) return;
@@ -6966,7 +6983,16 @@
       var oS = bar.startTs, oE = bar.endTs, oSpan = Math.max(1, oE - oS), nSpan = nE - nS;
       for (var gi = 0; gi < bar.guids.length; gi++) {
         var g = bar.guids[gi], op = opByGuid[g]; if (!op) continue;
+        var wasOutside = (op.start_ts < oS - 1 || op.end_ts > oE + 1);
         var r = _retimeSpan(op.start_ts, op.end_ts, oS, oE, nS, nE);
+        if (wasOutside) {
+          audOutside++;
+          var audDur = r.e - r.s;
+          if (audDur <= 60000) audCollapsed++;
+          if (audDur < 0) audInverted++;
+          if (audDur < audMinDur) audMinDur = audDur;
+          if (audDur > audMaxDur) audMaxDur = audDur;
+        }
         op.start_ts = r.s; op.end_ts = r.e;
         op.parameters._end_ts = r.e;
         upd.run([r.s, JSON.stringify(op.parameters), g]);
@@ -6977,6 +7003,10 @@
     upd.free();
     console.log('§GANTT_RETIME tasks=' + moved.length + ' rows=' + rows +
       ' ms=' + ((window.performance || Date).now() - t0).toFixed(1));
+    console.log('§RETIME_OUTLIER_AUDIT outsideOldWindow=' + audOutside + ' collapsed60s=' + audCollapsed +
+      ' inverted=' + audInverted +
+      (audOutside ? ' outlierDurMs=[' + audMinDur + ',' + audMaxDur + ']' : '') +
+      ' — outliers ride outside their bar (M2); collapse/inversion here is the §S7 edit-path defect');
     return rows;
   }
 
@@ -7074,6 +7104,20 @@
     drawGanttMini();
     renderAtTime(_cursor);
   }
+  // Test hooks (diagnostic only, same contract as __tmZoneProbe) — §S7's live drag reproduction:
+  // a headless probe needs the real commit path and the real computed bars, not a DOM gesture.
+  window.__tmGanttDrag = function (taskId, mode, deltaDays) {
+    for (var i = 0; i < _ganttTasks.length; i++) {
+      if (_ganttTasks[i].taskId === taskId) { commitGanttDrag(_ganttTasks[i], mode, deltaDays); return true; }
+    }
+    return false;
+  };
+  window.__tmGanttWindows = function () {   // NOT __tmGanttBars — drawGanttMini owns that name (rects)
+    return _ganttTasks.map(function (g) {
+      return { taskId: g.taskId, storey: g.storey, phase: g.phase, startTs: g.startTs, endTs: g.endTs,
+               n: g.guids ? g.guids.length : 0 };
+    });
+  };
 
   // §TM_RULER_SHIFT — drag the day ruler to move the WHOLE project's start/finish. Same shape as
   // commitGanttDrag (snapshot every leaf task's before-state + every touched guid's before-state


### PR DESCRIPTION
Implementing `bim-compiler prompts/4D_GANTT_TM_REFACTOR.md §S7` — measure-first, then fix. Run after S6 (#1406) per the §PRIORITY ruling: the measurement is against the post-S6 (spread) bar shapes.

## Measured (real commitGanttDrag, real viewer, Terminal `TASK_Superstructure_06_ROOF_LEVEL` n=11,004)
```
§RETIME_OUTLIER_AUDIT outsideOldWindow=440 collapsed60s=437 inverted=217 outlierDurMs=[-13113849,185810]   (move +5d)
§RETIME_OUTLIER_AUDIT outsideOldWindow=440 collapsed60s=437 inverted=217 outlierDurMs=[-8014019,113551]    (resizeR -30%)
```
The S7 hypothesis is CONFIRMED and worse than hypothesized: `_retimeSpan`'s affine map assumes containment; for the 440 ops that legitimately ride OUTSIDE the drawn Tukey bar (M2 outliers) it extrapolates then clamps — 437 collapse to the 60-second floor and **217 come out INVERTED (end before start, down to −3.6 h)**: corrupted kernel_ops that cannot render — the user's "bars disappear when pulled".

## Fix — §S7_OUTLIER_DELTA
An op outside the OLD window gets the window's uniform START delta with its TRUE duration preserved (a move shifts it with the task; a right-edge resize leaves it untouched, nS==oS ⇒ delta 0). Same never-squeeze-a-straggler doctrine M2 established for authoring, applied edit-side. Insiders keep the exact affine behavior.

## Re-measured, same drags
```
§RETIME_OUTLIER_AUDIT outsideOldWindow=440 collapsed60s=0 inverted=0 outlierDurMs=[106000,180000]   (both gestures)
```

## Regression evidence
- `witness_gantt_edit_undo` 9/0, `witness_gantt_edit_lock` 5/0 — untouched assertions, green.
- `gate_4d.sh` pass=8 fail=0 missing=1 (same pre-existing MISS).
- `probe_cpm_display_path.js` 7/7 PASS (floating 0, nonOutlierOutside 0, crewViol 0) — edit path only, solve untouched.
- `§RETIME_OUTLIER_AUDIT` §-log ships in `retimeTaskElements` (whitebox doctrine); `__tmGanttDrag`/`__tmGanttWindows` test hooks follow the `__tmZoneProbe` convention; new `scripts/probe_gantt_drag_outliers.js` is the repeatable harness. sw.js v1050.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
