### PR TITLE
refactor(4d): extract the Gantt bar model out of time_machine.js (§S53, item F3)

### DIFF
--- a/viewer/gantt_model.js
+++ b/viewer/gantt_model.js
@@ -1,0 +1,206 @@
+// Copyright (c) 2025-2026 Redhuan D. Oon <red1org@gmail.com>
+// SPDX-License-Identifier: MIT
+/* gantt_model.js — the Gantt DRAWER'S MODEL, extracted verbatim from time_machine.js
+ * (bim-compiler prompts/4D_GANTT_TM_REFACTOR.md §S52.4 item F3, spec'd in §S53).
+ *
+ * WHY THIS FILE EXISTS. Two reasons, both measured, neither cosmetic:
+ *   1. time_machine.js was 9,259 lines — 60% of the whole 4D surface (§S52.2). The bar model is a
+ *      self-contained, side-effect-free computation sitting inside a file that is otherwise state
+ *      and DOM; it does not need to be there.
+ *   2. witness_midair_zero.js could not test the drawer's rules without either slicing them out of
+ *      time_machine.js BY SOURCE TEXT (`_tukeyBound`, :139 — a slice that has already silently
+ *      widened once, §S20) or RE-IMPLEMENTING them (§S51_SCREEN mirrored buildGanttTasks' grouping;
+ *      §S51_RESIDUE re-derived §GANTT_ROW_ORDER's phase order). A mirrored judge is the
+ *      §S25_REVIEW.1 failure class one step removed: the drawer's rule changes, the witness keeps
+ *      measuring the old rule, and stays green. Now the witness calls THIS.
+ *
+ * CONTRACT: pure functions only. No module state, no TM variable, no DOM, no console side effects.
+ * The caller (time_machine.js) owns the state assignment, the dirty-flag gate and the §-log lines —
+ * this file computes and returns. Same dual-mode convention as cpm_schedule.js / lib/level_deriver.js.
+ *
+ * NOTHING HERE IS NEW. Every rule and every comment moved verbatim from time_machine.js; the WHY
+ * stays attached to the rule it explains, because in this lane the comments ARE the provenance.
+ */
+
+(function (global) {
+  'use strict';
+
+  // §TUKEY_BOUND (4D_GANTT_TM_REFACTOR.md stage 2, 2026-08-17) — hoisted out of _tmDisplayRemap
+  // (was a nested closure there) so buildGanttTasks() can share the SAME envelope math instead of
+  // re-deriving its own. This is the proven, already-shipped, already-measured rule (Hospital
+  // floating 664->63, window fidelity 97.03%->99.95% when this landed for §ZONE_WINDOW_DAGWINS_CLIP)
+  // — uniform at every group size, no group-size branch, no cliff. Percentile convention matches
+  // storeyOrderReport/§GANTT_GAP_CLAMP: sorted[Math.floor(n*p)], no interpolation.
+  function tukeyBound(arr, lowSide) {
+    var s = arr.slice().sort(function (a, b) { return a - b; });
+    var n = s.length, q1 = s[Math.floor(n * 0.25)], q3 = s[Math.floor(n * 0.75)], iqr = q3 - q1;
+    return lowSide ? Math.max(s[0], q1 - 1.5 * iqr) : Math.min(s[n - 1], q3 + 1.5 * iqr);
+  }
+
+  // §GANTT_ROW_ORDER (K1, 2026-08-04) — user report: "are you using any 4D convention used by P6 on
+  // gantt phase/task ordering? Last session was a mess putting substructure which has above ground
+  // appearing first." Correct answer at the time: we followed NO convention. Rows were sorted purely
+  // by `a.startTs - b.startTs`, so whichever zone happened to compute earliest floated to the top and
+  // a phase's floors appeared interleaved with other phases' — arbitrary, and unreadable as a
+  // construction programme.
+  //
+  // P6/MSP order rows by WBS path, THEN by early start. Our WBS is (phase → floor): the zone
+  // decomposition materializeZones already persists. So: phase in real construction sequence first,
+  // then start time within the phase (which tracks bottom-up floor order, because the engine builds
+  // floors bottom-up). Falls back to alphabetical for any phase outside the canonical list rather
+  // than silently bucketing it at position 0.
+  //
+  // ⚠ DERIVED FROM SEQUENCE_RULES, NEVER HARDCODED — and this matters, it is not tidiness.
+  // The first draft of this fix copied the order out of _VAR_ORDER (~time_machine.js:4238) and was
+  // WRONG: that array still reads Substructure/Superstructure/MEP Rough-in/Architecture/…, i.e. MEP
+  // rough-in BEFORE the building envelope — the exact backwards discipline PR #1165 fixed in
+  // SEQUENCE_RULES and across all 18 rate-template sources. _VAR_ORDER is a THIRD stale copy that
+  // #1165 missed (the two known-stale PHASE_ORDER arrays in time_machine.js are the other two). The
+  // real engine order, read from SEQUENCE_RULES' own sequence numbers, is:
+  //   Substructure(1) → Superstructure(2) → Architecture(5) → MEP Rough-in(7) → MEP Final(9) → Finishes(10)
+  // Deriving it kills this whole class of drift: the drawer cannot disagree with the engine again.
+  var FALLBACK_PHASE_ORDER = ['Substructure', 'Superstructure', 'Architecture', 'MEP Rough-in',
+                              'MEP Final', 'Finishes'];
+
+  function phaseOrder(seqRules) {
+    var SR = seqRules || (typeof global !== 'undefined' && global.SEQUENCE_RULES) || null;
+    if (SR) {
+      var minSeq = {};
+      for (var k in SR) {
+        var r = SR[k]; if (!r || !r.phase || r.sequence == null) continue;
+        if (minSeq[r.phase] == null || r.sequence < minSeq[r.phase]) minSeq[r.phase] = r.sequence;
+      }
+      var ks = Object.keys(minSeq);
+      if (ks.length) return ks.sort(function (a, b) { return minSeq[a] - minSeq[b]; });
+    }
+    // Fallback only when SEQUENCE_RULES has not loaded — matches the derived order above.
+    return FALLBACK_PHASE_ORDER.slice();
+  }
+
+  // §S51 item d (PR #1444) — the drawer groups bars BY THE SCHEDULE'S OWN CELLS. Precedence, in
+  // order: a real authored task id (exact, by guid) → the cell stamp the cell-path engine wrote →
+  // the un-authored storey|phase fallback. Ops with no task stay non-editable.
+  function groupKeyOf(taskId, cellId, storey, phase) {
+    return taskId ? ('T:' + taskId)
+         : (cellId ? ('C:' + cellId) : (storey + '|' + phase));
+  }
+
+  // buildTasks() — the storey|phase rollup, task-identity-aware (K0). Grouping key is the REAL
+  // task_id whenever the op's guid resolves through task_elements, so each resulting bar carries
+  // `taskId` and is addressable by moveTask/resizeTask/addDependency.
+  //   ops       — the FULL mixed kernel_ops history (this function does the ELEMENT_PLACE filter
+  //               itself; see §GANTT_OPS_BOOKKEEPING_LEAK below for why it must).
+  //   idx       — buildTaskIndex() output: { guidTask: {guid:taskId}, tasks: {taskId:{name}} } or null.
+  //   seqRules  — SEQUENCE_RULES (optional; falls back to global.SEQUENCE_RULES then the list above).
+  // Returns { tasks, identified, unidentified } — the caller assigns them, this returns them.
+  function buildTasks(ops, idx, seqRules) {
+    var groups = {};
+    var _idN = 0, _noIdN = 0;
+    for (var i = 0; i < ops.length; i++) {
+      var op = ops[i];
+      // §GANTT_OPS_BOOKKEEPING_LEAK: a non-construction op (BUILDING_OPEN, ELEMENT_PICK, GRID_*, ...)
+      // is not a task and must not become a bar — see computeDays()'s own header comment for the
+      // traced mechanism. _ops itself stays the full mixed history for other consumers (copyGuids).
+      if (op.op_type !== 'ELEMENT_PLACE') continue;
+      var p = op.parameters || {};
+      var storey = p.storey || '_UNKNOWN';
+      var phase = p.phase || 'Architecture';
+      // Real task identity first (exact, by guid); then §S51's cell stamp (the schedule's own
+      // grain, present only on cell-path generations); storey|phase only as the un-authored
+      // fallback — graph-path buildings and pre-§S51 ops group exactly as before.
+      var tid = idx && op.output_guid ? idx.guidTask[op.output_guid] : null;
+      if (tid) _idN++; else _noIdN++;
+      var cellId = (!tid && p._cell) ? String(p._cell) : null;
+      var key = groupKeyOf(tid, cellId, storey, phase);
+      if (!groups[key]) groups[key] = { storey: cellId ? (cellId.split('\u00b7')[2] || storey) : storey,
+        phase: phase, cell: cellId || null, taskId: tid || null,
+        taskName: tid && idx.tasks[tid] ? idx.tasks[tid].name : null,
+        starts: [], ends: [], count: 0, cap: 0, guids: [] };
+      var g = groups[key];
+      g.starts.push(op.start_ts);
+      g.ends.push(op.end_ts);
+      g.guids.push(op.output_guid);   // W1 needs the member set to re-time an edited bar
+      g.count++;
+      if (p._captured) g.cap++;   // §gate: captured = preset IFC 4D (verbatim) — drives the yellow frame
+    }
+
+    // §GANTT_MINI_TRIM (2026-08-17, 4D_GANTT_TM_REFACTOR.md stage 2 — REPLACES the 2026-07-18
+    // 2nd-98th-percentile-above-n20/true-min-max-below rule). The old rule's cliff at n=20 was
+    // measured live to be exactly the mechanism behind "one pile, full project length": most
+    // phase|storey groups are small (many storeys x 6 phases), so most bars got NO trim at all —
+    // one mistagged/outlier element (this project's own numbers show non-zero outliers on every
+    // building, by design) was enough to stretch an untrimmed small group's bar to cover it.
+    // Fix: the SAME Tukey-fence envelope §ZONE_WINDOW_DAGWINS_CLIP already uses for task-window
+    // authoring (tukeyBound above) — uniform at every group size, no cliff, no new tuned constant
+    // (reuses the exact proven formula, not a fresh invention).
+    // Members outside the fence still exist in the underlying data (§TIER_DAG_WINS doctrine:
+    // counted, never hidden) — they just don't get to single-handedly define the bar's span.
+    var tasks = [];
+    for (var k in groups) {
+      var gg = groups[k];
+      gg.startTs = tukeyBound(gg.starts, true);
+      gg.endTs = Math.max(tukeyBound(gg.ends, false), gg.startTs);   // degenerate-group safety (n=1)
+      delete gg.starts; delete gg.ends;
+      tasks.push(gg);
+    }
+
+    var ORDER = phaseOrder(seqRules);
+    function _phaseRank(p2) {
+      var i2 = ORDER.indexOf(p2);
+      return i2 < 0 ? ORDER.length : i2;      // unknown phases sort after the known ones
+    }
+    tasks.sort(function (a, b) {
+      var pa = _phaseRank(a.phase), pb = _phaseRank(b.phase);
+      if (pa !== pb) return pa - pb;
+      if (pa === ORDER.length && a.phase !== b.phase) return a.phase < b.phase ? -1 : 1;
+      return (a.startTs - b.startTs) || (a.storey < b.storey ? -1 : a.storey > b.storey ? 1 : 0);
+    });
+
+    return { tasks: tasks, identified: _idN, unidentified: _noIdN };
+  }
+
+  // computeDays() — the day ladder and BOTH time axes, from the ELEMENT_PLACE ops only.
+  // Returns { days, projectStart, projectEnd, axisStart, axisEnd, n }; the caller assigns them.
+  //
+  // §GANTT_AXIS_OUTLIER (2026-08-04, prompts/4D_SCHEDULE_PERFECTION.md) — axisStart/axisEnd are
+  // SEPARATE from projectStart/projectEnd on purpose: those two remain the real, unqualified
+  // playback bounds (renderAtTime, scrubbing, "every element must eventually build" — Prime Rule,
+  // do not touch). The axis pair is the DISPLAY axis for the Gantt drawer only.
+  function computeDays(placeOps) {
+    var cOps = placeOps;
+    var seen = {};
+    cOps.forEach(function (op) {
+      var d = new Date(op.start_ts);
+      var key = d.getFullYear() + '-' + (d.getMonth() + 1) + '-' + d.getDate();
+      if (!seen[key]) seen[key] = new Date(d.getFullYear(), d.getMonth(), d.getDate()).getTime();
+    });
+    var out = { days: Object.values(seen).sort(function (a, b) { return a - b; }),
+                projectStart: null, projectEnd: null, axisStart: null, axisEnd: null, n: cOps.length };
+    if (cOps.length) {
+      // projectStart = 1ms BEFORE first op so ⏪ = truly empty (no frontier)
+      out.projectStart = cOps[0].start_ts - 1;
+      out.projectEnd = Math.max.apply(null, cOps.map(function (o) { return o.end_ts; }));
+    }
+    // §GANTT_AXIS_OUTLIER — qualified DISPLAY axis. Was its own copy of the 2nd-98th-percentile-
+    // above-n20/true-max-below cliff §GANTT_MINI_TRIM used to use per-bar (buildGanttTasks) — the
+    // SAME broken rule, applied here to the GLOBAL population of end_ts that defines the whole
+    // chart's axis instead of one bar's span. Stage 2 (4D_GANTT_TM_REFACTOR.md) fixed the per-bar
+    // copy but not this one — a bar's DATA could be correct while its DRAWN pixel position was
+    // still wrong, because the axis it's scaled against was still cliff-computed. Fixed here the
+    // same way: the shared tukeyBound — uniform at every population size, no cliff, no new tuned
+    // constant, reuses the exact proven formula. Never exceeds the true max (tukeyBound's own
+    // Math.min(s[n-1], ...) clamp), so this stays a qualification of the real data, never an
+    // invention beyond it.
+    out.axisStart = out.projectStart;   // starts are not the observed problem; leave unqualified
+    out.axisEnd = cOps.length
+      ? tukeyBound(cOps.map(function (o) { return o.end_ts; }), false)
+      : out.projectEnd;
+    return out;
+  }
+
+  var API = { tukeyBound: tukeyBound, phaseOrder: phaseOrder, groupKeyOf: groupKeyOf,
+              buildTasks: buildTasks, computeDays: computeDays,
+              FALLBACK_PHASE_ORDER: FALLBACK_PHASE_ORDER };
+  global.GanttModel = API;
+  if (typeof module !== 'undefined' && module.exports) module.exports = API;
+})(typeof window !== 'undefined' ? window : (typeof globalThis !== 'undefined' ? globalThis : this));

