### PR TITLE
chore(sw): bump CACHE_VERSION — mirror/triplanar fix never went live

### DIFF
--- a/viewer/sw.js
+++ b/viewer/sw.js
@@ -8,7 +8,7 @@
 // Cache-first for heavy assets (.wasm, images). DB files skip SW (IndexedDB handles them).
 //
 // DEPLOY: bump CACHE_VERSION on every OCI upload. Old caches are purged on activate.
-const CACHE_VERSION = 'v1052';   // bump on each deploy; per-change detail is the git commit message.
+const CACHE_VERSION = 'v1053';   // bump on each deploy; per-change detail is the git commit message.
 // v1051 (2026-08-16) §S7_OUTLIER_DELTA: Gantt drag/resize no longer collapses (437/gesture) or
 // INVERTS (217/gesture) the ops riding outside their task's drawn Tukey bar — outsiders get the
 // window's uniform start delta with true duration preserved (time_machine.js, 4D_GANTT_TM_REFACTOR.md §S7).

--- a/viewer/viewer.html
+++ b/viewer/viewer.html
@@ -822,7 +822,7 @@ html.bim-embedded, html.bim-embedded body { background: #0b0b0b; }
 <script src="qrcode.min.js?v=1" onerror="console.warn('§LOAD_FAIL qrcode.min.js — QR sharing disabled')"></script>
 <script src="config.js?v=4" onerror="console.warn('§LOAD_FAIL config.js')"></script>
 <script src="db_resolve.js?v=2" onerror="console.warn('§LOAD_FAIL db_resolve.js')"></script>
-<script src="effects.js?v=23" onerror="console.warn('§LOAD_FAIL effects.js')"></script>
+<script src="effects.js?v=24" onerror="console.warn('§LOAD_FAIL effects.js')"></script>
 <script src="effects_gi_poc.js?v=3" onerror="console.warn('§LOAD_FAIL effects_gi_poc.js')"></script>
 <script src="lib/mp4_mux.js?v=1" onerror="console.warn('§LOAD_FAIL mp4_mux.js — MaxQ falls back to webm')"></script>
 <script src="cinema_path_editor.js?v=15" onerror="console.warn('§LOAD_FAIL cinema_path_editor.js — Alt+C path editing disabled')"></script>
@@ -837,7 +837,7 @@ html.bim-embedded, html.bim-embedded body { background: #0b0b0b; }
 <script src="scene.js?v=56" onerror="console.warn('§LOAD_FAIL scene.js')"></script>
 <script src="panel_nav.js?v=1" onerror="console.warn('§LOAD_FAIL panel_nav.js')"></script>
 <script src="helpers.js?v=6" onerror="console.warn('§LOAD_FAIL helpers.js')"></script>
-<script src="streaming.js?v=62" onerror="console.warn('§LOAD_FAIL streaming.js')"></script>
+<script src="streaming.js?v=63" onerror="console.warn('§LOAD_FAIL streaming.js')"></script>
 <script src="dlod.js?v=8" onerror="console.warn('§LOAD_FAIL dlod.js')"></script>
 <script src="panels.js?v=44" onerror="console.warn('§LOAD_FAIL panels.js')"></script>
 <script src="tools.js?v=42" onerror="console.warn('§LOAD_FAIL tools.js')"></script>


### PR DESCRIPTION
## Summary
PR #1409 changed `effects.js`/`streaming.js` but never bumped the service-worker `CACHE_VERSION`, so browsers with an existing install kept serving the pre-#1409 bundle — user reported "Mirror did not work" and their console log confirmed zero `§MIRROR_TRUE_REFLECT` output despite a full Alt+S cycle completing, the documented symptom for this exact bug class.

- `sw.js`: `CACHE_VERSION` v1052 → v1053
- `viewer.html`: `effects.js?v=23→24`, `streaming.js?v=62→63`

## Test plan
- [x] `node --check` on sw.js
- [x] Confirmed both files are in `PRECACHE_ASSETS`
- [ ] User to hard-refresh / accept the SW update toast and confirm the mirror now reflects

🤖 Generated with [Claude Code](https://claude.com/claude-code)