### PR TITLE
fix(4d): activation memory probe + retire STOREY_PHASE_TABLE landmine

### DIFF
--- a/scripts/probe_activation_memory.js
+++ b/scripts/probe_activation_memory.js
@@ -1,0 +1,59 @@
+#!/usr/bin/env node
+// probe_activation_memory.js (§S15/item2, bim-compiler prompts/4D_GANTT_TM_REFACTOR.md 🏁 RESUME) —
+// fresh JS-heap measurement across Time Machine activation, replacing the stale pre-#1399 "+390MB"
+// figure that predates S1/S4/S6/S9-S13's changes to this same path. Uses Puppeteer's own
+// page.metrics() (Chrome DevTools Performance domain, JSHeapUsedSize) at three points: page-loaded
+// baseline, immediately after `§TIME_MACHINE ON` fires, and after a settle window (catches any
+// post-activation growth the seam's own async work still does). Numbers only, no eyeballing.
+'use strict';
+const { spawn } = require('child_process');
+const puppeteer = require(process.env.PUPPETEER || 'puppeteer');
+const PORT = 8126;
+const BLD = process.env.BLD || 'Hospital_extracted';
+const URL = `http://localhost:${PORT}/viewer/viewer.html?db=/buildings/${BLD}.db`;
+const MB = 1024 * 1024;
+
+async function main() {
+  const server = spawn('python3', ['-m', 'http.server', String(PORT), '--directory', process.env.SERVE_ROOT || '/tmp/cpm-serve'], { stdio: 'ignore' });
+  await new Promise(r => setTimeout(r, 1500));
+  const browser = await puppeteer.launch({ headless: 'new',
+    args: ['--no-sandbox', '--disable-dev-shm-usage', '--use-angle=swiftshader', '--enable-unsafe-swiftshader'] });
+  const page = await browser.newPage();
+  const lines = [];
+  page.on('console', m => { const t = m.text(); if (t.indexOf('§') >= 0) lines.push(t); });
+  await page.goto(URL, { waitUntil: 'domcontentloaded', timeout: 60000 });
+  await page.waitForFunction(() => typeof window.toggleTimeMachine === 'function', { timeout: 180000 });
+  await page.waitForFunction(() => window.APP && window.APP.db, { timeout: 240000 }).catch(() => {});
+  await new Promise(r => setTimeout(r, 15000));
+
+  const mBaseline = await page.metrics();
+  console.log('§ACT_MEM_BASELINE BLD=' + BLD + ' JSHeapUsedMB=' + (mBaseline.JSHeapUsedSize / MB).toFixed(1) +
+    ' JSHeapTotalMB=' + (mBaseline.JSHeapTotalSize / MB).toFixed(1));
+
+  const _t0 = Date.now();
+  await page.evaluate(() => window.toggleTimeMachine());
+  const deadline = Date.now() + 300000;
+  while (Date.now() < deadline) {
+    if (lines.some(l => l.indexOf('§TIME_MACHINE ON') >= 0)) break;
+    await new Promise(r => setTimeout(r, 200));
+  }
+  const actMs = Date.now() - _t0;
+  const mPostActivation = await page.metrics();
+  console.log('§ACT_MEM_POST_ACTIVATION BLD=' + BLD + ' activationMs=' + actMs +
+    ' JSHeapUsedMB=' + (mPostActivation.JSHeapUsedSize / MB).toFixed(1) +
+    ' JSHeapTotalMB=' + (mPostActivation.JSHeapTotalSize / MB).toFixed(1) +
+    ' deltaFromBaselineMB=' + ((mPostActivation.JSHeapUsedSize - mBaseline.JSHeapUsedSize) / MB).toFixed(1));
+
+  // settle window — catches async post-activation growth (e.g. kernel_ops write loop tail,
+  // §WRITE_LOOP_TIMING) the ON-event fires before.
+  await new Promise(r => setTimeout(r, 20000));
+  const mSettled = await page.metrics();
+  console.log('§ACT_MEM_SETTLED BLD=' + BLD +
+    ' JSHeapUsedMB=' + (mSettled.JSHeapUsedSize / MB).toFixed(1) +
+    ' JSHeapTotalMB=' + (mSettled.JSHeapTotalSize / MB).toFixed(1) +
+    ' deltaFromBaselineMB=' + ((mSettled.JSHeapUsedSize - mBaseline.JSHeapUsedSize) / MB).toFixed(1) +
+    ' deltaFromPostActivationMB=' + ((mSettled.JSHeapUsedSize - mPostActivation.JSHeapUsedSize) / MB).toFixed(1));
+
+  await browser.close(); server.kill(); process.exit(0);
+}
+main().catch(e => { console.error('ERR ' + (e && e.stack || e)); process.exit(2); });

--- a/scripts/probe_captured_floating.js
+++ b/scripts/probe_captured_floating.js
@@ -586,13 +586,24 @@ async function main() {
     console.log('§EXP5B_FINAL_BYCLASS ' + JSON.stringify(m.c.byClass));
   }
 