--- a/viewer/sw.js
+++ b/viewer/sw.js
@@ -8,7 +8,11 @@
 // Cache-first for heavy assets (.wasm, images). DB files skip SW (IndexedDB handles them).
 //
 // DEPLOY: bump CACHE_VERSION on every OCI upload. Old caches are purged on activate.
-const CACHE_VERSION = 'v1061';   // bump on each deploy; per-change detail is the git commit message.
+const CACHE_VERSION = 'v1062';   // bump on each deploy; per-change detail is the git commit message.
+// v1062 (2026-08-21) 4D_GANTT_TM_REFACTOR.md §S53 (item F3): the Gantt bar MODEL extracted out of
+// time_machine.js into NEW gantt_model.js (precached above, viewer.html loads it first) —
+// buildGanttTasks/computeDays/_tukeyBound are now thin wrappers over it. Behaviour-preserving,
+// no rule changed; witness_midair_zero.js pass=49 fail=0 with every number identical.
 // v1061 (2026-08-21) §S51 item d (4D_GANTT_TM_REFACTOR.md §S51): the Gantt reads the cell
 // schedule — CELL-path generations stamp _cell into kernel_ops and buildGanttTasks groups bars by
 // it (graph-path buildings unchanged). _GANTT_CACHE_VERSION 36->37 regenerates pre-stamp ops.
