### PR TITLE
fix(4d): the ERP-twin loaders never guess a building (§S54, item F2)

### DIFF
--- a/viewer/sw.js
+++ b/viewer/sw.js
@@ -8,7 +8,11 @@
 // Cache-first for heavy assets (.wasm, images). DB files skip SW (IndexedDB handles them).
 //
 // DEPLOY: bump CACHE_VERSION on every OCI upload. Old caches are purged on activate.
-const CACHE_VERSION = 'v1062';   // bump on each deploy; per-change detail is the git commit message.
+const CACHE_VERSION = 'v1063';   // bump on each deploy; per-change detail is the git commit message.
+// v1063 (2026-08-21) 4D_GANTT_TM_REFACTOR.md §S54 (item F2): time_machine.js's two ERP-twin
+// loaders (_loadTwin/_loadShopfloor) no longer default a missing activeBuilding to 'Hospital' —
+// with no active building they now skip BEFORE the 25.8MB ad_seed.db fetch instead of attaching
+// another project's cost figures to an arbitrary IFC. Witness: witness_tm_erp_twin_guard.js.
 // v1062 (2026-08-21) 4D_GANTT_TM_REFACTOR.md §S53 (item F3): the Gantt bar MODEL extracted out of
 // time_machine.js into NEW gantt_model.js (precached above, viewer.html loads it first) —
 // buildGanttTasks/computeDays/_tukeyBound are now thin wrappers over it. Behaviour-preserving,

