### PR TITLE
feat(4d): ScheduleEngine — single-source schedule class (stage 1)

### DIFF
--- a/scripts/probe_schedule_engine.js
+++ b/scripts/probe_schedule_engine.js
@@ -1,0 +1,156 @@
+#!/usr/bin/env node
+// probe_schedule_engine.js — 4D_GANTT_TM_REFACTOR.md stage-1 witness. Feeds real fleet element
+// data through ScheduleEngine.compute() and diffs its per-element output against
+// ScheduleGate.computeSchedule -> CpmSchedule.run called directly (the exact reference pattern
+// scripts/probe_cpm_schedule.js already uses) on the SAME data. Any divergence is a bug in the
+// new class's wiring, since it repackages this pair rather than reimplementing it.
+// Also confirms floating=0/7 via the same judge probe_cpm_schedule.js already uses, independently
+// of the new class (proves the underlying engine is unaffected, not just that the wrapper agrees
+// with itself).
+'use strict';
+const fs = require('fs');
+const path = require('path');
+const initSqlJs = require(path.join(__dirname, '..', 'modeller', 'lib', 'sql-wasm.js'));
+const ScheduleGate = require(path.join(__dirname, '..', 'viewer', 'schedule_gate.js'));
+const ScheduleAuthor = require(path.join(__dirname, '..', 'viewer', 'schedule_author.js'));
+const CpmSchedule = require(path.join(__dirname, '..', 'viewer', 'cpm_schedule.js'));
+const ScheduleEngine = require(path.join(__dirname, '..', 'viewer', 'schedule_engine.js'));
+const tmSrc = fs.readFileSync(path.join(__dirname, '..', 'viewer', 'time_machine.js'), 'utf8');
+
+function sliceFn(src, name) {
+  const idx = src.lastIndexOf('function ' + name + '(');
+  if (idx < 0) throw new Error(name + ' not found');
+  let depth = 0, i = idx, seenOpen = false;
+  for (; i < src.length; i++) {
+    if (src[i] === '{') { depth++; seenOpen = true; }
+    else if (src[i] === '}') { depth--; if (seenOpen && depth === 0) break; }
+  }
+  return src.slice(idx, i + 1);
+}
+function buildFn(srcParts, ret) {
+  return new Function('ScheduleGate', srcParts.join('\n') + '\nreturn ' + ret + ';')(ScheduleGate);
+}
+const _contactGraph = buildFn([sliceFn(tmSrc, '_contactGraph')], '_contactGraph');
+
+const BLD_DIR = process.env.BLD_DIR || path.join(require('os').homedir(), 'bim-ootb', 'buildings');
+const FLEET = (process.env.ONLY ? [process.env.ONLY] : [
+  'Duplex_extracted', 'Clinic_extracted', 'HHS_Office_Federated_extracted', 'JKR_extracted',
+  'Hospital_extracted', 'Terminal_extracted', 'LTU_AHouse_extracted'
+]);
+const SHIFT_HOURS = process.env.SHIFT_HOURS ? Number(process.env.SHIFT_HOURS) : 24;
+
+// floatingCensus — same judge as probe_cpm_schedule.js, independent of ScheduleEngine.
+function floatingCensus(items) {
+  const G = _contactGraph(items);
+  let midair = 0; const byClass = {};
+  for (let i = 0; i < items.length; i++) {
+    const list = G.contacts[i]; if (!list) continue;
+    let first = Infinity;
+    for (const k of list) { const s = items[k].s; if (s < first) first = s; }
+    if (first > items[i].s + 1) { midair++; byClass[items[i].cls] = (byClass[items[i].cls] || 0) + 1; }
+  }
+  return { midair, orphans: G.orphans, grounded: G.groundedN, byClass };
+}
+
+async function runBuilding(RATES, name) {
+  const SQL = await getSQL();
+  const db = new SQL.Database(fs.readFileSync(path.join(BLD_DIR, name + '.db')));
+  const rawElements = ScheduleAuthor._buildScheduleElements(db, RATES.SEQUENCE_RULES, {
+    laborRates: RATES.LABOR_RATES, rates: RATES.RATES, nameOverrides: RATES.SEQUENCE_NAME_OVERRIDES,
+    defaultRule: RATES.SEQUENCE_DEFAULT
+  });
+  db.close();
+  const maxCrews = {};
+  for (const res in RATES.LABOR_RATES) if (RATES.LABOR_RATES[res].max_crews) maxCrews[res] = RATES.LABOR_RATES[res].max_crews;
+
+  // §CPM_ENGINE_REACHABILITY — proof this run exercised the REAL, required modules, not a slice.
+  console.log('§CPM_ENGINE_REACHABILITY ' + name +
+    ' ScheduleEngine=' + (typeof ScheduleEngine.compute === 'function') +
+    ' computeSchedule=' + (typeof ScheduleGate.computeSchedule === 'function') +
+    ' cpmScheduleRun=' + (typeof CpmSchedule.run === 'function'));
+
+  // ── REFERENCE — the exact direct-call pattern probe_cpm_schedule.js already uses, unmodified.
+  const refElements = rawElements.map(function (it) { return Object.assign({}, it, { bz: it.base_z, tz: it.top_z }); });
+  const refSchedule = ScheduleGate.computeSchedule(refElements, 0, 1, maxCrews, SHIFT_HOURS);
+  const refItems = refElements.map(function (el) {
+    const st = refSchedule[el.guid]; if (!st) return null;
+    return { guid: el.guid, cls: el.cls, seq: el.seq, phase: el.phase, storey: el.storey,
+             x0: el.x0, x1: el.x1, y0: el.y0, y1: el.y1, bz: el.bz, tz: el.tz,
+             s: st.start, e: st.end, resource: el.resource };
+  }).filter(Boolean);
+  const refRun = CpmSchedule.run(refItems, { maxCrews: maxCrews });
+  const refByGuid = {};
+  refItems.forEach(function (it, i) { refByGuid[it.guid] = refRun.solution.times[i]; });
+
+  // ── NEW CLASS — ScheduleEngine.compute(elements, opts), fed the SAME rawElements + SAME opts.
+  const model = ScheduleEngine.compute(rawElements, { baseMs: 0, scaleFactor: 1, maxCrews: maxCrews, shiftHours: SHIFT_HOURS });
+  if (!model.ok) { console.log('§SE_DIFF ' + name + ' FAIL error=' + model.error); return { name, fail: true }; }
+
+  // ── DIFF — per-element start/end, converted back to the SAME ms clock as the reference (the
+  // reference is ms since refRun's own base epoch; the class emits day-offset from its own solved
+  // min-start — both are anchored to the SAME earliest solved start, so a day->ms conversion off
+  // the class's own projectStart should reproduce the reference's ms values exactly).
+  let minRefMs = Infinity;
+  refItems.forEach(function (it, i) { if (refRun.solution.times[i].s < minRefMs) minRefMs = refRun.solution.times[i].s; });
+  const DAY = 86400000;
+  let mismatches = 0, checked = 0, maxDeltaMs = 0;
+  const missingInModel = [];
+  const modelByGuid = {};
+  model.elements.forEach(function (e) { modelByGuid[e.guid] = e; });
+  refItems.forEach(function (it, i) {
+    const refT = refRun.solution.times[i];
+    const me = modelByGuid[it.guid];
+    if (!me) { missingInModel.push(it.guid); return; }
+    checked++;
+    const meS = minRefMs + me.start * DAY, meE = minRefMs + me.end * DAY;
+    const dS = Math.abs(meS - refT.s), dE = Math.abs(meE - refT.e);
+    if (dS > 1 || dE > 1) mismatches++;
+    maxDeltaMs = Math.max(maxDeltaMs, dS, dE);
+  });
+  console.log('§SE_DIFF ' + name + ' refItems=' + refItems.length + ' modelElements=' + model.elements.length +
+    ' checked=' + checked + ' mismatches=' + mismatches + ' missingInModel=' + missingInModel.length +
+    ' maxDeltaMs=' + maxDeltaMs.toFixed(1) + ' deps=' + model.dependencies.length +
+    ' milestones=' + model.milestones.length + ' tasks=' + model.tasks.length +
+    ' ' + (mismatches === 0 && missingInModel.length === 0 ? 'PASS' : 'FAIL'));
+
+  // ── FLOATING GATE — same judge, on the CPM-SOLVED items (probe_cpm_schedule.js's own
+  // `cpmItems` pattern: refItems.s/e replaced with refRun.solution.times, NOT the raw pre-CPM
+  // times refItems still carries at this point — floating>0 on raw-only items is expected/normal,
+  // the invariant is about the CPM output). Independent of ScheduleEngine, proves the underlying
+  // engine's own invariant, not just that the wrapper agrees with itself.
+  const cpmItems = refItems.map(function (o, i) {
+    return Object.assign({}, o, { s: refRun.solution.times[i].s, e: refRun.solution.times[i].e });
+  });
+  const census = floatingCensus(cpmItems);
+  const STRUCTURAL = ['IfcFooting', 'IfcColumn', 'IfcBeam', 'IfcSlab'];
+  let structural = 0;
+  Object.keys(census.byClass).forEach(function (c) {
+    if (STRUCTURAL.some(function (p) { return c.indexOf(p) === 0; })) structural += census.byClass[c];
+  });
+  console.log('§SE_FLOATING ' + name + ' midair=' + census.midair + ' structural=' + structural +
+    ' orphans=' + census.orphans + ' ' + (census.midair === 0 && structural === 0 ? 'PASS' : 'FAIL'));
+
+  return { name, fail: mismatches > 0 || missingInModel.length > 0 || census.midair !== 0 || structural !== 0 };
+}
+
+let _SQL = null;
+async function getSQL() {
+  if (_SQL) return _SQL;
+  _SQL = await initSqlJs({ wasmBinary: fs.readFileSync(path.join(__dirname, '..', 'modeller', 'lib', 'sql-wasm.wasm')) });
+  return _SQL;
+}
+
+async function main() {
+  const ratesSrc = fs.readFileSync(path.join(__dirname, '..', 'viewer', 'rates.js'), 'utf8');
+  const RATES = (new Function(ratesSrc +
+    '\nreturn {SEQUENCE_RULES:SEQUENCE_RULES, SEQUENCE_DEFAULT:SEQUENCE_DEFAULT, ' +
+    'SEQUENCE_NAME_OVERRIDES:SEQUENCE_NAME_OVERRIDES, LABOR_RATES:LABOR_RATES, RATES:RATES};'))();
+  let anyFail = false;
+  for (const name of FLEET) {
+    const r = await runBuilding(RATES, name);
+    if (r.fail) anyFail = true;
+  }
+  console.log('§SE_FLEET_SUMMARY buildings=' + FLEET.length + ' ' + (anyFail ? 'FAIL' : 'PASS'));
+  process.exit(anyFail ? 1 : 0);
+}
+main().catch(e => { console.error('ERR ' + (e && e.stack || e)); process.exit(2); });