@@ -383,6 +387,7 @@ const PRECACHE_ASSETS = [
   'lib/level_deriver.js',   // §S50 — vertical axis of the cell-grain schedule
   'location_axis.js',       // §S50 — rooms injection; lib/room_walker.js is network-first below
   'cpm_schedule.js',
+  'gantt_model.js',      // §S53 (F3) — the Gantt bar model, extracted from time_machine.js
   'time_machine.js',
   'dlod_nav.js',
   'schedule_author.js',

--- a/viewer/tests/witness_gantt_model.js
+++ b/viewer/tests/witness_gantt_model.js
@@ -1,0 +1,169 @@
+#!/usr/bin/env node
+// witness_gantt_model.js — §S53 (bim-compiler prompts/4D_GANTT_TM_REFACTOR.md §S53, item F3).
+//
+// ISSUE this witness proves/disproves: the Gantt bar model — the grouping, the bar-span trim, the
+// row order and the display axis — was extracted out of time_machine.js into gantt_model.js. Are
+// those four rules still the rules, and can they be judged WITHOUT slicing source text?
+//
+// Until this file, they could not be. `witness_midair_zero.js` had to slice `_tukeyBound` out of
+// time_machine.js by source text (a slice that had already silently widened once, §S20) and to
+// RE-IMPLEMENT buildGanttTasks' grouping to report on it (§S51_SCREEN's own comment: "this witness
+// mirroring buildGanttTasks grouping"). A mirrored judge is §S25_REVIEW.1 one step removed — the
+// drawer's rule changes, the judge keeps measuring the retired rule, and stays green throughout.
+//
+// This witness `require()`s the real module and calls the real functions. Fixtures are synthetic
+// and tiny ON PURPOSE: each one is the smallest input that makes ONE rule's failure visible. Real
+// building numbers are the other witness's job (witness_midair_zero.js, 7 buildings, locked
+// baselines) — this one pins the rules those numbers are produced BY.
+//
+//   W-GM-1  grouping precedence: task id > cell stamp > storey|phase (the §S51 rule)
+//   W-GM-2  one outlier member cannot define a bar's span (§GANTT_MINI_TRIM), n=1 stays non-negative
+//   W-GM-3  row order is DERIVED from SEQUENCE_RULES, not a hardcoded copy (§GANTT_ROW_ORDER)
+//   W-GM-4  an unknown phase sorts AFTER the known ones, never at position 0
+//   W-GM-5  the DISPLAY axis is qualified while the PLAYBACK bounds stay true (§GANTT_AXIS_OUTLIER)
+'use strict';
+const path = require('path');
+const GM = require(path.join(__dirname, '..', 'gantt_model.js'));
+
+let pass = 0, fail = 0;
+function assert(cond, msg) { if (cond) { pass++; console.log('  PASS ' + msg); } else { fail++; console.log('  FAIL ' + msg); } }
+
+const D = 86400000;
+const T0 = Date.UTC(2026, 0, 1);
+// op(day, len, storey, phase, extra) — the ELEMENT_PLACE shape buildTasks consumes.
+let _g = 0;
+function op(day, len, storey, phase, extra) {
+  const p = { storey: storey, phase: phase };
+  if (extra) for (const k in extra) p[k] = extra[k];
+  return { op_type: 'ELEMENT_PLACE', start_ts: T0 + day * D, end_ts: T0 + (day + (len == null ? 1 : len)) * D,
+           output_guid: 'g' + (++_g), parameters: p };
+}
+
+// ── W-GM-1 — grouping precedence. The SAME three ops, differing only in what identity they carry.
+// If the cell stamp were dropped (the §S51 item-d regression this guards), all three collapse into
+// one storey|phase bar and the count silently drops from 3 to 1 — visible here, not on a screen.
+{
+  assert(GM.groupKeyOf('T7', 'L1·Arch·0', 'L1', 'Architecture') === 'T:T7',
+    'W-GM-1a a real authored task id wins over both the cell stamp and storey|phase');
+  assert(GM.groupKeyOf(null, 'L1·Arch·0', 'L1', 'Architecture') === 'C:L1·Arch·0',
+    'W-GM-1b with no task id, the schedule\'s own cell stamp is the grain');
+  assert(GM.groupKeyOf(null, null, 'L1', 'Architecture') === 'L1|Architecture',
+    'W-GM-1c with neither, the un-authored storey|phase fallback (graph-path buildings)');
+
+  const cells = GM.buildTasks([op(0, 1, 'L1', 'Architecture', { _cell: 'L1·Arch·0' }),
+                               op(1, 1, 'L1', 'Architecture', { _cell: 'L1·Arch·1' }),
+                               op(2, 1, 'L1', 'Architecture', { _cell: 'L1·Arch·2' })], null, null).tasks;
+  const flat = GM.buildTasks([op(0, 1, 'L1', 'Architecture'), op(1, 1, 'L1', 'Architecture'),
+                              op(2, 1, 'L1', 'Architecture')], null, null).tasks;
+  assert(cells.length === 3 && flat.length === 1,
+    'W-GM-1d end to end: three cell stamps make three bars, the same ops without stamps make one');
+
+  // The identity counters are what the §GANTT_BAR_IDENTITY log line reports as editable/not.
+  const idx = { guidTask: {}, tasks: { T1: { name: 'Pour L1' } } };
+  const o1 = op(0, 1, 'L1', 'Architecture'), o2 = op(1, 1, 'L1', 'Architecture');
+  idx.guidTask[o1.output_guid] = 'T1';
+  const r = GM.buildTasks([o1, o2], idx, null);
+  assert(r.identified === 1 && r.unidentified === 1 && r.tasks.length === 2 &&
+         r.tasks.filter(t => t.taskName === 'Pour L1').length === 1,
+    'W-GM-1e identified/unidentified are counted per op and the task NAME is carried onto its bar');
+
+  // A bookkeeping op (BUILDING_OPEN — §GANTT_OPS_BOOKKEEPING_LEAK) is not a task and must not become
+  // a bar; _ops legitimately carries the full mixed history for other consumers.
+  const mixed = GM.buildTasks([op(0, 1, 'L1', 'Architecture'),
+    { op_type: 'BUILDING_OPEN', start_ts: T0 + 900 * D, end_ts: T0 + 900 * D, output_guid: null, parameters: {} }], null, null);
+  assert(mixed.tasks.length === 1,
+    'W-GM-1f a non-ELEMENT_PLACE op never becomes a bar (§GANTT_OPS_BOOKKEEPING_LEAK)');
+}
+
+// ── W-GM-2 — §GANTT_MINI_TRIM. This is the fixture the OLD (pre-stage-2) rule got wrong: a small
+// group, so the retired n>=20 percentile rule applied NO trim at all and one outlier stretched the
+// bar across the whole project ("one pile, full project length"). 12 members inside 12 days, one at
+// day 900. If the trim ever regresses to a size-gated rule, this bar's span jumps ~75x.
+{
+  const ops = [];
+  for (let d = 0; d < 12; d++) ops.push(op(d, 1, 'L1', 'Architecture'));
+  ops.push(op(900, 1, 'L1', 'Architecture'));
+  const bar = GM.buildTasks(ops, null, null).tasks[0];
+  const spanDays = (bar.endTs - bar.startTs) / D;
+  assert(bar.count === 13 && spanDays < 30,
+    'W-GM-2a one outlier member (day 900 of 13) does not define the bar span — got ' +
+    spanDays.toFixed(1) + 'd over ' + bar.count + ' members (untrimmed would be 901d)');
+  assert(bar.guids.length === 13,
+    'W-GM-2b the trimmed-out member is still COUNTED and still a bar member (§TIER_DAG_WINS: counted, never hidden)');
+
+  const one = GM.buildTasks([op(5, 3, 'L1', 'Architecture')], null, null).tasks[0];
+  assert(one.endTs >= one.startTs,
+    'W-GM-2c an n=1 group is never negative-width (the degenerate-group clamp)');
+
+  // The envelope itself, on a population whose fences are hand-checkable.
+  const arr = [10, 11, 12, 13, 1000];
+  assert(GM.tukeyBound(arr, false) < 1000 && GM.tukeyBound(arr, true) === 10 &&
+         GM.tukeyBound([7], false) === 7,
+    'W-GM-2d tukeyBound clamps the high fence below a lone outlier, never invents a value past the true min/max');
+}
+
+// ── W-GM-3 — §GANTT_ROW_ORDER must be DERIVED. The fixture is deliberately the WRONG order the
+// stale _VAR_ORDER copy carries (MEP Rough-in before Architecture): if the derivation is ever
+// replaced by a hardcoded list again, the derived order stops tracking this input and the test goes
+// red. Sequence numbers here are arbitrary and out of order on purpose — only their RANK matters.
+{
+  const SR = { A: { phase: 'Finishes', sequence: 10 }, B: { phase: 'Substructure', sequence: 1 },
+               C: { phase: 'MEP Rough-in', sequence: 3 }, D: { phase: 'Architecture', sequence: 7 },
+               E: { phase: 'Substructure', sequence: 4 } };
+  const ord = GM.phaseOrder(SR);
+  assert(JSON.stringify(ord) === JSON.stringify(['Substructure', 'MEP Rough-in', 'Architecture', 'Finishes']),
+    'W-GM-3a phase order follows SEQUENCE_RULES\' own sequence numbers, MINIMUM per phase (got ' + JSON.stringify(ord) + ')');
+  assert(JSON.stringify(GM.phaseOrder({})) === JSON.stringify(GM.FALLBACK_PHASE_ORDER) &&
+         GM.FALLBACK_PHASE_ORDER[0] === 'Substructure' &&
+         GM.FALLBACK_PHASE_ORDER.indexOf('Architecture') < GM.FALLBACK_PHASE_ORDER.indexOf('MEP Rough-in'),
+    'W-GM-3b with no rules loaded, the fallback list is used AND it is the post-#1165 order (envelope before MEP rough-in)');
+
+  // Rows sort by phase rank first, then early start — a later-starting Substructure bar still
+  // outranks an earlier-starting Architecture one (the P6/MSP WBS-then-start convention).
+  const rows = GM.buildTasks([op(50, 1, 'L9', 'Architecture'), op(1, 1, 'L1', 'MEP Rough-in'),
+                              op(80, 1, 'L1', 'Substructure')], null, SR).tasks;
+  assert(rows.map(r => r.phase).join(',') === 'Substructure,MEP Rough-in,Architecture',
+    'W-GM-3c bars are ordered by derived phase rank BEFORE start time (got ' + rows.map(r => r.phase).join(',') + ')');
+}
+
+// ── W-GM-4 — an unknown phase must sort after the known ones. The failure this guards is real and
+// named in the code: a phase outside the canonical list silently bucketing at position 0, i.e. an
+// unrecognised trade drawn as if it came first in the programme.
+{
+  const SR = { B: { phase: 'Substructure', sequence: 1 }, D: { phase: 'Finishes', sequence: 10 } };
+  const rows = GM.buildTasks([op(0, 1, 'L1', 'Zebra Works'), op(1, 1, 'L1', 'Substructure'),
+                              op(2, 1, 'L1', 'Alpha Works'), op(3, 1, 'L1', 'Finishes')], null, SR).tasks;
+  const names = rows.map(r => r.phase);
+  assert(names[0] === 'Substructure' && names[1] === 'Finishes',
+    'W-GM-4a known phases keep their derived rank ahead of unknown ones (got ' + JSON.stringify(names) + ')');
+  assert(names[2] === 'Alpha Works' && names[3] === 'Zebra Works',
+    'W-GM-4b two unknown phases sort alphabetically between themselves, not by arrival order');
+}
+
+// ── W-GM-5 — §GANTT_AXIS_OUTLIER. The DISPLAY axis is qualified; the PLAYBACK bounds are not. Both
+// halves matter: a single malformed op must not rescale the whole chart, AND the real bounds must
+// still reach it or an element would never build (Prime Rule).
+{
+  const ops = [];
+  for (let d = 0; d < 30; d++) ops.push(op(d, 1, 'L1', 'Architecture'));
+  ops.push(op(1000, 1, '_UNKNOWN', 'Architecture'));
+  const r = GM.computeDays(ops);
+  assert(r.projectStart === ops[0].start_ts - 1,
+    'W-GM-5a projectStart is 1ms BEFORE the first op, so the start of the movie is truly empty');
+  assert(r.projectEnd === T0 + 1001 * D,
+    'W-GM-5b projectEnd (real playback bound) still reaches the outlier — every element must eventually build');
+  assert(r.axisEnd < r.projectEnd && (r.axisEnd - r.axisStart) / D < 100,
+    'W-GM-5c the DISPLAY axis is qualified away from the outlier — got ' +
+    ((r.axisEnd - r.axisStart) / D).toFixed(1) + 'd of axis for a 1001d unqualified span');
+  assert(r.axisEnd <= r.projectEnd,
+    'W-GM-5d the axis NEVER exceeds the true max (tukeyBound\'s own clamp) — a qualification, never an invention');
+  assert(r.days.length === 31 && r.n === 31,
+    'W-GM-5e the day ladder is one entry per distinct calendar day, outlier included (got ' + r.days.length + ')');
+
+  const empty = GM.computeDays([]);
+  assert(empty.days.length === 0 && empty.projectStart === null && empty.axisEnd === null,
+    'W-GM-5f an empty op list yields no bounds rather than NaN/Infinity ones');
+}
+
+console.log('\n§GANTT_MODEL_SUMMARY pass=' + pass + ' fail=' + fail);
+process.exit(fail ? 1 : 0);

--- a/viewer/tests/witness_midair_zero.js
+++ b/viewer/tests/witness_midair_zero.js
@@ -87,6 +87,11 @@ const initSqlJs = require(path.join(__dirname, '..', '..', 'modeller', 'lib', 's
 const ScheduleGate = require(path.join(__dirname, '..', 'schedule_gate.js'));
 const ScheduleAuthor = require(path.join(__dirname, '..', 'schedule_author.js'));
 const CpmSchedule = require(path.join(__dirname, '..', 'cpm_schedule.js'));
+// §S53 (F3): the Gantt bar MODEL as a REAL MODULE. This witness used to slice `_tukeyBound` out of
+// time_machine.js by source text and to RE-IMPLEMENT buildGanttTasks' grouping and §GANTT_ROW_ORDER's
+// phase derivation below — a mirrored judge stays green when the drawer's own rule changes
+// (§S25_REVIEW.1, one step removed). All three now call this, the same discipline CpmSchedule already had.
+const GanttModel = require(path.join(__dirname, '..', 'gantt_model.js'));
 // §S50 (4D_GANTT_TM_REFACTOR.md §S50, 2026-08-21) — the engine now gates per building on the
 // location axis. Register the REAL modules on globalThis so CpmSchedule (a real require, never a
 // slice) resolves them exactly the way a browser window would; globalThis.APP = { db } is set
@@ -136,7 +141,6 @@ const sliced = ['var _CPM_DISPLAY = true;',   // §S20: the only branch left rea
   classifyParts[0] || '', classifyParts[1] || '',
   sliceFn(tmSrc, '_promoteRoofLoadPath'), sliceFn(tmSrc, '_buildXrayElements'),
   sliceFn(tmSrc, '_contactGraph'), sliceFn(tmSrc, '_designatedSupport'), sliceFn(tmSrc, '_midairAudit'),
-  sliceFn(tmSrc, '_tukeyBound'),   // §S51_SCREEN — the display's own bar-trim envelope
   sliceFn(tmSrc, '_displayTimelineRemember'), sliceFn(tmSrc, '_displayTimeline')].join('\n');
 console.log('§MIDAIR_SLICE zoneHelpers=' + (zoneParts.length === 2 ? 'present' : 'absent (pre-#1313 revision)') +
   ' classifyHelpers=' + (classifyParts.length === 2 ? 'present' : 'absent (pre-§SCHEDULE_CLASSIFY_DEDUP revision)') +
@@ -176,10 +180,17 @@ assert(_dtBody.indexOf('_displayTimeline._lastCell = { map:') > 0 && _dtBody.ind
   'W-S51a _displayTimeline remembers cell identity on a CELL-path authoring and NULLs it on a GRAPH-path one');
 assert(/_cell:\s*_cellMap \? _cellMap\[el\.guid\] : undefined/.test(tmSrc),
   'W-S51b injectGantt stamps _cell into every op parameters JSON when the cell map covers the elements');
-const _bgtIdx = tmSrc.indexOf('function buildGanttTasks()');
-const _bgtBody = tmSrc.slice(_bgtIdx, tmSrc.indexOf('§GANTT_ROW_ORDER', _bgtIdx));
-assert(_bgtIdx > 0 && /\('C:' \+ cellId\)/.test(_bgtBody) && /p\._cell/.test(_bgtBody),
-  'W-S51c buildGanttTasks groups bars by the cell stamp between real task identity and the storey|phase fallback');
+// W-S51c — §S53 (F3): was a REGEX over buildGanttTasks' source text ("does the body contain
+// 'C:' + cellId"). Now the real rule is a real module, so this asserts the BEHAVIOUR instead: the
+// grouping precedence is exercised, not pattern-matched. A source regex would still pass against a
+// body that computes the key and then throws it away.
+{
+  const gk = GanttModel.groupKeyOf;
+  assert(gk('T7', 'L1\u00b7Arch\u00b70', 'L1', 'Architecture') === 'T:T7' &&
+         gk(null, 'L1\u00b7Arch\u00b70', 'L1', 'Architecture') === 'C:L1\u00b7Arch\u00b70' &&
+         gk(null, null, 'L1', 'Architecture') === 'L1|Architecture',
+    'W-S51c the drawer groups bars by the cell stamp BETWEEN real task identity and the storey|phase fallback');
+}
 
 function loadRatesTable() {
   const txt = fs.readFileSync(path.join(__dirname, '..', 'rates.js'), 'utf8');
@@ -349,11 +360,12 @@ function census(items) {
     // so _displayTimeline's own §S6_CREW_PASS max_crews_fixed/max_crews lookup sees real per-resource
     // caps instead of running crew-unconstrained.
     const sandbox = { console: { log: () => {}, warn: () => {} }, performance: { now: () => Date.now() },
-      window: { SEQUENCE_RULES: SR, SEQUENCE_DEFAULT: SD, SEQUENCE_NAME_OVERRIDES: NO, LABOR_RATES: RATES.LABOR_RATES },
+      window: { SEQUENCE_RULES: SR, SEQUENCE_DEFAULT: SD, SEQUENCE_NAME_OVERRIDES: NO,
+                LABOR_RATES: RATES.LABOR_RATES, GanttModel: GanttModel },   // §S53: sliced code's delegates read window.GanttModel
       ScheduleGate: ScheduleGate, Math: Math, A: () => ({ db: db }),
       URLSearchParams: URLSearchParams, CpmSchedule: CpmSchedule };
     vm.createContext(sandbox);
-    vm.runInContext(sliced + '\nthis.__bxe = _buildXrayElements; this.__dt = _displayTimeline; this.__tukey = _tukeyBound;', sandbox);
+    vm.runInContext(sliced + '\nthis.__bxe = _buildXrayElements; this.__dt = _displayTimeline;', sandbox);
     const els = sandbox.__bxe();
     if (!els || !els.length) { assert(false, 'W-MZ ' + bld + ' element build produced nothing'); db.close(); continue; }
 
@@ -446,36 +458,37 @@ function census(items) {
         ' float=' + floatPost + ' [ScheduleGate.auditFloating]' +
         ' midair=' + after.midair + ' [this witness\'s own census(), independent judge]');
     }
-    // ── §S51_SCREEN — what the Gantt DRAWS, before vs after item d, mirrored on this witness's
-    // own items with the display's own trim (_tukeyBound sliced from time_machine.js — the exact
-    // envelope buildGanttTasks applies). BEFORE = storey|phase grouping (pre-§S51 display). AFTER =
-    // cell stamp where present, storey|phase fallback otherwise (the shipped §S51 grouping rule).
+    // ── §S51_SCREEN — what the Gantt DRAWS, before vs after item d, measured on this witness's own
+    // items by THE DRAWER'S OWN MODEL. §S53 (F3): this block used to re-implement buildGanttTasks'
+    // grouping and slice `_tukeyBound` out of time_machine.js by source text; it now feeds items to
+    // GanttModel.buildTasks — the exact function time_machine.js's buildGanttTasks() wrapper calls —
+    // so a change to the drawer's grouping or trim shows up HERE instead of leaving this instrument
+    // silently measuring the retired rule. BEFORE = storey|phase grouping (pre-§S51 display, ops with
+    // no _cell stamp). AFTER = the cell stamp (the shipped §S51 grouping rule).
     {
       let lo = Infinity, hi = -Infinity;
       items.forEach(it => { if (it.s < lo) lo = it.s; if (it.e > hi) hi = it.e; });
       const span = hi - lo;
-      const tk = sandbox.__tukey;
-      const barW50 = groups => {
-        let wide = 0, n = 0;
-        for (const k in groups) {
-          const g = groups[k]; n++;
-          const s0 = tk(g.starts, true), e0 = Math.max(tk(g.ends, false), s0);
-          if (span && (e0 - s0) / span > 0.5) wide++;
-        }
-        return { wide, n };
+      // Items -> the ELEMENT_PLACE op shape buildTasks consumes. idx=null: no authored task index in
+      // this witness, so the task-identity branch is inert and the cell/storey|phase rule is what runs.
+      const asOps = cellOf => items.map((it, i2) => ({ op_type: 'ELEMENT_PLACE', start_ts: it.s, end_ts: it.e,
+        output_guid: it.guid, parameters: { storey: it.storey || '_UNKNOWN', phase: it.phase || 'Architecture',
+          _cell: cellOf ? cellOf(i2) : undefined } }));
+      const barW50 = ops => {
+        const bars = GanttModel.buildTasks(ops, null, SR).tasks;
+        let wide = 0;
+        bars.forEach(b => { if (span && (b.endTs - b.startTs) / span > 0.5) wide++; });
+        return { wide, n: bars.length };
       };
-      const collect = keyFn => { const m = {}; items.forEach((it, i2) => {
-        const k = keyFn(it, i2); (m[k] || (m[k] = { starts: [], ends: [] }));
-        m[k].starts.push(it.s); m[k].ends.push(it.e); }); return m; };
       const gate = dtResult && dtResult.stats && dtResult.stats.gate;
-      const beforeG = barW50(collect(it => (it.storey || '_UNKNOWN') + '|' + (it.phase || 'Architecture')));
+      const beforeG = barW50(asOps(null));
       const afterG = gate && gate.cellKeys
-        ? barW50(collect((it, i2) => 'C:' + gate.cellKeys[i2]))
+        ? barW50(asOps(i2 => gate.cellKeys[i2]))
         : beforeG;   // graph path: the display is UNCHANGED by construction (no stamp exists)
       console.log('§S51_SCREEN ' + bld + ' path=' + (gate ? gate.path : 'GRAPH') +
         ' wide50screen BEFORE=' + beforeG.wide + '/' + beforeG.n + 'bars (storey|phase, tukey-trimmed — the pre-§S51 drawer)' +
         ' AFTER=' + afterG.wide + '/' + afterG.n + 'bars (' + (gate && gate.cellKeys ? 'cell stamp — the §S51 drawer' : 'IDENTICAL: graph path, no stamp') + ')' +
-        ' [instrument: this witness mirroring buildGanttTasks grouping+_tukeyBound on the same items]');
+        ' [instrument: GanttModel.buildTasks — the drawer\'s own grouping+trim, on the same items]');
     }
     // ── §S51_RESIDUE — the ACCEPTANCE SPLIT on the locked midair residue (user: "within walls or
     // last"). General rule only — element class plays no part, no per-building constants:
@@ -486,10 +499,10 @@ function census(items) {
     //              rules table, same derivation as time_machine's §GANTT_ROW_ORDER);
     //   NEITHER  = early, free-standing — the only number that matters.
     {
-      const minSeq = {};
-      for (const k2 in SR) { const r2 = SR[k2]; if (r2 && r2.phase && r2.sequence != null &&
-        (minSeq[r2.phase] == null || r2.sequence < minSeq[r2.phase])) minSeq[r2.phase] = r2.sequence; }
-      const phOrder = Object.keys(minSeq).sort((a, b) => minSeq[a] - minSeq[b]);
+      // §S53 (F3): was a local re-derivation of the SEQUENCE_RULES minimum-sequence-per-phase order,
+      // annotated in this witness's own comment as "same derivation as time_machine's §GANTT_ROW_ORDER".
+      // It is now literally that derivation, called from the module both this witness and the drawer share.
+      const phOrder = GanttModel.phaseOrder(SR);
       const ffIdx = phOrder.indexOf('MEP Rough-in');
       const isLate = ph => ffIdx >= 0 && phOrder.indexOf(ph) > ffIdx;
       let emb = 0, late = 0, neither = 0;

--- a/viewer/tests/witness_zone_display_authoring.js
+++ b/viewer/tests/witness_zone_display_authoring.js
@@ -80,6 +80,13 @@ assert(/opts\.displayRemap/.test(saSrc) && /display_authored/.test(saSrc),
 const zoneParts = [sliceFn(tmSrc, '_zoneIndexBuild', 0, true), sliceFn(tmSrc, '_zoneIndex', 0, true)].filter(Boolean);
 const sliced = ["var _TIER1_ORDER = ['Substructure', 'Superstructure', 'Architecture'];",
   'var _CPM_DISPLAY = true;',   // §S20: only live branch left once Part B lands — see note above
+  // §S53 (F3, 4D_GANTT_TM_REFACTOR.md): _tmDisplayRemap's §ZONE_WINDOW_DAGWINS_CLIP calls
+  // _tukeyBound, which stage 2 (2026-08-17) hoisted to time_machine.js module scope WITHOUT adding
+  // it to this slice list — so every run of this witness has died with `ReferenceError: _tukeyBound
+  // is not defined` before reaching a single assertion since that day (verified at a4932ee, the same
+  // crash, before F3 touched anything). The envelope is now a real module, so it is BOUND here from
+  // GanttModel rather than sliced — the failure mode cannot come back.
+  'var _tukeyBound = GanttModel.tukeyBound;',
   (zoneParts.length === 2 ? 'var _zoneMemo = [];' : ''), zoneParts[0] || '', zoneParts[1] || '',
   sliceFn(tmSrc, '_zoneOf', 0, true) || '',
   sliceFn(tmSrc, '_contactGraph'),
@@ -90,7 +97,8 @@ const sliced = ["var _TIER1_ORDER = ['Substructure', 'Superstructure', 'Architec
 const _rlines = [];
 const sandbox = { console: { log: (...a) => _rlines.push(a.join(' ')), warn: () => {} }, performance: { now: () => Date.now() },
   ScheduleGate: ScheduleGate, Math: Math, URLSearchParams: URLSearchParams,
-  CpmSchedule: require(path.join(__dirname, '..', 'cpm_schedule.js')) };
+  CpmSchedule: require(path.join(__dirname, '..', 'cpm_schedule.js')),
+  GanttModel: require(path.join(__dirname, '..', 'gantt_model.js')) };   // §S53: the drawer's bar-trim envelope, as a real module
 vm.createContext(sandbox);
 vm.runInContext(sliced +
   '\nthis.__remapHook = _tmDisplayRemap; this.__sweep = _ogSupportSweep; this.__parity = _cjpJudgeParity; this.__cg = _contactGraph; this.__ds = _designatedSupport; this.__rescale = _capWindowRescale;', sandbox);
@@ -217,7 +225,8 @@ async function main() {
     console.log = quiet;
     const cpmSandbox = { console: { log: () => {}, warn: () => {} }, performance: { now: () => Date.now() },
       ScheduleGate: ScheduleGate, Math: Math, URLSearchParams: URLSearchParams,
-      CpmSchedule: require(path.join(__dirname, '..', 'cpm_schedule.js')) };
+      CpmSchedule: require(path.join(__dirname, '..', 'cpm_schedule.js')),
+      GanttModel: require(path.join(__dirname, '..', 'gantt_model.js')) };   // §S53, same as the sandbox above
     vm.createContext(cpmSandbox);
     vm.runInContext(sliced.replace('var _CPM_DISPLAY = false;', 'var _CPM_DISPLAY = true;') +
       '\nthis.__remapHook = _tmDisplayRemap; this.__cg = _contactGraph; this.__dt = _displayTimeline;', cpmSandbox);

--- a/viewer/time_machine.js
+++ b/viewer/time_machine.js
@@ -122,37 +122,20 @@
   // buildGanttTasks()'s bar grouping.
   function _placeOps() { return _ops.filter(function (o) { return o.op_type === 'ELEMENT_PLACE'; }); }
 
+  // computeDays() — THIN WRAPPER (§S53, F3). The model lives in gantt_model.js (GanttModel
+  // .computeDays); this function owns only the STATE assignment and the read-only debug hook, which
+  // is what belongs in time_machine.js. Every rule — the day ladder, the unqualified playback bounds,
+  // and §GANTT_AXIS_OUTLIER's Tukey-qualified DISPLAY axis — moved there verbatim with its comments.
   function computeDays() {
-    var cOps = _placeOps();
-    var seen = {};
-    cOps.forEach(function(op) {
-      var d = new Date(op.start_ts);
-      var key = d.getFullYear() + '-' + (d.getMonth()+1) + '-' + d.getDate();
-      if (!seen[key]) seen[key] = new Date(d.getFullYear(), d.getMonth(), d.getDate()).getTime();
-    });
-    _days = Object.values(seen).sort(function(a,b){ return a - b; });
-    if (cOps.length) {
-      // projectStart = 1ms BEFORE first op so ⏪ = truly empty (no frontier)
-      _projectStart = cOps[0].start_ts - 1;
-      _projectEnd = Math.max.apply(null, cOps.map(function(o){ return o.end_ts; }));
-    }
-    // §GANTT_AXIS_OUTLIER — qualified DISPLAY axis. Was its own copy of the 2nd-98th-percentile-
-    // above-n20/true-max-below cliff §GANTT_MINI_TRIM used to use per-bar (buildGanttTasks) — the
-    // SAME broken rule, applied here to the GLOBAL population of end_ts that defines the whole
-    // chart's axis instead of one bar's span. Stage 2 (4D_GANTT_TM_REFACTOR.md) fixed the per-bar
-    // copy but not this one — a bar's DATA could be correct while its DRAWN pixel position was
-    // still wrong, because the axis it's scaled against was still cliff-computed. Fixed here the
-    // same way: the shared _tukeyBound (hoisted to module scope, stage 2) — uniform at every
-    // population size, no cliff, no new tuned constant, reuses the exact proven formula. Never
-    // exceeds the true max (_tukeyBound's own Math.min(s[n-1], ...) clamp), so this stays a
-    // qualification of the real data, never an invention beyond it.
-    _ganttAxisStart = _projectStart;   // starts are not the observed problem; leave unqualified
-    _ganttAxisEnd = cOps.length
-      ? _tukeyBound(cOps.map(function (o) { return o.end_ts; }), false)
-      : _projectEnd;
-    // (G-3 fix 2026-08-11: a stale byte-duplicate of the block above sat here reading `_ops` —
+    var GM = (typeof window !== 'undefined' && window.GanttModel) || null;
+    if (!GM) { console.warn('§LOAD_FAIL gantt_model.js — computeDays skipped, timeline bounds unchanged'); return; }
+    var r = GM.computeDays(_placeOps());
+    _days = r.days;
+    if (r.projectStart !== null) { _projectStart = r.projectStart; _projectEnd = r.projectEnd; }
+    _ganttAxisStart = r.axisStart; _ganttAxisEnd = r.axisEnd;
+    // (G-3 fix 2026-08-11: a stale byte-duplicate of the axis block sat here reading `_ops` —
     // bookkeeping ops included — and OVERWROTE the qualified axis, so the display axis absorbed
-    // BUILDING_OPEN. Removed; the cOps-based block above is the single authority.)
+    // BUILDING_OPEN. Removed; GanttModel.computeDays is now the single authority.)
     // §GANTT_AXIS_RAW (2026-08-18, 4D_GANTT_TM_REFACTOR.md — the axis's own near-duplicate fix) —
     // read-only debug hook, same convention as __tmGanttBarsRaw, so this layer is verifiable by a
     // witness instead of only by reading source. Exposes both the qualified axis actually drawn
@@ -160,7 +143,7 @@
     // end exceed what it's scaled against" without a second, separate computation.
     try {
       window.__tmGanttAxis = { axisStart: _ganttAxisStart, axisEnd: _ganttAxisEnd,
-        projectStart: _projectStart, projectEnd: _projectEnd, n: cOps.length };
+        projectStart: _projectStart, projectEnd: _projectEnd, n: r.n };
     } catch (e) {}
   }
 
@@ -4410,10 +4393,11 @@
   // floating 664->63, window fidelity 97.03%->99.95% when this landed for §ZONE_WINDOW_DAGWINS_CLIP)
   // — uniform at every group size, no group-size branch, no cliff. Percentile convention matches
   // storeyOrderReport/§GANTT_GAP_CLAMP: sorted[Math.floor(n*p)], no interpolation.
+  // §S53 (F3): the formula itself now lives in gantt_model.js — ONE envelope shared by the drawer's
+  // bar spans, the display axis, and witness_midair_zero.js (which used to slice this function out
+  // of this file BY SOURCE TEXT). This delegate keeps the in-file callers reading unchanged.
   function _tukeyBound(arr, lowSide) {
-    var s = arr.slice().sort(function (a, b) { return a - b; });
-    var n = s.length, q1 = s[Math.floor(n * 0.25)], q3 = s[Math.floor(n * 0.75)], iqr = q3 - q1;
-    return lowSide ? Math.max(s[0], q1 - 1.5 * iqr) : Math.min(s[n - 1], q3 + 1.5 * iqr);
+    return window.GanttModel.tukeyBound(arr, lowSide);
   }
   function _tmDisplayRemap(elements, schedule) {
     (function () {
@@ -6094,111 +6078,20 @@
       ' AC=' + EVM.AC + ' CPI=' + EVM.CPI.toFixed(3) + ' CV=' + EVM.CV + ' BAC=' + EVM.BAC + ' EAC=' + EVM.EAC + ' VAC=' + EVM.VAC);
   }
 
-  // buildGanttTasks() — the storey|phase rollup, now cached and task-identity-aware (K0).
-  // Grouping key is the REAL task_id whenever the op's guid resolves through task_elements, so each
-  // resulting bar carries `taskId` and is addressable by moveTask/resizeTask/addDependency. Ops with
-  // no task fall back to the original storey|phase key and stay non-editable.
+  // buildGanttTasks() — THIN WRAPPER (§S53, F3). The model lives in gantt_model.js
+  // (GanttModel.buildTasks): the §S51 grouping precedence (task id -> cell stamp -> storey|phase),
+  // the §GANTT_MINI_TRIM Tukey bar-span trim, and the SEQUENCE_RULES-derived §GANTT_ROW_ORDER sort,
+  // all moved there verbatim with their comments. This function keeps what is genuinely
+  // time_machine's: the K0 dirty-flag gate, the state assignment, and the three §-log proof lines.
   function buildGanttTasks() {
     if (!_ganttDirty) return;
+    var GM = (typeof window !== 'undefined' && window.GanttModel) || null;
+    if (!GM) { console.warn('§LOAD_FAIL gantt_model.js — buildGanttTasks skipped, bars unchanged'); return; }
     _ganttDirty = false;
     var idx = buildTaskIndex();
-    var groups = {};
-    var _idN = 0, _noIdN = 0;
-    for (var i = 0; i < _ops.length; i++) {
-      var op = _ops[i];
-      // §GANTT_OPS_BOOKKEEPING_LEAK: a non-construction op (BUILDING_OPEN, ELEMENT_PICK, GRID_*, ...)
-      // is not a task and must not become a bar — see computeDays()'s own header comment for the
-      // traced mechanism. _ops itself stays the full mixed history for other consumers (copyGuids).
-      if (op.op_type !== 'ELEMENT_PLACE') continue;
-      var p = op.parameters || {};
-      var storey = p.storey || '_UNKNOWN';
-      var phase = p.phase || 'Architecture';
-      // Real task identity first (exact, by guid); then §S51's cell stamp (the schedule's own
-      // grain, present only on cell-path generations); storey|phase only as the un-authored
-      // fallback — graph-path buildings and pre-§S51 ops group exactly as before.
-      var tid = idx && op.output_guid ? idx.guidTask[op.output_guid] : null;
-      if (tid) _idN++; else _noIdN++;
-      var cellId = (!tid && p._cell) ? String(p._cell) : null;
-      var key = tid ? ('T:' + tid) : (cellId ? ('C:' + cellId) : (storey + '|' + phase));
-      if (!groups[key]) groups[key] = { storey: cellId ? (cellId.split('\u00b7')[2] || storey) : storey,
-        phase: phase, cell: cellId || null, taskId: tid || null,
-        taskName: tid && idx.tasks[tid] ? idx.tasks[tid].name : null,
-        starts: [], ends: [], count: 0, cap: 0, guids: [] };
-      var g = groups[key];
-      g.starts.push(op.start_ts);
-      g.ends.push(op.end_ts);
-      g.guids.push(op.output_guid);   // W1 needs the member set to re-time an edited bar
-      g.count++;
-      if (p._captured) g.cap++;   // §gate: captured = preset IFC 4D (verbatim) — drives the yellow frame
-    }
-    _ganttIdentified = _idN; _ganttUnidentified = _noIdN;
-
-    // §GANTT_MINI_TRIM (2026-08-17, 4D_GANTT_TM_REFACTOR.md stage 2 — REPLACES the 2026-07-18
-    // 2nd-98th-percentile-above-n20/true-min-max-below rule). The old rule's cliff at n=20 was
-    // measured live to be exactly the mechanism behind "one pile, full project length": most
-    // phase|storey groups are small (many storeys x 6 phases), so most bars got NO trim at all —
-    // one mistagged/outlier element (this project's own numbers show non-zero outliers on every
-    // building, by design) was enough to stretch an untrimmed small group's bar to cover it.
-    // Fix: the SAME Tukey-fence envelope §ZONE_WINDOW_DAGWINS_CLIP already uses for task-window
-    // authoring (_tukeyBound, hoisted to module scope above) — uniform at every group size, no
-    // cliff, no new tuned constant (reuses the exact proven formula, not a fresh invention).
-    // Members outside the fence still exist in the underlying data (§TIER_DAG_WINS doctrine:
-    // counted, never hidden) — they just don't get to single-handedly define the bar's span.
-    _ganttTasks = [];
-    for (var k in groups) {
-      var g = groups[k];
-      g.startTs = _tukeyBound(g.starts, true);
-      g.endTs = Math.max(_tukeyBound(g.ends, false), g.startTs);   // degenerate-group safety (n=1)
-      delete g.starts; delete g.ends;
-      _ganttTasks.push(g);
-    }
-
-    // §GANTT_ROW_ORDER (K1, 2026-08-04) — user report: "are you using any 4D convention used by P6 on
-    // gantt phase/task ordering? Last session was a mess putting substructure which has above ground
-    // appearing first." Correct answer at the time: we followed NO convention. Rows were sorted purely
-    // by `a.startTs - b.startTs`, so whichever zone happened to compute earliest floated to the top and
-    // a phase's floors appeared interleaved with other phases' — arbitrary, and unreadable as a
-    // construction programme.
-    //
-    // P6/MSP order rows by WBS path, THEN by early start. Our WBS is (phase → floor): the zone
-    // decomposition materializeZones already persists. So: phase in real construction sequence first,
-    // then start time within the phase (which tracks bottom-up floor order, because the engine builds
-    // floors bottom-up). Falls back to alphabetical for any phase outside the canonical list rather
-    // than silently bucketing it at position 0.
-    //
-    // ⚠ DERIVED FROM SEQUENCE_RULES, NEVER HARDCODED — and this matters, it is not tidiness.
-    // The first draft of this fix copied the order out of _VAR_ORDER (~:4238) and was WRONG: that
-    // array still reads Substructure/Superstructure/MEP Rough-in/Architecture/…, i.e. MEP rough-in
-    // BEFORE the building envelope — the exact backwards discipline PR #1165 fixed in SEQUENCE_RULES
-    // and across all 18 rate-template sources. _VAR_ORDER is a THIRD stale copy that #1165 missed
-    // (the two known-stale PHASE_ORDER arrays in this file are the other two). The real engine order,
-    // read from SEQUENCE_RULES' own sequence numbers, is:
-    //   Substructure(1) → Superstructure(2) → Architecture(5) → MEP Rough-in(7) → MEP Final(9) → Finishes(10)
-    // Deriving it kills this whole class of drift: the drawer cannot disagree with the engine again.
-    var _ROW_PHASE_ORDER = (function () {
-      var SR = (typeof window !== 'undefined' && window.SEQUENCE_RULES) || null;
-      if (SR) {
-        var minSeq = {};
-        for (var k in SR) {
-          var r = SR[k]; if (!r || !r.phase || r.sequence == null) continue;
-          if (minSeq[r.phase] == null || r.sequence < minSeq[r.phase]) minSeq[r.phase] = r.sequence;
-        }
-        var ks = Object.keys(minSeq);
-        if (ks.length) return ks.sort(function (a, b) { return minSeq[a] - minSeq[b]; });
-      }
-      // Fallback only when SEQUENCE_RULES has not loaded — matches the derived order above.
-      return ['Substructure', 'Superstructure', 'Architecture', 'MEP Rough-in', 'MEP Final', 'Finishes'];
-    })();
-    function _phaseRank(p) {
-      var i = _ROW_PHASE_ORDER.indexOf(p);
-      return i < 0 ? _ROW_PHASE_ORDER.length : i;      // unknown phases sort after the known ones
-    }
-    _ganttTasks.sort(function (a, b) {
-      var pa = _phaseRank(a.phase), pb = _phaseRank(b.phase);
-      if (pa !== pb) return pa - pb;
-      if (pa === _ROW_PHASE_ORDER.length && a.phase !== b.phase) return a.phase < b.phase ? -1 : 1;
-      return (a.startTs - b.startTs) || (a.storey < b.storey ? -1 : a.storey > b.storey ? 1 : 0);
-    });
+    var r = GM.buildTasks(_ops, idx, (typeof window !== 'undefined' && window.SEQUENCE_RULES) || null);
+    _ganttTasks = r.tasks;
+    _ganttIdentified = r.identified; _ganttUnidentified = r.unidentified;
 
     if (!_ganttTasksComputed) {
       var _idBars = 0;

--- a/viewer/viewer.html
+++ b/viewer/viewer.html
@@ -940,6 +940,9 @@ html.bim-embedded, html.bim-embedded body { background: #0b0b0b; }
 <script src="lib/level_deriver.js?v=1" onerror="console.warn('§LOAD_FAIL lib/level_deriver.js — level axis unavailable, schedule falls back to graph engine')"></script>
 <script src="location_axis.js?v=1" onerror="console.warn('§LOAD_FAIL location_axis.js — cell gate unavailable, schedule falls back to graph engine')"></script>
 <script src="cpm_schedule.js?v=2" onerror="console.warn('§LOAD_FAIL cpm_schedule.js')"></script>
+<!-- §S53 (F3, 4D_GANTT_TM_REFACTOR.md): the Gantt bar MODEL, extracted out of time_machine.js.
+     Must load BEFORE time_machine.js — its computeDays/buildGanttTasks wrappers call it. -->
+<script src="gantt_model.js?v=1" onerror="console.warn('§LOAD_FAIL gantt_model.js — Gantt bars and timeline bounds unavailable')"></script>
 <script src="time_machine.js?v=71" onerror="console.warn('§LOAD_FAIL time_machine.js')"></script>
 <script src="dlod_nav.js?v=2" onerror="console.warn('§LOAD_FAIL dlod_nav.js')"></script>
 <script src="schedule_author.js?v=14" onerror="console.warn('§LOAD_FAIL schedule_author.js')"></script>


### PR DESCRIPTION
`prompts/4D_GANTT_TM_REFACTOR.md` **§S53**, item **F3** from the §S52.4 watchdog list. Base `a4932ee`.

## What moved

The grouping, the bar-span trim, the row order and the display axis move **verbatim** (comments travel with their code) into a new `viewer/gantt_model.js`. `buildGanttTasks()` / `computeDays()` / `_tukeyBound` stay in `time_machine.js` as thin wrappers owning only what is genuinely time_machine's: the state assignment, the K0 dirty-flag gate, and the three `§GANTT_*` log lines.

| | before | after |
|---|---|---|
| `time_machine.js` | 9,293 | **9,186** (−107) |
| `gantt_model.js` | — | 206 |
| `witness_gantt_model.js` | — | 169 (**21 checks**) |
| source-text slices of `time_machine.js` in `witness_midair_zero.js` | 12 | **11** |
| re-implementations of a drawer rule inside a witness | 3 | **0** |

## Why, beyond length

`witness_midair_zero.js` could not judge the drawer's rules without either slicing `_tukeyBound` out of `time_machine.js` **by source text** (a slice that already silently widened once — §S20) or **re-implementing** them: its own comment read *"this witness mirroring buildGanttTasks grouping+_tukeyBound"*, and `§S51_RESIDUE` re-derived the SEQUENCE_RULES phase order it annotated as *"same derivation as time_machine's §GANTT_ROW_ORDER"*. A mirrored judge is §S25_REVIEW.1 one step removed: the drawer's rule changes, the judge keeps measuring the retired rule, and stays green. All three now call the real module, and `W-S51c` goes from a regex over source text to a behavioural check.

## Proof it changed nothing

`witness_midair_zero.js` at pristine `a4932ee` vs after, same tree, same DBs: **`pass=49 fail=0` both**, and a normalized diff of the two full 175-line logs is **empty** except wall-clock `ms={...}`/`compileMs=` timings and the two lines whose label text this PR deliberately changed.

## The new witness is not passing by absence

Three perturbations of the extracted module, each proven red, each reverted:

| perturbation | result |
|---|---|
| cell branch removed from `groupKeyOf` | `FAIL W-GM-1b`, `FAIL W-GM-1d` — `pass=19 fail=2` |
| `tukeyBound` → plain min/max | `FAIL W-GM-2a` (bar span 19.0d → **901.0d**), `W-GM-2d`, `W-GM-5c` (axis 48d → 1001d) — `pass=18 fail=3` |
| `phaseOrder` forced to the fallback | `FAIL W-GM-3a`, `FAIL W-GM-3c` — `pass=19 fail=2` |

## ⛔ Found while doing it: a witness dead since 2026-08-17

Auditing every consumer of the moved `_tukeyBound` turned up `witness_zone_display_authoring.js` dying with `ReferenceError: _tukeyBound is not defined` **before its first assertion** — stage 2 hoisted the function to module scope and `_tmDisplayRemap` started calling it, but this witness slices `_tmDisplayRemap` and was never given it. **Verified crashing identically at pristine `a4932ee`** — not caused by this PR. Fixed here by binding it from the real module.

Alive again it reads **`pass=16 fail=2`**: `W-ZDA-4a` red on Duplex (floating 22→37) and HHS (894→1839), while `outWindow` moves the other way (13→0, 707→11) and `W-ZDA-6` reads midair=0 on the same run. Documented as an open question in §S53.5 and deliberately **not chased here** — it is outside F3.

## Gates

`node --check` over all `viewer`+`modeller`, `npx eslint viewer modeller`, `audit_sw_precache.js` 121/121 (`gantt_model.js` registered), `audit_script_tags.js` 146/146 — all green. `sw.js` `CACHE_VERSION` v1061 → **v1062** in the same commit. Re-run green and unchanged: `witness_s50_cell_engine`, `witness_gantt_edit_undo` (9), `witness_gantt_native_generate` (5), `witness_gantt_group_move` (9), `witness_gantt_baseline` (11). `witness_gantt_lock_integrity` fails 1 of 20 (`G-LI-2e`), whose own assert message calls it a KNOWN PRE-EXISTING BUG — unrelated, untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)