### PR TITLE
feat(4d): §S51 — the Gantt reads the cell schedule (item d, drawer half) + accepted-residue composition

### DIFF
--- a/viewer/sw.js
+++ b/viewer/sw.js
@@ -8,7 +8,10 @@
 // Cache-first for heavy assets (.wasm, images). DB files skip SW (IndexedDB handles them).
 //
 // DEPLOY: bump CACHE_VERSION on every OCI upload. Old caches are purged on activate.
-const CACHE_VERSION = 'v1060';   // bump on each deploy; per-change detail is the git commit message.
+const CACHE_VERSION = 'v1061';   // bump on each deploy; per-change detail is the git commit message.
+// v1061 (2026-08-21) §S51 item d (4D_GANTT_TM_REFACTOR.md §S51): the Gantt reads the cell
+// schedule — CELL-path generations stamp _cell into kernel_ops and buildGanttTasks groups bars by
+// it (graph-path buildings unchanged). _GANTT_CACHE_VERSION 36->37 regenerates pre-stamp ops.
 // v1060 (2026-08-21) §S50 cell-grain schedule (4D_GANTT_TM_REFACTOR.md §S50, user ruling: the
 // support graph is retired as the live precedence carrier). cpm_schedule.js gates per building
 // (representability >= 0.88 -> (location, trade) cell schedule; below -> graph engine unchanged);

