### PR TITLE
feat(4d): §S13 — storey-ladder audit; the Clinic bake report's real (measured) cause

### DIFF
--- a/scripts/audit_storey_ladder.js
+++ b/scripts/audit_storey_ladder.js
@@ -1,0 +1,107 @@
+#!/usr/bin/env node
+// audit_storey_ladder.js (§S13, bim-compiler prompts/4D_GANTT_TM_REFACTOR.md) — measures the storey
+// ladder that ScheduleGate.deriveBandRanks builds, and flags the bands that are almost certainly the
+// SAME physical level wearing two names.
+//
+// THE ISSUE IT PROVES OR DISPROVES: deriveBandRanks groups elements by storey NAME and ranks the
+// groups by median base_z. When one physical floor carries two names — because the federation's
+// source models used different vocabularies — it becomes two adjacent ranks, and everything
+// downstream (§4D_BAND_MONOTONIC, §PHASE_OVERLAP_SUPPORT_GUARD, zone CPM, the movie) treats them as
+// different levels that must not overlap. Measured on Clinic: architecture starts its "First Floor"
+// on day 23 while the same floor's electrical/plumbing sits in "Level 1" and starts on day 106 — an
+// 83-day split of one storey, which in playback reads as walls appearing with their services missing
+// and services later appearing in mid-air. That is the shape of the user's bake report, and it is
+// NOT the split-pair defect §S10/§S11 fixed (Clinic's pair is byte-clean — see audit_split_pairs.js).
+//
+// This tool DETECTS ONLY. It deliberately does not merge anything: for three of the four fleet
+// buildings there is no extractable signal saying which names are the same level (see §S13's blocked
+// question), and inventing a z-proximity heuristic is exactly the kind of guess this project's Prime
+// Rule forbids. What it does extract, where the DB carries it:
+//   - `elements_meta.building` (present in <B>_extracted.db, DROPPED by the split so <B>_meta.db has
+//     no trace of it) names the source model per element. On Clinic it explains the whole thing:
+//     Architectural/Structural/HVAC say "First Floor"/"Second Floor", Electrical/Plumbing say
+//     "Level 1"/"Level 2". That is measured provenance, not a guess.
+//   - Overlap of the two bands' interquartile z ranges, printed with the numbers, so a human or a
+//     later extraction-side fix can judge each pair on evidence.
+//
+// Usage: node scripts/audit_storey_ladder.js [--dir buildings] [--building Name]
+// Always exit 0 — this reports, it does not gate.
+'use strict';
+const fs = require('fs'), path = require('path');
+const initSqlJs = require(path.join(__dirname, '..', 'modeller', 'lib', 'sql-wasm.js'));
+
+const arg = (n, d) => { const i = process.argv.indexOf('--' + n); return i < 0 ? d : process.argv[i + 1]; };
+const DIR = path.resolve(arg('dir', path.join(__dirname, '..', 'buildings')));
+const ONLY = arg('building', null);
+const q = (db, sql) => { try { const r = db.exec(sql); return r.length ? r[0].values : []; } catch (e) { return null; } };
+const pct = (a, p) => a[Math.min(a.length - 1, Math.floor(a.length * p))];
+
+async function main() {
+  const SQL = await initSqlJs({ wasmBinary: fs.readFileSync(path.join(__dirname, '..', 'modeller', 'lib', 'sql-wasm.wasm')) });
+  const names = Array.from(new Set(fs.readdirSync(DIR).filter(f => /_(meta|extracted)\.db$/.test(f))
+    .map(f => f.replace(/_(meta|extracted)\.db$/, '')))).filter(b => !ONLY || b === ONLY).sort();
+
+  for (const B of names) {
+    // Prefer meta.db (what the live viewer schedules) but read `building` from extracted.db, which
+    // is the only side that still carries it.
+    const fMeta = path.join(DIR, B + '_meta.db'), fExt = path.join(DIR, B + '_extracted.db');
+    const src = fs.existsSync(fMeta) ? fMeta : fExt;
+    if (!fs.existsSync(src)) continue;
+    const db = new SQL.Database(fs.readFileSync(src));
+    const rows = q(db, "SELECT COALESCE(m.storey,'NULL'), t.center_z - COALESCE(t.bbox_z,0)/2.0 " +
+      'FROM elements_meta m JOIN element_transforms t ON t.guid = m.guid');
+    if (!rows || !rows.length) { db.close(); console.log('§STOREY_LADDER ' + B + ' SKIP — no joinable transforms'); continue; }
+    const byStorey = new Map();
+    for (const [s, z] of rows) { const k = String(s); if (!byStorey.has(k)) byStorey.set(k, []); byStorey.get(k).push(z); }
+    db.close();
+
+    // provenance: which source model each storey name came from (extracted.db only)
+    const prov = new Map();
+    if (fs.existsSync(fExt)) {
+      const ex = new SQL.Database(fs.readFileSync(fExt));
+      const pr = q(ex, "SELECT COALESCE(storey,'NULL'), COALESCE(building,'?'), COUNT(*) FROM elements_meta GROUP BY 1,2");
+      ex.close();
+      if (pr) for (const [s, b, n] of pr) {
+        const k = String(s); if (!prov.has(k)) prov.set(k, []);
+        prov.get(k).push({ b: String(b), n: n });
+      }
+    }
+
+    const bands = [];
+    byStorey.forEach((zs, s) => {
+      zs.sort((a, b) => a - b);
+      bands.push({ s: s, n: zs.length, q1: pct(zs, 0.25), med: pct(zs, 0.5), q3: pct(zs, 0.75) });
+    });
+    bands.sort((a, b) => a.med - b.med);
+
+    console.log('§STOREY_LADDER ' + B + ' storeys=' + bands.length + ' src=' + path.basename(src));
+    for (const r of bands) {
+      const p = (prov.get(r.s) || []).sort((a, b) => b.n - a.n).map(x => x.b.replace(new RegExp('^' + B + '_?'), '') + ':' + x.n).join(' ');
+      console.log('   %s med=%s q1=%s q3=%s n=%s %s'
+        .replace('%s', (r.s === 'Unknown' || r.s === 'NULL' ? '⊘' : ' ') + ' ' + r.s.padEnd(38))
+        .replace('%s', r.med.toFixed(2).padStart(8)).replace('%s', r.q1.toFixed(2).padStart(8))
+        .replace('%s', r.q3.toFixed(2).padStart(8)).replace('%s', String(r.n).padStart(6))
+        .replace('%s', p ? ' from[' + p + ']' : ''));
+    }
+    // Overlapping-band pairs: adjacent in the ladder, IQRs intersect. Reported with the numbers and
+    // with whether the two names come from DIFFERENT source models — never merged here.
+    let flagged = 0;
+    for (let i = 0; i + 1 < bands.length; i++) {
+      const a = bands[i], b = bands[i + 1];
+      if (a.s === 'Unknown' || b.s === 'Unknown' || a.s === 'NULL' || b.s === 'NULL') continue;
+      if (b.q1 >= a.q3) continue;                       // disjoint IQRs — genuinely different levels
+      const pa = new Set((prov.get(a.s) || []).map(x => x.b)), pb = new Set((prov.get(b.s) || []).map(x => x.b));
+      let shared = 0; pa.forEach(x => { if (pb.has(x)) shared++; });
+      const srcSplit = pa.size && pb.size && shared === 0;
+      flagged++;
+      console.log('   ⚠ OVERLAP ' + a.s + ' (med ' + a.med.toFixed(2) + ', q3 ' + a.q3.toFixed(2) + ')' +
+        ' vs ' + b.s + ' (med ' + b.med.toFixed(2) + ', q1 ' + b.q1.toFixed(2) + ')' +
+        ' medianGap=' + (b.med - a.med).toFixed(2) + 'm' +
+        ' sourceModels=' + (prov.size ? (srcSplit ? 'DISJOINT (different source models — same level, two vocabularies)'
+          : 'shared (' + shared + ' in common)') : 'unknown (no building column)'));
+    }
+    console.log('§STOREY_LADDER_SUMMARY ' + B + ' overlappingPairs=' + flagged +
+      ' provenance=' + (prov.size ? 'available' : 'ABSENT (building column not in this DB)'));
+  }
+}
+main().catch(e => { console.error('§STOREY_LADDER ERR ' + (e && e.stack || e)); process.exit(2); });


