### PR TITLE
feat(4d): §GROUNDWORK_SLAB (S9) — grade slabs+beams are Substructure; frame beams <2d 16→0 engine-side

### DIFF
--- a/viewer/schedule_author.js
+++ b/viewer/schedule_author.js
@@ -317,7 +317,7 @@
       return best;
     }
 
-    return r[0].values.map(function (row) {
+    var _bseList = r[0].values.map(function (row) {
       var guid = row[0], cls = row[1], name = row[2], rawStorey = row[3];
       var cx = row[4], cy = row[5], cz = row[6], bx = row[7], by = row[8], bz = row[9];
       var storey = assignStoreyByZ(rawStorey, cz);
@@ -344,6 +344,28 @@
         noGeo: (bx === 0 && by === 0 && bz === 0 && cx === 0 && cy === 0 && cz === 0)
       };
     }).filter(function (e) { return !e.noGeo; });
+    _reclassGroundworkSlabs(_bseList, 'schedule_author');
+    return _bseList;
+  }
+
+  // §GROUNDWORK_SLAB (4D_GANTT_TM_REFACTOR.md §S9 / M5) — ONE shared definition
+  // (ScheduleGate.groundworkSlabs), applied identically by both element recipes (this one and
+  // time_machine.js's inline builder) so authored zones/tasks and the movie reclassify the SAME
+  // slabs. Mutates phase in place; seq/resource unchanged (CONCRETE_GANG already).
+  function _reclassGroundworkSlabs(list, who) {
+    // schedule_gate.js self-registers on its own wrapper global (globalThis in node, window in the
+    // browser) — this module's IIFE param is self||this, which in node is NOT globalThis, so check both.
+    var SG = (global && global.ScheduleGate) ||
+             (typeof globalThis !== 'undefined' && globalThis.ScheduleGate) ||
+             (typeof window !== 'undefined' && window.ScheduleGate) || null;
+    if (!SG || !SG.groundworkSlabs) return;
+    var gw = SG.groundworkSlabs(list), n = 0, levels = {};
+    for (var i = 0; i < list.length; i++) {
+      if (gw[list[i].guid]) { list[i].phase = 'Substructure'; n++; levels[list[i].storey || '_'] = 1; }
+    }
+    if (n) console.log('§GROUNDWORK_SLAB recipe=' + who + ' n=' + n +
+      ' levels=' + JSON.stringify(Object.keys(levels)) +
+      ' — slab-on-grade reclassified Substructure (bears on grade/piles/footings only, lowest Superstructure band)');
   }
 
   // materializeZones(db, rules, opts) — CPM_FLOAT_GAP.md Gap 1 (element-level, rolled up): the

--- a/viewer/schedule_gate.js
+++ b/viewer/schedule_gate.js
@@ -169,6 +169,82 @@
     return o;
   }
   function overlap(a, b) { return a.x0 <= b.x1 && a.x1 >= b.x0 && a.y0 <= b.y1 && a.y1 >= b.y0; }