--- a/viewer/schedule_engine.js
+++ b/viewer/schedule_engine.js
@@ -1,0 +1,140 @@
+// schedule_engine.js — 4D_GANTT_TM_REFACTOR.md's spec: ONE class, ONE method,
+// compute(elements, opts) -> ScheduleModel. Wraps ScheduleGate.computeSchedule -> CpmSchedule.run
+// (the actual duplicated pair) as the single place "when does each thing get built" is computed.
+// Pure function — no DOM, no SQL, no rendering/editor/movie knowledge. `elements` is whatever
+// ScheduleAuthor._buildScheduleElements already emits (classification stays exactly where it is,
+// not duplicated here) — verified fields, not assumed: guid, cls, name, storey, base_z, top_z,
+// x0, x1, y0, y1, seq, phase, resource, installSecs. `opts` is whatever computeSchedule/
+// CpmSchedule.run already take today: baseMs, scaleFactor, maxCrews, shiftHours — passed through
+// unchanged, not redesigned.
+(function (global) {
+  'use strict';
+
+  var DAY = 86400000;
+  var EDGE_KIND = ['SS', 'FS'];
+  // type: 0=member (element->its phase/level milestone), 1=E1 support, 2=E2 host/opening,
+  // 3=E3 discipline hammock, 4=E4 storey hammock — verified against cpm_schedule.js's own
+  // addEdge() call sites, not assumed.
+  var EDGE_TYPE = ['member', 'support', 'hostOpening', 'discipline', 'storey'];
+
+  function compute(elements, opts) {
+    opts = opts || {};
+    var i;
+    var SG = (typeof global.ScheduleGate !== 'undefined') ? global.ScheduleGate
+      : (typeof ScheduleGate !== 'undefined' ? ScheduleGate : null);
+    var CPM = (typeof global.CpmSchedule !== 'undefined') ? global.CpmSchedule
+      : (typeof CpmSchedule !== 'undefined' ? CpmSchedule : null);
+    if (!SG || !CPM) return { ok: false, error: 'ScheduleGate/CpmSchedule not loaded' };
+    if (!elements || !elements.length) return { ok: false, error: 'no elements' };
+
+    // Step 1 — raw schedule. ScheduleGate.computeSchedule(elements, baseMs, scaleFactor, maxCrews,
+    // shiftHours) -> {guid: {start, end}} in ms, verified by direct read of its own `out[el.guid] =
+    // {start: start, end: end}` assignment (schedule_gate.js:559). Does not mutate `elements`.
+    var raw = SG.computeSchedule(elements, opts.baseMs, opts.scaleFactor, opts.maxCrews, opts.shiftHours);
+
+    // Step 2 — CpmSchedule.run(items, opts) needs items carrying .s/.e (ms, from step 1 — only the
+    // DURATION e-s is actually read past graph construction, per cpm_schedule.js's own §S19 Part B
+    // note) and .bz/.tz — cpm_schedule.js's own field names, verified DIFFERENT from
+    // computeSchedule's .base_z/.top_z (schedule_gate.js uses base_z/top_z 41x, cpm_schedule.js uses
+    // bz/tz 12x, zero overlap) — this rename is a real bridge this class exists to do, not an
+    // assumption carried over.
+    // §RAW_SCHEDULE_MISS — an element with no computeSchedule entry is dropped, not defaulted, per
+    // the existing proven pattern (scripts/probe_cpm_schedule.js:118-123, `if (!st) return null` ->
+    // `.filter(Boolean)`). Defaulting it to a synthetic time would invent a schedule for something
+    // the raw scheduler explicitly did not place.
+    var items = [];
+    for (i = 0; i < elements.length; i++) {
+      var e = elements[i], r = raw[e.guid];
+      if (!r) continue;
+      items.push({
+        guid: e.guid, cls: e.cls, seq: e.seq, phase: e.phase, storey: e.storey, resource: e.resource,
+        x0: e.x0, x1: e.x1, y0: e.y0, y1: e.y1, bz: e.base_z, tz: e.top_z, s: r.start, e: r.end
+      });
+    }
+    var run = CPM.run(items, { maxCrews: opts.maxCrews });
+    if (!run.ok) return { ok: false, error: run.error || 'CpmSchedule.run failed' };
+
+    // Step 3 — assemble ScheduleModel. Primary truth is per-element (spec's own correction: no
+    // rollup baked in here — that summarization choice belongs to a future consumer). One clock:
+    // day-offset from the solved schedule's own earliest start (extracted from the solve, not
+    // invented). `run.solution.times[i]` indexes 1:1 with `items`/`elements` for i < nElements
+    // (verified: solve() allocates `times = new Array(n)` where n = graph.nElements, milestones
+    // are NOT included in `times`).
+    var solvedTimes = run.solution.times, n = run.graph.nElements;
+    var projStartMs = Infinity, projEndMs = -Infinity;
+    for (i = 0; i < solvedTimes.length; i++) {
+      if (solvedTimes[i].s < projStartMs) projStartMs = solvedTimes[i].s;
+      if (solvedTimes[i].e > projEndMs) projEndMs = solvedTimes[i].e;
+    }
+    if (!isFinite(projStartMs)) projStartMs = 0;
+    if (!isFinite(projEndMs)) projEndMs = 0;
+
+    var els = new Array(n), taskIndex = {};
+    for (i = 0; i < n; i++) {
+      var it = items[i], t = solvedTimes[i];
+      // Synthetic grouping key — this class is DB-free and has no knowledge of a real materialized
+      // task_id (that lives in schedule_author.js's own table, a separate concern). A future wiring
+      // stage reconciles this key to a real task identity if one is needed; not invented here.
+      var taskId = it.phase + '||' + it.storey + '||' + (it.resource || '_DEFAULT');
+      els[i] = { guid: it.guid, phase: it.phase, storey: it.storey, resource: it.resource,
+                 start: (t.s - projStartMs) / DAY, end: (t.e - projStartMs) / DAY, taskId: taskId };
+      var tk = taskIndex[taskId] || (taskIndex[taskId] = { id: taskId, phase: it.phase,
+        storey: it.storey, resource: it.resource, name: taskId, guids: [] });
+      tk.guids.push(it.guid);
+    }
+
+    // Milestones (phase/level completion gates, dur 0, synthetic — cpm_schedule.js's own
+    // `msMeta[k] = {level, phase}` for node index n+k) are real DAG nodes, not WBS tasks. E3/E4 —
+    // the storey/phase hammock edges, the actual precedence backbone for "staggered by trade and
+    // level" — originate FROM these nodes (verified: addEdge(milestone(...), succ[k], FS, 3, 'e3')
+    // and addEdge(m, succ[k], FS, 4, 'e4') in cpm_schedule.js). Excluding milestone-sourced edges
+    // would silently drop E3/E4 entirely from the output — so milestones get a synthetic id here
+    // and stay first-class dependency endpoints, not flattened into element-to-element pairs (which
+    // would combinatorially explode for a milestone feeding/gating thousands of elements).
+    var milestones = run.graph.msMeta.map(function (m, k) {
+      return { id: 'MS:' + m.level + '||' + m.phase, level: m.level, phase: m.phase };
+    });
+    function nodeId(idx) { return idx < n ? items[idx].guid : milestones[idx - n].id; }
+
+    // Dependencies — CpmSchedule.run's own graph edges, translated from node index to guid/
+    // milestone id. Dropped edges (solve()'s cycle-breaking, mutated in place onto the same edge
+    // objects) are excluded — they were NOT enforced, including them would misrepresent what
+    // actually ran. This engine has NO lag concept: verified by reading solve()'s own edge
+    // relaxation (`var b = e.kind === FS ? ef : ES[u];`) — no lag term exists anywhere in it, every
+    // edge is a hard zero-lag constraint. lag:0 states that fact; it is not a placeholder for
+    // missing data.
+    var deps = [];
+    for (var u = 0; u < run.graph.out.length; u++) {
+      var edges = run.graph.out[u];
+      if (!edges) continue;
+      for (var k = 0; k < edges.length; k++) {
+        var ed = edges[k];
+        if (ed.dropped) continue;
+        deps.push({ from: nodeId(u), to: nodeId(ed.to), kind: EDGE_KIND[ed.kind],
+                    edgeType: EDGE_TYPE[ed.type], lag: 0 });
+      }
+    }
+
+    return {
+      ok: true,
+      elements: els,
+      tasks: Object.keys(taskIndex).map(function (k) { return taskIndex[k]; }),
+      milestones: milestones,
+      dependencies: deps,
+      projectStart: 0,
+      projectEnd: (projEndMs - projStartMs) / DAY,
+      // No critical-path ids: CpmSchedule.run is a forward-only earliest-start solve — no backward
+      // pass / float computation exists anywhere in the current engine (verified: solve() never
+      // computes a late-start or float value). Omitted rather than invented; a future stage would
+      // need to ADD that computation, not just expose it.
+      criticalPathIds: null,
+      // Reachability/evidence — which real functions this call actually exercised, per this
+      // project's own standing rule (a probe must prove its call path, not just its behavior).
+      _via: { computeSchedule: true, cpmScheduleRun: true, floating: null }
+    };
+  }
+
+  var API = { compute: compute };
+  global.ScheduleEngine = API;
+  if (typeof module !== 'undefined' && module.exports) module.exports = API;
+})(typeof window !== 'undefined' ? window : (typeof globalThis !== 'undefined' ? globalThis : this));


