### PR TITLE
chore(lfs): stop LFS content shipping in GitHub source archives

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,15 @@
 modeller/*_geo.db filter=lfs diff=lfs merge=lfs -text
 modeller/mesh.db filter=lfs diff=lfs merge=lfs -text
+
+# ── LFS EGRESS GUARD (2026-08-19) ──────────────────────────────────────────────────────────────
+# GitHub bills LFS BANDWIDTH when a source archive containing real LFS content is downloaded, and
+# this repo cuts a release DAILY (auto-publish-release.yml, cron 0 1 * * *) — every tag adds another
+# permanently-downloadable tar.gz/zip. Measured 2026-08-19: the v1.49.1 tarball streamed 48MB+ before
+# being aborted, i.e. it carries real blob content, not pointers.
+# `export-ignore` removes these from `git archive` output (GitHub's source tarball/zipball) WITHOUT
+# touching history, clones, checkouts, or the Modeller — modeller.html, str_walker_outliner.js and
+# buildings_manifest.json all still reference mesh.db and are unaffected by this.
+# NOTE: this is only half the fix. The other half is a WEB-UI-ONLY repo setting not exposed by the
+# REST API: Settings -> Archives -> uncheck "Include Git LFS objects in archives".
+modeller/mesh.db export-ignore
+modeller/*_geo.db export-ignore


### PR DESCRIPTION
## Why

10GB LFS bandwidth quota exhausted again (2026-08-19). Diagnosed — it is **not** the usual suspects:

- **Worktrees are clean.** All 7 `bim-ootb` worktrees carry the identical `mesh.db` OID (`1cb80e700512`), so every checkout hits the local cache (7 objects, 841MB). Zero downloads. The `CLAUDE.md` worktree discipline is working.
- **CI is clean.** No workflow uses `lfs:` checkout, and `build_offline_bundle.sh` already excludes `modeller/` and `buildings/` with an explicit "LFS-heavy ~246MB" comment.

**The surface is source archives.** GitHub bills LFS bandwidth for source-archive downloads that contain real LFS content, and `auto-publish-release.yml` cuts a release **daily** (`cron: '0 1 * * *'`) — v1.43 → v1.49.1 in eight days, each tag adding another permanently-downloadable `tar.gz`/`zip`. Measured: the v1.49.1 tarball streamed **48MB+** before being aborted, so it carries blob content, not pointers.

## What this does

`export-ignore` on `modeller/mesh.db` and `modeller/*_geo.db` — removes them from `git archive` output (GitHub's tarball/zipball) **without touching history, clones, checkouts, or the Modeller**.

`mesh.db` stays fully functional: `modeller/modeller.html`, `modeller/str_walker_outliner.js` and `modeller/buildings_manifest.json` all reference it and are unaffected — `export-ignore` only affects archive generation.

## This is half the fix

The other half is a **web-UI-only** repo setting the REST API does not expose:

> Settings → Archives → uncheck **"Include Git LFS objects in archives"**

That one needs a human with repo admin.

## Not done, deliberately

- **No history rewrite.** Only 2 commits touch `mesh.db`, so a purge would be small — but it is a force-push on a repo with 7 live worktrees and concurrent sessions.
- **No change to the release cadence.** Reducing the daily cron is a separate call.

## The deeper finding, for a follow-up

`bim-compiler/CLAUDE.md:183-185` already states the doctrine: *extracted/derived building DBs — **mesh/geo DBs** — distribute via **OCI**, **never git/LFS***. `modeller/mesh.db` (120MB) and `modeller/*_geo.db` are in git LFS, which that rule forbids. **Moving them to OCI would remove this quota exposure permanently**, and is the real fix this PR only mitigates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RUz284UrV9vKLvy4tVgnGZ