### PR TITLE
feat(readiness): OpenBIM Readiness Assessment Toolkit — UI mockup for review

### DIFF
--- a/readiness/index.html
+++ b/readiness/index.html
@@ -1,0 +1,698 @@
+<title>OpenBIM Readiness Toolkit</title>
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Instrument+Sans:wght@400;500;600;700&family=IBM+Plex+Mono:wght@400;500;600&display=swap">
+
+<style>
+:root{
+  --ink:#131e1b; --ink-2:#3a4a45; --muted:#6b7d78; --faint:#9aaba6;
+  --paper:#f5f7f5; --surface:#ffffff; --surface-2:#eaefed; --surface-3:#dfe6e3;
+  --rule:#d3dcd9; --rule-soft:#e4e9e7;
+  --accent:#00897b; --accent-ink:#00695f; --accent-wash:#e0efec;
+  --warn:#a06a00; --warn-wash:#f7efdd;
+  --focus:#00897b;
+  --shadow:0 1px 2px rgba(19,30,27,.05),0 8px 24px -14px rgba(19,30,27,.18);
+}
+@media (prefers-color-scheme:dark){
+  :root:not([data-theme="light"]){
+    --ink:#e9efed; --ink-2:#c3d0cc; --muted:#93a5a0; --faint:#6d7f7a;
+    --paper:#0f1816; --surface:#182421; --surface-2:#1f2d29; --surface-3:#273733;
+    --rule:#2d3e39; --rule-soft:#22302c;
+    --accent:#1f9d87; --accent-ink:#4fc9b0; --accent-wash:#14312b;
+    --warn:#b1811f; --warn-wash:#2f2612;
+    --focus:#4fc9b0;
+    --shadow:0 1px 2px rgba(0,0,0,.35),0 10px 28px -16px rgba(0,0,0,.7);
+  }
+}
+:root[data-theme="dark"]{
+  --ink:#e9efed; --ink-2:#c3d0cc; --muted:#93a5a0; --faint:#6d7f7a;
+  --paper:#0f1816; --surface:#182421; --surface-2:#1f2d29; --surface-3:#273733;
+  --rule:#2d3e39; --rule-soft:#22302c;
+  --accent:#1f9d87; --accent-ink:#4fc9b0; --accent-wash:#14312b;
+  --warn:#b1811f; --warn-wash:#2f2612;
+  --focus:#4fc9b0;
+  --shadow:0 1px 2px rgba(0,0,0,.35),0 10px 28px -16px rgba(0,0,0,.7);
+}
+
+*{box-sizing:border-box}
+body{
+  margin:0;background:var(--paper);color:var(--ink);
+  font-family:"Instrument Sans",-apple-system,"Segoe UI",Helvetica,Arial,sans-serif;
+  font-size:16px;line-height:1.55;-webkit-font-smoothing:antialiased;
+}
+.mono,.num{font-family:"IBM Plex Mono",ui-monospace,Menlo,monospace;font-variant-numeric:tabular-nums}
+h1,h2,h3{margin:0;text-wrap:balance;letter-spacing:-.02em}
+p{margin:0}
+button{font:inherit;color:inherit}
+:focus-visible{outline:2px solid var(--focus);outline-offset:2px;border-radius:3px}
+
+/* ---- MOCKUP BANNER ---- */
+.mockbar{
+  background:var(--warn-wash);border-bottom:1px solid var(--warn);
+  padding:7px 16px;font-family:"IBM Plex Mono",monospace;font-size:11px;
+  letter-spacing:.09em;text-transform:uppercase;color:var(--warn);
+  display:flex;gap:12px;align-items:center;justify-content:center;flex-wrap:wrap;text-align:center
+}
+
+/* ---- SHELL ---- */
+.shell{max-width:820px;margin:0 auto;padding:0 22px 80px}
+
+.topbar{display:flex;align-items:center;gap:14px;padding:20px 0 0;flex-wrap:wrap}
+.brandmark{
+  width:30px;height:30px;border-radius:6px;background:var(--accent);flex:none;
+  display:grid;place-items:center;color:#fff;font-weight:700;font-size:13px;
+  font-family:"IBM Plex Mono",monospace
+}
+:root[data-theme="dark"] .brandmark,
+:root:not([data-theme="light"]) .brandmark{color:#0f1816}
+@media (prefers-color-scheme:light){:root:not([data-theme="dark"]) .brandmark{color:#fff}}
+.brandtext{font-size:14px;font-weight:600;letter-spacing:-.01em;line-height:1.25}
+.brandtext small{display:block;font-weight:400;font-size:11.5px;color:var(--muted);letter-spacing:0}
+.topspacer{flex:1}
+.ghostbtn{
+  background:transparent;border:1px solid var(--rule);border-radius:6px;
+  padding:6px 11px;font-size:13px;cursor:pointer;color:var(--ink-2)
+}
+.ghostbtn:hover{background:var(--surface-2);border-color:var(--accent);color:var(--accent-ink)}
+
+/* ---- PROGRESS RAIL ---- */
+.rail{display:flex;gap:5px;margin:20px 0 0;list-style:none;padding:0}
+.rail li{flex:1;height:3px;border-radius:2px;background:var(--rule);transition:background .2s}
+.rail li.done{background:var(--accent)}
+.rail li.now{background:var(--accent);opacity:.45}
+.railcap{
+  display:flex;justify-content:space-between;margin-top:8px;
+  font-family:"IBM Plex Mono",monospace;font-size:10.5px;letter-spacing:.08em;
+  text-transform:uppercase;color:var(--muted)
+}
+
+/* ---- SCREENS ---- */
+.screen{display:none;padding-top:30px}
+.screen.on{display:block;animation:fade .22s ease}
+@keyframes fade{from{opacity:0;transform:translateY(5px)}to{opacity:1;transform:none}}
+@media (prefers-reduced-motion:reduce){*{animation:none!important;transition:none!important}}
+
+.eyebrow{
+  font-family:"IBM Plex Mono",monospace;font-size:11px;letter-spacing:.13em;
+  text-transform:uppercase;color:var(--accent-ink);font-weight:600;margin-bottom:14px
+}
+h1{font-size:clamp(27px,4.6vw,38px);line-height:1.12;font-weight:700}
+h2{font-size:21px;font-weight:600;line-height:1.25}
+h3{font-size:15.5px;font-weight:600}
+.sub{font-size:17px;color:var(--ink-2);margin-top:14px;max-width:56ch}
+.small{font-size:14px;color:var(--muted)}
+
+.card{
+  background:var(--surface);border:1px solid var(--rule);border-radius:9px;
+  padding:20px 22px;margin:22px 0;box-shadow:var(--shadow)
+}
+.card.flat{box-shadow:none}
+.card.formal{border-left:3px solid var(--accent)}
+.card p + p{margin-top:12px}
+
+.actions{display:flex;gap:10px;margin-top:26px;flex-wrap:wrap;align-items:center}
+.btn{
+  background:var(--accent);color:#fff;border:1px solid var(--accent);
+  border-radius:7px;padding:11px 20px;font-size:15px;font-weight:600;cursor:pointer
+}
+:root[data-theme="dark"] .btn,:root:not([data-theme="light"]) .btn{color:#0f1816}
+@media (prefers-color-scheme:light){:root:not([data-theme="dark"]) .btn{color:#fff}}
+.btn:hover{filter:brightness(1.08)}
+.btn.sec{background:transparent;color:var(--ink-2);border-color:var(--rule)}
+.btn.sec:hover{background:var(--surface-2);filter:none;border-color:var(--accent)}
+.btn.sm{padding:8px 14px;font-size:13.5px}
+
+/* ---- FIELDS ---- */
+.field{margin:18px 0}
+.field > label,.qhead{
+  display:flex;gap:8px;align-items:flex-start;
+  font-size:14.5px;font-weight:600;margin-bottom:9px;line-height:1.4
+}
+.qid{
+  font-family:"IBM Plex Mono",monospace;font-size:11px;color:var(--accent-ink);
+  background:var(--accent-wash);border-radius:3px;padding:2px 6px;flex:none;margin-top:1px;font-weight:600
+}
+select,input[type=text]{
+  width:100%;background:var(--surface);color:var(--ink);
+  border:1px solid var(--rule);border-radius:7px;padding:10px 12px;font:inherit;font-size:15px
+}
+select:hover,input[type=text]:hover{border-color:var(--accent)}
+.grid2{display:grid;grid-template-columns:repeat(auto-fit,minmax(230px,1fr));gap:16px}
+
+/* pill radios (firm size etc) */
+.pills{display:flex;flex-wrap:wrap;gap:7px}
+.pills input{position:absolute;opacity:0;pointer-events:none}
+.pills label{
+  border:1px solid var(--rule);border-radius:20px;padding:7px 14px;
+  font-size:13.5px;cursor:pointer;background:var(--surface);color:var(--ink-2)
+}
+.pills label:hover{border-color:var(--accent)}
+.pills input:checked + label{background:var(--accent-wash);border-color:var(--accent);color:var(--accent-ink);font-weight:600}
+.pills input:focus-visible + label{outline:2px solid var(--focus);outline-offset:2px}
+
+/* level radio list */
+.opts{display:flex;flex-direction:column;gap:1px;background:var(--rule);border:1px solid var(--rule);border-radius:8px;overflow:hidden}
+.opts input{position:absolute;opacity:0;pointer-events:none}
+.opts label{
+  display:grid;grid-template-columns:30px 18px 1fr;gap:11px;align-items:start;
+  background:var(--surface);padding:11px 14px;cursor:pointer;font-size:14.5px;color:var(--ink-2)
+}
+.opts label:hover{background:var(--surface-2)}
+.opts .lv{font-family:"IBM Plex Mono",monospace;font-size:11px;color:var(--faint);font-weight:600;padding-top:3px}
+.opts .dot{width:15px;height:15px;border:1.5px solid var(--rule);border-radius:50%;margin-top:2px}
+.opts input:checked + label{background:var(--accent-wash);color:var(--ink);font-weight:500}
+.opts input:checked + label .dot{border-color:var(--accent);border-width:4.5px}
+.opts input:checked + label .lv{color:var(--accent-ink)}
+.opts input:focus-visible + label{outline:2px solid var(--focus);outline-offset:-2px}
+
+/* checkbox rows */
+.chk{display:flex;gap:10px;align-items:flex-start;font-size:14.5px;color:var(--ink-2);cursor:pointer;margin:9px 0}
+.chk input{width:16px;height:16px;margin:2px 0 0;accent-color:var(--accent);flex:none}
+
+/* ---- TOOLTIP ---- */
+.tip{position:relative;display:inline-flex;flex:none;margin-top:1px}
+.tipbtn{
+  width:17px;height:17px;border-radius:50%;border:1px solid var(--rule);
+  background:var(--surface-2);color:var(--muted);font-size:11px;font-weight:700;
+  cursor:pointer;display:grid;place-items:center;padding:0;line-height:1
+}
+.tipbtn:hover{border-color:var(--accent);color:var(--accent-ink)}
+.tipbody{
+  display:none;position:absolute;z-index:40;top:24px;left:-8px;width:min(310px,78vw);
+  background:var(--surface);border:1px solid var(--accent);border-radius:8px;
+  padding:13px 15px;box-shadow:var(--shadow);font-size:13.5px;font-weight:400;
+  color:var(--ink-2);line-height:1.5;text-align:left
+}
+.tip.open .tipbody{display:block}
+.tipbody .anchor{
+  display:block;margin-top:9px;padding-top:9px;border-top:1px solid var(--rule-soft);
+  font-family:"IBM Plex Mono",monospace;font-size:10.5px;letter-spacing:.05em;
+  text-transform:uppercase;color:var(--muted)
+}
+
+/* ---- DROPZONE ---- */
+.drop{
+  border:2px dashed var(--rule);border-radius:10px;padding:34px 22px;text-align:center;
+  background:var(--surface);cursor:pointer
+}
+.drop:hover{border-color:var(--accent);background:var(--accent-wash)}
+.drop .big{font-size:16px;font-weight:600;margin-bottom:5px}
+.drop.filled{border-style:solid;border-color:var(--accent);text-align:left;padding:18px 20px}
+
+/* ---- PAYLOAD ---- */
+pre.payload{
+  margin:0;background:var(--surface-2);border:1px solid var(--rule);border-radius:7px;
+  padding:14px 16px;overflow-x:auto;font-family:"IBM Plex Mono",monospace;
+  font-size:12px;line-height:1.65;color:var(--ink-2)
+}
+
+/* ---- METRIC GRID ---- */
+.mgrid{display:grid;grid-template-columns:repeat(auto-fit,minmax(158px,1fr));gap:1px;background:var(--rule);border:1px solid var(--rule);border-radius:8px;overflow:hidden}
+.mcell{background:var(--surface);padding:13px 15px}
+.mcell dt{font-family:"IBM Plex Mono",monospace;font-size:10px;letter-spacing:.09em;text-transform:uppercase;color:var(--muted);margin-bottom:6px}
+.mcell dd{margin:0;font-size:17px;font-weight:600;font-variant-numeric:tabular-nums}
+.mcell dd .unit{font-size:12.5px;font-weight:400;color:var(--muted);margin-left:3px}
+.mcell.flag dd{color:var(--warn)}
+
+/* ---- CHART ---- */
+.chart{margin:20px 0 6px}
+.crow{display:grid;grid-template-columns:132px 1fr 42px;gap:13px;align-items:center;padding:7px 0}
+.crow .cname{font-size:14px;font-weight:500;text-align:right;color:var(--ink-2);line-height:1.25}
+.ctrack{position:relative;height:19px;background:var(--surface-3);border-radius:4px}
+.cbar{position:absolute;left:0;top:0;bottom:0;background:var(--accent);border-radius:4px}
+.cclaim{position:absolute;top:-4px;bottom:-4px;width:2px;background:var(--ink);border-radius:1px}
+.cclaim::after{
+  content:"";position:absolute;top:-3px;left:-3px;
+  border-left:4px solid transparent;border-right:4px solid transparent;border-top:5px solid var(--ink)
+}
+.crow .cval{font-family:"IBM Plex Mono",monospace;font-size:13.5px;font-weight:600;font-variant-numeric:tabular-nums}
+.cscale{display:grid;grid-template-columns:132px 1fr 42px;gap:13px;margin-top:4px}
+.cticks{display:flex;justify-content:space-between;font-family:"IBM Plex Mono",monospace;font-size:10.5px;color:var(--faint)}
+.clegend{
+  display:flex;gap:18px;flex-wrap:wrap;margin-top:14px;padding-top:13px;
+  border-top:1px solid var(--rule-soft);font-size:12.5px;color:var(--muted)
+}
+.clegend span{display:flex;gap:7px;align-items:center}
+.swatch{width:13px;height:11px;border-radius:3px;background:var(--accent);flex:none}
+.swtick{width:2px;height:13px;background:var(--ink);flex:none}
+
+/* ---- DELTA ---- */
+.delta{
+  background:var(--warn-wash);border:1px solid var(--warn);border-radius:8px;
+  padding:15px 17px;margin:13px 0;display:grid;grid-template-columns:auto 1fr;gap:13px
+}
+.delta .ic{
+  width:21px;height:21px;border-radius:50%;background:var(--warn);color:var(--paper);
+  display:grid;place-items:center;font-size:13px;font-weight:700;flex:none
+}
+.delta h4{margin:0 0 5px;font-size:14.5px;font-weight:600;color:var(--warn)}
+.delta p{font-size:14px;color:var(--ink-2)}
+.delta .vs{display:flex;gap:20px;margin-top:10px;flex-wrap:wrap;font-size:13px}
+.delta .vs b{display:block;font-family:"IBM Plex Mono",monospace;font-size:11px;color:var(--muted);font-weight:500;letter-spacing:.06em;text-transform:uppercase}
+
+/* ---- FIX LIST ---- */
+.fixes{list-style:none;padding:0;margin:16px 0;counter-reset:f}
+.fixes li{
+  counter-increment:f;display:grid;grid-template-columns:27px 1fr;gap:13px;
+  padding:13px 0;border-bottom:1px solid var(--rule-soft);align-items:start
+}
+.fixes li:last-child{border-bottom:none}
+.fixes li::before{
+  content:counter(f);font-family:"IBM Plex Mono",monospace;font-size:12px;font-weight:600;
+  color:var(--accent-ink);background:var(--accent-wash);border-radius:5px;
+  height:23px;display:grid;place-items:center
+}
+.fixes h4{margin:0 0 3px;font-size:14.5px;font-weight:600}
+.fixes p{font-size:13.5px;color:var(--muted)}
+
+/* ---- INDICES ---- */
+.idx2{display:grid;grid-template-columns:repeat(auto-fit,minmax(215px,1fr));gap:14px;margin:18px 0}
+.ix{background:var(--surface);border:1px solid var(--rule);border-radius:8px;padding:16px 18px}
+.ix .who{font-family:"IBM Plex Mono",monospace;font-size:10px;letter-spacing:.09em;text-transform:uppercase;color:var(--muted)}
+.ix .v{font-size:27px;font-weight:700;font-variant-numeric:tabular-nums;margin:7px 0 2px}
+.ix .v small{font-size:14px;font-weight:400;color:var(--muted)}
+.ix p{font-size:13px;color:var(--ink-2);margin-top:6px}
+
+table.tv{width:100%;border-collapse:collapse;font-size:13.5px;margin-top:10px}
+table.tv th,table.tv td{text-align:left;padding:8px 10px;border-bottom:1px solid var(--rule-soft)}
+table.tv th{font-size:10.5px;letter-spacing:.08em;text-transform:uppercase;color:var(--muted);font-weight:600}
+table.tv td.n{font-family:"IBM Plex Mono",monospace;font-variant-numeric:tabular-nums}
+details.tvwrap{margin-top:16px}
+details.tvwrap summary{cursor:pointer;font-size:13.5px;color:var(--accent-ink);font-weight:500}
+
+@media (max-width:600px){
+  .crow,.cscale{grid-template-columns:96px 1fr 38px;gap:9px}
+  .crow .cname{font-size:12.5px}
+  .opts label{grid-template-columns:26px 16px 1fr;gap:8px;font-size:14px}
+}
+</style>
+
+<div class="mockbar" id="mockbar">
+  <span>⚠ Mockup for review — canned data, nothing wired</span>
+  <span>·</span>
+  <span>v0.1 · 2026-08-21</span>
+</div>
+
+<div class="shell">
+
+  <div class="topbar">
+    <div class="brandmark">OB</div>
+    <div class="brandtext">OpenBIM Readiness Assessment Toolkit<small>Research instrument · v0.1 draft</small></div>
+    <div class="topspacer"></div>
+    <button class="ghostbtn" id="themebtn" type="button">Theme</button>
+    <button class="ghostbtn" id="helpbtn" type="button">? Read more</button>
+  </div>
+
+  <ul class="rail" id="rail" hidden>
+    <li data-step="1"></li><li data-step="2"></li><li data-step="3"></li>
+    <li data-step="4"></li><li data-step="5"></li>
+  </ul>
+  <div class="railcap" id="railcap" hidden><span id="railnow">About you</span><span id="railpct">Step 1 of 5</span></div>
+
+  <div id="screens"></div>
+
+</div>
+
+<script>
+/* ============================================================
+   MOCKUP ONLY — canned data, no scoring, no parsing, no network.
+   Real logic specified in SCORING_SPEC.md; wiring comes later.
+   ============================================================ */
+
+var TIP = function (text, anchor) {
+  return '<span class="tip"><button class="tipbtn" type="button" aria-label="Why we ask this">?</button>' +
+    '<span class="tipbody">' + text +
+    (anchor ? '<span class="anchor">Anchor · ' + anchor + '</span>' : '') + '</span></span>';
+};
+
+var LV = ['L0', 'L1', 'L2', 'L3', 'L4'];
+function opts(name, list) {
+  return '<div class="opts">' + list.map(function (t, i) {
+    return '<input type="radio" name="' + name + '" id="' + name + i + '"' + (i === 1 ? ' checked' : '') + '>' +
+      '<label for="' + name + i + '"><span class="lv">' + LV[i] + '</span><span class="dot"></span><span>' + t + '</span></label>';
+  }).join('') + '</div>';
+}
+function q(id, title, tip, anchor, list) {
+  return '<div class="field"><div class="qhead"><span class="qid">' + id + '</span><span>' + title + '</span>' +
+    TIP(tip, anchor) + '</div>' + opts(id, list) + '</div>';
+}
+
+/* ---------- CANNED RESULTS ---------- */
+var DIMS = [
+  { name: 'Governance',        measured: 1.8, claimed: 2.0 },
+  { name: 'People & skills',   measured: 1.3, claimed: 1.5 },
+  { name: 'Technology',        measured: 2.3, claimed: 2.5 },
+  { name: 'Data & standards',  measured: 0.9, claimed: 2.8 },
+  { name: 'Process',           measured: 1.5, claimed: 1.8 }
+];
+
+var SCREENS = {};
+
+/* ---------- 1 · INTRO ---------- */
+SCREENS.intro =
+  '<p class="eyebrow">Research instrument · open access</p>' +
+  '<h1>You&rsquo;re expected to deliver open BIM.<br>Nothing tells you whether you&rsquo;re ready.</h1>' +
+  '<p class="sub">Twenty questions about how your firm works, plus one IFC file we read inside your browser. ' +
+  'You get a checklist of what to fix, in order.</p>' +
+
+  '<div class="card formal">' +
+    '<p><strong>This OpenBIM Readiness Assessment Toolkit</strong> is a research instrument that measures an ' +
+    'organisation&rsquo;s readiness to adopt open BIM standards across five dimensions &mdash; governance, people and ' +
+    'skills, technology, data and standards, and process &mdash; combining self-reported organisational evidence ' +
+    'with metrics computed directly from your own IFC model.</p>' +
+    '<p class="small">It measures readiness and model data quality. It does not certify regulatory compliance, ' +
+    'and no software does so in any jurisdiction.</p>' +
+  '</div>' +
+
+  '<div class="card">' +
+    '<h3>Before you start</h3>' +
+    '<p class="small" style="margin-top:9px">It takes about fifteen minutes. Your IFC file is read inside your ' +
+    'browser and is never uploaded &mdash; you can see exactly what would leave your device at any point.</p>' +
+    '<label class="chk" style="margin-top:14px"><input type="checkbox" checked>' +
+      '<span>Answer anonymously. No name, firm, email, or project details are collected.</span></label>' +
+    '<label class="chk"><input type="checkbox">' +
+      '<span>Include my (anonymous) results in the industry benchmark, so I can see how I compare.</span></label>' +
+  '</div>' +
+
+  '<div class="actions">' +
+    '<button class="btn" data-go="context">Start assessment</button>' +
+    '<button class="btn sec" data-go="results">Skip to sample results</button>' +
+  '</div>';
+
+/* ---------- 2 · CONTEXT ---------- */
+SCREENS.context =
+  '<p class="eyebrow">Step 1 of 5 · About you</p>' +
+  '<h2>A little context</h2>' +
+  '<p class="sub small">None of this identifies you. It selects the right rules for your jurisdiction and ' +
+  'places you in a comparable group.</p>' +
+
+  '<div class="card">' +
+    '<div class="grid2">' +
+      '<div class="field"><label for="c1">Country <span class="small">&mdash; sets your locale pack</span></label>' +
+        '<select id="c1">' +
+          '<option>Malaysia</option><option selected>United Arab Emirates</option>' +
+          '<option>Singapore</option><option>United Kingdom</option>' +
+          '<option>Australia</option><option>Other &mdash; drafted live, marked provisional</option>' +
+        '</select></div>' +
+      '<div class="field"><label for="c4">Type of firm</label>' +
+        '<select id="c4">' +
+          '<option>Architecture</option><option selected>Engineering (structural / MEP)</option>' +
+          '<option>Contractor</option><option>Developer / owner</option>' +
+          '<option>Facilities management</option><option>Multidisciplinary consultant</option>' +
+        '</select></div>' +
+    '</div>' +
+
+    '<div class="field"><label>Firm size</label><div class="pills">' +
+      ['1', '2–10', '11–50', '51–200', '200+'].map(function (s, i) {
+        return '<input type="radio" name="c2" id="c2' + i + '"' + (i === 2 ? ' checked' : '') + '>' +
+               '<label for="c2' + i + '">' + s + '</label>';
+      }).join('') + '</div></div>' +
+
+    '<div class="field"><label for="c3">Your role</label>' +
+      '<select id="c3">' +
+        '<option>Principal / owner</option><option selected>Technical or BIM lead</option>' +
+        '<option>Project manager</option><option>Designer / engineer</option>' +
+        '<option>Owner-side / facilities</option><option>Other</option>' +
+      '</select></div>' +
+
+    '<div class="field"><label for="c6">In one sentence, what made you open this? ' +
+      '<span class="small">&mdash; optional, stays on your device</span></label>' +
+      '<input type="text" id="c6" value="A client has started asking for IFC and we are not sure we can deliver it."></div>' +
+  '</div>' +
+
+  '<div class="actions">' +
+    '<button class="btn" data-go="assess">Continue</button>' +
+    '<button class="btn sec" data-go="intro">Back</button>' +
+  '</div>';
+
+/* ---------- 3 · ASSESSMENT ---------- */
+SCREENS.assess =
+  '<p class="eyebrow">Step 2 of 5 · Governance &nbsp;·&nbsp; 1 of 5 sections</p>' +
+  '<h2>How your firm is set up</h2>' +
+  '<p class="sub small">Each question asks about the <strong>last real instance</strong>, not general practice. ' +
+  'There is no right answer here &mdash; only an accurate one.</p>' +
+
+  '<div class="card">' +
+    q('A1', 'Is there a written position on open / IFC deliverables?',
+      'A policy that exists but is never checked behaves differently from one that is enforced. We are separating those two, not judging either.',
+      'ISO 19650 · organisational information requirements',
+      ['Nothing, and it has not come up',
+       'Discussed, nothing written',
+       'Written into a policy or BEP template',
+       'Written, someone owns it, checked on projects',
+       'As above, and non-compliance is escalated']) +
+
+    q('A2', 'Your most recent contract &mdash; what did it say about deliverable format?',
+      'Naming IFC and naming a schema version are different commitments. The second is checkable; the first often is not.',
+      'ISO 19650 · exchange information requirements',
+      ['Did not mention format, or I don’t know',
+       'Named native files only',
+       'Named IFC among the deliverables',
+       'Named IFC with a schema version',
+       'Named IFC with schema and a validation criterion']) +
+
+    q('A3', 'Have you ever taken a finished model out of your BIM software and opened it elsewhere?',
+      '&ldquo;We own our data&rdquo; is a belief until somebody has actually pulled a model out and opened it somewhere else. This is the single strongest signal of lock-in exposure.',
+      'Vendor lock-in · data portability',
+      ['Never tried',
+       'Tried, it did not work',
+       'Once, roughly worked, not repeated',
+       'Done on delivery and the result is checked',
+       'Routine, archived vendor-neutrally, re-opened periodically']) +
+
+    q('A4', 'For authority submission, what do you actually hand over?',
+      'Submission requirements vary by jurisdiction &mdash; your locale pack adjusts this question. If model-based submission does not exist where you work, choose N/A and it is excluded from scoring rather than counted as a zero.',
+      'Locale pack · UAE authority submission',
+      ['Paper or PDF drawings only',
+       'Native model files',
+       'IFC alongside other formats',
+       'IFC to a schema the authority named',
+       'IFC that passes the authority’s validation first']) +
+
+    '<p class="small" style="margin-top:20px;padding-top:16px;border-top:1px solid var(--rule-soft)">' +
+    'Remaining sections: People &amp; skills · Technology · Data &amp; standards · Process &mdash; four questions each. ' +
+    '<em>Not built in this mockup.</em></p>' +
+  '</div>' +
+
+  '<div class="actions">' +
+    '<button class="btn" data-go="model">Continue to model check</button>' +
+    '<button class="btn sec" data-go="context">Back</button>' +
+  '</div>';
+
+/* ---------- 4 · MODEL ---------- */
+SCREENS.model =
+  '<p class="eyebrow">Step 3 of 5 · Your model</p>' +
+  '<h2>Now let&rsquo;s look at an actual file</h2>' +
+  '<p class="sub small">This is the part a questionnaire cannot do. We read the file here, in your browser, and ' +
+  'compare what it contains against what you just told us. <strong>The file is never uploaded.</strong></p>' +
+
+  '<div class="drop filled" id="drop">' +
+    '<div style="display:flex;gap:13px;align-items:center;flex-wrap:wrap">' +
+      '<div class="brandmark" style="background:var(--accent-wash);color:var(--accent-ink)">IFC</div>' +
+      '<div style="flex:1;min-width:170px">' +
+        '<div style="font-weight:600;font-size:15px">Tower_ARC_Rev04.ifc</div>' +
+        '<div class="small mono">IFC2X3 · 84.2 MB · read locally · 12,847 elements</div>' +
+      '</div>' +
+      '<button class="btn sec sm" type="button">Choose a different file</button>' +
+    '</div>' +
+  '</div>' +
+
+  '<div class="card">' +
+    '<h3>What we found in it</h3>' +
+    '<dl class="mgrid" style="margin-top:13px">' +
+      '<div class="mcell"><dt>Schema</dt><dd class="mono">IFC2X3</dd></div>' +
+      '<div class="mcell"><dt>Elements</dt><dd class="mono">12,847</dd></div>' +
+      '<div class="mcell"><dt>Spatial chain</dt><dd>Complete</dd></div>' +
+      '<div class="mcell flag"><dt>Spaces (rooms)</dt><dd class="mono">0</dd></div>' +
+      '<div class="mcell flag"><dt>Classified</dt><dd class="mono">4.2<span class="unit">%</span></dd></div>' +
+      '<div class="mcell flag"><dt>Property sets</dt><dd class="mono">39<span class="unit">%</span></dd></div>' +
+      '<div class="mcell flag"><dt>Quantities</dt><dd>Absent</dd></div>' +
+      '<div class="mcell flag"><dt>Duplicate GUIDs</dt><dd class="mono">47</dd></div>' +
+    '</dl>' +
+    '<p class="small" style="margin-top:14px">Counted from the file directly, not from anything we stored &mdash; ' +
+    'so these are your model&rsquo;s numbers, not our extractor&rsquo;s view of it.</p>' +
+  '</div>' +
+
+  '<div class="card">' +
+    '<h3>Exactly what would leave your browser</h3>' +
+    '<p class="small" style="margin:9px 0 13px">Numbers and fixed categories only. No file, no names, no GUIDs, ' +
+    'no coordinates, no free text.</p>' +
+    '<pre class="payload">{\n' +
+      '  "locale":        "AE",\n' +
+      '  "firm_size":     "11-50",\n' +
+      '  "firm_type":     "engineering",\n' +
+      '  "answers":       [1,2,0,1, 1,1,2,1, 2,2,3,2, 3,1,4,0, 1,2,1,1],\n' +
+      '  "schema":        "IFC2X3",\n' +
+      '  "elements":      12847,\n' +
+      '  "spaces":        0,\n' +
+      '  "classified_pc": 4.2,\n' +
+      '  "psets_pc":      39.0,\n' +
+      '  "quantities":    false,\n' +
+      '  "georef":        true,\n' +
+      '  "dup_guids":     47,\n' +
+      '  "exporter":      "other",\n' +
+      '  "toolkit":       "v0.1",\n' +
+      '  "kb":            "core-0.1 / ae-v1"\n}</pre>' +
+    '<label class="chk" style="margin-top:14px"><input type="checkbox">' +
+      '<span>Send this. Optional &mdash; your checklist is complete either way.</span></label>' +
+  '</div>' +
+
+  '<div class="actions">' +
+    '<button class="btn" data-go="results">See my results</button>' +
+    '<button class="btn sec" data-go="assess">Back</button>' +
+  '</div>';
+
+/* ---------- 5 · RESULTS ---------- */
+function chartRows() {
+  return DIMS.map(function (d) {
+    var w = (d.measured / 4 * 100).toFixed(1), c = (d.claimed / 4 * 100).toFixed(1);
+    var gap = Math.abs(d.claimed - d.measured) >= 2;
+    return '<div class="crow" title="' + d.name + ' — measured ' + d.measured.toFixed(1) +
+      ' of 4, you said ' + d.claimed.toFixed(1) + '">' +
+      '<div class="cname">' + d.name + (gap ? ' <span style="color:var(--warn)">&#9650;</span>' : '') + '</div>' +
+      '<div class="ctrack"><div class="cbar" style="width:' + w + '%"></div>' +
+      '<div class="cclaim" style="left:' + c + '%"></div></div>' +
+      '<div class="cval">' + d.measured.toFixed(1) + '</div></div>';
+  }).join('');
+}
+
+SCREENS.results =
+  '<p class="eyebrow">Step 5 of 5 · Your results</p>' +
+  '<h2>Where you stand</h2>' +
+  '<p class="sub small">Two numbers per dimension: what your answers claimed, and what the evidence supports. ' +
+  'Where they disagree by two levels or more, the measurement is used and the gap is shown.</p>' +
+
+  '<div class="card">' +
+    '<h3>Readiness profile</h3>' +
+    '<p class="small" style="margin-top:5px">Maturity 0&ndash;4 across five dimensions</p>' +
+    '<div class="chart">' + chartRows() +
+      '<div class="cscale"><span></span><div class="cticks">' +
+        '<span>0</span><span>1</span><span>2</span><span>3</span><span>4</span></div><span></span></div>' +
+    '</div>' +
+    '<div class="clegend">' +
+      '<span><i class="swatch"></i>Assessed level</span>' +
+      '<span><i class="swtick"></i>What you said</span>' +
+      '<span style="color:var(--warn)">&#9650; Claim and evidence disagree</span>' +
+    '</div>' +
+    '<details class="tvwrap"><summary>View as a table</summary>' +
+      '<table class="tv"><thead><tr><th>Dimension</th><th>Assessed</th><th>You said</th><th>Gap</th></tr></thead><tbody>' +
+      DIMS.map(function (d) {
+        var g = (d.claimed - d.measured);
+        return '<tr><td>' + d.name + '</td><td class="n">' + d.measured.toFixed(1) + '</td><td class="n">' +
+          d.claimed.toFixed(1) + '</td><td class="n">' + (g >= 2 ? '+' + g.toFixed(1) + ' ▲' : g.toFixed(1)) + '</td></tr>';
+      }).join('') + '</tbody></table></details>' +
+  '</div>' +
+
+  '<div class="card">' +
+    '<h3>Where your model disagreed with your answers</h3>' +
+    '<div class="delta" style="margin-top:13px">' +
+      '<div class="ic">!</div><div>' +
+        '<h4>Classification</h4>' +
+        '<p>You reported a classification standard applied consistently. 4.2% of elements in the file carry a ' +
+        'classification reference. We scored the measurement.</p>' +
+        '<div class="vs"><span><b>You said</b>L3 · applied consistently</span>' +
+        '<span><b>Measured</b>L1 · 4.2% coverage</span></div>' +
+      '</div></div>' +
+    '<div class="delta">' +
+      '<div class="ic">!</div><div>' +
+        '<h4>Quality checking before issue</h4>' +
+        '<p>You reported validating IFC with a checker tool before sending. The file carries 47 duplicate GUIDs, ' +
+        'which a checker would have caught.</p>' +
+        '<div class="vs"><span><b>You said</b>L4 · validated with a tool</span>' +
+        '<span><b>Measured</b>L1 · 47 duplicate GUIDs</span></div>' +
+      '</div></div>' +
+    '<p class="small">This is not a gotcha. Most firms score differently on claim and evidence, and the gap is ' +
+    'usually a reporting problem rather than a competence one &mdash; but it is the most useful thing here.</p>' +
+  '</div>' +
+
+  '<div class="card">' +
+    '<h3>What to fix first</h3>' +
+    '<p class="small" style="margin-top:5px">Ordered by how much each unlocks downstream</p>' +
+    '<ol class="fixes">' +
+      '<li><div><h4>Add spaces to the model</h4><p>Zero IfcSpace entities. Rooms are the spine of anything ' +
+      'downstream &mdash; FM, area schedules, analysis. Nothing that needs a room can consume this file.</p></div></li>' +
+      '<li><div><h4>Classify at type level, not element level</h4><p>234 of 339 types carry no code. Coding types ' +
+      'rather than 12,847 elements is roughly a day of work instead of a month.</p></div></li>' +
+      '<li><div><h4>Resolve 47 duplicate GUIDs before the next issue</h4><p>Duplicates break round-tripping and ' +
+      'change tracking silently.</p></div></li>' +
+      '<li><div><h4>Turn on quantity export</h4><p>No IfcElementQuantity present, so nothing downstream can do ' +
+      'cost or carbon from this model.</p></div></li>' +
+      '<li><div><h4>Write down what the model must contain, before the next project starts</h4>' +
+      '<p>Your lowest-scoring governance item, and the cheapest to fix.</p></div></li>' +
+    '</ol>' +
+  '</div>' +
+
+  '<div class="idx2">' +
+    '<div class="ix"><span class="who">Can we start?</span>' +
+      '<div class="v">1.6<small> / 4</small></div>' +
+      '<div style="font-weight:600;font-size:14px">Entry readiness</div>' +
+      '<p>The open route is reachable, but not with this model as it stands.</p></div>' +
+    '<div class="ix"><span class="who">How exposed are we?</span>' +
+      '<div class="v">3.1<small> / 4</small></div>' +
+      '<div style="font-weight:600;font-size:14px">Lock-in exposure</div>' +
+      '<p>High. No model has been retrieved from your authoring tool and re-opened elsewhere.</p></div>' +
+  '</div>' +
+
+  '<div class="card flat" style="background:var(--surface-2)">' +
+    '<h3>Compare yourself to others</h3>' +
+    '<p class="small" style="margin-top:8px">No assessments have been submitted yet &mdash; yours would be the ' +
+    'first. As responses accumulate this becomes a real industry picture, built from practitioners rather than ' +
+    'asserted.</p>' +
+  '</div>' +
+
+  '<div class="actions">' +
+    '<button class="btn">Download checklist (PDF)</button>' +
+    '<button class="btn sec">See these gaps in 3D</button>' +
+    '<button class="btn sec" data-go="intro">Start over</button>' +
+  '</div>' +
+  '<p class="small mono" style="margin-top:20px;padding-top:14px;border-top:1px solid var(--rule)">' +
+  'core-0.1 · locale ae-v1 · toolkit v0.1 · 2026-08-21 · scoring is deterministic &mdash; ' +
+  'same answers and same versions always produce this same result</p>';
+
+/* ---------- NAV ---------- */
+var ORDER = ['intro', 'context', 'assess', 'model', 'results'];
+var LABELS = { intro: 'Introduction', context: 'About you', assess: 'Your firm', model: 'Your model', results: 'Results' };
+var host = document.getElementById('screens');
+
+function show(name) {
+  host.innerHTML = '<div class="screen on">' + SCREENS[name] + '</div>';
+  var i = ORDER.indexOf(name);
+  var rail = document.getElementById('rail'), cap = document.getElementById('railcap');
+  rail.hidden = cap.hidden = (name === 'intro');
+  [].forEach.call(rail.children, function (li, n) {
+    li.className = n < i ? 'done' : (n === i ? 'now' : '');
+  });
+  document.getElementById('railnow').textContent = LABELS[name];
+  document.getElementById('railpct').textContent = 'Step ' + (i + 1) + ' of ' + ORDER.length;
+  window.scrollTo({ top: 0, behavior: 'instant' });
+}
+
+document.addEventListener('click', function (e) {
+  var go = e.target.closest('[data-go]');
+  if (go) { show(go.dataset.go); return; }
+
+  var tb = e.target.closest('.tipbtn');
+  document.querySelectorAll('.tip.open').forEach(function (t) {
+    if (!tb || t !== tb.parentNode) t.classList.remove('open');
+  });
+  if (tb) { tb.parentNode.classList.toggle('open'); return; }
+
+  if (e.target.id === 'themebtn') {
+    var r = document.documentElement;
+    var dark = r.getAttribute('data-theme') === 'dark' ||
+      (!r.getAttribute('data-theme') && matchMedia('(prefers-color-scheme:dark)').matches);
+    r.setAttribute('data-theme', dark ? 'light' : 'dark');
+  }
+  if (e.target.id === 'helpbtn') {
+    alert('MOCKUP — this opens the "Read more" explainer page on GitHub Pages:\n\n' +
+      '· Why open BIM matters (industry)\n· Where you stand (your gap)\n· What to do about it (roadmap)\n\n' +
+      'Charts there use measured or cited data only — never invented figures.');
+  }
+});
+
+document.addEventListener('keydown', function (e) {
+  if (e.key === 'Escape') document.querySelectorAll('.tip.open').forEach(function (t) { t.classList.remove('open'); });
+});
+
+show('intro');
+</script>


### PR DESCRIPTION
Publishes a static UI mockup of the **OpenBIM Readiness Assessment Toolkit** at `/readiness/` so it can be reviewed on the live Pages site.

Context: grant deliverable for REFREX → KFK Vision (`QTN.KFK.260703-01`), artifact milestone 7 Sep 2026. The toolkit assesses an organisation's readiness for open BIM and measures their own IFC against what an open-standard consumer needs.

## What this is
Five clickable screens — intro, context, governance questions, model check, results. **All data is canned. Nothing is wired**: no IFC parsing, no scoring, no network calls. This is for reviewing layout, copy and flow before any logic goes behind it.

## Notes
- Single file, vanilla JS, no dependencies, no build step — house idiom
- Theme-aware; all colour tokens defined on bare `:root`, redefined for both dark paths
- Chart palette was validated rather than eyeballed. First attempt failed two checks (teal below chroma floor, amber/red pair at ΔE 11.9 normal-vision). Re-stepped to `#00897b`/`#a06a00` light and `#1f9d87`/`#b1811f` dark — both pass all six checks
- Readiness profile uses horizontal bars on one shared 0–4 axis, not a radar; claimed vs measured sit on the same scale so no second axis is needed
- Deltas carry icon + label, never colour alone; table view provided for accessibility

## Not in scope here
Scoring logic, IFC metric extraction, locale packs and the tooltip citation anchors are specified outside this repo and land later.

## Verification
Served locally and fetched: `status=200 bytes=35705 type=text/html`, all expected markers present. `node --check` passes on the inline script. No existing file touched — this only adds `readiness/index.html`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)