+  // ══ §GROUNDWORK_SLAB (2026-08-16, bim-compiler prompts/4D_GANTT_TM_REFACTOR.md §S9 / M5 v2) ═══
+  // groundworkSlabs(els) -> { guid: 1 } for every IfcSlab/IfcBeam currently classified
+  // Superstructure that is GROUNDWORK, not deck/frame: (1) its 3m z-band (the shipped §GANTT
+  // quantum) is the building's LOWEST band containing any Superstructure element — "ground"
+  // extracted per building, no assumed datum; (2) FIXPOINT membership: it joins the set when every
+  // bearing-below contact (this module's own EPS/GAP bearing predicate — the judge's) is
+  // Substructure-phase OR already in the set — grade beams join first (they bear on piles/footings
+  // only), the plate joins next (it bears on piles + grade beams). A deck slab bears on frame
+  // beams (Superstructure, higher band, never members) and a frame beam bears on columns —
+  // neither ever joins. The SEQUENCE_RULES class defaults (IfcBeam seq 3 / IfcSlab seq 4,
+  // Superstructure) are FRAME logic, right for upper floors — a slab-on-grade or grade beam
+  // sequenced by them appears with the steel all round it, the user-reported symptom. Same
+  // shared-pure-function status as hostPairs: one definition, both element recipes call it, so
+  // zone authoring, task bars, milestones (E3's Substructure→Superstructure chain then orders
+  // groundwork-before-frame with zero solver changes) and the movie stay one truth. Pure
+  // geometry — no timing read.
+  function groundworkSlabs(els) {
+    var out = {}, idx = {}, t, e, cs, c, k, S;
+    var minSupBand = Infinity;
+    for (t = 0; t < els.length; t++) {
+      e = els[t];
+      if (e.phase === 'Superstructure') {
+        var b = Math.floor(e.base_z / 3);
+        if (b < minSupBand) minSupBand = b;
+      }
+    }
+    if (!isFinite(minSupBand)) return out;
+    // M5 v3: only a STRUCTURE-POOL element can make a candidate a deck — the module's own bearing
+    // definition (seq<=4, IfcWall*, promoted slab = IfcSlab seq>4, stair flight). Under-slab
+    // services (MEP seq 7/9 — measured 905 such pairs under Terminal's plate) are real contacts
+    // (E1's SS edge keeps that physical order) but cannot BEAR a slab, so they never disqualify.
+    function isStructBearing(S) {
+      return S.seq <= 4 || (S.cls && S.cls.indexOf('IfcWall') === 0) ||
+             (S.cls === 'IfcSlab' && S.seq > 4) || S.cls === 'IfcStairFlight';
+    }
+    for (t = 0; t < els.length; t++) {
+      e = els[t];
+      if (e.phase === 'Substructure') continue;   // only non-Substructure can disqualify a bearing
+      if (!isStructBearing(e)) continue;
+      cs = cellsOf(e);
+      for (c = 0; c < cs.length; c++) (idx[cs[c]] = idx[cs[c]] || []).push(t);
+    }
+    // candidates + their potentially-disqualifying bearing-below contact lists, computed once
+    var cand = [], bearings = [];
+    for (t = 0; t < els.length; t++) {
+      e = els[t];
+      if ((e.cls !== 'IfcSlab' && e.cls !== 'IfcBeam') || e.phase !== 'Superstructure') continue;
+      if (Math.floor(e.base_z / 3) !== minSupBand) continue;
+      var bl = [], seen = {};
+      cs = cellsOf(e);
+      for (c = 0; c < cs.length; c++) {
+        var arr = idx[cs[c]]; if (!arr) continue;
+        for (k = 0; k < arr.length; k++) {
+          S = els[arr[k]];
+          if (S.guid === e.guid || seen[arr[k]]) continue;
+          seen[arr[k]] = 1;
+          if (S.base_z < e.base_z - EPS && S.top_z >= e.base_z - GAP && overlap(S, e)) bl.push(arr[k]);
+        }
+      }
+      cand.push(t); bearings.push(bl);
+    }
+    var changed = true;
+    while (changed) {
+      changed = false;
+      for (t = 0; t < cand.length; t++) {
+        e = els[cand[t]];
+        if (out[e.guid]) continue;
+        var blocked = false;
+        for (k = 0; k < bearings[t].length; k++) {
+          if (!out[els[bearings[t][k]].guid]) { blocked = true; break; }
+        }
+        if (!blocked) { out[e.guid] = 1; changed = true; }
+      }
+    }
+    return out;
+  }
   // ══ §DOOR_WINDOW_HOST_WALL_DISPLAY (2026-08-12, bim-compiler prompts/4D_SCHEDULE_PERFECTION.md) ══
   // MEASURED (witness_curtain_wall_opening's own G-CWO-DISPLAY, left non-asserting on purpose so a
   // fix could promote it): openingGate holds PERFECTLY on the generative timeline — rawEARLY 0.0% on
@@ -1074,7 +1150,7 @@
   // SHIFT_MS/DAY_MS + the two mappers are exported for the same reason EPS/GAP/CELL are: the live
   // movie clock (time_machine.js injectGantt's scaleFactor/projectDays) must size a day with THIS
   // module's shift, not a second hand-typed 8h constant to drift (§TM_DURATION_SYNC's lesson).
