### PR TITLE
fix(4d): Gantt axis-end — Tukey fence, the axis's own near-duplicate cliff

### DIFF
--- a/scripts/probe_gantt_axis_fit.js
+++ b/scripts/probe_gantt_axis_fit.js
@@ -1,0 +1,68 @@
+#!/usr/bin/env node
+// probe_gantt_axis_fit.js — 4D_GANTT_TM_REFACTOR.md, the axis near-duplicate fix. Reads the REAL
+// rendered axis (window.__tmGanttAxis) and the REAL rendered bars (window.__tmGanttBarsRaw), via a
+// real browser click on the panel toggle, and checks whether any bar's true end exceeds the axis
+// it's actually drawn/scaled against — the "data-correct, draw-wrong" failure mode: a bar's per-
+// element times can be perfectly correct and still render squashed/pushed off-panel if the axis
+// qualifying them is too short.
+'use strict';
+const { spawn } = require('child_process');
+const puppeteer = require(process.env.PUPPETEER || 'puppeteer');
+const PORT = process.env.PORT ? Number(process.env.PORT) : 8130;
+const BLD = process.env.BLD || 'Terminal_extracted';
+const URL = `http://localhost:${PORT}/viewer/viewer.html?db=/buildings/${BLD}.db`;
+const D = 86400000;
+
+async function main() {
+  const server = spawn('python3', ['-m', 'http.server', String(PORT), '--directory', process.env.SERVE_ROOT || '/tmp/serve-after'], { stdio: 'ignore' });
+  await new Promise(r => setTimeout(r, 1500));
+  const browser = await puppeteer.launch({ headless: 'new',
+    args: ['--no-sandbox', '--disable-dev-shm-usage', '--use-angle=swiftshader', '--enable-unsafe-swiftshader'] });
+  const page = await browser.newPage();
+  const lines = [];
+  page.on('console', m => { const t = m.text(); if (t.indexOf('§') >= 0) lines.push(t); });
+  await page.goto(URL, { waitUntil: 'domcontentloaded', timeout: 60000 });
+  await page.waitForFunction(() => typeof window.toggleTimeMachine === 'function', { timeout: 180000 });
+  await page.waitForFunction(() => window.APP && window.APP.db, { timeout: 240000 }).catch(() => {});
+  await new Promise(r => setTimeout(r, 15000));
+  await page.evaluate(() => window.toggleTimeMachine());
+  const deadline1 = Date.now() + 300000;
+  while (Date.now() < deadline1) {
+    if (lines.some(l => l.indexOf('§TIME_MACHINE ON') >= 0)) break;
+    await new Promise(r => setTimeout(r, 200));
+  }
+  const clicked = await page.evaluate(() => {
+    const btn = document.getElementById('tm-gantt');
+    if (!btn) return false;
+    btn.dispatchEvent(new PointerEvent('pointerup', { bubbles: true }));
+    return true;
+  });
+  const deadline2 = Date.now() + 30000;
+  let bars = null, axis = null;
+  while (Date.now() < deadline2) {
+    bars = await page.evaluate(() => window.__tmGanttBarsRaw || null);
+    axis = await page.evaluate(() => window.__tmGanttAxis || null);
+    if (bars && bars.length && axis) break;
+    await new Promise(r => setTimeout(r, 300));
+  }
+  await browser.close(); server.kill();
+  if (!bars || !bars.length || !axis) {
+    console.log('§GANTT_AXIS_FIT BLD=' + BLD + ' ERROR clicked=' + clicked + ' bars=' + (bars ? bars.length : null) + ' axis=' + JSON.stringify(axis));
+    process.exit(2);
+  }
+
+  const axisSpanDays = (axis.axisEnd - axis.axisStart) / D;
+  const trueSpanDays = (axis.projectEnd - axis.axisStart) / D;
+  const overflow = bars.filter(b => b.endTs > axis.axisEnd + 1);   // +1ms float-compare slack
+  const worstOverflowDays = overflow.length ? Math.max.apply(null, overflow.map(b => (b.endTs - axis.axisEnd) / D)) : 0;
+  console.log('§GANTT_AXIS_FIT BLD=' + BLD + ' axisN=' + axis.n +
+    ' axisSpanDays=' + axisSpanDays.toFixed(1) + ' trueSpanDays=' + trueSpanDays.toFixed(1) +
+    ' qualifiedFraction=' + (trueSpanDays > 0 ? (axisSpanDays / trueSpanDays).toFixed(3) : '1') +
+    ' bars=' + bars.length + ' overflowBars=' + overflow.length +
+    ' worstOverflowDays=' + worstOverflowDays.toFixed(1) +
+    ' overflowDetail=' + JSON.stringify(overflow.slice(0, 5).map(b => (b.taskId || b.storey + '|' + b.phase) +
+      ' n=' + b.count + ' endTs=' + ((b.endTs - axis.axisStart) / D).toFixed(1) + 'd axisEnd=' + axisSpanDays.toFixed(1) + 'd')) +
+    ' ' + (overflow.length === 0 ? 'PASS' : 'FAIL'));
+  process.exit(overflow.length === 0 ? 0 : 1);
+}
+main().catch(e => { console.error('ERR ' + (e && e.stack || e)); process.exit(2); });

