### PR TITLE
fix(4d): §S26.2 support-pool predicate — RE-LAND of the squash-orphaned #1439

### DIFF
--- a/viewer/cpm_schedule.js
+++ b/viewer/cpm_schedule.js
@@ -124,7 +124,18 @@
     for (var i = 0; i < n; i++) {
       out[i] = -1;
       var list = G.contacts[i]; if (!list) continue;
+      // §S26.2 (2026-08-19) — STRUCTURE FIRST, contact only as a last resort. The election used to
+      // take any lower touching box, so an IfcFlowSegment under a wall "bore" that wall: a CONTACT,
+      // not a precedence, and those edges are what contradict phase order (Duplex: 761 physics-vs-
+      // phase contradictions vs 1 when supports are restricted to load-bearing classes).
+      // Electing ONLY from the pool was measured FIRST and is wrong: an element whose every contact
+      // is non-pool then gets no support at all, starts at day 0, and appears before the thing it
+      // touches — W-MZ-2 went 0 -> 2,781 on LTU, 0 -> 107 on Hospital. So the same classification
+      // elects TWICE: the pool winner when one exists, else the unrestricted winner. Nothing loses
+      // its support edge; a real structural support simply outranks a pipe.
       var T = items[i], bestJ = -1, bestCls = 9, bestScore = Infinity;
+      var poolJ = -1, poolCls = 9, poolScore = Infinity;
+      var inPool = SG.supportPool || function () { return true; };
       for (var k = 0; k < list.length; k++) {
         var j = list[k], S = items[j], cls, score;
         if (S.bz < T.bz - EPS && S.tz >= T.bz - GAP) { cls = 0; score = -S.tz; }
@@ -134,7 +145,12 @@
             (score === bestScore && (bestJ < 0 || String(S.guid) < String(items[bestJ].guid)))))) {
           bestCls = cls; bestScore = score; bestJ = j;
         }
+        if (inPool(S) && (cls < poolCls || (cls === poolCls && (score < poolScore ||
+            (score === poolScore && (poolJ < 0 || String(S.guid) < String(items[poolJ].guid))))))) {
+          poolCls = cls; poolScore = score; poolJ = j;
+        }
       }
+      if (poolJ >= 0) { bestJ = poolJ; bestCls = poolCls; }   // §S26.2 structure outranks contact
       if (bestCls === 2 && G.grounded[i]) continue;   // carrier-above rejected ONLY when grounded
       out[i] = bestJ;
     }

--- a/viewer/schedule_gate.js
+++ b/viewer/schedule_gate.js
@@ -507,7 +507,7 @@
       // The DAG makes the rule explicit and uniform: between two pool members only BELOW orders
       // them; the §GEO_SUPPORT_LEAK cases this clause exists for were all non-pool consumers
       // (IfcWallStandardCase / Proxy) and keep it unchanged.