-  var API = { computeSchedule: computeSchedule, collapsePhase: collapsePhase, elementsInPhase: elementsInPhase, auditFloating: auditFloating, deriveBandRanks: deriveBandRanks, deriveZones: deriveZones, hostPairs: hostPairs, openingPairs: openingPairs, CELL: CELL, EPS: EPS, GAP: GAP, BIG_ELEMENT_VOL: BIG_ELEMENT_VOL, SHIFT_MS: SHIFT_MS, DAY_MS: DAY_MS, toProductive: toProductive, toWall: toWall };
+  var API = { computeSchedule: computeSchedule, collapsePhase: collapsePhase, elementsInPhase: elementsInPhase, auditFloating: auditFloating, deriveBandRanks: deriveBandRanks, deriveZones: deriveZones, hostPairs: hostPairs, openingPairs: openingPairs, groundworkSlabs: groundworkSlabs, CELL: CELL, EPS: EPS, GAP: GAP, BIG_ELEMENT_VOL: BIG_ELEMENT_VOL, SHIFT_MS: SHIFT_MS, DAY_MS: DAY_MS, toProductive: toProductive, toWall: toWall };
   global.ScheduleGate = API;
   if (typeof module !== 'undefined' && module.exports) module.exports = API;
 })(typeof window !== 'undefined' ? window : (typeof globalThis !== 'undefined' ? globalThis : this));

--- a/viewer/schedule_gate.js
+++ b/viewer/schedule_gate.js
@@ -169,41 +169,48 @@
     return o;
   }
   function overlap(a, b) { return a.x0 <= b.x1 && a.x1 >= b.x0 && a.y0 <= b.y1 && a.y1 >= b.y0; }
-  // ══ §GROUNDWORK_SLAB (2026-08-16, bim-compiler prompts/4D_GANTT_TM_REFACTOR.md §S9 / M5 v2) ═══
+  // ══ §GROUNDWORK_SLAB (2026-08-16, bim-compiler prompts/4D_GANTT_TM_REFACTOR.md §S9 / M5 v4) ═══
   // groundworkSlabs(els) -> { guid: 1 } for every IfcSlab/IfcBeam currently classified
