### PR TITLE
fix(4d): §S19 Part B — resolve E5, comment-only (already retired by S6)

### DIFF
--- a/scripts/probe_e5_resolution.js
+++ b/scripts/probe_e5_resolution.js
@@ -1,0 +1,97 @@
+#!/usr/bin/env node
+// probe_e5_resolution.js — 4D_GANTT_TM_REFACTOR.md §S19 Part B evidence.
+//
+// §S2_REVIEW_VERDICT (S6 spec) said E5-as-lower-bound "becomes redundant once slots are claimed
+// in-pass" but §S6_RESULTS never measured/reported it removed. This probe answers the open question
+// directly against cpm_schedule.js's real solve(), on a real building, not by reading code alone:
+//
+//   §E5_BOUND_CHECK — is ES(T) >= computeSchedule(T).start still enforced PER ELEMENT? If it were,
+//     cpmStart could never be earlier than rawStart for any element. Measured: it legitimately is,
+//     for a large fraction of elements — the per-element floor is gone (only a single shared epoch,
+//     `base` = min over all items, remains, per §S6_CREW_PASS's own comment in solve()).
+//   §E5_SUMMARY / durations — is DUR[i] = items[i].e - items[i].s (computeSchedule's crew-leveled
+//     duration) still the ONLY source cpm_schedule.js uses for element duration? Measured: yes,
+//     bit-exact (maxDelta 0ms) across the whole fleet — S6's crew-slot pass changes START only,
+//     never recomputes duration. This is why E5 is not dead weight: solve() has no independent
+//     duration model, so deleting the `s`/`e` read would leave DUR undefined for every element.
+//
+// Command: BLD_DIR=~/bim-ootb/buildings BLD=Terminal_extracted node scripts/probe_e5_resolution.js
+'use strict';
+const fs = require('fs');
+const path = require('path');
+const initSqlJs = require(path.join(__dirname, '..', 'modeller', 'lib', 'sql-wasm.js'));
+const ScheduleGate = require(path.join(__dirname, '..', 'viewer', 'schedule_gate.js'));
+const ScheduleAuthor = require(path.join(__dirname, '..', 'viewer', 'schedule_author.js'));
+const CpmSchedule = require(path.join(__dirname, '..', 'viewer', 'cpm_schedule.js'));
+
+const BLD_DIR = process.env.BLD_DIR || path.join(require('os').homedir(), 'bim-ootb', 'buildings');
+const BLD = process.env.BLD || 'Terminal_extracted';
+const ratesSrc = fs.readFileSync(path.join(__dirname, '..', 'viewer', 'rates.js'), 'utf8');
+const RATES = (new Function(ratesSrc +
+  '\nreturn {SEQUENCE_RULES:SEQUENCE_RULES, SEQUENCE_DEFAULT:SEQUENCE_DEFAULT, ' +
+  'SEQUENCE_NAME_OVERRIDES:SEQUENCE_NAME_OVERRIDES, LABOR_RATES:LABOR_RATES, RATES:RATES};'))();
+
+async function main() {
+  const SQL = await initSqlJs({ wasmBinary: fs.readFileSync(path.join(__dirname, '..', 'modeller', 'lib', 'sql-wasm.wasm')) });
+  const db = new SQL.Database(fs.readFileSync(path.join(BLD_DIR, BLD + '.db')));
+  const rawElements = ScheduleAuthor._buildScheduleElements(db, RATES.SEQUENCE_RULES, {
+    laborRates: RATES.LABOR_RATES, rates: RATES.RATES, nameOverrides: RATES.SEQUENCE_NAME_OVERRIDES,
+    defaultRule: RATES.SEQUENCE_DEFAULT
+  });
+  db.close();
+  const elements = rawElements.map(it => Object.assign({}, it, { bz: it.base_z, tz: it.top_z }));
+  const maxCrews = {};
+  for (const r in RATES.LABOR_RATES) if (RATES.LABOR_RATES[r].max_crews) maxCrews[r] = RATES.LABOR_RATES[r].max_crews;
+  const schedule = ScheduleGate.computeSchedule(elements, 0, 1, maxCrews, 24);
+  const items = elements.map(el => {
+    const st = schedule[el.guid]; if (!st) return null;
+    return { guid: el.guid, cls: el.cls, seq: el.seq, phase: el.phase, storey: el.storey,
+             x0: el.x0, x1: el.x1, y0: el.y0, y1: el.y1, bz: el.bz, tz: el.tz,
+             s: st.start, e: st.end, resource: el.resource };
+  }).filter(Boolean);
+  console.log('§E5_BUILDING ' + BLD + ' n=' + items.length);
+
+  const res = CpmSchedule.run(items, { maxCrews });
+  if (!res.ok) throw new Error('CPM failed: ' + res.error);
+
+  // Duration preservation, fleet-wide for this building.
+  let allDurMatch = true, maxDelta = 0;
+  items.forEach((it, i) => {
+    const d = Math.abs((it.e - it.s) - (res.solution.times[i].e - res.solution.times[i].s));
+    if (d > maxDelta) maxDelta = d;
+    if (d > 1) allDurMatch = false;   // 1ms tolerance
+  });
+
+  // One concrete named example (longest-duration roof element, or longest overall if none on roof).
+  let worstIdx = 0, worstDur = -1;
+  items.forEach((it, i) => { const d = it.e - it.s; if (it.storey && it.storey.indexOf('ROOF') >= 0 && d > worstDur) { worstDur = d; worstIdx = i; } });
+  if (worstDur <= 0) items.forEach((it, i) => { const d = it.e - it.s; if (d > worstDur) { worstDur = d; worstIdx = i; } });
+  const ex = items[worstIdx], exCpm = res.solution.times[worstIdx];
+  console.log('§E5_ELEMENT_EXAMPLE guid=' + ex.guid + ' cls=' + ex.cls + ' storey=' + ex.storey +
+    ' rawStart(computeSchedule/E5)=' + new Date(ex.s).toISOString() +
+    ' rawDurHrs=' + ((ex.e - ex.s) / 3600000).toFixed(3) +
+    ' cpmStart(solve)=' + new Date(exCpm.s).toISOString() +
+    ' cpmDurHrs=' + ((exCpm.e - exCpm.s) / 3600000).toFixed(3) +
+    ' startShiftDays=' + ((exCpm.s - ex.s) / 86400000).toFixed(2));
+
+  const durs = items.map(it => (it.e - it.s) / 3600000).sort((a, b) => a - b);
+  const pct = p => durs[Math.floor(p * (durs.length - 1))];
+  console.log('§E5_DUR_PERCENTILES_HRS p10=' + pct(0.10).toFixed(3) + ' p50=' + pct(0.50).toFixed(3) +
+    ' p90=' + pct(0.90).toFixed(3) + ' p99=' + pct(0.99).toFixed(3) + ' max=' + durs[durs.length - 1].toFixed(3) +
+    ' zeroCount=' + durs.filter(d => d === 0).length + '/' + durs.length);
+  console.log('§E5_SUMMARY allDurationsPreservedExactly=' + allDurMatch + ' maxDeltaMs=' + maxDelta +
+    ' (E5-as-DURATION-SOURCE is the only source -- cpmDur === rawDur exactly, S6 never recomputes it)');
+
+  // The decisive check: is ES(T) >= computeSchedule(T).start still enforced per element? If so,
+  // cpmStart must never be earlier than rawStart for ANY element.
+  let earlier = 0, later = 0, same = 0;
+  items.forEach((it, i) => {
+    const d = res.solution.times[i].s - it.s;
+    if (d < -1000) earlier++; else if (d > 1000) later++; else same++;
+  });
+  console.log('§E5_BOUND_CHECK ' + BLD + ': cpmStart<rawStart(per-element bound NOT enforced)=' + earlier +
+    ' cpmStart>rawStart=' + later + ' cpmStart==rawStart=' + same + '/' + items.length +
+    ' -- ' + (earlier > 0 ? 'CONFIRMS E5-as-lower-bound is fully retired (S6 superseded it)'
+                          : 'UNEXPECTED: per-element floor still holds, investigate before concluding E5 is dead'));
+}
+main().catch(e => { console.error(e); process.exit(1); });