### PR DESCRIPTION
Closes the Clinic follow-up from the §S11 close — by **disproving its premise** and measuring what is actually wrong. Spec + full numbers: bim-compiler `prompts/4D_GANTT_TM_REFACTOR.md` **§S13**.

## The two Clinic claims, re-measured
- **"Missing ground slabs" is false.** Clinic has a ground plate and the engine already gets it right: four slabs named `Floor:150mm Slab on Grade` / `Exterior Slab on Grade` at base_z −1.37, −1.15, −0.15, −0.15 (main one **2,939 m²**), all `phase=Substructure, seq=1`, as are all 96 `IfcFooting`. The old note's "min slab z=2.06" is the minimum of the *Superstructure-classified* slabs only (3 stair pans + decks/roofs). Counting one bucket and concluding the element does not exist was the error.
- **"Hanging MEPs" is 9 elements.** `probe_captured_floating.js` on `Clinic_meta`: `§EXP8_FINAL floating=9/16071`, of which 3 `IfcFlowSegment` + 1 `IfcFlowFitting` — 0.04% of Clinic's 9,738 MEP elements.

## What the bake symptom actually is
`deriveBandRanks` groups by storey **name** and ranks by median `base_z`, so one physical floor with two names becomes two adjacent ranks that `§4D_BAND_MONOTONIC`, `§PHASE_OVERLAP_SUPPORT_GUARD`, zone CPM and the movie all treat as levels that must not overlap.