--- a/viewer/sw.js
+++ b/viewer/sw.js
@@ -8,7 +8,15 @@
 // Cache-first for heavy assets (.wasm, images). DB files skip SW (IndexedDB handles them).
 //
 // DEPLOY: bump CACHE_VERSION on every OCI upload. Old caches are purged on activate.
-const CACHE_VERSION = 'v1057';   // bump on each deploy; per-change detail is the git commit message.
+const CACHE_VERSION = 'v1058';   // bump on each deploy; per-change detail is the git commit message.
+// v1058 (2026-08-18) 4D_GANTT_TM_REFACTOR.md, the axis near-duplicate fix: computeDays()'s
+// _ganttAxisEnd used the SAME cliff rule stage 2 fixed inside buildGanttTasks() (2nd-98th
+// percentile above n=20, true max below), applied to the GLOBAL end_ts population instead of one
+// bar's span. Fleet-measured live (before fix): every one of the 7 buildings had bars whose real
+// end exceeded the axis they were drawn against — worst LTU 17.8d/12 bars, Hospital 10.6d/5 bars
+// (top floors squashed toward the panel edge). Data-correct, draw-wrong. Now uses the same shared
+// _tukeyBound as the bar-span fix — 0 overflow, all 7 buildings, after. _GANTT_CACHE_VERSION
+// 33->34 bumped alongside.
 // v1057 (2026-08-17) 4D_GANTT_TM_REFACTOR.md stage 2: buildGanttTasks()'s bar-span rule replaced
 // (2nd-98th-percentile-above-n20/true-min-max-below -> uniform Tukey-fence, no cliff) — the
 // mechanism behind the live "one pile, full project length" report. _GANTT_CACHE_VERSION 32->33

--- a/viewer/time_machine.js
+++ b/viewer/time_machine.js
@@ -136,24 +136,32 @@
       _projectStart = cOps[0].start_ts - 1;
       _projectEnd = Math.max.apply(null, cOps.map(function(o){ return o.end_ts; }));
     }
-    // §GANTT_AXIS_OUTLIER — qualified DISPLAY axis. Same 2nd-98th percentile trim §GANTT_MINI_TRIM
-    // already uses per-bar (buildGanttTasks), applied here to the GLOBAL population of end_ts that
-    // would otherwise define the whole chart's axis. n>20 real percentiles, else true min/max — same
-    // threshold, never a new invented one. Kept as real, independent defense against genuinely
-    // mistagged construction data even now that cOps excludes bookkeeping ops (§GANTT_MINI_TRIM's own
-    // proven case — a handful of real elements DO carry a real-but-wrong storey tag).
-    var ends = cOps.map(function (o) { return o.end_ts; }).sort(function (a, b) { return a - b; });
-    var n = ends.length;
+    // §GANTT_AXIS_OUTLIER — qualified DISPLAY axis. Was its own copy of the 2nd-98th-percentile-
+    // above-n20/true-max-below cliff §GANTT_MINI_TRIM used to use per-bar (buildGanttTasks) — the
+    // SAME broken rule, applied here to the GLOBAL population of end_ts that defines the whole
+    // chart's axis instead of one bar's span. Stage 2 (4D_GANTT_TM_REFACTOR.md) fixed the per-bar
+    // copy but not this one — a bar's DATA could be correct while its DRAWN pixel position was
+    // still wrong, because the axis it's scaled against was still cliff-computed. Fixed here the
+    // same way: the shared _tukeyBound (hoisted to module scope, stage 2) — uniform at every
+    // population size, no cliff, no new tuned constant, reuses the exact proven formula. Never
+    // exceeds the true max (_tukeyBound's own Math.min(s[n-1], ...) clamp), so this stays a
+    // qualification of the real data, never an invention beyond it.
     _ganttAxisStart = _projectStart;   // starts are not the observed problem; leave unqualified