-  // ══ EXP6 — BROWSER-FAITHFUL captured pipeline (2026-08-16, §CHASE_TO_ZERO_WINDOW_AUTHORING
-  // correction from the user's live Hospital log). Everything above feeds the rescale from
-  // computeSchedule's RAW times — but the real injectGantt overlay reads kernel_ops timestamps,
-  // which carry the TWO-TIER DISPLAY timeline (_twoTierRemap + _midairRepair, §TIER_SERIAL 420d on
-  // Hospital), while task windows are authored from the RAW schedule (334d). Live divergence proof:
-  // browser §PHASE_OVERLAP_SUPPORT_GUARD pushed=4117 vs this probe's raw-fed 1152. This section
-  // reproduces the REAL input using witness_midair_zero.js's validated display-timeline recipe. ════
+  // ══ EXP6 — captured pipeline (2026-08-16, §CHASE_TO_ZERO_WINDOW_AUTHORING correction from the
+  // user's live Hospital log). Everything above feeds the rescale from computeSchedule's RAW times
+  // — the real injectGantt overlay reads kernel_ops timestamps, which carry the TWO-TIER DISPLAY
+  // timeline (_twoTierRemap + _midairRepair, §TIER_SERIAL 420d on Hospital), while task windows are
+  // authored from the RAW schedule (334d). Live divergence proof at the time: browser
+  // §PHASE_OVERLAP_SUPPORT_GUARD pushed=4117 vs this probe's raw-fed 1152.
+  //
+  // ⚠ RETRACTED LABEL, KEPT CODE (§S13.8/§S14.0, bim-compiler prompts/4D_GANTT_TM_REFACTOR.md
+  // §PATHS NOT TO TAKE #1/#2): this was called "BROWSER-FAITHFUL" when written — that claim is now
+  // KNOWN FALSE. `_twoTierRemap`/`_midairRepair` are reachable ONLY via `_displayTimeline`'s
+  // `§CPM_DISPLAY_FALLBACK` branch (time_machine.js), which has never fired live in this lane
+  // (`§CPM_DISPLAY_REUSE` hits it instead). This section slices and calls those two functions
+  // directly — it measures a real function's behavior, not what the live default path executes.
+  // §S14.0 re-measured the SAME per-phase/per-storey table on the confirmed-live `CpmSchedule.run`
+  // path (bim-ootb PR #1421, `probe_cpm_display_path.js`) and the scrambling this section reproduces
+  // did NOT reproduce there. Do not cite STOREY_PHASE_TABLE output from this section as a live root
+  // cause without ALSO printing, in the same log, proof this exact call matches the live default
+  // path — the standing guardrail those sections established. ════════════════════════════════════
   {
     const vm = require('vm');
     function sliceAt(src, name, which, optional) {
@@ -676,6 +687,10 @@ async function main() {
     // question the aggregate cannot: WITHIN one phase, is p50 start still monotonic in z? If yes,
     // the inversion is a mix artifact of the metric; if no, the ordering is genuinely broken.
     if (process.env.STOREY_PHASE_TABLE) {
+      console.log('§STOREY_PHASE_TABLE_REACHABILITY_WARNING this table is computed from a sliced ' +
+        '_twoTierRemap/_midairRepair call (EXP6, above), NOT the live default path — see §S13.8/' +
+        '§S14.0 in bim-compiler prompts/4D_GANTT_TM_REFACTOR.md. Do not write up a number from ' +
+        'here as a live root cause without independent live-path proof (probe_cpm_display_path.js).');
       // Run the SAME table on the raw pre-remap starts and on the post-remap ones, so the answer
       // to "does the remap break it or was it already broken" is one diff instead of two runs.
       [['RAW', function (o) { return _preRemapS[o.guid]; }],


### PR DESCRIPTION
## Summary
- §S16: new `scripts/probe_activation_memory.js` — fresh JS-heap measurement across TM activation (page.metrics()), replacing the stale pre-#1399 "+390MB" figure per `bim-compiler prompts/4D_GANTT_TM_REFACTOR.md` 🏁 RESUME item 2.
- §S15 item 5: `probe_captured_floating.js`'s EXP6/`STOREY_PHASE_TABLE` section still slices+calls `_twoTierRemap`/`_midairRepair` directly and was labeled "BROWSER-FAITHFUL" — a claim §S13.8/§S14.0 already retracted (that path is unreachable on the live default path). Added a retraction comment + a runtime `§STOREY_PHASE_TABLE_REACHABILITY_WARNING` log line so future sessions can't re-cite its numbers as a live root cause unnoticed.

Detection/log-only — no behavior change to any shipped viewer path.

## Test plan
- [x] `node --check` both files
- [x] Ran `probe_activation_memory.js` against Hospital_extracted and Terminal_extracted, confirmed §ACT_MEM_* lines
- [x] Ran `STOREY_PHASE_TABLE=1 probe_captured_floating.js` end-to-end, confirmed the new warning line fires before the (still-retracted) table output

🤖 Generated with [Claude Code](https://claude.com/claude-code)