-  // Superstructure that is GROUNDWORK, not deck/frame: (1) its 3m z-band (the shipped §GANTT
-  // quantum) is the building's LOWEST band containing any Superstructure element — "ground"
-  // extracted per building, no assumed datum; (2) FIXPOINT membership: it joins the set when every
-  // bearing-below contact (this module's own EPS/GAP bearing predicate — the judge's) is
-  // Substructure-phase OR already in the set — grade beams join first (they bear on piles/footings
-  // only), the plate joins next (it bears on piles + grade beams). A deck slab bears on frame
-  // beams (Superstructure, higher band, never members) and a frame beam bears on columns —
-  // neither ever joins. The SEQUENCE_RULES class defaults (IfcBeam seq 3 / IfcSlab seq 4,
-  // Superstructure) are FRAME logic, right for upper floors — a slab-on-grade or grade beam
-  // sequenced by them appears with the steel all round it, the user-reported symptom. Same
-  // shared-pure-function status as hostPairs: one definition, both element recipes call it, so
-  // zone authoring, task bars, milestones (E3's Substructure→Superstructure chain then orders
-  // groundwork-before-frame with zero solver changes) and the movie stay one truth. Pure
-  // geometry — no timing read.
+  // Superstructure that is GROUNDWORK, not deck/frame. Two membership routes, both extracted:
+  //  (a) ZERO structural bearings (slab-on-grade over soil): joins iff its 3m z-band (the shipped
+  //      §GANTT quantum) equals the LOWEST band among the candidate classes themselves (IfcSlab/
+  //      IfcBeam Superstructure — NOT all Superstructure: measured live, 3 stray IfcColumn bases
+  //      one band below Terminal's plate voided every candidate, and band quantization shifts
+  //      between z-datums; keying on the candidate population is frame-invariant).
+  //  (b) HAS structural bearings: FIXPOINT — joins when every structure-pool bearing-below contact
+  //      (seq<=4 / IfcWall* / promoted slab / stair flight — the module's own bearing definition;
+  //      under-slab MEP never counts, a pipe cannot bear a slab) is Substructure-phase or already
+  //      a member. Grade beams join first (they bear on piles/footings), the plate joins next
+  //      (piles + grade beams), toppings join off the plate. A deck slab bears on frame beams and
+  //      a frame beam on columns — columns are not candidates, so neither ever joins.
+  // The SEQUENCE_RULES class defaults (IfcBeam seq 3 / IfcSlab seq 4, Superstructure) are FRAME
+  // logic, right for upper floors — groundwork sequenced by them appears with the steel all round
+  // it, the user-reported symptom. Same shared-pure-function status as hostPairs: one definition,
+  // both element recipes call it, so zone authoring, task bars, milestones (E3's existing
+  // Substructure→Superstructure chain then orders groundwork-before-frame with zero solver
+  // changes) and the movie stay one truth. Pure geometry — no timing read.
   function groundworkSlabs(els) {
     var out = {}, idx = {}, t, e, cs, c, k, S;
-    var minSupBand = Infinity;
+    function isStructBearing(s2) {
+      return s2.seq <= 4 || (s2.cls && s2.cls.indexOf('IfcWall') === 0) ||
+             (s2.cls === 'IfcSlab' && s2.seq > 4) || s2.cls === 'IfcStairFlight';
+    }
+    function isCand(e2) {
+      return (e2.cls === 'IfcSlab' || e2.cls === 'IfcBeam') && e2.phase === 'Superstructure';
+    }
+    // v6: the ground window is PER CANDIDATE CLASS and DATUM-INVARIANT. Two measured traps led
+    // here: (v5) Terminal's grade beams base one 3m band below the plate, so one shared minimum
+    // starved the plate — the ground reference must be each class's own; and (v6) the viewer
+    // rebases the z-datum in its in-memory DB, so floor(z/3) BIN EQUALITY gave 233 members on the
+    // raw datum and 29 on the shifted one for the SAME building — the same 3m quantum must be
+    // applied as a continuous window above the class's own minimum base_z, not as a bin boundary.
+    var minZByCls = {};
     for (t = 0; t < els.length; t++) {
-      e = els[t];
-      if (e.phase === 'Superstructure') {
-        var b = Math.floor(e.base_z / 3);
-        if (b < minSupBand) minSupBand = b;
+      if (isCand(els[t])) {
+        if (!(els[t].cls in minZByCls) || els[t].base_z < minZByCls[els[t].cls]) minZByCls[els[t].cls] = els[t].base_z;
       }
     }
-    if (!isFinite(minSupBand)) return out;
-    // M5 v3: only a STRUCTURE-POOL element can make a candidate a deck — the module's own bearing
-    // definition (seq<=4, IfcWall*, promoted slab = IfcSlab seq>4, stair flight). Under-slab
-    // services (MEP seq 7/9 — measured 905 such pairs under Terminal's plate) are real contacts
-    // (E1's SS edge keeps that physical order) but cannot BEAR a slab, so they never disqualify.
-    function isStructBearing(S) {
-      return S.seq <= 4 || (S.cls && S.cls.indexOf('IfcWall') === 0) ||
-             (S.cls === 'IfcSlab' && S.seq > 4) || S.cls === 'IfcStairFlight';
-    }
+    if (!('IfcSlab' in minZByCls) && !('IfcBeam' in minZByCls)) return out;
     for (t = 0; t < els.length; t++) {
       e = els[t];
       if (e.phase === 'Substructure') continue;   // only non-Substructure can disqualify a bearing
@@ -211,12 +218,11 @@
       cs = cellsOf(e);
       for (c = 0; c < cs.length; c++) (idx[cs[c]] = idx[cs[c]] || []).push(t);
     }
-    // candidates + their potentially-disqualifying bearing-below contact lists, computed once
+    // candidates + their potentially-disqualifying structural bearing lists, computed once
     var cand = [], bearings = [];
     for (t = 0; t < els.length; t++) {
       e = els[t];
-      if ((e.cls !== 'IfcSlab' && e.cls !== 'IfcBeam') || e.phase !== 'Superstructure') continue;
-      if (Math.floor(e.base_z / 3) !== minSupBand) continue;
+      if (!isCand(e)) continue;
       var bl = [], seen = {};
       cs = cellsOf(e);
       for (c = 0; c < cs.length; c++) {
@@ -228,6 +234,11 @@
           if (S.base_z < e.base_z - EPS && S.top_z >= e.base_z - GAP && overlap(S, e)) bl.push(arr[k]);
         }
       }
+      // route (a): no structural bearing — within one 3m quantum of its own class's lowest base
+      if (!bl.length) {
+        if (e.base_z <= minZByCls[e.cls] + 3) out[e.guid] = 1;
+        continue;
+      }
       cand.push(t); bearings.push(bl);
     }
     var changed = true;
@@ -238,7 +249,8 @@
         if (out[e.guid]) continue;
         var blocked = false;
         for (k = 0; k < bearings[t].length; k++) {
-          if (!out[els[bearings[t][k]].guid]) { blocked = true; break; }
+          S = els[bearings[t][k]];
+          if (S.phase !== 'Substructure' && !out[S.guid]) { blocked = true; break; }
         }
         if (!blocked) { out[e.guid] = 1; changed = true; }
       }