--- a/viewer/tests/witness_midair_zero.js
+++ b/viewer/tests/witness_midair_zero.js
@@ -136,6 +136,7 @@ const sliced = ['var _CPM_DISPLAY = true;',   // §S20: the only branch left rea
   classifyParts[0] || '', classifyParts[1] || '',
   sliceFn(tmSrc, '_promoteRoofLoadPath'), sliceFn(tmSrc, '_buildXrayElements'),
   sliceFn(tmSrc, '_contactGraph'), sliceFn(tmSrc, '_designatedSupport'), sliceFn(tmSrc, '_midairAudit'),
+  sliceFn(tmSrc, '_tukeyBound'),   // §S51_SCREEN — the display's own bar-trim envelope
   sliceFn(tmSrc, '_displayTimelineRemember'), sliceFn(tmSrc, '_displayTimeline')].join('\n');
 console.log('§MIDAIR_SLICE zoneHelpers=' + (zoneParts.length === 2 ? 'present' : 'absent (pre-#1313 revision)') +
   ' classifyHelpers=' + (classifyParts.length === 2 ? 'present' : 'absent (pre-§SCHEDULE_CLASSIFY_DEDUP revision)') +
@@ -168,6 +169,17 @@ assert(/ok:\s*n <= base\.floating && ma\.midair <= base\.midair/.test(_vgiBody),
   'W-MZ-6b the lock gate REFUSES on a midair INCREASE (§GANTT_LOCK_DELTA: ok requires BOTH audits no worse ' +
   'than the edit-start baseline — absolute zero was the old contract and it refused the lock on 4 of 7 ' +
   'buildings for an unedited schedule)');
+// W-S51 — item d wiring (4D_GANTT_TM_REFACTOR.md §S51): the display reads the cell schedule.
+// Three links, each checked by source text so a one-file edit cannot go green on unwired code:
+// authoring remembers cells -> injectGantt stamps them into ops -> buildGanttTasks groups by them.
+assert(_dtBody.indexOf('_displayTimeline._lastCell = { map:') > 0 && _dtBody.indexOf('_displayTimeline._lastCell = null') > 0,
+  'W-S51a _displayTimeline remembers cell identity on a CELL-path authoring and NULLs it on a GRAPH-path one');
+assert(/_cell:\s*_cellMap \? _cellMap\[el\.guid\] : undefined/.test(tmSrc),
+  'W-S51b injectGantt stamps _cell into every op parameters JSON when the cell map covers the elements');
+const _bgtIdx = tmSrc.indexOf('function buildGanttTasks()');
+const _bgtBody = tmSrc.slice(_bgtIdx, tmSrc.indexOf('§GANTT_ROW_ORDER', _bgtIdx));
+assert(_bgtIdx > 0 && /\('C:' \+ cellId\)/.test(_bgtBody) && /p\._cell/.test(_bgtBody),
+  'W-S51c buildGanttTasks groups bars by the cell stamp between real task identity and the storey|phase fallback');
 
 function loadRatesTable() {
   const txt = fs.readFileSync(path.join(__dirname, '..', 'rates.js'), 'utf8');
@@ -269,7 +281,7 @@ function census(items) {
   const worst = [];
   let probe = null;   // any non-grounded element WITH contacts — used by W-MZ-7 to re-create a hanging
   items.forEach((T, i) => {
-    let lowest = Infinity, firstContact = Infinity, contacts = 0;
+    let lowest = Infinity, firstContact = Infinity, contacts = 0, embHit = false;
     const seen = {};
     for (const c of cellsOf(T)) {
       const arr = grid[c]; if (!arr) continue;
@@ -287,6 +299,7 @@ function census(items) {
         const carrier = S.bz >= T.tz - GAP && S.tz > T.tz + EPS;
         const embedded = S.bz <= T.bz + EPS && S.tz >= T.tz - EPS;
         if (!bearing && !carrier && !embedded) continue;
+        if (embedded) embHit = true;   // §S51 — the judge's own enclosure clause, recorded per element
         contacts++;
         if (S.s < firstContact) firstContact = S.s;
       }
@@ -297,7 +310,7 @@ function census(items) {
     if (firstContact <= T.s + 1) { ok++; return; }
     if (isGround) { grounded++; return; }
     midair++;
-    worst.push({ cls: T.cls, seq: T.seq, phase: T.phase, bz: T.bz, start: T.s / D, sup: firstContact / D });
+    worst.push({ cls: T.cls, seq: T.seq, phase: T.phase, bz: T.bz, start: T.s / D, sup: firstContact / D, emb: embHit });
   });
   worst.sort((a, b) => (b.sup - b.start) - (a.sup - a.start));
   return { midair, orphan, grounded, ok, worst, probe };
@@ -327,7 +340,7 @@ function census(items) {
       ScheduleGate: ScheduleGate, Math: Math, A: () => ({ db: db }),
       URLSearchParams: URLSearchParams, CpmSchedule: CpmSchedule };
     vm.createContext(sandbox);
-    vm.runInContext(sliced + '\nthis.__bxe = _buildXrayElements; this.__dt = _displayTimeline;', sandbox);
+    vm.runInContext(sliced + '\nthis.__bxe = _buildXrayElements; this.__dt = _displayTimeline; this.__tukey = _tukeyBound;', sandbox);
     const els = sandbox.__bxe();
     if (!els || !els.length) { assert(false, 'W-MZ ' + bld + ' element build produced nothing'); db.close(); continue; }
 
@@ -419,6 +432,88 @@ function census(items) {
         ' wide50cell=' + wide50Cell + ' [cell bars, CpmSchedule gate.cellKeys]' +
         ' float=' + floatPost + ' [ScheduleGate.auditFloating]' +
         ' midair=' + after.midair + ' [this witness\'s own census(), independent judge]');
+    }
+    // ── §S51_SCREEN — what the Gantt DRAWS, before vs after item d, mirrored on this witness's
+    // own items with the display's own trim (_tukeyBound sliced from time_machine.js — the exact
+    // envelope buildGanttTasks applies). BEFORE = storey|phase grouping (pre-§S51 display). AFTER =
+    // cell stamp where present, storey|phase fallback otherwise (the shipped §S51 grouping rule).
+    {
+      let lo = Infinity, hi = -Infinity;
+      items.forEach(it => { if (it.s < lo) lo = it.s; if (it.e > hi) hi = it.e; });
+      const span = hi - lo;
+      const tk = sandbox.__tukey;
+      const barW50 = groups => {
+        let wide = 0, n = 0;
+        for (const k in groups) {
+          const g = groups[k]; n++;
+          const s0 = tk(g.starts, true), e0 = Math.max(tk(g.ends, false), s0);
+          if (span && (e0 - s0) / span > 0.5) wide++;
+        }
+        return { wide, n };
+      };
+      const collect = keyFn => { const m = {}; items.forEach((it, i2) => {
+        const k = keyFn(it, i2); (m[k] || (m[k] = { starts: [], ends: [] }));
+        m[k].starts.push(it.s); m[k].ends.push(it.e); }); return m; };
+      const gate = dtResult && dtResult.stats && dtResult.stats.gate;
+      const beforeG = barW50(collect(it => (it.storey || '_UNKNOWN') + '|' + (it.phase || 'Architecture')));
+      const afterG = gate && gate.cellKeys
+        ? barW50(collect((it, i2) => 'C:' + gate.cellKeys[i2]))
+        : beforeG;   // graph path: the display is UNCHANGED by construction (no stamp exists)
+      console.log('§S51_SCREEN ' + bld + ' path=' + (gate ? gate.path : 'GRAPH') +
+        ' wide50screen BEFORE=' + beforeG.wide + '/' + beforeG.n + 'bars (storey|phase, tukey-trimmed — the pre-§S51 drawer)' +
+        ' AFTER=' + afterG.wide + '/' + afterG.n + 'bars (' + (gate && gate.cellKeys ? 'cell stamp — the §S51 drawer' : 'IDENTICAL: graph path, no stamp') + ')' +
+        ' [instrument: this witness mirroring buildGanttTasks grouping+_tukeyBound on the same items]');
+    }
+    // ── §S51_RESIDUE — the ACCEPTANCE SPLIT on the locked midair residue (user: "within walls or
+    // last"). General rule only — element class plays no part, no per-building constants:
+    //   embedded = some contact SPANS the element's height (the census judge's own `embedded`
+    //              clause, recorded per element above — enclosure, not a new predicate);
+    //   late     = the element's phase sorts STRICTLY AFTER first-fix MEP ('MEP Rough-in') in the
+    //              SEQUENCE_RULES-derived phase order (minimum sequence per phase — the global
+    //              rules table, same derivation as time_machine's §GANTT_ROW_ORDER);
+    //   NEITHER  = early, free-standing — the only number that matters.
+    {
+      const minSeq = {};
+      for (const k2 in SR) { const r2 = SR[k2]; if (r2 && r2.phase && r2.sequence != null &&
+        (minSeq[r2.phase] == null || r2.sequence < minSeq[r2.phase])) minSeq[r2.phase] = r2.sequence; }
+      const phOrder = Object.keys(minSeq).sort((a, b) => minSeq[a] - minSeq[b]);
+      const ffIdx = phOrder.indexOf('MEP Rough-in');
+      const isLate = ph => ffIdx >= 0 && phOrder.indexOf(ph) > ffIdx;
+      let emb = 0, late = 0, neither = 0;
+      const neitherByPhase = {}, neitherByCls = {};
+      let lo2 = Infinity, hi2 = -Infinity;
+      items.forEach(it => { if (it.s < lo2) lo2 = it.s; if (it.e > hi2) hi2 = it.e; });
+      const first10 = (lo2 + 0.10 * (hi2 - lo2)) / D;
+      let neitherEarly10 = 0;
+      after.worst.forEach(w => {
+        if (w.emb) emb++;
+        else if (isLate(w.phase)) late++;
+        else {
+          neither++;
+          neitherByPhase[w.phase] = (neitherByPhase[w.phase] || 0) + 1;
+          neitherByCls[w.cls] = (neitherByCls[w.cls] || 0) + 1;
+          if (w.start < first10) neitherEarly10++;
+        }
+      });
+      const profTotal = emb + late + neither;
+      console.log('§S51_RESIDUE ' + bld + ' population=' + items.length + ' midairLocked=' + CPM_MIDAIR_BASELINE[bld] +
+        ' profiled=' + profTotal +
+        ' | embedded(withinWalls)=' + emb + ' late(afterFirstFixMEP,notEmbedded)=' + late +
+        ' NEITHER(early,freeStanding)=' + neither +
+        (profTotal ? ' (' + (100 * neither / profTotal).toFixed(1) + '% of residue, ' + (100 * neither / items.length).toFixed(3) + '% of population)' : '') +
+        ' neitherInFirst10pctDays=' + neitherEarly10 +
+        ' neitherByPhase=' + JSON.stringify(neitherByPhase) +
+        ' neitherTopClasses=' + JSON.stringify(Object.keys(neitherByCls).sort((a, b) => neitherByCls[b] - neitherByCls[a])
+          .slice(0, 4).reduce((o, k3) => { o[k3] = neitherByCls[k3]; return o; }, {})) +
+        ' [instrument: this witness\'s census() emb flag + SEQUENCE_RULES-derived phase order; no per-building constants]');
+      console.log('§S51_RESIDUE_GUARD ' + bld +
+        ' phaseOrder=[' + phOrder.join('>') + '] firstFixIdx=' + ffIdx +
+        ' embBranchFired=' + (emb > 0 ? 'YES' : 'no (0 embedded among midair here — flag CAN fire: clause is the judge\'s own, exercised fleet-wide)') +
+        ' lateBranchFired=' + (late > 0 ? 'YES' : 'no') +
+        ' — profiled MUST equal the locked baseline or the assert below goes red');
+      assert(profTotal === CPM_MIDAIR_BASELINE[bld],
+        'W-S51d ' + bld + ' residue profile covers EXACTLY the locked midair population (profiled=' + profTotal +
+        ' locked=' + CPM_MIDAIR_BASELINE[bld] + ') — a profile over a different population than the lock is the §S46 subset trap');
     }
     assert(floatPost === CPM_FLOAT_AFTER_BASELINE[bld],
       'W-MZ-8 ' + bld + ' the measured TRADE is locked at ' + CPM_FLOAT_AFTER_BASELINE[bld] + ' (got ' + floatPost +

--- a/viewer/time_machine.js
+++ b/viewer/time_machine.js
@@ -4335,6 +4335,23 @@
         for (var i = 0; i < items.length; i++) { items[i].s = r.solution.times[i].s; items[i].e = r.solution.times[i].e; }
         var aud = _midairAudit(items);
         _displayTimelineRemember(items, r.graph.stragglerOf);
+        // §S51 item d (4D_GANTT_TM_REFACTOR.md §S51): when the CELL path authored this timeline,
+        // remember each element's cell identity so injectGantt stamps it into the ops and the
+        // Gantt groups bars BY CELL — the display reads the schedule's own grain instead of
+        // re-deriving a coarser one. NOT one-shot (the partner consumer of the same generation
+        // cycle replays via the REUSE branch above and still needs it); overwritten on every
+        // fresh authoring, and set NULL on a GRAPH-path authoring so a building switch can never
+        // leak one building's cells onto another's bars.
+        if (r.gate && r.gate.cellKeys) {
+          var _cm = {};
+          for (var _cki = 0; _cki < items.length; _cki++) {
+            var _ckp = String(r.gate.cellKeys[_cki]).split('\u0001');
+            _cm[items[_cki].guid] = 'L' + _ckp[0] + '\u00b7T' + _ckp[1] + '\u00b7' + _ckp[2];
+          }
+          _displayTimeline._lastCell = { map: _cm, n: items.length };
+        } else {
+          _displayTimeline._lastCell = null;
+        }
         console.log('§CPM_DISPLAY on — one-DAG schedule authored the display timeline' +
           ' midair=' + aud.midair + ' orphans=' + aud.orphans +
           ' stragglers=' + r.graph.counts.stragglers + ' (0 midair = nothing appears before what it touches)');
@@ -5217,6 +5234,18 @@
     for (var _sg in _disp) if (_disp[_sg].end > _schedEnd) _schedEnd = _disp[_sg].end;
     if (_noGeoN) console.log('§4D_NOGEO parked=' + _noGeoN + ' at project end (no transform/zero bbox — cannot bear, hang, or be witnessed)');
 
+    // §S51 item d — cell identity for the Gantt: stamped into each op so buildGanttTasks groups
+    // bars by CELL on cell-path buildings (GRAPH-path authoring set _lastCell = null above, so
+    // those buildings' ops carry no stamp and group exactly as before). Coverage-checked the same
+    // way as _displayTimeline._last: a different building's guids miss and the stamp is skipped.
+    var _cellMap = null;
+    if (_displayTimeline._lastCell && _displayTimeline._lastCell.map) {
+      var _chit = 0, _cmiss = 0, _cmap0 = _displayTimeline._lastCell.map;
+      _twItems.forEach(function (it) { if (_cmap0[it.guid]) _chit++; else _cmiss++; });
+      if (_chit > 0 && _chit >= 0.999 * (_chit + _cmiss)) _cellMap = _cmap0;
+      console.log('§S51_CELL_STAMP coverage=' + _chit + '/' + (_chit + _cmiss) +
+        ' stamping=' + (_cellMap ? 'YES — bars group by cell' : 'NO — coverage below 99.9%, bars stay storey|phase this generation'));
+    }
     // §S280h: ONE transaction + prepared statement (batched INSERTs — avoids the multi-second freeze).
     db.run('BEGIN');
     var _gStmt = db.prepare('INSERT INTO kernel_ops (timestamp,op_type,parameters,input_guids,output_guid,undone) VALUES(?,?,?,?,?,0)');
@@ -5225,7 +5254,8 @@
       var s = _disp[el.guid] || { start: _schedEnd, end: _schedEnd + 60000 };   // §4D_NOGEO park at the DISPLAY end (§TIER_SERIAL), was baseMs (day 0)
       _gStmt.run([s.start, 'ELEMENT_PLACE',
          JSON.stringify({phase:el.phase, cls:el.cls, name:el.name, storey:el.storey,
-           resource:el.resource, _end_ts:s.end, _genVersion:_GANTT_CACHE_VERSION}),
+           resource:el.resource, _end_ts:s.end, _genVersion:_GANTT_CACHE_VERSION,
+           _cell: _cellMap ? _cellMap[el.guid] : undefined}),
          JSON.stringify([el.guid]), el.guid]);
       count++;
       if (s.end > _projEnd) _projEnd = s.end;
@@ -6083,11 +6113,15 @@
       var p = op.parameters || {};
       var storey = p.storey || '_UNKNOWN';
       var phase = p.phase || 'Architecture';
-      // Real task identity first (exact, by guid); storey|phase only as the un-authored fallback.
+      // Real task identity first (exact, by guid); then §S51's cell stamp (the schedule's own
+      // grain, present only on cell-path generations); storey|phase only as the un-authored
+      // fallback — graph-path buildings and pre-§S51 ops group exactly as before.
       var tid = idx && op.output_guid ? idx.guidTask[op.output_guid] : null;
       if (tid) _idN++; else _noIdN++;
-      var key = tid ? ('T:' + tid) : (storey + '|' + phase);
-      if (!groups[key]) groups[key] = { storey: storey, phase: phase, taskId: tid || null,
+      var cellId = (!tid && p._cell) ? String(p._cell) : null;
+      var key = tid ? ('T:' + tid) : (cellId ? ('C:' + cellId) : (storey + '|' + phase));
+      if (!groups[key]) groups[key] = { storey: cellId ? (cellId.split('\u00b7')[2] || storey) : storey,
+        phase: phase, cell: cellId || null, taskId: tid || null,
         taskName: tid && idx.tasks[tid] ? idx.tasks[tid].name : null,
         starts: [], ends: [], count: 0, cap: 0, guids: [] };
       var g = groups[key];
@@ -7916,7 +7950,7 @@
   // huts going first before the walls" AFTER a hard reset, because §GANTT_CACHE_HIT served a
   // gantt:v4 entry generated under the old ordering. A hard reset cannot clear it — the entry is in
   // IndexedDB, not the HTTP cache. This bump is that fix's second half.
-  var _GANTT_CACHE_VERSION = 36;   // §S50 cell-grain schedule (4D_GANTT_TM_REFACTOR.md §S50) — gated buildings now schedule by (location, trade) cells; the schedule shape changed, regenerate
+  var _GANTT_CACHE_VERSION = 37;   // §S51 item d — ops now carry the cell stamp (_cell) so the Gantt groups by the schedule's own cells; pre-§S51 kernel_ops lack it, regenerate
   // was 28:   // §CPM_DISPLAY (2026-08-16): display timeline authored by the one-DAG CPM pass
   // was 27:   // §ZONE_DISPLAY_AUTHORING (2026-08-16): task windows authored from
                                    // the DISPLAY timeline + strict-bar sweep skipped on that path —


### PR DESCRIPTION
Implements bim-compiler `prompts/4D_GANTT_TM_REFACTOR.md` **§S51**. User direction: pragmatic, outliers acceptable, ship — the §S50 midair residue is ACCEPTED as the leg-4 exception surface (no enforcement built, no harder gating).

## Item d (drawer half): bars ARE the schedule's cells
Three source-text-asserted links (W-S51a/b/c): `_displayTimeline` remembers guid→cell on a CELL-path authoring (NULL on graph — no cross-building leakage; survives the same generation cycle's REUSE replay) → `injectGantt` stamps `_cell` into each op's parameters (coverage-checked ≥99.9%, `§S51_CELL_STAMP`) → `buildGanttTasks` groups **taskId → cell stamp → storey|phase**. Graph-path buildings and pre-§S51 ops group exactly as before. `_GANTT_CACHE_VERSION` 36→37, `sw.js` v1061.

**On-screen wide50** (instrument: witness `§S51_SCREEN`, the drawer's own grouping + `_tukeyBound` trim mirrored; can-fail: graph rows must and do read IDENTICAL):

| building | path | BEFORE (storey\|phase, trimmed) | AFTER (cell bars) |
|---|---|---|---|
| Terminal | CELL | 9/72 | **0/197** |
| Hospital | CELL | 6/35 | **0/451** |
| Clinic | CELL | 4/32 | **0/255** |
| Duplex · HHS · JKR · LTU | GRAPH | 3/16 · 4/17 · 8/64 · 21/58 | IDENTICAL |

Four axes vs `eb832c1`: **days/float/midair byte-identical** (schedule untouched — all §S50 locks green, `pass=49 fail=0`); wide50 is the axis this PR moves, on screen.

## Acceptance split on the accepted residue (`§S51_RESIDUE`)
General rule only — the census judge's own `embedded` clause + the SEQUENCE_RULES-derived phase order (late = strictly after first-fix MEP); no per-building constants, no tuned thresholds. Can-fail guard **W-S51d**: profiled must equal the locked §S50 baseline (§S46 subset-trap protection).

| building | residue | embedded | late | **NEITHER** (early, free-standing) | % of population |
|---|---|---|---|---|---|
| Terminal | 684 | 210 | 0 | 474 (326 = metal-deck IfcPlates) | 0.979% |
| Hospital | 218 | 153 | 1 | 64 | 0.101% |
| Clinic | 422 | 320 | 0 | 102 | 0.635% |

Early free-standing **MEP** — the named unacceptable case — is 75/30/37 elements (0.15%/0.05%/0.23% of population); Hospital's first-10%-of-days window carries exactly **1** free-standing element of any kind. 5% tolerance already cleared by arithmetic on the locks (1.41%/0.35%/2.63%).

Pre-existing reds unchanged (PASS/FAIL sets identical to `eb832c1` baselines, only ms timings differ): `G-LI-2e`, `witness_zone_display_authoring`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PE2SPWkf2qhTL7bSdBw21g