| storey | med base_z | q1 | q3 | n | source models (`elements_meta.building`) |
|---|---|---|---|---|---|
| TOF Footing | −0.52 | −0.55 | −0.32 | 1,676 | Plumbing 1476, Structural 197 |
| **Level 1** | 0.34 | −0.32 | 2.86 | 3,728 | **Plumbing 3713, Electrical 168** |
| **First Floor** | 2.93 | 0.00 | 3.85 | 2,343 | **Architectural 1154, HVAC 1050, Structural 463** |
| **Level 2** | 3.21 | 3.06 | 4.76 | 1,410 | **Plumbing 1396, Electrical 123** |
| Second Floor | 7.48 | 4.57 | 8.11 | 1,708 | HVAC 793, Architectural 751, Structural 386 |

The vocabularies are **provenance-disjoint, not guessed** — Architectural/Structural/HVAC say "First Floor", Electrical/Plumbing say "Level 1". Result: `First Floor` runs day 23→121 while `Level 1`, the same floor's services, runs day 106→106. **An 83-day split of one storey** — in playback, walls without services, then services appearing in mid-air. That is the reported symptom.

## `scripts/audit_storey_ladder.js`
Prints the ladder per building (median/q1/q3 base_z, n, and the source model behind each storey name) and flags adjacent bands whose IQRs intersect, saying whether their source models are disjoint.

| building | storeys | overlapping pairs | storey-order violations | worst inversion | floating |
|---|---|---|---|---|---|
| Clinic | 8 | 3 (2 provenance-disjoint) | 1/6 | 49d | 9/16,071 |
| Hospital | 9 | **0** | 2/7 | **174d** | 60/63,182 |
| Terminal | 23 | 11 | 12/21 | 95d | 256/48,428 |
| LTU_AHouse | 19 | 12 | (probe exceeds the run window) | — | — |

LTU's three vocabularies coincide exactly — VÅN 3 ≡ VÅNING 3 at medianGap **0.00m**, VÅNING 2 ≡ VÅN 2 at **0.00m** — which is the §S11 follow-up (3), now measured as the same defect. **Hospital's ladder is clean yet holds the fleet's worst inversion at 174 days, so storey naming is not the whole story** — that is flagged as the next dig rather than assumed solved.

## It detects only — on purpose
For three of the four buildings nothing in the data says which names are one floor. Checked, not assumed: `elements_meta.building` settles Clinic but **the split drops it**, so `meta.db` — the DB the viewer schedules from — cannot see it; `spatial_structure` carries real IfcBuilding parentage only for LTU (9 IfcBuilding, 751 `rel_aggregates`), the others hold 3-7 COMPILED rows; no shipped DB carries `IfcBuildingStorey.Elevation`. A z-proximity merge would be inference, which the Prime Rule forbids. Recommended fix (needs a go, §S13.5): carry `building` through the split and extract storey Elevation + IfcBuilding parentage, so the merge becomes a lookup.

## Also found, reported not shipped
`normalize_storey.py` states *"Never invents a level"* and does exactly that on Terminal: `Ceiling Level 01-04` / `Ceiling Level Kedai` → `Level 01-04` / `Level Kedai`, **673 elements given five storey names that do not exist in that building**, landing as phantom rungs 0.06m from the real ones. The candidate fix was measured before proposing it: ranks 22→17, violations 12/21→9/16, but worst inversion 95d→**97d** and floating 256→**260**. It removes the pollution and does not improve the schedule, so re-patching a production DB for it is the user's call.

🤖 Generated with [Claude Code](https://claude.com/claude-code)