--- a/viewer/tests/witness_tm_erp_twin_guard.js
+++ b/viewer/tests/witness_tm_erp_twin_guard.js
@@ -1,0 +1,101 @@
+#!/usr/bin/env node
+// witness_tm_erp_twin_guard.js — §S54 (bim-compiler prompts/4D_GANTT_TM_REFACTOR.md §S54.2, item F2).
+//
+// ISSUE this witness proves/disproves: with NO active building, do time_machine.js's two ERP-twin
+// loaders still guess one? They used to read `(app && app.activeBuilding) || 'Hospital'`, so an
+// arbitrary IFC opened straight into the viewer silently got HOSPITAL's cost and phase figures
+// attached to it — the single real per-building hardcoding left in the 4D path (§S52.1).
+//
+// A guard like this is exactly the kind that rots quietly: nothing throws, no number goes red, the
+// dashboard just shows another project's money. So it is asserted three ways — the resolved value,
+// the FETCH (the guard must fire before the 25.8MB ad_seed.db read, not after), and the source
+// itself (no fallback expression may creep back in a different shape).
+//
+//   W-TET-1  no active building -> _loadTwin resolves null AND never fetches ad_seed.db
+//   W-TET-2  no active building -> _loadShopfloor resolves null AND never fetches
+//   W-TET-3  WITH an active building both still fetch and still resolve — the guard did not
+//            disable the feature (a guard that always skips would pass W-TET-1/2 trivially)
+//   W-TET-4  no quoted building-name fallback survives in either function's live source
+'use strict';
+const fs = require('fs');
+const path = require('path');
+const vm = require('vm');
+const tmSrc = fs.readFileSync(path.join(__dirname, '..', 'time_machine.js'), 'utf8');
+
+let pass = 0, fail = 0;
+function assert(cond, msg) { if (cond) { pass++; console.log('  PASS ' + msg); } else { fail++; console.log('  FAIL ' + msg); } }
+
+function sliceFn(src, name) {
+  const idx = src.indexOf('function ' + name + '(');
+  if (idx < 0) throw new Error(name + ' not found');
+  let depth = 0, i = idx, seenOpen = false;
+  for (; i < src.length; i++) {
+    if (src[i] === '{') { depth++; seenOpen = true; }
+    else if (src[i] === '}') { depth--; if (seenOpen && depth === 0) break; }
+  }
+  return src.slice(idx, i + 1);
+}
+const twinSrc = sliceFn(tmSrc, '_loadTwin');
+const shopSrc = sliceFn(tmSrc, '_loadShopfloor');
+
+// A sandbox with the module state both functions close over, and a cachedFetch that COUNTS instead
+// of fetching — reaching it at all is the failure this witness exists to catch.
+function mkSandbox(activeBuilding) {
+  const state = { fetches: 0 };
+  const sandbox = {
+    console: { log: () => {}, warn: () => {} }, Promise: Promise, Number: Number, Date: Date, Math: Math,
+    A: () => ({ activeBuilding: activeBuilding, _SQL: { Database: function () { throw new Error('unreachable in this witness'); } } }),
+    APP: { cachedFetch: () => { state.fetches++; return Promise.reject(new Error('§WITNESS fetch blocked')); } },
+    window: {},
+    _twin: null, _twinLoading: false, _twinMiss: null,
+    _shopfloor: null, _shopfloorLoading: false, _shopfloorMiss: null
+  };
+  sandbox.window.SQL = sandbox.A()._SQL;
+  vm.createContext(sandbox);
+  vm.runInContext(twinSrc + '\n' + shopSrc + '\nthis.__twin = _loadTwin; this.__shop = _loadShopfloor;', sandbox);
+  return { sandbox, state };
+}
+
+(async () => {
+  // ── W-TET-1 / W-TET-2 — the real state this fixes: an arbitrary IFC, no active building.
+  {
+    const { sandbox, state } = mkSandbox(undefined);
+    const t = await sandbox.__twin().catch(e => '(threw: ' + e.message + ')');
+    assert(t === null && state.fetches === 0,
+      'W-TET-1 no active building: _loadTwin resolves null (got ' + JSON.stringify(t) +
+      ') and never fetched ad_seed.db (fetches=' + state.fetches + ') — the guess is gone, and gone BEFORE the 25.8MB read');
+
+    const s = await sandbox.__shop().catch(e => '(threw: ' + e.message + ')');
+    assert(s === null && state.fetches === 0,
+      'W-TET-2 no active building: _loadShopfloor resolves null (got ' + JSON.stringify(s) +
+      ') and never fetched (fetches=' + state.fetches + ')');
+  }
+
+  // ── W-TET-3 — the control. A guard that skips unconditionally would pass the two above while
+  // silently killing the ERP twin for every building; this proves the loaders still run.
+  {
+    const { sandbox, state } = mkSandbox('Duplex');
+    await sandbox.__twin().catch(() => {});
+    assert(state.fetches === 1,
+      'W-TET-3a WITH an active building _loadTwin still reaches the ad_seed.db fetch (fetches=' + state.fetches + ')');
+    const before = state.fetches;
+    await sandbox.__shop().catch(() => {});
+    assert(state.fetches === before + 1,
+      'W-TET-3b WITH an active building _loadShopfloor still reaches the fetch (fetches=' + state.fetches + ')');
+  }
+
+  // ── W-TET-4 — source, comments stripped: no quoted building-name fallback in either function.
+  // Comments are stripped ON PURPOSE — the fix's own comment quotes the retired `|| 'Hospital'`
+  // expression to record what it replaced, and a naive scan would match that and pass/fail on prose.
+  {
+    const strip = src => src.split('\n').filter(l => !l.trim().startsWith('//')).join('\n');
+    const live = strip(twinSrc) + '\n' + strip(shopSrc);
+    assert(live.indexOf("'Hospital'") < 0 && live.indexOf('"Hospital"') < 0,
+      'W-TET-4a no quoted building name survives in the live source of either loader');
+    assert(!/activeBuilding\s*\)?\s*\|\|\s*['"]/.test(live),
+      'W-TET-4b activeBuilding is never OR-ed into a string literal fallback — the shape cannot come back under another name');
+  }
+
+  console.log('\n§TM_ERP_TWIN_GUARD_SUMMARY pass=' + pass + ' fail=' + fail);
+  process.exit(fail ? 1 : 0);
+})();

