### PR TITLE
test(sw): audit the other direction — every script viewer.html loads must be precached (W-SW-UNLISTED)

### DIFF
--- a/tests/audit_sw_precache.js
+++ b/tests/audit_sw_precache.js
@@ -1,6 +1,15 @@
 /**
- * audit_sw_precache.js — Verify every file in sw.js PRECACHE_ASSETS exists on disk
- * Issue: Missing precache file → offline user gets blank page with no error
+ * audit_sw_precache.js — the sw.js precache list and the viewer's real script set agree.
+ *
+ * Two invariants, deliberately both directions (§S61.2, bim-compiler
+ * prompts/SCRIPT_LENGTH_REFACTOR_SEAMS.md):
+ *   1. LISTED-IS-REAL   every entry in PRECACHE_ASSETS exists on disk.
+ *      Issue: Missing precache file → offline user gets blank page with no error.
+ *   2. NEEDED-IS-LISTED every non-lib <script src> in viewer.html is in PRECACHE_ASSETS.
+ *      Issue (W-SW-UNLISTED): a NEW viewer file wired into viewer.html but forgotten in
+ *      PRECACHE_ASSETS passed this audit, passed audit_script_tags.js, passed every witness —
+ *      and broke only offline users, silently. Invariant 1 alone cannot see that: it only ever
+ *      asks about files someone already remembered to list.
  */
 const fs = require('fs');
 const path = require('path');
@@ -37,4 +46,49 @@ for (const entry of entries) {
 }
 
 console.log('§SW_AUDIT_SUMMARY ' + pass + ' found, ' + fail + ' missing, ' + warn + ' known-missing, ' + (pass + fail + warn) + ' total');
-if (fail > 0) process.exit(1);
+
+// ── Invariant 2: NEEDED-IS-LISTED (W-SW-UNLISTED) ───────────────────────────────────────────
+// Same <script src> parse as audit_script_tags.js:13 and the same two skips it makes
+// (:21 http/protocol-relative, :23 lib/ third-party). ONE parser shape, two callers — a second
+// divergent regex here would be its own drift.
+const htmlPath = path.resolve(__dirname, '..', 'viewer', 'viewer.html');
+const htmlSrc = fs.readFileSync(htmlPath, 'utf8');
+const listed = new Set(entries.map(e => e.replace(/'/g, '')));
+
+// Lanes deliberately outside the offline shell. A PREFIX rule, each with its reason — not a
+// bare skip list, so a new file inside one of these lanes is also knowingly excluded.
+var UNLISTED_LANES = [
+  { prefix: '../hr_bim_asset/', why: 'HBA demo lane — its own page, not part of the viewer offline shell' },
+  { prefix: 'hba_',             why: 'HBA demo lane (viewer-side half), same scope as above' },
+  { prefix: 'connect_',         why: 'dev-only cross-window harness, never shipped to an offline user' },
+  { prefix: 'effects_gi_poc',   why: 'GI proof-of-concept behind Alt+G, not a shell asset' }
+];
+// Individually captured on 2026-08-21 at a98b62c. These are NOT blessed — each is a real
+// offline gap owed a decision (§S61.2). They are listed so the audit can gate anything NEW
+// while the existing 18 get triaged, instead of the check being unshippable on day one.
+var UNLISTED_TRIAGE = ['../common/history_tap.js', 'share.js', '../erp/bigdecimal.js',
+  '../erp/ad_docfsm.js', 'blue_fold.js', 'proj_fold.js', 'vo_fold.js', 'proj_control.js',
+  'whatif.js', 'whatif_panel.js', 'vo_approve.js', 'proj_period.js', 'proj_claim.js',
+  '../common/whole_history.js', '../common/history_bar.js', '../common/about_diy.js',
+  'universal_history.js', 'sfx.js'];
+
+const scriptTags = htmlSrc.match(/src="([^"]+\.js[^"]*)"/g) || [];
+var uPass = 0, uFail = 0, uLane = 0, uTriage = 0;
+for (const tag of scriptTags) {
+  const file = tag.match(/src="([^"]+)"/)[1].split('?')[0];
+  if (file.startsWith('http') || file.startsWith('//') || file.startsWith('lib/')) continue;
+  if (listed.has(file)) { uPass++; continue; }
+  const lane = UNLISTED_LANES.find(l => file.startsWith(l.prefix));
+  if (lane) { uLane++; continue; }
+  if (UNLISTED_TRIAGE.includes(file)) {
+    uTriage++;
+    console.log('  §SW_AUDIT_UNLISTED WARN: ' + file + ' — captured 2026-08-21, offline gap owed a decision');
+  } else {
+    uFail++;
+    console.log('  §SW_AUDIT_UNLISTED FAIL: ' + file + ' — loaded by viewer.html, absent from PRECACHE_ASSETS');
+  }
+}
+console.log('§SW_AUDIT_UNLISTED_SUMMARY ' + uPass + ' precached, ' + uFail + ' unlisted, ' +
+  uTriage + ' known-gap, ' + uLane + ' out-of-shell, ' + (uPass + uFail + uTriage + uLane) + ' scripts');
+
+if (fail > 0 || uFail > 0) process.exit(1);


### PR DESCRIPTION
Implements `prompts/SCRIPT_LENGTH_REFACTOR_SEAMS.md` §S61.2 (bim-compiler). Witness: **W-SW-UNLISTED**.

## The gap
`tests/audit_sw_precache.js` and `tests/audit_script_tags.js` both ask *"is this listed thing real?"*. Neither asks *"is every needed thing listed?"*

A new viewer file wired into `viewer.html` but forgotten in `PRECACHE_ASSETS` passed both audits, passed every witness, and broke **only offline users** — silently, and only for those holding an old cache. This is the recurring `sw.js` cache bug class; the same-PR `CACHE_VERSION` rule exists as discipline precisely because the check did not.

## Measured before the gate was wired
51 of 146 script tags were unlisted at `a98b62c`, so this ships capturing today's state and gates what is **new**:

| bucket | n | treatment |
|---|---|---|
| precached | 95 | pass |
| out-of-shell | 33 | PREFIX rule (`../hr_bim_asset/`, `hba_`, `connect_`, `effects_gi_poc`), **each with a stated reason** — new files in those lanes stay knowingly excluded |
| known-gap | 18 | captured individually, printed `WARN`, **not blessed** — each is a real offline gap owed a decision (`share.js`, `sfx.js`, `universal_history.js`, the ERP fold set, `../common/history_*`) |
| unlisted | 0 | would exit 1 |

Reuses `audit_script_tags.js:13`'s parse and its two skips (`:21` http, `:23` `lib/`) — one parser shape, two callers, not a second divergent regex.

## Proven red, then reverted
An audit never seen failing proves nothing:

- drop `'gantt_model.js'` from `PRECACHE_ASSETS` → `FAIL` names it, 94 precached, **exit 1**
- add `<script src="brand_new_feature.js">` to `viewer.html` → `FAIL` names it, 147 scripts, **exit 1**

Clean tree: `§SW_AUDIT_SUMMARY 121 found, 0 missing` · `§SW_AUDIT_UNLISTED_SUMMARY 95 precached, 0 unlisted, 18 known-gap, 33 out-of-shell, 146 scripts` · exit 0. `audit_script_tags.js` 146/146, exit 0.

No `CACHE_VERSION` bump — `tests/` only, no served asset changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)