### PR TITLE
test(4d): §STOREY_PHASE_ORDER — localises the schedule scrambling to _twoTierRemap, and to MEP

### DIFF
--- a/scripts/probe_captured_floating.js
+++ b/scripts/probe_captured_floating.js
@@ -669,6 +669,45 @@ async function main() {
     storeyOrderReport(disp.map(function (o) {
       return { storey: ScheduleGate.collapsePhase(o.storey), bz: o.bz, s: o.s };
     }), 'POST_REMAP_LEVEL');
+    // §STOREY_PHASE_ORDER (2026-08-17) — the storey report's p50 is taken over ALL of a storey's
+    // elements, so a storey whose mix is 58% MEP and one that is mostly structure are compared on
+    // different things: a global phase ordering alone will make the MEP-heavy storey's median look
+    // late and register as an "inversion" with nothing actually out of order. This dump asks the
+    // question the aggregate cannot: WITHIN one phase, is p50 start still monotonic in z? If yes,
+    // the inversion is a mix artifact of the metric; if no, the ordering is genuinely broken.
+    if (process.env.STOREY_PHASE_TABLE) {
+      // Run the SAME table on the raw pre-remap starts and on the post-remap ones, so the answer
+      // to "does the remap break it or was it already broken" is one diff instead of two runs.
+      [['RAW', function (o) { return _preRemapS[o.guid]; }],
+       ['POST_REMAP', function (o) { return o.s; }]].forEach(function (mode) {
+      const startOf = mode[1];
+      const byKey = {};
+      disp.forEach(function (o) {
+        const k = (o.phase || '_NONE') + '||' + ScheduleGate.collapsePhase(o.storey);
+        (byKey[k] = byKey[k] || { s: [], z: [] }).s.push(startOf(o));
+        byKey[k].z.push(o.bz);
+      });
+      const gmin = Math.min.apply(null, disp.map(startOf));
+      const phases = {};
+      Object.keys(byKey).forEach(function (k) {
+        const parts = k.split('||'), ph = parts[0], st = parts[1], g = byKey[k];
+        const ss = g.s.slice().sort(function (a, b) { return a - b; });
+        (phases[ph] = phases[ph] || []).push({ st: st, n: ss.length,
+          z: g.z.reduce(function (a, b) { return a + b; }, 0) / g.z.length,
+          p50: Math.round((ss[Math.floor(ss.length / 2)] - gmin) / DAY5) });
+      });
+      Object.keys(phases).sort().forEach(function (ph) {
+        const rows = phases[ph].filter(function (r) { return r.st !== 'Unknown' && r.n >= 20; })
+          .sort(function (a, b) { return a.z - b.z; });
+        let v = 0, worst = 0;
+        for (let i = 1; i < rows.length; i++)
+          if (rows[i].p50 < rows[i - 1].p50) { v++; worst = Math.max(worst, rows[i - 1].p50 - rows[i].p50); }
+        console.log('§STOREY_PHASE_ORDER ' + mode[0] + ' phase=' + ph + ' storeys=' + rows.length +
+          ' violations=' + v + '/' + Math.max(0, rows.length - 1) + ' worst=' + worst + 'd ' +
+          JSON.stringify(rows.map(function (r) { return [r.st, r.z.toFixed(1), r.n, r.p50]; })));
+      });
+      });
+    }
     // §STOREY_ORDER_L1_DIAG — who exactly moved, and by how much, within raw storey "Level 1"?
     {
       const l1 = disp.filter(function (o) { return o.storey === 'Level 1'; })


### PR DESCRIPTION
Follow-up measurement to #1419, and it **moves the blame**. Write-up: bim-compiler `prompts/4D_GANTT_TM_REFACTOR.md` §S13.7.

## Why the existing report could not answer this
`§STOREY_ORDER_REPORT` takes its p50 over **all** of a storey's elements. A storey that is 58% MEP and one that is mostly structure are then compared on different things — a global phase ordering alone makes the MEP-heavy storey's median look late and registers as an "inversion" with nothing actually out of order. So the aggregate could not say *which phase* was mis-ordered, nor whether the engine or the display remap did it.

`STOREY_PHASE_TABLE=1` runs the same p50-by-storey table **within each phase**, on the raw pre-remap starts and the post-remap ones, in one run.

## Hospital — p50 start day per storey
| phase | RAW (`computeSchedule`) | POST_REMAP (`_twoTierRemap`) |
|---|---|---|
| Substructure | 0/0 | 0/0 |
| **Superstructure** | **0/7 violations** — 13, 20, 27, 35, 171, 175, 177, 178 | **0/7** — 23, 25, 28, 39, 171, 176, 177, 178 |
| **MEP Rough-in** | **0/6, worst 0d** — 51, 87, 128, 204, 258, 292, 298 | **1/6, worst 180d** — **Level 1 348**, 168, 182, 313, 375, 418, 418 |
| Architecture | 1/7, 109d — 14, 29, 105, 183, 240, 288, 179, 298 | 3/7, 165d — **Level 1 195**, 30, 106, 311, 374, 299, 182, 417 |
| MEP Final | 0/4, 0d | 1/4, 41d |
| Finishes | 1/4, 12d | 2/4, 12d |

Clinic shows the same signature: MEP Rough-in **RAW 0/5 worst 0d → POST_REMAP 2/5 worst 86d** (Level 1 47→106, Second Floor 100→197), with Superstructure and Substructure at 0 violations on both sides.

## What this establishes
**The generative schedule is bottom-up correct, per phase, on both buildings. `_twoTierRemap` is what scrambles it — and it scrambles MEP specifically, and the ground floor hardest** (Hospital Level 1 MEP rough-in p50 51 → 348, +297 days, while Level 2's goes 87 → 168 and Level 3's 128 → 182). Structure is left untouched throughout.

That is "hanging MEPs" and "Hospital lighting float" with a number on it, and it is a *second* live-side cap, distinct from the corrupted-DB cap that §S10/§S11 fixed — this one survives a clean DB.

**No behaviour change in this PR.** It is the gate a fix has to pass. The fix itself belongs in `_twoTierRemap`'s Tier-2 per-zone barrier (`t1EndZ[z]` clamps every Tier-2 element to the *latest* end of any Tier-1 element in its zone), which carries several explicit prior user rulings — worth its own bounded pass with this measurement in front of it, rather than a change made at the end of a long session.

Corrects one over-reading in #1419's comment: those table numbers are **p10/p50**, not min/max, so "collapses bands to zero-width windows" was wrong. What actually happens is that ≥40% of a band's elements land on a single start day (Clinic `Level 1` p10 = p50 = 106).

🤖 Generated with [Claude Code](https://claude.com/claude-code)