### PR TITLE
fix(4d): §S18 Part B — viewer-side storey-band merge from EXTRACTED Elevation

### DIFF
--- a/scripts/probe_gantt_stagger.js
+++ b/scripts/probe_gantt_stagger.js
@@ -21,7 +21,7 @@ async function main() {
   // write-loop lines to stdout as they arrive (previously only pushed to the internal `lines` array
   // and never printed — a real gap, this fixes it for the timing-relevant subset without flooding
   // stdout with every § line the activation logs).
-  const TIMING_RE = /§(S4_ACTIVATION|S4_RAW_SCHEDULE_REUSE|WRITE_LOOP_TIMING|CPM_DISPLAY_REUSE|GANTT_SOURCE|4D_COVERAGE|TM_OPS_CHECK|GANTT_CACHE)/;
+  const TIMING_RE = /§(S4_ACTIVATION|S4_RAW_SCHEDULE_REUSE|WRITE_LOOP_TIMING|CPM_DISPLAY_REUSE|GANTT_SOURCE|4D_COVERAGE|TM_OPS_CHECK|GANTT_CACHE|S18_STOREY_MERGE)/;
   page.on('console', m => {
     const t = m.text();
     if (t.indexOf('§') >= 0) lines.push(t);

--- a/viewer/schedule_author.js
+++ b/viewer/schedule_author.js
@@ -420,7 +420,26 @@
         }
       } catch (e) { console.log('§ZONE_DISPLAY_AUTHORING_FAIL ' + e.message + ' — raw-schedule windows kept'); }
     }
-    var rolled = SG.deriveZones(elements, schedule);
+    // §S18 (2026-08-17, prompts/4D_GANTT_TM_REFACTOR.md Part B): storey-band merge, sourced from
+    // spatial_structure's EXTRACTED IfcBuildingStorey.Elevation when the loaded DB carries it (older
+    // shipped DBs, not yet regenerated with the fixed extractor, simply lack the `elevation` column —
+    // the query throws, storeyMergeMap stays null, deriveZones falls back to its pre-§S18 behavior
+    // byte-identically; no building regresses for not having been regenerated yet).
+    var storeyMergeMap = null;
+    if (SG.deriveStoreyMergeMap) {
+      try {
+        var _ssRes = db.exec("SELECT type,name,elevation FROM spatial_structure WHERE type='IfcBuildingStorey' AND elevation IS NOT NULL");
+        if (_ssRes.length) {
+          var _ssCols = _ssRes[0].columns, _tI = _ssCols.indexOf('type'), _nI = _ssCols.indexOf('name'), _eI = _ssCols.indexOf('elevation');
+          var _ssRows = _ssRes[0].values.map(function (v) { return { type: v[_tI], name: v[_nI], elevation: v[_eI] }; });
+          storeyMergeMap = SG.deriveStoreyMergeMap(_ssRows);
+          var _mergedN = 0;
+          for (var _mk in storeyMergeMap) if (storeyMergeMap[_mk] !== _mk) _mergedN++;
+          console.log('§S18_STOREY_MERGE names=' + Object.keys(storeyMergeMap).length + ' merged=' + _mergedN);
+        }
+      } catch (e) { console.log('§S18_STOREY_MERGE_FAIL ' + e.message + ' — no elevation data, bands unmerged'); }
+    }
+    var rolled = SG.deriveZones(elements, schedule, storeyMergeMap);
     if (!rolled.zones.length) { console.log('§AUTHOR_ZONES_FAIL reason=no_zones'); return { ok: false, reason: 'no_zones' }; }
 
     _ensureSchedulesGenVersion(db);

--- a/viewer/schedule_gate.js
+++ b/viewer/schedule_gate.js
@@ -320,10 +320,17 @@
   // a second consumer (schedule_author.js's zone-level CPM rollup) can get the SAME real floor order
   // without a duplicate copy of this math to drift out of sync with the live scheduler.
   // Returns { bandRank: {collapsedStorey: rank}, rankList: [{ph,z,n}, ...], unbanded: N }.
