### PR TITLE
feat(4d): §S58 observability — the log lines that would have caught things

### DIFF
--- a/viewer/location_axis.js
+++ b/viewer/location_axis.js
@@ -55,7 +55,14 @@
     try {
       var pr = db.exec("SELECT COUNT(*), SUM(CASE WHEN space_guid NOT LIKE 'RM_%' THEN 1 ELSE 0 END) FROM rel_contained_in_space");
       if (pr.length) { var t = pr[0].values[0]; persisted.ifc = t[1] || 0; persisted.rm = t[0] - persisted.ifc; }
-    } catch (e) { /* no table — fine */ }
+    } catch (e) {
+      // §S58 (§S58.2): "no table" is the expected case, but this also swallows a REAL failure —
+      // and then §LOC_AXIS reports persistedRM=0 as if it had checked and found none, rather than
+      // "could not check." Only the unexpected shape is logged, so the normal case stays quiet.
+      if (!/no such table/i.test((e && e.message) || ''))
+        console.warn('§LOC_AXIS_PERSISTED_UNREADABLE rel_contained_in_space read failed — ' +
+          (e && e.message) + ' — persistedRM/ifc below read 0 because the check FAILED, not because it is empty');
+    }
     var rooms = [], suspects = 0, compileMs = 0, joinKey = null, byFloor = {};
     if (d.RW && d.RW.compileRooms && d.RW._makeJoinKey && d.RW._canonicalFloor) {
       var t0 = (typeof performance !== 'undefined' && performance.now) ? performance.now() : Date.now();

--- a/viewer/schedule_author.js
+++ b/viewer/schedule_author.js
@@ -114,7 +114,14 @@
       r = db.exec("SELECT m.ifc_class, COUNT(*), SUM(" + _AREA_EXPR + ") FROM elements_meta m " +
         "JOIN element_transforms t ON m.guid=t.guid WHERE t.bbox_x IS NOT NULL AND t.bbox_x>0 " +
         "AND m.ifc_class IN (" + q(m2Classes) + ") GROUP BY m.ifc_class");
-    } catch (e) { return out; }   // no element_transforms table (e.g. a stripped test DB) — degrade to count-based
+    } catch (e) {   // no element_transforms table (e.g. a stripped test DB) — degrade to count-based
+      // §S58 (§S58.2): this catch fires on ANY throw, not just the commented stripped-DB case, and
+      // silently reverts durations to count-based — the §LABOR_QUANTITY_WEIGHT fix just doesn't
+      // happen, with no trace. Behaviour unchanged; it is now VISIBLE.
+      console.warn('§LABOR_QUANTITY_WEIGHT_SKIP no area weighting — ' + (e && e.message) +
+        ' (durations fall back to count-based; not necessarily a stripped DB)');
+      return out;
+    }
     var fragClasses = [];
     if (r.length && r[0].values.length) {
       r[0].values.forEach(function (row) {
@@ -166,7 +173,13 @@
       r = db.exec("SELECT m.ifc_class, COUNT(*), SUM(" + LEN_EXPR + ") FROM elements_meta m " +
         "JOIN element_transforms t ON m.guid=t.guid WHERE t.bbox_x IS NOT NULL AND t.bbox_x>0 " +
         "AND m.ifc_class IN (" + q(mClasses) + ") GROUP BY m.ifc_class");
-    } catch (e) { return out; }   // no element_transforms table — degrade to flat (no weighting)
+    } catch (e) {   // no element_transforms table — degrade to flat (no weighting)
+      // §S58 (§S58.2): same silent-revert as above — §HEAVY_MEMBER_SPEED_LIMIT stops firing and
+      // per-element speed stops scaling with real size, invisibly. Behaviour unchanged, now visible.
+      console.warn('§HEAVY_MEMBER_SPEED_LIMIT_SKIP no length weighting — ' + (e && e.message) +
+        ' (durations fall back to flat per-class totals)');
+      return out;
+    }
     var haveClasses = [];
     if (r.length && r[0].values.length) {
       r[0].values.forEach(function (row) {
@@ -1011,7 +1024,14 @@
       if (r.length && r[0].values.length) r[0].values.forEach(function (row) {
         (adj[row[0]] = adj[row[0]] || []).push(row[1]);
       });
-    } catch (e) {}
+    } catch (e) {
+      // §S58 (§S58.2): this guard FAILS OPEN. With adj={} the DFS below finds nothing and
+      // wouldCycle() returns false for EVERY check — the sole guard against a cyclic (invalid)
+      // schedule is blind, and silently. The fail-open behaviour is NOT changed here (that is a
+      // separate decision with its own witness); this makes the blindness loud.
+      console.warn('§WOULD_CYCLE_BLIND task_sequences unreadable — ' + (e && e.message) +
+        ' — cycle detection is DISABLED for this call, every edge will be reported acyclic');
+    }
     var stack = [succId], seen = {};
     while (stack.length) {
       var cur = stack.pop();
@@ -1262,7 +1282,13 @@
         (preds[row[1]] = preds[row[1]] || []).push(e);
         (succs[row[0]] = succs[row[0]] || []).push(e);
       });
-    } catch (e) {}
+    } catch (e) {
+      // §S58 (§S58.2): on a throw, preds/succs stay empty and the cascade computes a move with NO
+      // predecessor clamp and NO successor cascade — indistinguishable in the log from "this task
+      // genuinely has no dependencies." Behaviour unchanged; the difference is now stated.
+      console.warn('§CASCADE_BLIND task_sequences unreadable — ' + (e && e.message) +
+        ' — this move runs with no predecessor clamp and no successor cascade');
+    }
 
     // ---- C2: clamp against this task's own predecessors.
     var want = _dayNum(newStart);