--- a/viewer/cpm_schedule.js
+++ b/viewer/cpm_schedule.js
@@ -7,14 +7,26 @@
  * (replaces nothing yet — §EXECUTION_PLAN stages 1-3). A node is an element (dur = crew-leveled
  * duration from ScheduleGate.computeSchedule, which stays — §WHAT_STAYS) or a dur-0 milestone.
  * An edge means "T cannot start until S starts (SS) / finishes (FS)". Earliest-start = one Kahn
- * topological pass, ES(T) = max(crew lower bound, max over in-edges). No fixpoint, no sweep cap.
+ * topological pass, ES(T) = max(crew-slot availability, max over in-edges) — see §S6_CREW_PASS in
+ * solve() below. No fixpoint, no sweep cap.
  *
  * Edge types (§CPM_SPEC — every edge traces to a real geometry query or an already-shipped rule):
  *   E1 support   SS  designated physical support from the contact graph (judge's own relation)
  *   E2 host/open FS  ScheduleGate.hostPairs / openingPairs (the one shared definition)
  *   E3 discipline FS Tier-1 chain + Tier-2-after-Tier-1 per level, via hammock milestones
  *   E4 storey    FS  phase P complete at level k -> phase P elements at level k+1 (THE missing edge)
- *   E5 crew       -  per-element lower bound ES(T) >= computeSchedule(T).start (no explicit edges)
+ *   E5 crew       -  RESOLVED (4D_GANTT_TM_REFACTOR.md §S19 Part B, 2026-08-17): originally a
+ *                    per-element lower bound ES(T) >= computeSchedule(T).start (no explicit edges,
+ *                    hence no counts.e5 in buildGraph()). §S6_CREW_PASS (below, in solve()) retired
+ *                    that bound — ES no longer seeds from each element's own computeSchedule start,
+ *                    only from a single shared epoch (`base` = min over all items). What's still
+ *                    read from computeSchedule per element is DUR = e-s (the crew-leveled work
+ *                    DURATION) — S6 has no independent duration model, so this is a live dependency,
+ *                    not dead weight. Measured (§S19_RESULTS, probe_e5_resolution.js, Terminal
+ *                    48,428 elements): cpmStart < rawStart for 12,131 elements (25%) — impossible if
+ *                    the old per-element floor still held — while cpmDur === rawDur bit-exact
+ *                    (maxDelta=0ms) for all 48,428. Comment corrected; solve()'s code needed no
+ *                    change, it already only uses `.s`/`.e` this way.
  *
  * Cycle policy (§TIER_DAG_WINS doctrine — physics beats phase tidiness): Tarjan SCC first. A
  * cycle containing a hammock/membership edge drops exactly those edges INSIDE the cycle (tidiness
@@ -103,7 +115,9 @@
   }
 
   // buildGraph(items, G) — items need guid,cls,seq,phase,storey,x0,x1,y0,y1,bz,tz,s,e where s/e are
-  // the crew-leveled generative times (E5 lower bound + durations). Returns the whole graph.
+  // computeSchedule's crew-leveled generative times. Only e-s (duration) is read past this point —
+  // s alone no longer seeds a per-element lower bound, see §S19 Part B note at the top of this file
+  // and §S6_CREW_PASS in solve(). Returns the whole graph.
   //
   // §CPM_STRAGGLER_MEMBERSHIP: an element whose PHYSICS ancestry (E1/E2 transitive closure)
   // reaches a later (level, phase) group than its own is a dag-wins straggler — the shipped


### PR DESCRIPTION
## Summary
- `4D_GANTT_TM_REFACTOR.md §S19 Part B` asked whether cpm_schedule.js's E5 (crew lower-bound) is dead weight now that S6's in-pass crew-slot allocator claims slots directly, or still bounding something real.
- Answer, measured: E5-as-per-element-START-bound was **already fully retired** by §S6_CREW_PASS — no code change needed there. E5-as-**DURATION-SOURCE** is still fully live (S6 has no independent duration model). Fixed two stale top-of-file comments that still described E5 as a live per-element bound.
- New committed probe `scripts/probe_e5_resolution.js` proves both halves against a real building.

## Evidence (Terminal_extracted, n=48,428)
```
§E5_ELEMENT_EXAMPLE guid=T0_Terminal_2fKPxuZcr6CuQ1jIJYQwwS cls=IfcMember storey=06 ROOF LEVEL
  rawStart(computeSchedule/E5)=1970-02-16T21:38:21.000Z rawDurHrs=1.564
  cpmStart(solve)=1970-04-09T05:11:39.000Z cpmDurHrs=1.564 startShiftDays=51.31
§E5_SUMMARY allDurationsPreservedExactly=true maxDeltaMs=0
§E5_BOUND_CHECK Terminal_extracted: cpmStart<rawStart(per-element bound NOT enforced)=12131
  cpmStart>rawStart=36296 cpmStart==rawStart=1/48428
  -- CONFIRMS E5-as-lower-bound is fully retired (S6 superseded it)
```
12,131/48,428 elements (25%) legitimately start *earlier* than their raw computeSchedule/E5 start — impossible if the per-element floor still held. Every element's duration survives the CPM solve bit-exact (maxDelta 0ms) — proving duration is still sourced only from computeSchedule.

## Regression check
- `probe_cpm_schedule.js` fleet output byte-identical to `origin/main`: floating(midair)=0/7, crewViol=0/7 unchanged both before/after (this PR is comment-only in cpm_schedule.js's logic).
- Named witnesses (§S5/§S18 set) all green: `witness_zone_display_authoring` 16/0, `witness_midair_zero` 39/0, `witness_tier_serial_display` 57/0, `witness_crosstask_judge_parity` 20/0.
- `gate_4d.sh`: pass=7 fail=0 missing=1 — confirmed identical to a fresh `origin/main` worktree run (the MISS, `witness_arch_area_weight.js`, genuinely does not exist in this revision — pre-existing, not introduced here; the historical "pass=8" cited in §S6/§S7_RESULTS is stale from an earlier repo state).

## Test plan
- [x] `scripts/probe_e5_resolution.js` (new, committed) — measured evidence above
- [x] `node scripts/probe_cpm_schedule.js` — fleet floating 0/7, byte-identical to baseline
- [x] 4 named witnesses green
- [x] `gate_4d.sh` pass count confirmed unchanged vs fresh origin/main baseline

Implementing bim-compiler `prompts/4D_GANTT_TM_REFACTOR.md §S19 Part B`.

https://claude.ai/code/session_013Wtyz1mg8yFkJ2T5pJsgUn