### PR TITLE
fix(photo): mirror metalness — roughness fix alone wasn't enough

### DIFF
--- a/viewer/effects.js
+++ b/viewer/effects.js
@@ -2766,6 +2766,21 @@ async function setupEffects(A, renderer, scene, camera) {
         // force near-zero roughness instead of the metal scale-down.
         m.roughness = isMirror ? 0.03 : Math.max(0.05, m.roughness * PHOTO_METAL_ROUGHNESS_SCALE);
       }
+      // §MIRROR_TRUE_REFLECT_METALNESS (found live 2026-08-16+1 — the roughness-only fix above
+      // shipped but user reported "still not reflection in mirror"): STD_MAT.IfcFlowTerminal's
+      // metal:0.30 was never touched by the fix above. MeshStandardMaterial's PBR split is driven
+      // by metalness, not roughness — at metalness 0.3 the BRDF still blends ~70% diffuse albedo
+      // into the output (diffuseColor = albedo*(1-metalness)), so even a perfectly sharp, boosted
+      // envMap reflection reads as a faint sheen on top of a mostly-flat grey surface, not a mirror
+      // image. Roughness alone controls how BLURRY a reflection is, not how STRONG it is relative
+      // to diffuse — the two are independent PBR parameters, and only one was fixed. Force
+      // near-1.0 metalness for mirrors specifically (glass/other glossy classes keep their real
+      // metalness — this is mirror-only, gated by the same `isMirror` exclusivity as the rest of
+      // this fix).
+      if (isMirror) {
+        m.userData._photoOrigMetalness = m.metalness;
+        m.metalness = 0.95;
+      }
       m.userData._photoBoosted = true;
       m.needsUpdate = true;
       if (isGlossy) _photoEnvBoostedMats.push(m);
@@ -3555,6 +3570,12 @@ async function setupEffects(A, renderer, scene, camera) {
       if (m.userData._photoOrigRoughness !== undefined) {
         m.roughness = m.userData._photoOrigRoughness;
         delete m.userData._photoOrigRoughness;
+      }
+      // §MIRROR_TRUE_REFLECT_METALNESS: undo the forced near-1.0 metalness, same restore
+      // discipline as roughness/envMapIntensity above.
+      if (m.userData._photoOrigMetalness !== undefined) {
+        m.metalness = m.userData._photoOrigMetalness;
+        delete m.userData._photoOrigMetalness;
       }
       delete m.userData._photoBoosted;
       // §MIRROR_ROOM_PROBE: drop back to the sky env map — same "restore what you borrowed" rule

--- a/viewer/sw.js
+++ b/viewer/sw.js
@@ -8,7 +8,7 @@
 // Cache-first for heavy assets (.wasm, images). DB files skip SW (IndexedDB handles them).
 //
 // DEPLOY: bump CACHE_VERSION on every OCI upload. Old caches are purged on activate.
-const CACHE_VERSION = 'v1053';   // bump on each deploy; per-change detail is the git commit message.
+const CACHE_VERSION = 'v1054';   // bump on each deploy; per-change detail is the git commit message.
 // v1051 (2026-08-16) §S7_OUTLIER_DELTA: Gantt drag/resize no longer collapses (437/gesture) or
 // INVERTS (217/gesture) the ops riding outside their task's drawn Tukey bar — outsiders get the
 // window's uniform start delta with true duration preserved (time_machine.js, 4D_GANTT_TM_REFACTOR.md §S7).

--- a/viewer/viewer.html
+++ b/viewer/viewer.html
@@ -822,7 +822,7 @@ html.bim-embedded, html.bim-embedded body { background: #0b0b0b; }
 <script src="qrcode.min.js?v=1" onerror="console.warn('§LOAD_FAIL qrcode.min.js — QR sharing disabled')"></script>
 <script src="config.js?v=4" onerror="console.warn('§LOAD_FAIL config.js')"></script>
 <script src="db_resolve.js?v=2" onerror="console.warn('§LOAD_FAIL db_resolve.js')"></script>
-<script src="effects.js?v=24" onerror="console.warn('§LOAD_FAIL effects.js')"></script>
+<script src="effects.js?v=25" onerror="console.warn('§LOAD_FAIL effects.js')"></script>
 <script src="effects_gi_poc.js?v=3" onerror="console.warn('§LOAD_FAIL effects_gi_poc.js')"></script>
 <script src="lib/mp4_mux.js?v=1" onerror="console.warn('§LOAD_FAIL mp4_mux.js — MaxQ falls back to webm')"></script>
 <script src="cinema_path_editor.js?v=15" onerror="console.warn('§LOAD_FAIL cinema_path_editor.js — Alt+C path editing disabled')"></script>


### PR DESCRIPTION
## Summary
Follow-up to #1409/#1411. User confirmed after the sw.js cache-bust landed: "still not reflection in mirror." Real bug, not caching this time — #1409 forced roughness near-zero for mirror materials but left `metalness` at `STD_MAT.IfcFlowTerminal`'s 0.30. `MeshStandardMaterial`'s diffuse/specular split is driven by metalness, not roughness — at 0.30 the shader still blends ~70% diffuse albedo into the output, so even a sharp, boosted envMap reflection reads as a faint sheen, not a mirror image.

- Force `metalness = 0.95` for mirror materials only (same `isMirror` exclusivity gate), save/restore on teardown.
- Bundles the `sw.js` `CACHE_VERSION` bump (v1053→v1054) in this same PR this time, after missing it in #1409.

## Test plan
- [x] `node --check` on both touched files
- [x] Live headless witness on Clinic: mirror material metalness 0.30→0.95, roughness 0.03, envMapIntensity boosted, envMap = real room-probe capture
- [ ] User to reload and confirm the mirror visually reflects

🤖 Generated with [Claude Code](https://claude.com/claude-code)