--- a/viewer/schedule_gate.js
+++ b/viewer/schedule_gate.js
@@ -150,15 +150,24 @@
   // caller can pair once and then compare whatever stage of the timeline it owns.
   function hostPairs(els) {
     var idx = {}, out = [], t, cs, c, e, k, bi;
+    // §S58 (§S58.1b): §HOSTED_BEFORE_HOST had NO log line anywhere — it is the fix for the reported
+    // "outlets and hanging elements appearing a bit early" bug, and §GEO_ORDER reported only
+    // hostEdges= (matches found), with no denominator and no count of hosted elements that fell
+    // through UNGUARDED to baseMs. Its own sibling §CURTAIN_WALL_OPENING already reports
+    // cwGated=/stillUngated=; this is the same shape. Counted here, reported by the caller.
+    var _hostedTotal = 0, _noCell = 0, _noNearest = 0;
     for (t = 0; t < els.length; t++) { e = els[t];
       if (!HOST_CLS.test(e.cls || '')) continue;
       cs = cellsOf(e); for (c = 0; c < cs.length; c++) (idx[cs[c]] = idx[cs[c]] || []).push(t); }
     for (t = 0; t < els.length; t++) { e = els[t];
       if (!isHosted(e)) continue;
-      k = idx[hostCellKey(e)]; if (!k) continue;
+      _hostedTotal++;
+      k = idx[hostCellKey(e)]; if (!k) { _noCell++; continue; }
       bi = nearestHostAt(e, k, els);
-      if (bi >= 0) out.push({ i: t, h: k[bi] });
+      if (bi >= 0) out.push({ i: t, h: k[bi] }); else _noNearest++;
     }
+    out.census = { hostedTotal: _hostedTotal, matched: out.length,
+                   fellThroughNoHostCell: _noCell, fellThroughNoNearest: _noNearest };
     return out;
   }
 
@@ -928,6 +937,16 @@
         (_cyc.length ? ' sample=[' + _cyc.slice(0, 5).map(function (x) { return elements[x].guid; }).join(',') + ']' : ''));
       console.log('§GEO_ORDER n=' + N + ' edges=' + _edges + ' hangNearest=' + _hangNearest +
         ' hostEdges=' + _hostEdges + ' orderMs=' + (Date.now() - _t0));