--- a/viewer/sw.js
+++ b/viewer/sw.js
@@ -8,7 +8,7 @@
 // Cache-first for heavy assets (.wasm, images). DB files skip SW (IndexedDB handles them).
 //
 // DEPLOY: bump CACHE_VERSION on every OCI upload. Old caches are purged on activate.
-const CACHE_VERSION = 'v1051';   // bump on each deploy; per-change detail is the git commit message.
+const CACHE_VERSION = 'v1052';   // bump on each deploy; per-change detail is the git commit message.
 // v1051 (2026-08-16) §S7_OUTLIER_DELTA: Gantt drag/resize no longer collapses (437/gesture) or
 // INVERTS (217/gesture) the ops riding outside their task's drawn Tukey bar — outsiders get the
 // window's uniform start delta with true duration preserved (time_machine.js, 4D_GANTT_TM_REFACTOR.md §S7).

--- a/viewer/time_machine.js
+++ b/viewer/time_machine.js
@@ -5441,6 +5441,22 @@
     if (nameOverrides) console.log('§NAME_OVERRIDE ' + nameOverrides + ' elements reclassified by name (' +
       NO.map(function(o){ return o.id; }).join(',') + ') — see rates/sequence_rules.json NAME_OVERRIDES');
 
+    // §GROUNDWORK_SLAB (4D_GANTT_TM_REFACTOR.md §S9 / M5) — ONE shared definition
+    // (ScheduleGate.groundworkSlabs), applied by BOTH element recipes (schedule_author's
+    // _buildScheduleElements applies the same call) so authored zones/tasks and this movie recipe
+    // reclassify the SAME slabs: a slab-on-grade (bears on grade/piles/footings only, in the
+    // building's lowest Superstructure band) is Substructure work — E3's phase chain then orders
+    // plate-before-steel at its level with zero solver changes. seq/resource unchanged.
+    if (typeof ScheduleGate !== 'undefined' && ScheduleGate.groundworkSlabs) {
+      var _gw = ScheduleGate.groundworkSlabs(elements), _gwN = 0, _gwLevels = {};
+      elements.forEach(function (el) {
+        if (_gw[el.guid]) { el.phase = 'Substructure'; _gwN++; _gwLevels[el.storey || '_'] = 1; }
+      });
+      if (_gwN) console.log('§GROUNDWORK_SLAB recipe=time_machine n=' + _gwN +
+        ' levels=' + JSON.stringify(Object.keys(_gwLevels)) +
+        ' — slab-on-grade reclassified Substructure (bears on grade/piles/footings only, lowest Superstructure band)');
+    }
+
     // §4D_ROOF_LOAD_PATH M1 + §4D_WALLS_BEFORE_ROOF M4 — roof/load-path promotion, shared
     // classifier (full doctrine comments live on _promoteRoofLoadPath above, moved there verbatim
     // when the two inline copies were consolidated 2026-08-10).
@@ -8272,7 +8288,7 @@
   // huts going first before the walls" AFTER a hard reset, because §GANTT_CACHE_HIT served a
   // gantt:v4 entry generated under the old ordering. A hard reset cannot clear it — the entry is in
   // IndexedDB, not the HTTP cache. This bump is that fix's second half.