-    if (n > 20) {
-      var hiI = Math.min(n - 1, Math.ceil(n * 0.98) - 1);
-      _ganttAxisEnd = ends[hiI];
-    } else {
-      _ganttAxisEnd = _projectEnd;
-    }
+    _ganttAxisEnd = cOps.length
+      ? _tukeyBound(cOps.map(function (o) { return o.end_ts; }), false)
+      : _projectEnd;
     // (G-3 fix 2026-08-11: a stale byte-duplicate of the block above sat here reading `_ops` —
     // bookkeeping ops included — and OVERWROTE the qualified axis, so the display axis absorbed
     // BUILDING_OPEN. Removed; the cOps-based block above is the single authority.)
+    // §GANTT_AXIS_RAW (2026-08-18, 4D_GANTT_TM_REFACTOR.md — the axis's own near-duplicate fix) —
+    // read-only debug hook, same convention as __tmGanttBarsRaw, so this layer is verifiable by a
+    // witness instead of only by reading source. Exposes both the qualified axis actually drawn
+    // against and the true unqualified bounds, so a probe can directly check "does any bar's real
+    // end exceed what it's scaled against" without a second, separate computation.
+    try {
+      window.__tmGanttAxis = { axisStart: _ganttAxisStart, axisEnd: _ganttAxisEnd,
+        projectStart: _projectStart, projectEnd: _projectEnd, n: cOps.length };
+    } catch (e) {}
   }
 
   // ── Scene: emerge from nothing ──
@@ -7848,7 +7856,7 @@
   // huts going first before the walls" AFTER a hard reset, because §GANTT_CACHE_HIT served a
   // gantt:v4 entry generated under the old ordering. A hard reset cannot clear it — the entry is in
   // IndexedDB, not the HTTP cache. This bump is that fix's second half.
-  var _GANTT_CACHE_VERSION = 33;   // §GANTT_MINI_TRIM (4D_GANTT_TM_REFACTOR.md stage 2) — bar-span rule changed (Tukey fence, no n=20 cliff), regenerate
+  var _GANTT_CACHE_VERSION = 34;   // §GANTT_AXIS_OUTLIER (4D_GANTT_TM_REFACTOR.md) — axis-end rule changed (Tukey fence, no n=20 cliff), regenerate
   // was 28:   // §CPM_DISPLAY (2026-08-16): display timeline authored by the one-DAG CPM pass
   // was 27:   // §ZONE_DISPLAY_AUTHORING (2026-08-16): task windows authored from
                                    // the DISPLAY timeline + strict-bar sweep skipped on that path —


### PR DESCRIPTION
## Summary
Real bug found live after stage 2 (#1432) landed. `computeDays()`'s `_ganttAxisEnd` — the axis every Gantt bar gets pixel-scaled against — used the SAME 2nd-98th-percentile-above-n20/true-max-below cliff stage 2 already fixed inside `buildGanttTasks()`, just applied to the GLOBAL `end_ts` population instead of one bar's span. Stage 2's scope was `buildGanttTasks()` only, so this near-duplicate (the code's own comment named it as such) went unfixed.

Why it mattered even with stage 2's bar data already correct: a bar's per-element times could be exactly right and still render squashed or pushed past the visible panel width, because the axis qualifying its pixel position could land shorter than what some bars actually needed. Data-correct, draw-wrong.

**Fix:** replaced the cliff with the same shared `_tukeyBound` already hoisted to module scope in stage 2 — one implementation, not a third copy. Axis start stays unqualified (unchanged). Added `window.__tmGanttAxis` — a read-only debug hook, same convention as `__tmGanttBarsRaw` — so this layer is verifiable by a witness going forward.

## Acceptance — real rendered axis + bars, live browser click, all 7 fleet buildings

| building | overflow bars (before) | worst overflow | after |
|---|---|---|---|
| LTU_AHouse | 12/62 | 17.8d | 0/62 |
| Hospital | 5/36 | 10.6d (top floors squashed) | 0/36 |
| Clinic | 2/33 | 2.5d | 0/33 |
| JKR | 12/67 | 1.5d | 0/67 |
| HHS | 3/17 | 1.4d | 0/17 |
| Duplex | 1/19 | 0.2d | 0/19 |
| Terminal | 4/49 | 0.9d | 0/49 |

Every one of the 7 fleet buildings had real overflow before this fix. `qualifiedFraction` (axis span / true span) now reads exactly 1.000 on all 7.

- `floating=0/7` reconfirmed unaffected.
- `_GANTT_CACHE_VERSION` 33->34 and `sw.js` `CACHE_VERSION` v1057->v1058 bumped together.

## Test plan
- [x] `node --check` all changed/new files
- [x] Full-fleet before/after via `scripts/probe_gantt_axis_fit.js` (table above)
- [x] `floating=0/7` reconfirmed via `probe_cpm_schedule.js`

🤖 Generated with [Claude Code](https://claude.com/claude-code)