+      // §S58 (§S58.1b) — §HOSTED_BEFORE_HOST's own proof line. hostEdges above is the numerator
+      // only; this is the denominator and the miss breakdown, so "did the outlets-appear-early fix
+      // actually cover this building" is readable from the log instead of inferred. Same shape as
+      // §CURTAIN_WALL_OPENING's cwGated=/stillUngated=. matched+fellThrough == hostedTotal is an
+      // accounting identity a witness can assert, not a bare count.
+      var _hc = _hostPairs && _hostPairs.census;
+      if (_hc) console.log('§HOSTED_BEFORE_HOST hostedTotal=' + _hc.hostedTotal +
+        ' matched=' + _hc.matched + ' fellThrough=' + (_hc.fellThroughNoHostCell + _hc.fellThroughNoNearest) +
+        ' (noHostCell=' + _hc.fellThroughNoHostCell + ' noNearest=' + _hc.fellThroughNoNearest + ')' +
+        ' — fellThrough elements are gated at baseMs only, i.e. NOT held behind their host');
     }
     var nonst = elements.filter(function (e) { return e.seq > 4; });
     // §DEQ_V1 repair loop — the zero-contradiction guarantee. The gates above are only as good as

--- a/viewer/sw.js
+++ b/viewer/sw.js
@@ -8,7 +8,14 @@
 // Cache-first for heavy assets (.wasm, images). DB files skip SW (IndexedDB handles them).
 //
 // DEPLOY: bump CACHE_VERSION on every OCI upload. Old caches are purged on activate.
-const CACHE_VERSION = 'v1063';   // bump on each deploy; per-change detail is the git commit message.
+const CACHE_VERSION = 'v1064';   // bump on each deploy; per-change detail is the git commit message.
+// v1064 (2026-08-21) 4D_GANTT_TM_REFACTOR.md §S58 — observability hardening, ADDITIVE LOGGING
+// ONLY, no rule or behaviour changed. (a) the three §GANTT_* proof lines now fire on every
+// model REBUILD instead of once per building, so an edit is auditable (rebuild=N ordinal).
+// (b) NEW §HOSTED_BEFORE_HOST line — it had no log line at all; first run exposed Terminal
+// 268/2367 hosted elements (11.3%) falling through unguarded. (c) NEW §GANTT_AXIS line.
+// (d) five silent catches now warn: §LABOR_QUANTITY_WEIGHT_SKIP, §HEAVY_MEMBER_SPEED_LIMIT_SKIP,
+// §WOULD_CYCLE_BLIND, §CASCADE_BLIND, §LOC_AXIS_PERSISTED_UNREADABLE.
 // v1063 (2026-08-21) 4D_GANTT_TM_REFACTOR.md §S54 (item F2): time_machine.js's two ERP-twin
 // loaders (_loadTwin/_loadShopfloor) no longer default a missing activeBuilding to 'Hospital' —
 // with no active building they now skip BEFORE the 25.8MB ad_seed.db fetch instead of attaching

--- a/viewer/time_machine.js
+++ b/viewer/time_machine.js
@@ -145,6 +145,17 @@
       window.__tmGanttAxis = { axisStart: _ganttAxisStart, axisEnd: _ganttAxisEnd,
         projectStart: _projectStart, projectEnd: _projectEnd, n: r.n };
     } catch (e) {}
+    // §S58 (§S58.2): the qualified DISPLAY axis vs the true playback end was written to the debug
+    // hook above and NEVER logged, though §GANTT_AXIS_OUTLIER's own header names that exact
+    // difference as the cause of a prior bug class ("a bar's DATA could be correct while its DRAWN
+    // pixel position was still wrong"). A reader had to poke a global. Now it is a log line.
+    var _axD = 86400000;
+    console.log('§GANTT_AXIS n=' + r.n +
+      ' axisDays=' + (r.axisEnd != null ? ((r.axisEnd - r.axisStart) / _axD).toFixed(1) : 'n/a') +
+      ' trueDays=' + (r.projectEnd != null ? ((r.projectEnd - _projectStart) / _axD).toFixed(1) : 'n/a') +
+      ' qualifiedAway=' + (r.axisEnd != null && r.projectEnd != null
+        ? ((r.projectEnd - r.axisEnd) / _axD).toFixed(1) + 'd' : 'n/a') +
+      ' (display axis is Tukey-qualified; playback bounds are NOT — they must reach every element)');
   }
 
   // ── Scene: emerge from nothing ──