### PR DESCRIPTION
## Summary
- New `viewer/schedule_engine.js`: one class, `compute(elements, opts) -> ScheduleModel`, wrapping `ScheduleGate.computeSchedule -> CpmSchedule.run` (the actual duplicated schedule-computation pair) as the single place "when does each thing get built" is computed.
- `elements` = `ScheduleAuthor._buildScheduleElements`'s own output — classification stays exactly where it already correctly lives, not duplicated or re-homed.
- Primary output is **per-element**, one time base (day-offset from the solve's own earliest start) — no rollup baked in; that summarization choice is left to a future consumer.
- Dependencies expose the real E1-E4 graph edges including E3/E4 storey/phase hammocks (which originate from synthetic milestone nodes) as first-class endpoints, not silently dropped or flattened.
- No invented fields: no `lag` (the engine has no lag concept — verified by reading `solve()`'s own edge relaxation), no `criticalPathIds` (the engine is forward-only, no backward-pass/float computation exists to expose).
- **Not wired into `buildGanttTasks()`, the editor, or the movie** — that's a separate stage, per `prompts/4D_GANTT_TM_REFACTOR.md`'s own scope.

## Test plan
- [x] `node --check` both new files
- [x] New witness `scripts/probe_schedule_engine.js`: diffs the class's per-element output against `ScheduleGate.computeSchedule` + `CpmSchedule.run` called directly (the exact pattern `probe_cpm_schedule.js` already uses) on all 7 fleet buildings — byte-identical, `maxDeltaMs=0.0` everywhere
- [x] `floating=0/7` confirmed independently via the same judge probe used elsewhere in this project
- [x] Orphan counts match the established fleet baseline exactly on all 7 buildings (Duplex=1, Clinic=27, HHS=36, JKR=1, Hospital=35, Terminal=7, LTU=51)

🤖 Generated with [Claude Code](https://claude.com/claude-code)