-      var elPool = el.seq <= 4 || isPromotedSlab(el) || isStairFlight(el);
+      var elPool = supportPool(el);   // §S26.2: same test, one definition (was inline here)
       for (c = 0; c < cs.length; c++) { arr = grid[cs[c]]; if (!arr) continue;
         for (k = 0; k < arr.length; k++) { S = arr[k]; if (S.guid === el.guid) continue;
           var below = S.base_z < el.base_z - EPS;
@@ -1216,7 +1216,21 @@
   // SHIFT_MS/DAY_MS + the two mappers are exported for the same reason EPS/GAP/CELL are: the live
   // movie clock (time_machine.js injectGantt's scaleFactor/projectDays) must size a day with THIS
   // module's shift, not a second hand-typed 8h constant to drift (§TM_DURATION_SYNC's lesson).
-  var API = { computeSchedule: computeSchedule, collapsePhase: collapsePhase, elementsInPhase: elementsInPhase, auditFloating: auditFloating, deriveBandRanks: deriveBandRanks, deriveZones: deriveZones, deriveStoreyMergeMap: deriveStoreyMergeMap, hostPairs: hostPairs, openingPairs: openingPairs, groundworkSlabs: groundworkSlabs, CELL: CELL, EPS: EPS, GAP: GAP, BIG_ELEMENT_VOL: BIG_ELEMENT_VOL, SHIFT_MS: SHIFT_MS, DAY_MS: DAY_MS, toProductive: toProductive, toWall: toWall };
+  // §S26.2 (2026-08-19, prompts/4D_GANTT_TM_REFACTOR.md) — the SUPPORT POOL, expressed once and
+  // exported. This is not a new concept: it is verbatim the membership test computeSchedule's
+  // geoGate already used inline (`el.seq <= 4 || isPromotedSlab(el) || isStairFlight(el)`), lifted
+  // to module scope so designatedSupport() in cpm_schedule.js and _designatedSupport() in
+  // time_machine.js can ask the same question instead of treating every touching box as structure.
+  // Measured on Duplex (§S26.2): support = anything below gives 4,706 bearing relations and 761
+  // physics-vs-phase contradictions; support = load-bearing classes gives 702 and 1. The 760
+  // difference is the engine insisting a pipe must be installed before the wall above it.
+  function supportPool(e) {
+    return e.seq <= 4 ||                                   // PASS-A structure
+           (e.cls === 'IfcSlab' && e.seq > 4) ||           // §DEQ_V1 promoted roof slab
+           e.cls === 'IfcStairFlight';                     // §STAIR_FLIGHT_GRID_VISIBILITY
+  }
+
+  var API = { supportPool: supportPool, computeSchedule: computeSchedule, collapsePhase: collapsePhase, elementsInPhase: elementsInPhase, auditFloating: auditFloating, deriveBandRanks: deriveBandRanks, deriveZones: deriveZones, deriveStoreyMergeMap: deriveStoreyMergeMap, hostPairs: hostPairs, openingPairs: openingPairs, groundworkSlabs: groundworkSlabs, CELL: CELL, EPS: EPS, GAP: GAP, BIG_ELEMENT_VOL: BIG_ELEMENT_VOL, SHIFT_MS: SHIFT_MS, DAY_MS: DAY_MS, toProductive: toProductive, toWall: toWall };
   global.ScheduleGate = API;
   if (typeof module !== 'undefined' && module.exports) module.exports = API;
 })(typeof window !== 'undefined' ? window : (typeof globalThis !== 'undefined' ? globalThis : this));

--- a/viewer/tests/witness_midair_zero.js
+++ b/viewer/tests/witness_midair_zero.js
@@ -205,8 +205,15 @@ const BUILDINGS = (process.env.ONLY || 'Terminal,Hospital,Duplex,HHS_Office_Fede
 //   Duplex 289 → 239 → 237 → 237           ·  HHS 1538 → 1606 → 1491 → 1491
 //   Clinic 3523 → 958 → 1205 → 1205        ·  LTU 15896 → 15296 → 12686 → 12686
 //   JKR 3736 → 3656 → 3385 → 3385
-const CPM_FLOAT_AFTER_BASELINE = { Terminal: 4256, Hospital: 8210, Duplex: 237, HHS_Office_Federated: 1491,
-  Clinic: 1205, LTU_AHouse: 12686, JKR: 3385 };
+// §S26.2 RE-LOCK (2026-08-19) — structure-first support election. The numbers this replaces were
+// themselves freshly measured in the same branch stack (§S39 re-lock, correct `_meta.db` files);
+// these are the SAME instrument on the SAME files with only the predicate changed, so the deltas
+// below are the fix and nothing else:
+//   Terminal 4256 → 2151 (−49.5%) · Hospital 8210 → 3960 (−51.8%) · Duplex 237 → 44 (−81.4%)
+//   HHS 1491 → 889 (−40.4%) · Clinic 1205 → 877 (−27.2%) · LTU 12686 → 5023 (−60.4%)
+//   JKR 3385 → 1222 (−63.9%)      — better on 7/7, worse on none.
+const CPM_FLOAT_AFTER_BASELINE = { Terminal: 2151, Hospital: 3960, Duplex: 44, HHS_Office_Federated: 889,
+  Clinic: 877, LTU_AHouse: 5023, JKR: 1222 };
 // Orphans (W-MZ-4) are purely geometric (x0/x1/y0/y1/bz/tz contact only, never reads .s/.e) so they
 // are independent of which display-authoring path produced the times — MEASURED to be IDENTICAL to
 // the retired legacy-chain baseline (Terminal 7, Hospital 35, Duplex 1, HHS 36, Clinic 27,

--- a/viewer/time_machine.js
+++ b/viewer/time_machine.js
@@ -4579,7 +4579,18 @@
     for (var i = 0; i < n; i++) {
       out[i] = -1;
       var list = G.contacts[i]; if (!list) continue;
+      // §S26.2 (2026-08-19) — STRUCTURE FIRST, contact only as a last resort. The election used to
+      // take any lower touching box, so an IfcFlowSegment under a wall "bore" that wall: a CONTACT,
+      // not a precedence, and those edges are what contradict phase order (Duplex: 761 physics-vs-
+      // phase contradictions vs 1 when supports are restricted to load-bearing classes).
+      // Electing ONLY from the pool was measured FIRST and is wrong: an element whose every contact
+      // is non-pool then gets no support at all, starts at day 0, and appears before the thing it
+      // touches — W-MZ-2 went 0 -> 2,781 on LTU, 0 -> 107 on Hospital. So the same classification
+      // elects TWICE: the pool winner when one exists, else the unrestricted winner. Nothing loses
+      // its support edge; a real structural support simply outranks a pipe.
       var T = items[i], bestJ = -1, bestCls = 9, bestScore = Infinity;
+      var poolJ = -1, poolCls = 9, poolScore = Infinity;
+      var inPool = SG.supportPool || function () { return true; };
       for (var k = 0; k < list.length; k++) {
         var j = list[k], S = items[j], cls, score;
         if (S.bz < T.bz - EPS && S.tz >= T.bz - GAP) { cls = 0; score = -S.tz; }
@@ -4589,7 +4600,12 @@
             (score === bestScore && (bestJ < 0 || String(S.guid) < String(items[bestJ].guid)))))) {
           bestCls = cls; bestScore = score; bestJ = j;
         }