@@ -5665,7 +5676,8 @@
   }
 
   // ── Mini Gantt chart ──
-  var _ganttTasksComputed = false; // log once flag
+  var _ganttTasksComputed = false; // §S58: no longer gates the log lines; "has ever built" only
+  var _ganttRebuildN = 0;          // §S58: rebuild ordinal — N rebuilds per gesture is readable
 
   // ── §GANTT_BAR_IDENTITY (K0 — prompts/4D_SCHEDULE_PERFECTION.md §GANTT_EDIT) ──
   // The drawer used to derive its bars purely by grouping raw kernel_ops on storey|phase, yielding
@@ -6101,18 +6113,29 @@
     _ganttTasks = r.tasks;
     _ganttIdentified = r.identified; _ganttUnidentified = r.unidentified;
 
-    if (!_ganttTasksComputed) {
+    // §S58 (4D_GANTT_TM_REFACTOR.md §S58.1a): these three lines used to be gated on
+    // `_ganttTasksComputed`, a "log once flag" reset only at building-close — so they reported the
+    // FIRST build of a building and never again. But this function recomputes the whole model
+    // whenever `_ganttDirty` is set, i.e. after every drag, retime, group-move, link and undo,
+    // which is exactly when a reader needs the numbers. A drag that duplicated bars, reordered
+    // phases or flipped the editable/non-editable mix was invisible in the log for the rest of the
+    // session. Now reported on every real REBUILD. NOT per-frame: the `!_ganttDirty` early-return
+    // above means a redraw with an unchanged model logs nothing.
+    {
+      _ganttRebuildN++;
       var _idBars = 0;
       for (var bi = 0; bi < _ganttTasks.length; bi++) if (_ganttTasks[bi].taskId) _idBars++;
-      console.log('§GANTT_MINI tasks=' + _ganttTasks.length);
+      console.log('§GANTT_MINI tasks=' + _ganttTasks.length + ' rebuild=' + _ganttRebuildN);
       // K0 proof line: how many bars carry a real tasks.task_id (i.e. are addressable by the edit
       // verbs) vs how many are still the un-authored storey|phase fallback. editable=0 means no
       // authored schedule exists for this building, NOT that the join failed.
       // K1 proof line: the row order actually drawn, so "is substructure first" is checkable from the
       // log instead of from a screenshot.
-      console.log('§GANTT_ROW_ORDER phases=' + JSON.stringify(_ganttTasks.map(function (t) { return t.phase; })
+      console.log('§GANTT_ROW_ORDER rebuild=' + _ganttRebuildN + ' phases=' +
+        JSON.stringify(_ganttTasks.map(function (t) { return t.phase; })
         .filter(function (p, i, arr) { return i === 0 || arr[i - 1] !== p; })));
-      console.log('§GANTT_BAR_IDENTITY schedule=' + ((_taskIndex && _taskIndex.scheduleId) || 'none') +
+      console.log('§GANTT_BAR_IDENTITY rebuild=' + _ganttRebuildN +
+        ' schedule=' + ((_taskIndex && _taskIndex.scheduleId) || 'none') +
         ' bars=' + _ganttTasks.length + ' editable=' + _idBars +
         ' opsWithTask=' + _ganttIdentified + ' opsWithout=' + _ganttUnidentified +
         ' modelTasks=' + ((_taskIndex && _taskIndex.n) || 0));
@@ -8270,7 +8293,7 @@
     _sCurveData = null;
     _shopfloor = null; _shopfloorLoading = false;    // §E2b: invalidate shopfloor cache on building change
     _ganttTasks = [];
-    _ganttTasksComputed = false;
+    _ganttTasksComputed = false; _ganttRebuildN = 0;   // §S58: ordinal is per building
     invalidateGanttModel();   // K0: building changed → drop the cached task index + bar rollup
     var ganttBtn = document.getElementById('tm-gantt');
     if (ganttBtn) ganttBtn.classList.remove('tm-active');


### PR DESCRIPTION
`prompts/4D_GANTT_TM_REFACTOR.md` **§S58**. **Additive logging only** — no rule, no behaviour, no fail-open changed. Every claim was scouted, then verified first-hand on `origin/main` before any edit. Base `cab9ad5`.

Both headline gaps sit exactly on the two acceptance goals for this lane.

## (a) The Gantt's three proof lines fired ONCE PER BUILDING, ever — so every EDIT was unlogged

`_ganttTasksComputed` (its own comment: *"log once flag"*) gated `§GANTT_MINI` / `§GANTT_ROW_ORDER` / `§GANTT_BAR_IDENTITY`, and was reset only at building-close. But `buildGanttTasks()` recomputes the whole model whenever `_ganttDirty` is set — after every drag, retime, group-move, link and undo. **That is the "Gantt editable, timeline updated" goal with no proof line on the edit path**: a drag that duplicated bars, reordered phases, or flipped the editable/non-editable identity mix was invisible in the log for the rest of the session.

Now reported on every real rebuild, with a `rebuild=N` ordinal so N rebuilds per gesture is readable. **Not per-frame** — the `!_ganttDirty` early-return means an unchanged redraw logs nothing.

## (b) `§HOSTED_BEFORE_HOST` had no log line at all — and the first run found something

`grep -c "console.log('§HOSTED_BEFORE_HOST"` was **0**, despite it being the fix for the reported *"electrical outlets and hanging elements appearing a bit early"* bug. `§GEO_ORDER` reported `hostEdges=` — the numerator — with no denominator and no count of hosted elements that fell through unguarded. Its sibling `§CURTAIN_WALL_OPENING` already reports `cwGated=`/`stillUngated=`; this is the same shape.

First run, real buildings:

| building | hostedTotal | matched | fellThrough |
|---|---|---|---|
| Hospital | 2,877 | 2,830 | **47** (1.6%) |
| **Terminal** | 2,367 | 2,099 | **268 (11.3%)** |
| Clinic | 2,742 | 2,737 | **5** (0.2%) |

Every fall-through is `noNearest` — the host cell was found, no nearest host matched. Those elements are gated at `baseMs` only, i.e. **not held behind their host**. Terminal's 268 are the "appearing early" symptom class, and they were unmeasurable until this line existed. **Reported, not chased.**

## (c) New `§GANTT_AXIS` line

The Tukey-qualified display axis vs the true playback bounds was written to `window.__tmGanttAxis` and never logged — though `§GANTT_AXIS_OUTLIER`'s own header names that exact difference as the cause of a prior bug class (*"a bar's DATA could be correct while its DRAWN pixel position was still wrong"*). A reader had to poke a global.

## (d) Five silent catches now warn

Behaviour unchanged; the blindness is made loud. `§LABOR_QUANTITY_WEIGHT_SKIP` and `§HEAVY_MEMBER_SPEED_LIMIT_SKIP` (durations silently revert to count/flat, so a measured realism fix just doesn't fire), `§WOULD_CYCLE_BLIND` (**the sole guard against a cyclic schedule fails OPEN** — with an empty adjacency it returns "no cycle" for every check), `§CASCADE_BLIND` (a move computes with no predecessor clamp, logged identically to "no dependencies"), `§LOC_AXIS_PERSISTED_UNREADABLE` (reported 0 as if it had checked).

Making fail-open into fail-closed is a **separate decision with its own witness** — this PR is the visible half, which is the cheap half and the honest order.

## Gates

`sw.js` `CACHE_VERSION` v1063 to **v1064**. `node --check` over all `viewer`+`modeller`, `audit_sw_precache.js` 121/121, `audit_script_tags.js` 146/146, eslint clean on every touched file. `witness_s55_identity_vs_cell.js` re-run `pass=18 fail=0` with the new lines present in its log.

**Owed, named:** the §S58.3 witness (W-S58-1..5, including inducing each catch to prove the warn fires) is not in this PR — pushed now so the new lines are live-testable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)