### PR TITLE
feat(photo): mirror true reflection + MEP triplanar texture gaps

### DIFF
--- a/viewer/effects.js
+++ b/viewer/effects.js
@@ -2596,6 +2596,47 @@ async function setupEffects(A, renderer, scene, camera) {
   // streaming.js's own STD_MAT table already uses for "metal" elsewhere), not every surface.
   var PHOTO_METAL_THRESHOLD = 0.3;
   var PHOTO_METAL_ROUGHNESS_SCALE = 0.4;  // tighter/brighter specular highlight (was 0.6)
+  // ══ §MIRROR_TRUE_REFLECT (PHOTOREAL_STILL_RENDER.md ▶RESUME item 1) — mirrors are IfcFlowTerminal,
+  // and STD_MAT.IfcFlowTerminal carries envInt:0.05 (§HOSPITAL_BLUE_TINT/§PIPE_DUCT_BLUE_TINT — a
+  // fix meant to kill a blue-sky-tint on pipes/ducts, applied class-wide). That sets
+  // mat.userData._photoEnvExempt=true in streaming.js's _getMaterial(), which is
+  // _reassertPhotoMatBoost's very FIRST early-return guard below — mirrors get swept up in a fix
+  // meant for a different fixture and never get boosted, never get room-probe-eligible, never get a
+  // true-mirror roughness. Confirmed exclusive by direct DB query (Clinic): the 22 real
+  // "M_Mirror:Mirror 600mm x 900mm" elements carry material_rgba 0.843,0.843,0.843,1.000 — not
+  // shared with any other IfcFlowTerminal fixture in the building (grab bars/lights/exit signs/etc
+  // all carry distinct rgba values). streaming.js _getMaterial's cacheKey includes rgba+class, so
+  // this is a genuinely exclusive material — excluding it from the exemption cannot leak into
+  // diffusers/grilles/any other fixture sharing the class. Lookup uses the same
+  // name-keyword-query-via-elements_meta pattern as §PHOTO_EMBER's EMBER_WORDS, cached per building.
+  var _mirrorMatSet = null, _mirrorMatBuilding = null;
+  function _mirrorReflectMats() {
+    if (_mirrorMatSet && _mirrorMatBuilding === A.activeBuilding) return _mirrorMatSet;
+    _mirrorMatSet = Object.create(null);
+    _mirrorMatBuilding = A.activeBuilding;
+    if (typeof A.dbQuery !== 'function' || !A.guidMap || !A.collectMeshes) return _mirrorMatSet;
+    var rows;
+    try {
+      rows = A.dbQuery("SELECT guid FROM elements_meta WHERE ifc_class='IfcFlowTerminal' AND lower(element_name) LIKE '%mirror%'") || [];
+    } catch (e) { console.warn('§MIRROR_TRUE_REFLECT query failed: ' + e.message); return _mirrorMatSet; }
+    if (!rows.length) { console.log('§MIRROR_TRUE_REFLECT bld=' + A.activeBuilding + ' no mirrors — nothing to fix'); return _mirrorMatSet; }
+    var want = Object.create(null);
+    for (var i = 0; i < rows.length; i++) want[rows[i][0]] = 1;
+    var ids = Object.create(null), hits = 0;
+    for (var k in A.guidMap) if (want[A.guidMap[k]]) { ids[parseInt(String(k).split('_')[0], 10)] = 1; hits++; }
+    var meshes = 0, mats = 0;
+    A.collectMeshes(function(o) { return o.isMesh; }).forEach(function(o) {
+      if (!ids[o.id]) return;
+      meshes++;
+      (Array.isArray(o.material) ? o.material : [o.material]).forEach(function(m) {
+        if (!m || _mirrorMatSet[m.uuid]) return;
+        _mirrorMatSet[m.uuid] = m; mats++;
+      });
+    });
+    console.log('§MIRROR_TRUE_REFLECT bld=' + A.activeBuilding + ' guids=' + rows.length +
+      ' guidMapHits=' + hits + ' meshes=' + meshes + ' materials=' + mats);
+    return _mirrorMatSet;
+  }
   // §PHOTO_HEMI_FILL (user ask, "Ground still too dark"): re-read _setGroundColor (tools.js) and
   // found the actual bug — when the ground has a texture map (which it does, 'paved'), that
   // function IGNORES whatever hex tint is passed and forces plain WHITE (full brightness, no
@@ -2701,24 +2742,29 @@ async function setupEffects(A, renderer, scene, camera) {
   }
   function _reassertPhotoMatBoost() {
     if (!_photoMatBoostActive || !A._matCache) return;
+    var mirrorMats = _mirrorReflectMats();  // §MIRROR_TRUE_REFLECT — cached per building, cheap to call every tick
     Object.keys(A._matCache).forEach(function(k) {
       var m = A._matCache[k];
-      if (!m || (m.userData && (m.userData._photoBoosted || m.userData._photoEnvExempt)) ||
+      if (!m) return;
+      var isMirror = !!mirrorMats[m.uuid];  // §MIRROR_TRUE_REFLECT — exclusive material, bypasses the exemption below
+      if ((m.userData && (m.userData._photoBoosted || (m.userData._photoEnvExempt && !isMirror))) ||
           typeof m.envMapIntensity !== 'number') return;
       // §PHOTO_ENVMAP_DOUBLE_BOOST_FIX (2026-08-15): _photoEnvExempt (streaming.js's per-class
       // §HOSPITAL_BLUE_TINT envInt override) skips this blanket boost entirely — that override was
       // already hand-tuned to fight the sky's blue PMREM reflection on these specific classes;
       // re-boosting on top of it undid the tuning specifically during Alt+S/Alt+G captures.
       var isMetal = typeof m.metalness === 'number' && m.metalness > PHOTO_METAL_THRESHOLD;
-      var isGlossy = isMetal || (typeof m.roughness === 'number' && m.roughness <= PHOTO_GLOSSY_ROUGHNESS_MAX);
+      var isGlossy = isMirror || isMetal || (typeof m.roughness === 'number' && m.roughness <= PHOTO_GLOSSY_ROUGHNESS_MAX);
       if (isGlossy) {
         m.userData._photoOrigEnvMapIntensity = m.envMapIntensity;
         m.envMapIntensity = m.envMapIntensity * PHOTO_ENVMAP_BOOST;
         m.userData._photoRoomProbeEligible = true;  // §MIRROR_ROOM_PROBE — read every tick by _reassertPhotoEnvMap above
       }
-      if (isMetal) {
+      if (isMetal || isMirror) {
         m.userData._photoOrigRoughness = m.roughness;
-        m.roughness = Math.max(0.05, m.roughness * PHOTO_METAL_ROUGHNESS_SCALE);
+        // §MIRROR_TRUE_REFLECT: a real mirror is near-perfect specular, not tightened-metal —
+        // force near-zero roughness instead of the metal scale-down.
+        m.roughness = isMirror ? 0.03 : Math.max(0.05, m.roughness * PHOTO_METAL_ROUGHNESS_SCALE);
       }
       m.userData._photoBoosted = true;
       m.needsUpdate = true;

--- a/viewer/streaming.js
+++ b/viewer/streaming.js
@@ -540,7 +540,23 @@ function setupStreaming(A) {
       // ── IFC2x3 generic-MEP convention (Clinic/LTU/HHS export these instead of the above) ──
       IfcFlowSegment: _TRI_METAL,
       IfcFlowTerminal: _TRI_METAL,
-      IfcFlowFitting: _TRI_METAL
+      IfcFlowFitting: _TRI_METAL,
+      // §TRIPLANAR_MEP_GAPS (PHOTOREAL_STILL_RENDER.md ▶RESUME item 2, user: "it replaces
+      // selectively in some piping but not exactly similar next to it"). Real MEP runs mix inline
+      // devices (valves/dampers/pumps/gauges) between segments/fittings — those classes carried no
+      // triplanar entry, so an untextured device sitting between two grain-streaked pipe/duct
+      // segments on the SAME run read flat/plain right next to its textured neighbours, exactly the
+      // "selective" symptom. IfcValve found the same way as the other 4 (STD_MAT metal>0.3, same as
+      // the group comment above) but had no triplanar entry either — Terminal alone carries 111 of
+      // them, a real gap, not a hypothetical one; confirmed via elements_meta counts before adding
+      // (Clinic: IfcFlowController 369, IfcFlowMovingDevice 13, IfcFlowStorageDevice 1; Terminal:
+      // IfcFlowController 21, IfcValve 111). IfcFlowInstrument has zero real occurrences in any
+      // building checked but is added anyway for schema completeness, same as its siblings.
+      IfcFlowController: _TRI_METAL,
+      IfcFlowMovingDevice: _TRI_METAL,
+      IfcFlowInstrument: _TRI_METAL,
+      IfcFlowStorageDevice: _TRI_METAL,
+      IfcValve: _TRI_METAL
     };
 
     const key = rgbaStr || '_default';


### PR DESCRIPTION
## Summary
- §MIRROR_TRUE_REFLECT: Clinic's 22 real `M_Mirror` `IfcFlowTerminal` elements were caught by `STD_MAT.IfcFlowTerminal`'s `envInt:0.05` exemption (a fix meant for pipes/ducts) and never got the Alt+S envMap boost, room-probe reflection, or a true-mirror roughness. Confirmed the mirror's material is exclusive (unique `material_rgba`, no other fixture shares it) and added a name-keyword lookup (same pattern as `§PHOTO_EMBER`) that bypasses the exemption for mirror-only materials, forces near-zero roughness, and lets them pick up the local room-probe capture.
- §TRIPLANAR_MEP_GAPS: `TRIPLANAR_MAT` was missing several inline MEP device classes (valves/dampers/pumps/gauges) that sit between textured pipe/duct segments on the same run — explains the "replaces selectively in some piping" report. Added `IfcFlowController`/`IfcFlowMovingDevice`/`IfcFlowInstrument`/`IfcFlowStorageDevice`/`IfcValve` (the last a real gap found via the same metal>0.3 convention, 111 live elements on Terminal).

Both root-caused and live-verified against real buildings (Clinic, Terminal) headless before this PR — see `bim-compiler/prompts/PHOTOREAL_STILL_RENDER.md` for full diagnostic detail.

## Test plan
- [x] `node --check` on both touched files
- [x] Live headless witness on Clinic: mirror material picks up room-probe envMap, roughness 0.03, envMapIntensity boosted; control (grab-bar) material untouched
- [x] Live headless witness on Terminal: `IfcValve`/`IfcFlowController` materials compile with the real `uTriNorm` triplanar shader instead of the flat/fake-grain fallback

🤖 Generated with [Claude Code](https://claude.com/claude-code)