-  function deriveBandRanks(elements) {
+  // storeyMergeMap: OPTIONAL {collapsedName: canonicalName}, built by deriveStoreyMergeMap() below
+  // from spatial_structure's EXTRACTED IfcBuildingStorey.Elevation (§S18, 2026-08-17,
+  // prompts/4D_GANTT_TM_REFACTOR.md). When supplied, storey names that share one physical floor
+  // collapse to ONE band before ranking — DISPLAY/AUDIT layer only. computeSchedule's own internal
+  // call to this function (line ~418, inside PASS-B's band-monotonic trade gate) never passes this
+  // map, so engine timing and the floating=0 gate are provably unaffected by this parameter existing.
+  function deriveBandRanks(elements, storeyMergeMap) {
     var byPhase = {};
     elements.forEach(function (e) {
       var ph = collapsePhase(e.storey);
+      if (storeyMergeMap && storeyMergeMap[ph]) ph = storeyMergeMap[ph];
       (byPhase[ph] = byPhase[ph] || []).push(e.base_z);
     });
     var rows = [], bandRank = {}, unbanded = 0;
@@ -337,6 +344,50 @@
     rows.sort(function (a, b) { return a.z - b.z; });
     rows.forEach(function (r, i) { bandRank[r.ph] = i; });
     return { bandRank: bandRank, rankList: rows, unbanded: unbanded };
+  }
+
+  // deriveStoreyMergeMap(spatialStructure) — §S18 (2026-08-17): groups storey NAMES that share one
+  // physical floor using EXTRACTED IfcBuildingStorey.Elevation, never inferred from element z-values
+  // (§PATHS NOT TO TAKE #7 forbids exactly that — mean/median-Z-of-ELEMENTS proximity). Each
+  // collapsePhase()'d name's representative elevation is the MEDIAN of every spatial_structure row
+  // with that name — robust to a single mis-scaled outlier (measured need: one of Clinic's 5
+  // federated discipline files has a "Second Floor" row reading 4570 where its own IfcProject
+  // declares LENGTHUNIT=METRE — a real source-file authoring defect, not a units-conversion miss;
+  // 3 of that name's 4 rows agree at ~4.57, so the median rejects the one bad row the same way this
+  // project's other Tukey/median derivations already do). Names within GAP (this module's own 0.5m
+  // "audit: within this of" constant, line ~39 — reused, not a new tuned constant) of a lower band's
+  // representative elevation join that band; chaining compares to the BAND'S elevation, not the
+  // previous row's, so a band stays bounded to within GAP of where it started rather than drifting
+  // through a long chain of small steps. Measured same-floor agreement in real data is far tighter
+  // than GAP (~1e-13m — floating-point noise between independently-authored files) — GAP is
+  // deliberately generous headroom above that, not a floor-height heuristic; it is far below every
+  // measured real floor-to-floor gap in the fleet (Clinic's smallest is 4.57m).
+  //
+  // Parentage (spatial_structure.parent_guid, IfcBuilding<-IfcBuildingStorey, also extracted by
+  // §S18) is NOT used as a hard partition here. Every federated "IfcBuilding" row measured in the
+  // fleet so far (Clinic's 5 discipline files, LTU_AHouse's 9) represents ONE physical building
+  // split across per-discipline exports, not genuinely distinct structures sharing a site — there is
+  // no fleet case yet where an elevation coincidence could falsely merge two REAL different
+  // buildings. If one appears, gate this merge to same-building parentage groups first; inventing
+  // that partition today, with no case to verify it against, is exactly what Prime Rule forbids.
+  function deriveStoreyMergeMap(spatialStructure) {
+    var byName = {};
+    (spatialStructure || []).forEach(function (r) {
+      if (!r || r.type !== 'IfcBuildingStorey' || r.elevation == null || r.name == null) return;
+      var name = collapsePhase(r.name);
+      (byName[name] = byName[name] || []).push(r.elevation);
+    });
+    var rows = Object.keys(byName).map(function (name) {
+      var zs = byName[name].slice().sort(function (a, b) { return a - b; });
+      return { name: name, z: zs[Math.floor(zs.length / 2)] };
+    });
+    rows.sort(function (a, b) { return a.z - b.z; });
+    var map = {}, bandName = null, bandZ = null;
+    rows.forEach(function (r) {
+      if (bandName === null || Math.abs(r.z - bandZ) > GAP) { bandName = r.name; bandZ = r.z; }
+      map[r.name] = bandName;
+    });
+    return map;
   }
 
   // Collapse sub-storeys onto their Level so the phase list stays ~8 (user: "collapsing is better").
@@ -1097,12 +1148,15 @@
   // whole graph is consistent with one global "real start time" ordering and cannot cycle by
   // construction; computeCpm's cycle guard is defence-in-depth, not the primary safeguard here.
   // Returns { zones: [{id,phase,storey,rank,start,end,guids,count}], edges: [{predId,succId,lagMs}] }.
-  function deriveZones(elements, schedule) {
-    var ranks = deriveBandRanks(elements).bandRank;
+  // storeyMergeMap: same optional §S18 parameter as deriveBandRanks — applied identically here so a
+  // zone's storey label and the rank it looks up (both keyed by the SAME merged name) never diverge.
+  function deriveZones(elements, schedule, storeyMergeMap) {
+    var ranks = deriveBandRanks(elements, storeyMergeMap).bandRank;
     var byZone = {};   // zoneId -> { phase, storey, rank, seq, guids:[], start:Infinity, end:-Infinity }
     elements.forEach(function (e) {
       var st = schedule[e.guid]; if (!st) return;   // unscheduled (e.g. a class computeSchedule skipped)
       var storey = collapsePhase(e.storey);
+      if (storeyMergeMap && storeyMergeMap[storey]) storey = storeyMergeMap[storey];
       var zid = (e.phase || '_UNPHASED') + '||' + storey;
       var z = byZone[zid] || (byZone[zid] = {
         id: zid, phase: e.phase || '_UNPHASED', storey: storey, rank: ranks[storey],
@@ -1162,7 +1216,7 @@
   // SHIFT_MS/DAY_MS + the two mappers are exported for the same reason EPS/GAP/CELL are: the live
   // movie clock (time_machine.js injectGantt's scaleFactor/projectDays) must size a day with THIS
   // module's shift, not a second hand-typed 8h constant to drift (§TM_DURATION_SYNC's lesson).
-  var API = { computeSchedule: computeSchedule, collapsePhase: collapsePhase, elementsInPhase: elementsInPhase, auditFloating: auditFloating, deriveBandRanks: deriveBandRanks, deriveZones: deriveZones, hostPairs: hostPairs, openingPairs: openingPairs, groundworkSlabs: groundworkSlabs, CELL: CELL, EPS: EPS, GAP: GAP, BIG_ELEMENT_VOL: BIG_ELEMENT_VOL, SHIFT_MS: SHIFT_MS, DAY_MS: DAY_MS, toProductive: toProductive, toWall: toWall };
+  var API = { computeSchedule: computeSchedule, collapsePhase: collapsePhase, elementsInPhase: elementsInPhase, auditFloating: auditFloating, deriveBandRanks: deriveBandRanks, deriveZones: deriveZones, deriveStoreyMergeMap: deriveStoreyMergeMap, hostPairs: hostPairs, openingPairs: openingPairs, groundworkSlabs: groundworkSlabs, CELL: CELL, EPS: EPS, GAP: GAP, BIG_ELEMENT_VOL: BIG_ELEMENT_VOL, SHIFT_MS: SHIFT_MS, DAY_MS: DAY_MS, toProductive: toProductive, toWall: toWall };
   global.ScheduleGate = API;
   if (typeof module !== 'undefined' && module.exports) module.exports = API;
 })(typeof window !== 'undefined' ? window : (typeof globalThis !== 'undefined' ? globalThis : this));


### PR DESCRIPTION
## Summary
- `deriveStoreyMergeMap()` (schedule_gate.js) groups storey NAMES sharing one physical floor using spatial_structure's EXTRACTED `IfcBuildingStorey.Elevation` (companion bim-compiler PR #83) — never inferred from element z-values (§PATHS NOT TO TAKE #7). Representative elevation per name is the MEDIAN across all rows with that name (robust to a single mis-scaled outlier — measured on Clinic's Structural discipline file). Adjacent names within `GAP` (0.5m, an existing constant, reused not invented) merge.
- Threaded through `deriveBandRanks`/`deriveZones` as an OPTIONAL parameter. `computeSchedule`'s own internal `deriveBandRanks` call (the band-monotonic trade gate) never receives it — engine timing and the `floating=0` gate are provably unaffected.
- Wired at the one live call site that matters: `schedule_author.js` `materializeZones()`. Falls back to `null` (pre-§S18, byte-identical behavior) via try/catch when the loaded DB has no `elevation` data yet.
- `probe_gantt_stagger.js`: forwards `§S18_STOREY_MERGE` to stdout for live-path evidence.

## Measured (headless real-viewer probe)
Clinic (regenerated per bim-compiler PR #83) — before -> after:
```
tasks          33 -> 23   (10 Level-N/X-Floor task pairs merged; element counts sum EXACTLY)
overlapping    44 -> 33   overlapDaysSum 1986 -> 1597   parallelism 13.47x -> 9.50x
same-start cluster (tasks sharing one start day): 23/33 -> 11/23
§LAYER_BUILDUP: unchanged, violations=1/5 (kernel_ops write-order metric, correctly unaffected)
```

Regression check — same modified code against **unregenerated** Terminal/Hospital data:
```
§S18_STOREY_MERGE_FAIL no such column: elevation — no elevation data, bands unmerged   (Terminal)
§S18_STOREY_MERGE_FAIL no such table: spatial_structure — no elevation data, bands unmerged   (Hospital)
tasks=73 (Terminal)  tasks=36 (Hospital)   — both match the already-documented §S15 baseline exactly
```

## Test plan
- [x] `node --check` all 3 files
- [x] Live headless probe (`scripts/probe_gantt_stagger.js`) against modified viewer + regenerated Clinic DB — real measured improvement, see above
- [x] Same probe against unregenerated Terminal + Hospital DBs — zero behavior change (fallback confirmed live, task counts match documented baseline)

Part of `prompts/4D_GANTT_TM_REFACTOR.md` §S18 Part B — companion bim-compiler PR #83 carries the extraction fix that supplies this data.

https://claude.ai/code/session_013Wtyz1mg8yFkJ2T5pJsgUn