-  var _GANTT_CACHE_VERSION = 31;   // §S6_CREW_PASS (4D_GANTT_TM_REFACTOR.md) — crew-aware forward pass reshapes every schedule
+  var _GANTT_CACHE_VERSION = 32;   // §GROUNDWORK_SLAB (4D_GANTT_TM_REFACTOR.md §S9) — grade slab+beam reclassification reshapes ground-level schedule
   // was 28:   // §CPM_DISPLAY (2026-08-16): display timeline authored by the one-DAG CPM pass
   // was 27:   // §ZONE_DISPLAY_AUTHORING (2026-08-16): task windows authored from
                                    // the DISPLAY timeline + strict-bar sweep skipped on that path —


### PR DESCRIPTION
Implementing `bim-compiler prompts/4D_GANTT_TM_REFACTOR.md §S9 / M5 (v3-v6 amendments in-file)` — user live report: *"still do not see the ground slabs proceeding first before the beams all round."*

## Cause (measured, not assumed)
`IfcSlab`/`IfcBeam` class defaults are FRAME logic (deck slabs seq 4 after beams seq 3) — Terminal's pile→grade-beam→plate groundwork was classified Superstructure, its level had no Substructure milestone, so E3 never gated it, and E1's SS (start-start) semantics let the frame race: first 5 days of a 100-day schedule contained 93 Architecture walls, 165 MEP pieces, 84 band-7 frame beams, 25 light fixtures.

## Fix
`ScheduleGate.groundworkSlabs(els)` — shared pure helper (same status as `hostPairs`), applied by BOTH element recipes (`§GROUNDWORK_SLAB` log in each): fixpoint over `{IfcSlab, IfcBeam}`; joins when every STRUCTURE-POOL bearing-below contact (seq≤4 / IfcWall* / promoted / stair — the module's own bearing definition) is Substructure or already a member; zero-bearing candidates join within one 3m quantum of their own class's lowest base (datum-invariant — bin equality gave 233 vs 29 for the same building across z-datums). Under-slab MEP (905 measured pairs) never disqualifies — a pipe cannot bear a slab. E3's existing phase chain does the ordering; zero solver changes.

## Terminal, engine-side (extracted-DB recipe)
```
frame (Superstructure) beams starting < day 2:  16 → 0   (earliest now day 4.7)
plate: 200 pieces + 20 grade beams → Substructure; p90 end 2.1d ≤ min Superstructure start 2.1d (+1d tol)
early window: piles → plate+grade beams → columns (2-4.5d) → frame (4.7d+)
```

## Fleet gates
```
floating 0/7 · §CPM_GATE_CHECK 0/7 · §CREW_FEASIBILITY 0/7 · §CREW_SPREAD_FLOOR 0
§CPMDP_FLEET 7/7 PASS (nonOutlierOutside=0, crewViol=0)
gate_4d pass=8 fail=0 missing=1 (same pre-existing MISS) · §CACHE_VERSION_GUARD PASS version_bumped=1
witness_zone_display_authoring 16/0 · witness_crosstask_judge_parity 20/0 (assertions untouched)
§LAYER_BUILDUP: Terminal 0/12 PASS · Hospital 1/14 (same pre-existing band54 artifact)
storeyViol: unchanged except LTU 6→7 (documented federated name-soup residual)
sw.js v1052 · _GANTT_CACHE_VERSION 32
```

## ⚠ Known live-side gap (measured, documented in the prompts file as the ⛔ follow-up)
The live viewer's element pipeline diverges from the extracted-DB recipe the probes measure: live Terminal reclassifies only **29** members vs 233 engine-side, and the live early window barely moves. Measured deltas between the two element sets for the SAME building: 125 more Superstructure slabs live, 60 Architecture/seq8 slabs live vs 0, different z-frames, plate bearing profiles differ (386 beam / 479 slab / 251 wall pairs live vs ~60 total engine-side). This is the same "third recipe" divergence S1's results note already flagged (live stragglers 11,215 vs probe 13,084) — it caps what ANY engine fix can show on screen and is named as its own follow-up lane. This PR ships the engine-proven, fleet-green foundation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