--- a/viewer/time_machine.js
+++ b/viewer/time_machine.js
@@ -5813,7 +5813,14 @@
   // Same lazy-fetch idiom as navigate_find._ensureErpDb; read-only (db.close after extracting the figures).
   function _loadTwin() {
     var app = A();
-    var building = (app && app.activeBuilding) || 'Hospital';
+    // §S54 (4D_GANTT_TM_REFACTOR.md §S54.2, item F2): this used to read
+    // `(app && app.activeBuilding) || 'Hospital'` — with no active building it silently loaded
+    // HOSPITAL's ERP twin and attached its cost/phase figures to whatever model was on screen.
+    // No active building is a REAL state (an arbitrary IFC opened straight into the viewer) and
+    // the honest answer there is the one both functions already give a building with no C_Project
+    // row: no folded project. Skip, never guess — and skip BEFORE the 25.8MB ad_seed.db fetch.
+    var building = app && app.activeBuilding;
+    if (!building) { console.log('§TM_TWIN_NOBLD no active building — ERP twin skipped (never defaulted to another building\'s project)'); return Promise.resolve(null); }
     if (_twin && _twin.building === building) return Promise.resolve(_twin);   // cached for THIS building
     if (_twinMiss === building) return Promise.resolve(null);   // §PERF_NEG_CACHE — see _loadShopfloor
     if (_twinLoading) return Promise.resolve(null);                            // a load is in flight; caller retries
@@ -5842,7 +5849,8 @@
   // Same fetch/cache pattern as _loadTwin; closed over _shopfloor/_shopfloorLoading.
   function _loadShopfloor() {
     var app = A();
-    var building = (app && app.activeBuilding) || 'Hospital';
+    var building = app && app.activeBuilding;   // §S54 (item F2) — see _loadTwin: skip, never guess a building
+    if (!building) { console.log('§PERF_NEG_CACHE shopfloor no-building — skipped before the ad_seed.db fetch (not a cached miss: the miss cache is keyed by name and this state has none)'); return Promise.resolve(null); }
     if (_shopfloor && _shopfloor.building === building) return Promise.resolve(_shopfloor);
     // §PERF_NEG_CACHE: remember a MISS too. drawDash() calls this every tick behind
     // `if (!_shopfloor && !_shopfloorLoading)`, and every failure path below cleared the


### PR DESCRIPTION
`prompts/4D_GANTT_TM_REFACTOR.md` **§S54.2**, item **F2** — the last code item on the §S52.4 watchdog list. Base `a0885e2`.

## The bug

Both ERP-twin loaders in `time_machine.js` opened with:

```js
var building = (app && app.activeBuilding) || 'Hospital';
```

With no active building they did not skip — they loaded **Hospital's** ERP twin and attached its cost and phase figures to whatever model was on screen. This is the one real per-building hardcoding left in the 4D path; §S52.1 audited the rest clean (every other building name in the scheduler is a comment citing measured evidence, not a code branch).

## The fix

No active building is a **real state** — an arbitrary IFC opened straight into the viewer — and the honest answer there is the one both functions already give a building with no `C_Project` row: no folded project. Both now skip on a falsy `activeBuilding` and return `null` **before** the 25.8MB `ad_seed.db` fetch. Not a `_twinMiss` entry: that cache is keyed by building name and this state has none, so it is a skip, not a cached miss. Everything below the guard — the cache checks, the in-flight guards, the negative caches — is untouched, and a building that IS active behaves exactly as before.

## Witness

New `witness_tm_erp_twin_guard.js`, `pass=6 fail=0`. A guard like this rots quietly (nothing throws, no number goes red, the dashboard just shows another project's money), so it is asserted three ways: the resolved value, the **fetch count** (the guard must fire before the read, not after), and the source itself.

Restoring the exact pre-fix line takes it to **`pass=2 fail=4`** — `W-TET-1`/`W-TET-2` catch it at `fetches=1`/`fetches=2`, and `W-TET-4a/b` catch the literal. `W-TET-3a/b` is the control: with an active building both loaders still reach the fetch, so a guard that skipped unconditionally would not pass this file.

## F4 closed with evidence, no change

§S52.1 also listed `mep_qto_populate.js:19` as a hardcoded DB filename that "should take an argument". Re-read before touching: the tool **already** takes `[db_path ...]` (`:31-34`, `:83-85`), and `:19` is the first entry of a six-building default fleet used only when no path is passed. The audit read one line and inferred the rest. Nothing to change — recorded in §S54.1 so it is not re-discovered.

## Gates

`sw.js` `CACHE_VERSION` v1062 → **v1063** (`time_machine.js` changed). `audit_sw_precache.js` 121/121, `audit_script_tags.js` 146/146, `node --check` over all `viewer`+`modeller` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)