+        if (inPool(S) && (cls < poolCls || (cls === poolCls && (score < poolScore ||
+            (score === poolScore && (poolJ < 0 || String(S.guid) < String(items[poolJ].guid))))))) {
+          poolCls = cls; poolScore = score; poolJ = j;
+        }
       }
+      if (poolJ >= 0) { bestJ = poolJ; bestCls = poolCls; }   // §S26.2 structure outranks contact
       if (bestCls === 2 && G.grounded[i]) continue;
       out[i] = bestJ;
     }


### PR DESCRIPTION
**#1439 merged, but its content never reached `main`.** #1438 was squash-merged into `main` at 12:33Z; #1439 then merged into that same (now-squashed) branch at 12:51Z, so `3bf771e` is reachable only from `origin/fix/wmz8-relock-after-1434-1435`. `git merge-base --is-ancestor 3bf771e origin/main` → false. This is the squash-orphan failure mode CLAUDE.md names from PR #138.

This PR cherry-picks `3bf771e` onto fresh `origin/main` (`-x`, so the original is recorded). The branch is not merged — its base predates #1438's squash and conflicts in `witness_midair_zero.js`.

**Do not delete `fix/wmz8-relock-after-1434-1435` until this lands** — it is currently the only copy.

## Unchanged from #1439

The support election took any lower box in contact, so an `IfcFlowSegment` under a wall "bore" that wall — a CONTACT, not a precedence. `ScheduleGate.supportPool(e)` (lifted verbatim from `geoGate`'s existing inline test, no new class list) makes both `designatedSupport` twins elect **structure first**, falling back to the unrestricted winner when an element has no pool contact at all.

The fallback is load-bearing, not decoration: pool-only election sent W-MZ-2 (strict midair, 0 on all 7) to **2,781 on LTU**, 107 Hospital, 87 Clinic. With it, W-MZ-2 is 0 on all 7.

## Verified on THIS branch (cherry-pick re-run, not carried over)

`§MIDAIR_ZERO_SUMMARY pass=39 fail=0`, and `§W_MZ_DBFILE` confirms the `_meta.db` files are the ones read.

| building | before | after | |
|---|---|---|---|
| Terminal | 4,256 | 2,151 | −49.5% |
| Hospital | 8,210 | 3,960 | −51.8% |
| Duplex | 237 | 44 | −81.4% |
| HHS_Office | 1,491 | 889 | −40.4% |
| Clinic | 1,205 | 877 | −27.2% |
| LTU_AHouse | 12,686 | 5,023 | −60.4% |
| JKR | 3,385 | 1,222 | −63.9% |

Fleet **31,470 → 14,166, −55%**. Better on 7/7, worse on none.

Other gates, from the original run: `§E3_SYNTHETIC_SUITE 7/7` · `§CPM_PARITY_SUPPORT elementMismatch=0` all 7 · `§CPM_ACCEPT floating=0 structural=0` before and after · `probe_cpm_schedule.js fails=6` both sides (pre-existing), `storeyViolations` net zero.

🤖 Generated with [Claude Code](https://claude.com/claude-code)