### PR TITLE
docs(readiness): adopt the funded proposal's language across both pages

### DIFF
--- a/readiness/disclaimer.html
+++ b/readiness/disclaimer.html
@@ -1,0 +1,336 @@
+<title>Disclaimer Notice</title>
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Instrument+Sans:wght@400;500;600;700&family=Source+Serif+4:opsz,wght@8..60,400;8..60,600&family=IBM+Plex+Mono:wght@400;500;600&display=swap">
+
+<style>
+:root{
+  --ink:#131e1b; --ink-2:#3a4a45; --muted:#6b7d78; --faint:#9aaba6;
+  --paper:#f5f7f5; --surface:#ffffff; --surface-2:#eaefed; --surface-3:#dbe3e0;
+  --rule:#d3dcd9; --rule-soft:#e4e9e7;
+  --accent:#00897b; --accent-ink:#00695f; --accent-wash:#e0efec;
+  --warn:#a06a00; --warn-wash:#f7efdd;
+  --focus:#00897b;
+  --shadow:0 1px 2px rgba(19,30,27,.05),0 10px 30px -18px rgba(19,30,27,.22);
+}
+@media (prefers-color-scheme:dark){
+  :root:not([data-theme="light"]){
+    --ink:#e9efed; --ink-2:#c3d0cc; --muted:#93a5a0; --faint:#6d7f7a;
+    --paper:#0f1816; --surface:#182421; --surface-2:#1f2d29; --surface-3:#2b3b36;
+    --rule:#2d3e39; --rule-soft:#22302c;
+    --accent:#1f9d87; --accent-ink:#4fc9b0; --accent-wash:#14312b;
+    --warn:#b1811f; --warn-wash:#2f2612;
+    --focus:#4fc9b0;
+    --shadow:0 1px 2px rgba(0,0,0,.35),0 12px 32px -18px rgba(0,0,0,.75);
+  }
+}
+:root[data-theme="dark"]{
+  --ink:#e9efed; --ink-2:#c3d0cc; --muted:#93a5a0; --faint:#6d7f7a;
+  --paper:#0f1816; --surface:#182421; --surface-2:#1f2d29; --surface-3:#2b3b36;
+  --rule:#2d3e39; --rule-soft:#22302c;
+  --accent:#1f9d87; --accent-ink:#4fc9b0; --accent-wash:#14312b;
+  --warn:#b1811f; --warn-wash:#2f2612;
+  --focus:#4fc9b0;
+  --shadow:0 1px 2px rgba(0,0,0,.35),0 12px 32px -18px rgba(0,0,0,.75);
+}
+
+*{box-sizing:border-box}
+body{
+  margin:0;background:var(--paper);color:var(--ink);
+  font-family:"Source Serif 4",Georgia,serif;font-size:17.5px;line-height:1.65;
+  -webkit-font-smoothing:antialiased;
+}
+h1,h2,h3,h4,.ui{font-family:"Instrument Sans",-apple-system,"Segoe UI",Helvetica,Arial,sans-serif}
+h1,h2,h3{margin:0;text-wrap:balance;letter-spacing:-.022em}
+p{margin:0}
+.mono{font-family:"IBM Plex Mono",ui-monospace,Menlo,monospace;font-variant-numeric:tabular-nums}
+a{color:var(--accent-ink);text-underline-offset:2px}
+:focus-visible{outline:2px solid var(--focus);outline-offset:2px;border-radius:3px}
+
+.wrap{max-width:800px;margin:0 auto;padding:0 22px 90px}
+
+/* ---- topbar ---- */
+.topbar{display:flex;align-items:center;gap:13px;padding:18px 0;border-bottom:1px solid var(--rule)}
+.brandmark{
+  width:28px;height:28px;border-radius:6px;background:var(--accent);flex:none;
+  display:grid;place-items:center;color:var(--paper);font-weight:700;font-size:12px;
+  font-family:"IBM Plex Mono",monospace
+}
+.brandtext{font-family:"Instrument Sans",sans-serif;font-size:13.5px;font-weight:600;line-height:1.3}
+.brandtext small{display:block;font-weight:400;font-size:11.5px;color:var(--muted)}
+.topspacer{flex:1}
+.ghostbtn{
+  background:transparent;border:1px solid var(--rule);border-radius:6px;padding:6px 12px;
+  font-family:"Instrument Sans",sans-serif;font-size:13px;cursor:pointer;color:var(--ink-2);
+  text-decoration:none;display:inline-block
+}
+.ghostbtn:hover{background:var(--surface-2);border-color:var(--accent);color:var(--accent-ink)}
+
+/* ---- hero ---- */
+.hero{padding:56px 0 40px;border-bottom:2px solid var(--ink)}
+.eyebrow{
+  font-family:"IBM Plex Mono",monospace;font-size:11px;letter-spacing:.14em;
+  text-transform:uppercase;color:var(--accent-ink);font-weight:600;margin-bottom:16px
+}
+h1{font-family:"Instrument Sans",sans-serif;font-size:clamp(31px,5.2vw,46px);line-height:1.08;font-weight:700}
+.standfirst{font-size:19px;color:var(--ink-2);margin-top:18px;max-width:58ch;line-height:1.55}
+
+/* ---- sections ---- */
+section{margin:64px 0 0;scroll-margin-top:20px}
+.shead{display:flex;gap:14px;align-items:baseline;margin-bottom:10px}
+.snum{
+  font-family:"IBM Plex Mono",monospace;font-size:12px;font-weight:600;color:var(--accent-ink);
+  flex:none;padding-top:5px;letter-spacing:.05em
+}
+h2{font-family:"Instrument Sans",sans-serif;font-size:26px;font-weight:600;line-height:1.2}
+h3{font-family:"Instrument Sans",sans-serif;font-size:16.5px;font-weight:600;margin:30px 0 8px}
+section p{margin:15px 0;max-width:64ch}
+.lede{font-size:18.5px;color:var(--ink-2)}
+strong{font-weight:600;color:var(--ink)}
+
+/* ---- nav chips ---- */
+.jump{display:flex;gap:8px;flex-wrap:wrap;margin:26px 0 0}
+.jump a{
+  font-family:"Instrument Sans",sans-serif;font-size:13px;text-decoration:none;
+  border:1px solid var(--rule);border-radius:20px;padding:7px 14px;color:var(--ink-2);background:var(--surface)
+}
+.jump a:hover{border-color:var(--accent);color:var(--accent-ink);background:var(--accent-wash)}
+
+/* ---- figure ---- */
+figure{
+  margin:26px 0;background:var(--surface);border:1px solid var(--rule);border-radius:10px;
+  padding:22px 24px;box-shadow:var(--shadow)
+}
+figure h4{
+  font-family:"Instrument Sans",sans-serif;font-size:15.5px;font-weight:600;margin:0 0 4px
+}
+figure .fsub{font-family:"Instrument Sans",sans-serif;font-size:13px;color:var(--muted);margin-bottom:18px}
+figcaption{
+  margin-top:16px;padding-top:13px;border-top:1px solid var(--rule-soft);
+  font-family:"Instrument Sans",sans-serif;font-size:12.5px;color:var(--muted);line-height:1.5
+}
+figcaption b{
+  font-family:"IBM Plex Mono",monospace;font-size:10.5px;letter-spacing:.09em;
+  text-transform:uppercase;color:var(--accent-ink);font-weight:600;display:block;margin-bottom:4px
+}
+
+/* ---- stacked bar ---- */
+.stack{display:flex;height:38px;border-radius:6px;overflow:hidden;gap:2px;background:var(--surface)}
+.seg{display:grid;place-items:center;font-family:"IBM Plex Mono",monospace;font-size:12px;font-weight:600;min-width:0}
+.seg.a{background:var(--accent);color:var(--paper)}
+.seg.n{background:var(--surface-3);color:var(--ink-2)}
+.seg.w{background:var(--warn);color:var(--paper)}
+.stacklab{
+  display:flex;justify-content:space-between;margin-top:9px;gap:14px;
+  font-family:"Instrument Sans",sans-serif;font-size:13px;color:var(--ink-2)
+}
+.stacklab span{display:flex;gap:7px;align-items:center}
+.sw{width:12px;height:11px;border-radius:3px;flex:none}
+.sw.a{background:var(--accent)} .sw.n{background:var(--surface-3)} .sw.w{background:var(--warn)}
+
+/* ---- hbars ---- */
+.hb{display:grid;grid-template-columns:150px 1fr 74px;gap:12px;align-items:center;padding:6px 0}
+.hb .n{font-family:"Instrument Sans",sans-serif;font-size:13.5px;text-align:right;color:var(--ink-2);line-height:1.25}
+.hb .t{height:17px;background:var(--surface-3);border-radius:4px;position:relative;overflow:hidden}
+.hb .f{position:absolute;inset:0 auto 0 0;background:var(--accent);border-radius:4px}
+.hb .v{font-family:"IBM Plex Mono",monospace;font-size:12.5px;font-weight:600;color:var(--ink-2)}
+
+/* ---- hero stat ---- */
+.bignum{
+  display:flex;gap:26px;align-items:baseline;flex-wrap:wrap;
+  padding:6px 0 2px
+}
+.bignum .n{
+  font-family:"Instrument Sans",sans-serif;font-size:clamp(46px,9vw,74px);font-weight:700;
+  line-height:.95;letter-spacing:-.04em;color:var(--warn);font-variant-numeric:tabular-nums
+}
+.bignum .n.ok{color:var(--accent)}
+.bignum .t{font-size:16px;color:var(--ink-2);max-width:34ch;font-family:"Instrument Sans",sans-serif;line-height:1.4}
+
+/* ---- matrix ---- */
+.mx{width:100%;border-collapse:collapse;font-family:"Instrument Sans",sans-serif;font-size:13.5px}
+.mx th{
+  text-align:left;font-size:10.5px;letter-spacing:.09em;text-transform:uppercase;color:var(--muted);
+  padding:9px 10px;border-bottom:1px solid var(--rule);font-weight:600
+}
+.mx th.c,.mx td.c{text-align:center;width:88px}
+.mx td{padding:10px;border-bottom:1px solid var(--rule-soft);color:var(--ink-2)}
+.mx tr:last-child td{border-bottom:none}
+.yes{color:var(--accent);font-weight:700}
+.no{color:var(--warn);font-weight:700}
+.mxscroll{overflow-x:auto}
+
+/* ---- bands ---- */
+.bands{display:flex;gap:2px;border-radius:6px;overflow:hidden;margin-top:4px}
+.band{padding:11px 12px;flex:1;font-family:"Instrument Sans",sans-serif;font-size:12.5px;text-align:center;line-height:1.35}
+.band b{display:block;font-family:"IBM Plex Mono",monospace;font-size:14px;margin-bottom:3px}
+.band.g{background:var(--accent-wash);color:var(--accent-ink)}
+.band.m{background:var(--surface-3);color:var(--ink-2)}
+.band.b{background:var(--warn-wash);color:var(--warn)}
+
+/* ---- pull quote ---- */
+blockquote.ps{
+  margin:30px 0;padding:24px 26px;background:var(--surface);
+  border:1px solid var(--rule);border-left:3px solid var(--accent);border-radius:8px;
+  box-shadow:var(--shadow)
+}
+blockquote.ps p{margin:0 0 13px;font-size:17px;line-height:1.6;max-width:none}
+blockquote.ps p:last-of-type{margin-bottom:0}
+blockquote.ps .k{font-weight:600;color:var(--ink)}
+blockquote.ps cite{
+  display:block;margin-top:16px;padding-top:13px;border-top:1px solid var(--rule-soft);
+  font-family:"IBM Plex Mono",monospace;font-size:10.5px;letter-spacing:.08em;
+  text-transform:uppercase;color:var(--muted);font-style:normal
+}
+
+/* ---- callout ---- */
+.call{
+  background:var(--surface);border:1px solid var(--rule);border-left:3px solid var(--accent);
+  border-radius:8px;padding:19px 22px;margin:26px 0
+}
+.call.warn{border-left-color:var(--warn)}
+.call .lab{
+  font-family:"IBM Plex Mono",monospace;font-size:10.5px;letter-spacing:.11em;text-transform:uppercase;
+  color:var(--accent-ink);font-weight:600;display:block;margin-bottom:8px
+}
+.call.warn .lab{color:var(--warn)}
+.call p{margin:0 0 11px;max-width:none}
+.call p:last-child{margin-bottom:0}
+
+/* ---- ladder ---- */
+.ladder{display:flex;flex-direction:column;gap:1px;background:var(--rule);border:1px solid var(--rule);border-radius:8px;overflow:hidden;margin:22px 0}
+.rung{background:var(--surface);padding:12px 16px;display:grid;grid-template-columns:38px 1fr;gap:14px;align-items:baseline}
+.rung .l{font-family:"IBM Plex Mono",monospace;font-size:11.5px;font-weight:600;color:var(--accent-ink)}
+.rung b{font-family:"Instrument Sans",sans-serif;font-size:14.5px}
+.rung p{margin:2px 0 0;font-size:14.5px;color:var(--muted);max-width:none}
+
+/* ---- cta ---- */
+.cta{
+  margin:60px 0 0;padding:30px 26px;background:var(--accent-wash);
+  border:1px solid var(--accent);border-radius:12px;text-align:center
+}
+.cta h3{margin:0 0 8px;font-size:20px}
+.cta p{margin:0 auto 20px;max-width:46ch;color:var(--ink-2);font-size:15.5px}
+.btn{
+  background:var(--accent);color:var(--paper);border:1px solid var(--accent);border-radius:8px;
+  padding:12px 24px;font-family:"Instrument Sans",sans-serif;font-size:15.5px;font-weight:600;
+  cursor:pointer;text-decoration:none;display:inline-block
+}
+.btn:hover{filter:brightness(1.08)}
+
+footer{
+  margin:64px 0 0;padding-top:20px;border-top:1px solid var(--rule);
+  font-family:"IBM Plex Mono",monospace;font-size:11.5px;color:var(--faint);line-height:1.8
+}
+
+@media (max-width:600px){
+  .hb{grid-template-columns:96px 1fr 62px;gap:9px}
+  .hb .n{font-size:12.5px}
+  .bands{flex-direction:column}
+  figure{padding:18px 16px}
+}
+@media (prefers-reduced-motion:reduce){*{animation:none!important;transition:none!important}}
+</style>
+<div class="wrap">
+
+<div class="topbar">
+  <div class="brandmark">OB</div>
+  <div class="brandtext">OpenBIM Readiness Assessment Toolkit<small>Disclaimer Notice</small></div>
+  <div class="topspacer"></div>
+  <button class="ghostbtn" id="themebtn" type="button">Theme</button>
+  <a class="ghostbtn" href="./">Back to assessment</a>
+</div>
+
+<div class="hero">
+  <p class="eyebrow">Disclaimer Notice &middot; v0.1 &middot; 22 August 2026</p>
+  <h1>What this assessment is, and what it is not.</h1>
+  <p class="standfirst">This notice applies to the OpenBIM Readiness Assessment Toolkit, to every
+  assessment taken with it, and to every report, checklist or record it produces.</p>
+</div>
+
+<section>
+  <div class="shead"><span class="snum">01</span><h2>Scope</h2></div>
+  <p><strong>This is only a technical readiness assessment.</strong> It measures organisational
+  readiness for open-standard working, and the data quality of a model file supplied by the
+  respondent. That is its entire scope.</p>
+  <p>It says nothing about the lawfulness, safety, structural adequacy, buildability, fitness for
+  purpose or professional adequacy of any design, model, building or asset. It does not assess the
+  respondent, their competence, or their standing to practise.</p>
+</section>
+
+<section>
+  <div class="shead"><span class="snum">02</span><h2>It qualifies nothing and no one</h2></div>
+  <p>This assessment and any report produced from it confer <strong>no certification, accreditation,
+  licence, approval, registration, endorsement or professional status</strong> of any kind, on any
+  person or organisation.</p>
+  <p>They are <strong>not evidence of compliance</strong> with any regulation, building code,
+  standard, mandate, contract, appointment or client requirement, and must not be presented as such
+  &mdash; to a client, an authority having jurisdiction, an insurer, a certifying body, or in a
+  tender or prequalification submission.</p>
+  <p>No BIM software holds local-authority compliance certification in any jurisdiction. Compliance
+  rests with the Appointing Party and the Lead Appointed Party. Software is never a legal party to it.</p>
+</section>
+
+<section>
+  <div class="shead"><span class="snum">03</span><h2>Nothing here is audited or verified</h2></div>
+  <p>The inputs are <strong>self-reported by the respondent</strong> and computed from a file the
+  respondent supplies. No third party has witnessed, inspected, checked or attested to any answer,
+  measurement or result.</p>
+  <p>Results reflect what the respondent reported and what their file contained at the moment of
+  assessment, at the scope they declared. They are not a statement of fact about the organisation.</p>
+</section>
+
+<section>
+  <div class="shead"><span class="snum">04</span><h2>Your obligations remain yours</h2></div>
+  <p>Where <strong>insurance, professional indemnity, licensing, certification, registration or any
+  formal qualification process</strong> is required or applicable under the respondent&rsquo;s
+  regulations, contract, appointment or client requirements, that obligation is the
+  respondent&rsquo;s and must be discharged directly with the responsible body.</p>
+  <p><strong>This report substitutes for none of it, in whole or in part.</strong></p>
+  <p>Nothing in this toolkit or its outputs is insurance, indemnity, legal, regulatory or
+  professional advice. Whether working to open standards affects any cover or obligation is a matter
+  for the respondent&rsquo;s insurer and legal counsel. Two facts are offered only as context for that
+  conversation: warranty disclaimers are near-universal in software licensing, proprietary licences
+  included; and professional indemnity insures the professional, not the tool.</p>
+</section>
+
+<section>
+  <div class="shead"><span class="snum">05</span><h2>Figures and measurements</h2></div>
+  <p>Figures published by this toolkit are either measured from a named individual model, cited from
+  a public source, or aggregated from assessments taken &mdash; and are labelled accordingly. A
+  measurement from one building is not an industry statistic and must not be quoted as one.</p>
+  <p>Coverage and validity are reported as separate figures. A result showing well-formed data says
+  nothing about whether the right data is present. No single headline score is produced.</p>
+</section>
+
+<section>
+  <div class="shead"><span class="snum">06</span><h2>Research instrument, in development</h2></div>
+  <p>This toolkit supports academic research and is a work in progress. Its readiness dimensions,
+  assessment criteria, capability thresholds and weightings are subject to expert validation and
+  pilot testing, and <strong>will change</strong>. Results produced under one version are not
+  directly comparable with results produced under another.</p>
+  <p>Each report states the versions under which it was produced. Quote them whenever you quote a
+  result.</p>
+</section>
+
+<div class="cta">
+  <h3>Understood?</h3>
+  <p>You can take the assessment, or read the background on why any of this matters.</p>
+  <a class="btn" href="./">Go to the assessment</a>
+</div>
+
+<footer>
+  Disclaimer Notice v0.1 &middot; 22 August 2026<br>
+  OpenBIM Readiness Assessment Toolkit &middot; applies to the toolkit and every output it produces.
+</footer>
+
+</div>
+
+<script>
+document.getElementById('themebtn').addEventListener('click', function () {
+  var r = document.documentElement;
+  var dark = r.getAttribute('data-theme') === 'dark' ||
+    (!r.getAttribute('data-theme') && matchMedia('(prefers-color-scheme:dark)').matches);
+  r.setAttribute('data-theme', dark ? 'light' : 'dark');
+});
+</script>

--- a/readiness/index.html
+++ b/readiness/index.html
@@ -92,6 +92,28 @@ button{font:inherit;color:inherit}
 @keyframes fade{from{opacity:0;transform:translateY(5px)}to{opacity:1;transform:none}}
 @media (prefers-reduced-motion:reduce){*{animation:none!important;transition:none!important}}
 
+/* ---- PRINTED NOTICE (travels with the PDF) ---- */
+.printnotice{
+  border:1.5px solid var(--warn);border-radius:8px;padding:16px 18px;margin:26px 0 0;
+  background:var(--warn-wash)
+}
+.printnotice h4{
+  margin:0 0 8px;font-size:11px;letter-spacing:.11em;text-transform:uppercase;
+  color:var(--warn);font-family:"IBM Plex Mono",monospace;font-weight:600
+}
+.printnotice p{font-size:13px;color:var(--ink-2);line-height:1.55}
+.printnotice p + p{margin-top:9px}
+.printnotice a{color:var(--warn);font-weight:600}
+
+@media print{
+  .mockbar,.topbar,.rail,.railcap,.actions,.tvwrap{display:none!important}
+  body{background:#fff;color:#000;font-size:11pt}
+  .card,.printnotice,figure{break-inside:avoid;box-shadow:none}
+  .printnotice{border:1.5pt solid #000;background:#fff;break-inside:avoid}
+  .printnotice h4,.printnotice a{color:#000}
+  a[href]:after{content:" (" attr(href) ")";font-size:9pt;word-break:break-all}
+}
+
 .eyebrow{
   font-family:"IBM Plex Mono",monospace;font-size:11px;letter-spacing:.13em;
   text-transform:uppercase;color:var(--accent-ink);font-weight:600;margin-bottom:14px
@@ -118,6 +140,7 @@ h3{font-size:15.5px;font-weight:600}
 :root[data-theme="dark"] .btn,:root:not([data-theme="light"]) .btn{color:#0f1816}
 @media (prefers-color-scheme:light){:root:not([data-theme="dark"]) .btn{color:#fff}}
 .btn:hover{filter:brightness(1.08)}
+.btn:disabled{opacity:.42;cursor:not-allowed;filter:none}
 .btn.sec{background:transparent;color:var(--ink-2);border-color:var(--rule)}
 .btn.sec:hover{background:var(--surface-2);filter:none;border-color:var(--accent)}
 .btn.sm{padding:8px 14px;font-size:13.5px}
@@ -313,7 +336,7 @@ details.tvwrap summary{cursor:pointer;font-size:13.5px;color:var(--accent-ink);f
   </div>
 
   <ul class="rail" id="rail" hidden>
-    <li></li><li></li><li></li><li></li><li></li><li></li><li></li><li></li><li></li>
+    <li></li><li></li><li></li><li></li><li></li><li></li><li></li><li></li><li></li><li></li>
   </ul>
   <div class="railcap" id="railcap" hidden><span id="railnow">About you</span><span id="railpct">Step 1 of 5</span></div>
 
@@ -390,13 +413,82 @@ SCREENS.intro =
   '</div>' +
 
   '<div class="actions">' +
-    '<button class="btn" data-go="context">Start assessment</button>' +
+    '<button class="btn" data-go="agree">Start assessment</button>' +
     '<button class="btn sec" data-go="results">Skip to sample results</button>' +
+  '</div>';
+
+/* ---------- 1b · ACKNOWLEDGEMENT GATE ---------- */
+SCREENS.agree =
+  '<p class="eyebrow">Before you begin</p>' +
+  '<h2>What this is, and what it is not</h2>' +
+  '<p class="sub small">Please read this. It takes thirty seconds and it decides how you may use the ' +
+  'result.</p>' +
+
+  '<div class="card" style="border-left:3px solid var(--warn)">' +
+    '<h3>Scope</h3>' +
+    '<p class="small" style="margin-top:8px"><strong>This is only a technical readiness assessment.</strong> ' +
+    'It measures organisational readiness for open-standard working and the data quality of a model you ' +
+    'supply. That is its entire scope. It says nothing about the lawfulness, safety, buildability or ' +
+    'professional adequacy of anything you produce.</p>' +
+
+    '<h3 style="margin-top:22px">It qualifies nothing and no one</h3>' +
+    '<p class="small" style="margin-top:8px">It confers no certification, accreditation, licence, approval ' +
+    'or professional status. It is not evidence of compliance with any regulation, standard, code or ' +
+    'contract, and must not be presented as such &mdash; to a client, an authority, an insurer, or in a ' +
+    'tender.</p>' +
+
+    '<h3 style="margin-top:22px">Nothing here is audited</h3>' +
+    '<p class="small" style="margin-top:8px">Your answers are self-reported and the measurements come from ' +
+    'a file you supply. No third party has witnessed, checked or attested to any of it.</p>' +
+
+    '<h3 style="margin-top:22px">Your obligations remain yours</h3>' +
+    '<p class="small" style="margin-top:8px">Where insurance, professional indemnity, licensing, ' +
+    'certification or a formal qualification process is required or applicable under your regulations, ' +
+    'contract or client requirements, that obligation is yours and must be discharged directly with the ' +
+    'responsible body. This report substitutes for none of it.</p>' +
+
+    '<h3 style="margin-top:22px">Your data</h3>' +
+    '<p class="small" style="margin-top:8px">Any model file you choose is read inside your browser and is ' +
+    'never uploaded. Submitting anonymous results at the end is optional, you will see the exact payload ' +
+    'first, and your checklist is complete either way.</p>' +
+
+    '<h3 style="margin-top:22px">Research instrument</h3>' +
+    '<p class="small" style="margin-top:8px">This is a work in progress supporting academic research. Its ' +
+    'criteria, thresholds and weightings are subject to expert validation and will change.</p>' +
+  '</div>' +
+
+  '<label class="chk" style="font-size:15px;margin:20px 0 0"><input type="checkbox" id="ackbox">' +
+    '<span>I have read and understood the above, and I understand this assessment qualifies nothing ' +
+    'and no one.</span></label>' +
+
+  '<div class="actions">' +
+    '<button class="btn" id="agreebtn" data-go="context" disabled>Agree and continue</button>' +
+    '<button class="btn sec" data-go="declined">I do not agree</button>' +
+  '</div>' +
+  '<p class="small" style="margin-top:16px"><a href="disclaimer.html">Read the full Disclaimer Notice ' +
+  '&rarr;</a> &nbsp;&middot;&nbsp; <span class="mono">Terms v0.1 &middot; 22 Aug 2026</span></p>';
+
+/* ---------- 1c · DECLINED ---------- */
+SCREENS.declined =
+  '<p class="eyebrow">No assessment taken</p>' +
+  '<h2>That is a legitimate answer</h2>' +
+  '<p class="sub">Nothing has been recorded and nothing has left your device. If the limits on what this ' +
+  'can tell you make it not worth your time, that is a reasonable read &mdash; it is a narrow instrument ' +
+  'by design.</p>' +
+  '<div class="card">' +
+    '<h3>You may still find these useful</h3>' +
+    '<p class="small" style="margin-top:9px">The background reading covers what the industry actually ' +
+    'certifies, where delivered models really stand, and what closing the gap involves. None of it ' +
+    'requires taking the assessment.</p>' +
+  '</div>' +
+  '<div class="actions">' +
+    '<a class="btn" href="why.html">Read the background</a>' +
+    '<button class="btn sec" data-go="agree">Back</button>' +
   '</div>';
 
 /* ---------- 2 · CONTEXT ---------- */
 SCREENS.context =
-  '<p class="eyebrow">Step 2 of 9 &middot; About you</p>' +
+  '<p class="eyebrow">Step 3 of 10 &middot; About you</p>' +
   '<h2>A little context</h2>' +
   '<p class="sub small">None of this identifies you. It selects the right rules for your jurisdiction and ' +
   'places you in a comparable group.</p>' +
@@ -437,7 +529,7 @@ SCREENS.context =
 
   '<div class="actions">' +
     '<button class="btn" data-go="dim0">Continue</button>' +
-    '<button class="btn sec" data-go="intro">Back</button>' +
+    '<button class="btn sec" data-go="agree">Back</button>' +
   '</div>';
 
 /* ---------- THE 20 SCORED ITEMS ---------- */
@@ -554,7 +646,7 @@ function renderItem(it) {
 
 function dimScreen(n) {
   var d = DIMENSIONS[n];
-  return '<p class="eyebrow">Step ' + (n + 2) + ' of 9 &nbsp;&middot;&nbsp; ' + d.name +
+  return '<p class="eyebrow">Step ' + (n + 4) + ' of 10 &nbsp;&middot;&nbsp; ' + d.name +
       ' &nbsp;&middot;&nbsp; section ' + (n + 1) + ' of 5</p>' +
     '<h2>' + d.blurb + '</h2>' +
     '<p class="sub small">Each question asks about the <strong>last real instance</strong>, not general practice. ' +
@@ -569,7 +661,7 @@ function dimScreen(n) {
 
 /* ---------- 4 · MODEL ---------- */
 SCREENS.model =
-  '<p class="eyebrow">Step 8 of 9 &middot; Your model</p>' +
+  '<p class="eyebrow">Step 9 of 10 &middot; Your model</p>' +
   '<h2>Now let&rsquo;s look at an actual file</h2>' +
   '<p class="sub small">This is the part a questionnaire cannot do. We read the file here, in your browser, and ' +
   'compare what it contains against what you just told us. <strong>The file is never uploaded.</strong></p>' +
@@ -648,7 +740,7 @@ function chartRows() {
 }
 
 SCREENS.results =
-  '<p class="eyebrow">Step 9 of 9 &middot; Your results</p>' +
+  '<p class="eyebrow">Step 10 of 10 &middot; Your results</p>' +
   '<h2>Where you stand</h2>' +
   '<p class="sub small">Two numbers per dimension: what your answers claimed, and what the evidence supports. ' +
   'Where they disagree by two levels or more, the measurement is used and the gap is shown.</p>' +
@@ -763,6 +855,21 @@ SCREENS.results =
     '<p class="small">Where insurance, professional indemnity, licensing or a formal qualification process ' +
     'is required or applicable under your regulations, contract or client requirements, that obligation is ' +
     'yours and must be discharged directly with the responsible body. This report substitutes for none of it.</p>' +
+    '<p class="small"><a href="disclaimer.html">Read the full Disclaimer Notice &rarr;</a></p>' +
+  '</div>' +
+
+  '<div class="printnotice">' +
+    '<h4>Notice &mdash; printed with every copy of this report</h4>' +
+    '<p><strong>This is only a technical readiness assessment. It qualifies nothing and no one.</strong> ' +
+    'It confers no certification, accreditation, licence, approval or professional status, and is not ' +
+    'evidence of compliance with any regulation, standard, code or contract. Do not present it as such ' +
+    '&mdash; to a client, an authority, an insurer, or in a tender.</p>' +
+    '<p>Answers are self-reported and measurements come from a file supplied by the respondent. Nothing ' +
+    'here has been audited or verified by any third party. Where insurance, professional indemnity, ' +
+    'licensing or a formal qualification process is required or applicable under your regulations or ' +
+    'appointment, that obligation is yours and this report substitutes for none of it.</p>' +
+    '<p><a href="disclaimer.html">Read the full Disclaimer Notice &rarr;</a> &nbsp;&middot;&nbsp; ' +
+    '<span class="mono">Notice v0.1 &middot; 22 Aug 2026</span></p>' +
   '</div>' +
 
   '<div class="actions">' +
@@ -771,16 +878,16 @@ SCREENS.results =
     '<button class="btn sec" data-go="intro">Start over</button>' +
   '</div>' +
   '<p class="small mono" style="margin-top:20px;padding-top:14px;border-top:1px solid var(--rule)">' +
-  'core-0.1 · locale ae-v1 · toolkit v0.1 · scope: one office or region · scoring is deterministic &mdash; ' +
+  'core-0.1 · locale ae-v1 · toolkit v0.1 · terms v0.1 acknowledged · scope: one office or region · scoring is deterministic &mdash; ' +
   'same answers and same versions always produce this same result. Technical readiness assessment only: ' +
   'self-reported, unaudited, qualifies nothing and no one, confers no certification or professional status.</p>';
 
 /* ---------- NAV ---------- */
 DIMENSIONS.forEach(function (d, i) { SCREENS['dim' + i] = dimScreen(i); });
 
-var ORDER = ['intro', 'context', 'dim0', 'dim1', 'dim2', 'dim3', 'dim4', 'model', 'results'];
+var ORDER = ['intro', 'agree', 'context', 'dim0', 'dim1', 'dim2', 'dim3', 'dim4', 'model', 'results'];
 var LABELS = {
-  intro: 'Introduction', context: 'About you',
+  intro: 'Introduction', agree: 'Before you begin', declined: 'No assessment taken', context: 'About you',
   dim0: 'Governance', dim1: 'People and skills', dim2: 'Technology',
   dim3: 'Data and standards', dim4: 'Organisational processes',
   model: 'Your model', results: 'Results'
@@ -790,8 +897,9 @@ var host = document.getElementById('screens');
 function show(name) {
   host.innerHTML = '<div class="screen on">' + SCREENS[name] + '</div>';
   var i = ORDER.indexOf(name);
+  if (i < 0) { window.scrollTo({ top: 0, behavior: 'instant' }); return; }
   var rail = document.getElementById('rail'), cap = document.getElementById('railcap');
-  rail.hidden = cap.hidden = (name === 'intro');
+  rail.hidden = cap.hidden = (name === 'intro' || name === 'agree' || name === 'declined');
   [].forEach.call(rail.children, function (li, n) {
     li.className = n < i ? 'done' : (n === i ? 'now' : '');
   });
@@ -800,8 +908,15 @@ function show(name) {
   window.scrollTo({ top: 0, behavior: 'instant' });
 }
 
+document.addEventListener('change', function (e) {
+  if (e.target.id === 'ackbox') {
+    document.getElementById('agreebtn').disabled = !e.target.checked;
+  }
+});
+
 document.addEventListener('click', function (e) {
   var go = e.target.closest('[data-go]');
+  if (go && go.disabled) return;
   if (go) { show(go.dataset.go); return; }
 
   var tb = e.target.closest('.tipbtn');

--- a/readiness/index.html
+++ b/readiness/index.html
@@ -324,7 +324,7 @@ var TIP = function (text, anchor) {
     (anchor ? '<span class="anchor">Anchor · ' + anchor + '</span>' : '') + '</span></span>';
 };
 
-var LV = ['L0', 'L1', 'L2', 'L3', 'L4'];
+var LV = ['L0', 'L1', 'L2', 'L3', 'L4', 'L5'];
 function opts(name, list) {
   return '<div class="opts">' + list.map(function (t, i) {
     return '<input type="radio" name="' + name + '" id="' + name + i + '"' + (i === 1 ? ' checked' : '') + '>' +
@@ -338,11 +338,11 @@ function q(id, title, tip, anchor, list) {
 
 /* ---------- CANNED RESULTS ---------- */
 var DIMS = [
-  { name: 'Governance',        measured: 1.8, claimed: 2.0 },
-  { name: 'People and skills',  measured: 1.3, claimed: 1.5 },
-  { name: 'Technology',        measured: 2.3, claimed: 2.5 },
-  { name: 'Data and standards', measured: 0.9, claimed: 2.8 },
-  { name: 'Organisational processes', measured: 1.5, claimed: 1.8 }
+  { name: 'Governance',               measured: 2.0, claimed: 2.25 },
+  { name: 'People and skills',        measured: 1.5, claimed: 1.75 },
+  { name: 'Technology',               measured: 2.8, claimed: 3.00 },
+  { name: 'Data and standards',       measured: 1.0, claimed: 3.25 },
+  { name: 'Organisational processes', measured: 1.8, claimed: 2.00 }
 ];
 
 var SCREENS = {};
@@ -433,92 +433,93 @@ var DIMENSIONS = [
 { key:'A', name:'Governance', blurb:'How your firm is set up', items:[
   { id:'A1', pre:2, q:'Is there a written position on open / IFC deliverables?',
     tip:'A policy that exists but is never checked behaves differently from one that is enforced. We are separating those two, not judging either.',
-    anchor:'ISO 19650 · organisational information requirements',
-    o:['Nothing, and it has not come up','Discussed, nothing written','Written into a policy or BEP template','Written, someone owns it, checked on projects','As above, and non-compliance is escalated'] },
-  { id:'A2', pre:2, q:'Your most recent contract &mdash; what did it say about deliverable format?',
+    anchor:'ISO 19650-1 &middot; organisational information requirements',
+    o:['Nothing, and it has not come up','It happens case by case, when someone remembers','Written into a policy or BEP template and kept current','A standard position applied across all projects','Compliance is checked and reported per project','Those reports drive changes to the policy'] },
+  { id:'A2', pre:3, q:'Your most recent contract &mdash; what did it say about deliverable format?',
     tip:'Naming IFC and naming a schema version are different commitments. The second is checkable; the first often is not.',
-    anchor:'ISO 19650 · exchange information requirements',
-    o:['Did not mention format, or I don&rsquo;t know','Named native files only','Named IFC among the deliverables','Named IFC with a schema version','Named IFC with schema and a validation criterion'] },
+    anchor:'ISO 19650-2 &middot; exchange information requirements',
+    o:['Did not mention format, or I don&rsquo;t know','Format agreed informally, project by project','Named IFC in the appointment documents','A standard clause naming IFC and a schema version, every appointment','Conformance to that clause is verified at handover','Verification findings feed back into the clause'] },
   { id:'A3', pre:1, q:'Have you ever taken a finished model out of your BIM software and opened it elsewhere?',
     tip:'&ldquo;We own our data&rdquo; is a belief until somebody has actually pulled a model out and opened it somewhere else. This is the single strongest signal of lock-in exposure.',
-    anchor:'Vendor lock-in · data portability',
-    o:['Never tried','Tried, it did not work','Once, roughly worked, not repeated','Done on delivery and the result is checked','Routine, archived vendor-neutrally, re-opened periodically'] },
+    anchor:'Vendor lock-in &middot; data portability',
+    o:['Never tried','Tried once, ad hoc','Done on delivery and the result is kept','A standard step in every project close-out','Fidelity is measured against the source each time','Those measurements change how we export'] },
   { id:'A4', pre:3, q:'For authority submission, what do you actually hand over?',
     tip:'Submission requirements vary by jurisdiction &mdash; your locale pack adjusts this question. If model-based submission does not exist where you work, choose N/A and it is excluded from scoring rather than counted as a zero.',
-    anchor:'Locale pack · authority submission route',
-    o:['Paper or PDF drawings only','Native model files','IFC alongside other formats','IFC to a schema the authority named','IFC that passes the authority&rsquo;s validation first'], na:true } ]},
-
+    anchor:'Locale pack &middot; authority submission route',
+    o:['Paper or PDF drawings only','Native model files, as asked','IFC alongside other formats','IFC to the authority&rsquo;s named schema, every submission','Validated against the authority&rsquo;s criteria before sending','Validation findings change our authoring templates'], na:true }
+]},
 { key:'B', name:'People and skills', blurb:'Who actually knows this, and what happens without them', items:[
-  { id:'B1', pre:1, q:'Who in the firm could explain what an IFC property set is?',
+  { id:'B1', pre:2, q:'Who in the firm could explain what an IFC property set is?',
     tip:'Not a test of anyone&rsquo;s knowledge. We are finding out whether open-standards understanding sits with one person or is spread &mdash; that difference decides how fragile your capability is.',
-    anchor:'ISO 19650 · information management competence',
-    o:['Nobody','One person','Two or three','Most of the technical team','It is assumed knowledge here'] },
+    anchor:'ISO 19650-1 &middot; information management competence',
+    o:['Nobody','One person, self-taught','One person, and it is written down somewhere','Most of the technical team, through defined onboarding','Competence is assessed and tracked','Assessment results drive the training programme'] },
   { id:'B2', pre:2, q:'Is information or BIM management in anyone&rsquo;s job description?',
     tip:'Doing the job and being accountable for it are different things. A role with time allocated behaves differently from someone absorbing it on top of their real work.',
-    anchor:'ISO 19650 · Information Manager role',
-    o:['No','One person does it informally','Part of a named role','A defined role with time allocated','A defined role with authority to stop a delivery'] },
+    anchor:'ISO 19650-1 &middot; Information Manager function',
+    o:['No','Someone does it informally','Part of a named role, with time allocated','A defined role with documented responsibilities','Role performance is measured','Measurement reshapes the role'] },
   { id:'B3', pre:1, q:'If that person left tomorrow, what happens?',
     tip:'The most honest question in this section. Firms often score well on capability and badly here, and it is the best single predictor of whether a BIM programme survives a resignation.',
-    anchor:'BIM maturity · key-person concentration',
-    o:['BIM capability stops','Severely degraded for months','Slowed, but recoverable','Minor disruption, handover is documented','No material impact'] },
+    anchor:'Key-person concentration &middot; continuity',
+    o:['BIM capability stops','Severely degraded for months','Slowed; some handover notes exist','Documented handover and a defined backup role','Continuity is tested, not assumed','Test results drive succession planning'] },
   { id:'B4', pre:2, q:'Has anyone had BIM or open-standards training in the last 12 months?',
     tip:'Vendor product training and open-standards training are different investments. Learning one application deeply can even increase lock-in &mdash; that is not a criticism, just a different thing.',
-    anchor:'Succar · competency development',
-    o:['None','Self-taught only','Vendor product training','Open-standards training (IFC / ISO 19650)','An ongoing programme with a budget line'] } ]},
-
+    anchor:'Succar &middot; competency development',
+    o:['None','Self-taught only','Vendor product training, when budget allowed','A defined training path including open standards','Training outcomes are measured','Measured outcomes set next year&rsquo;s programme'] }
+]},
 { key:'C', name:'Technology', blurb:'What you run, and what it would take to change it', items:[
-  { id:'C1', pre:2, q:'How many BIM authoring tools are in regular use?',
+  { id:'C1', pre:3, q:'How many BIM authoring tools are in regular use?',
     tip:'One tool used well is not a failure. We are measuring concentration, not sophistication &mdash; a single-tool firm is efficient and exposed at the same time.',
-    anchor:'Vendor concentration · switching cost',
-    o:['None','Exactly one','One main, one occasional','Two or more in genuine use','Chosen per task; exchange between them is routine'] },
-  { id:'C2', pre:3, q:'Last time you received an IFC from someone else, what happened?',
+    anchor:'Vendor concentration &middot; switching cost',
+    o:['None','Exactly one, by default','One main, one occasional','Tool choice is a defined decision per task','Exchange between them is measured for loss','Those measurements drive the toolchain'] },
+  { id:'C2', pre:4, q:'Last time you received an IFC from someone else, what happened?',
     tip:'The most useful answer here is usually &ldquo;geometry fine, data missing&rdquo;. That is the normal state of IFC exchange and worth recording honestly rather than rounding up.',
-    anchor:'buildingSMART · IFC exchange fidelity',
-    o:['Never received one','Opened but unusable','Geometry fine, data missing','Opened and used it for real work','Used it and fed changes back'] },
+    anchor:'buildingSMART &middot; IFC exchange fidelity',
+    o:['Never received one','Opened but unusable','Geometry fine, data missing','Opened and used within a defined workflow','Import quality is checked and recorded','Findings go back to the sender and the exchange improves'] },
   { id:'C3', pre:2, q:'What most limits how many people here use BIM tools?',
     tip:'If licence cost is the answer, say so. That is the constraint the open route is most likely to relieve, and understating it makes your recommendations less useful.',
-    anchor:'Adoption barriers · licensing',
-    o:['Licence cost, severely','Licence cost, significantly','Hardware or skills','Minor constraints only','Nothing material'] },
+    anchor:'Adoption barriers &middot; licensing',
+    o:['Licence cost, severely','Licence cost, significantly','Hardware or skills, being managed','Access is planned and provisioned','Utilisation is measured against need','Measurement drives licensing decisions'] },
   { id:'C4', pre:3, q:'Has the firm ever evaluated an alternative to its main BIM tool?',
     tip:'Not a loyalty question. Having tested an alternative is what turns &ldquo;we could move if we had to&rdquo; from a hope into a known quantity.',
-    anchor:'Switching cost · optionality',
-    o:['Never considered it','Discussed only','Someone trialled one','Trialled and costed a switch','Ran a real project on an alternative'] } ]},
-
+    anchor:'Switching cost &middot; optionality',
+    o:['Never considered it','Discussed only','Someone trialled one','Evaluation is a defined periodic exercise','Switching cost is quantified','That figure informs procurement'] }
+]},
 { key:'D', name:'Data and standards', blurb:'What is actually inside the model', items:[
-  { id:'D1', pre:3, q:'Do your models use a classification system?',
+  { id:'D1', pre:4, q:'Do your models use a classification system?',
     tip:'A file-naming convention is not a classification system. Both are useful and they answer different questions &mdash; the gap analysis needs to know which one you actually have.',
-    anchor:'ISO 12006-2 · Uniclass / OmniClass / MasterFormat',
-    o:['No','A file-naming convention only','A classification standard, partly applied','Applied consistently','Applied and validated before issue'] },
-  { id:'D2', pre:2, q:'Is what the model must contain written down before the project starts?',
+    anchor:'ISO 12006-2 &middot; Uniclass / OmniClass / MasterFormat',
+    o:['No','A file-naming convention only','A classification standard, partly applied','Applied consistently through a defined process','Coverage is measured and reported per project','Coverage figures drive template changes'] },
+  { id:'D2', pre:3, q:'Is what the model must contain written down before the project starts?',
     tip:'This is about information requirements, whatever they are called locally. Written before the project behaves very differently from agreed as you go.',
-    anchor:'ISO 19650 · EIR / AIR',
-    o:['No','Verbally agreed','A written requirement exists','Written and referenced during the project','Written and verified at handover'] },
+    anchor:'ISO 19650-2 &middot; EIR / AIR',
+    o:['No','Verbally agreed','A written requirement exists','A standard requirement applied to every project','Compliance is measured at handover','Measurement changes the standard requirement'] },
   { id:'D3', pre:4, q:'Before sending an IFC out, is it checked?',
     tip:'Opening it to see whether it looks right is a real answer and a common one. We are separating &ldquo;looked at it&rdquo; from &ldquo;ran it through something that reports errors&rdquo;.',
-    anchor:'buildingSMART · validation service',
-    o:['Never sent one','Not checked','Opened once to eyeball it','Checked against a written expectation','Validated with a checker tool and the result recorded'] },
+    anchor:'buildingSMART &middot; validation service',
+    o:['Never sent one','Not checked','Opened once to eyeball it','Checked against a defined expectation, every issue','Validated with a checker tool and results recorded','Recorded results drive authoring changes'] },
   { id:'D4', pre:2, q:'Where will your finished project models be in five years?',
     tip:'An asset outlives the software that modelled it by decades. This is the question owners eventually ask, and most firms have never been asked it.',
-    anchor:'ISO 19650 · long-term information stewardship',
-    o:['Nowhere specific','Native format on a server somewhere','Deliberately archived, native only','Archived including IFC','Archived, IFC, re-opened periodically to confirm it still reads'] } ]},
-
+    anchor:'ISO 19650-3 &middot; long-term information stewardship',
+    o:['Nowhere specific','Native format on a server somewhere','Deliberately archived, native only','A defined archive process including IFC','Archive readability is tested periodically','Test results change the archive policy'] }
+]},
 { key:'E', name:'Organisational processes', blurb:'How the work actually flows', items:[
   { id:'E1', pre:2, q:'How is model data shared on a project?',
     tip:'A shared drive is a real answer. We are distinguishing a place where files sit from an environment that manages versions, status, and who has what.',
-    anchor:'ISO 19650 · Common Data Environment',
-    o:['Email or file transfer','A shared drive','A CDE for documents','A CDE handling models','A CDE handling IFC natively, with issue tracking'] },
-  { id:'E2', pre:2, q:'Are model exchanges scheduled?',
+    anchor:'ISO 19650-1 &middot; Common Data Environment',
+    o:['Email or file transfer','A shared drive','A CDE for documents','A CDE handling models, with defined states','CDE compliance is measured','Measurement drives CDE configuration'] },
+  { id:'E2', pre:3, q:'Are model exchanges scheduled?',
     tip:'Ad hoc on request is extremely common and not a failure. Scheduled exchange is what lets other disciplines plan around you.',
-    anchor:'ISO 19650 · information delivery planning',
-    o:['Ad hoc, on request','Around milestones, informally','Defined in a plan','Defined and tracked','Defined, tracked, and missed exchanges have consequences'] },
+    anchor:'ISO 19650-2 &middot; information delivery planning',
+    o:['Ad hoc, on request','Around milestones, informally','Defined in a plan','A standard delivery plan on every project','Exchange punctuality is measured','Measurement changes the plan'] },
   { id:'E3', pre:1, q:'After handover, is the model used for anything?',
     tip:'Most models stop at handover. If yours does, that is the normal case &mdash; and it is the largest unrealised value in the whole lifecycle.',
-    anchor:'Asset information model · FM handover',
-    o:['No','Occasionally referenced','Handed to the client, unclear if used','Used for FM or asset management','Drives O&amp;M with data flowing back to the model'] },
+    anchor:'ISO 19650-3 &middot; asset information model',
+    o:['No','Occasionally referenced','Handed over, unclear if used','A defined role in FM or asset management','Its operational value is measured','Measurement drives what we model'] },
   { id:'E4', pre:2, q:'Is anything about your BIM work measured?',
     tip:'Anecdotes count as an honest &ldquo;no&rdquo;. Without measurement there is no way to tell whether a change you make actually worked.',
-    anchor:'Maturity · measurement and improvement',
-    o:['No','Anecdotally','Some metrics collected','Metrics reviewed periodically','Metrics drive changes in how projects run'] } ]}
+    anchor:'ISO/IEC 33020 &middot; measurement and improvement',
+    o:['No','Anecdotally','Some metrics collected','A defined metric set on every project','Metrics reviewed against targets','Reviews change how projects run'] }
+]}
 ];
 
 function renderItem(it) {
@@ -616,10 +617,10 @@ SCREENS.model =
 /* ---------- 5 · RESULTS ---------- */
 function chartRows() {
   return DIMS.map(function (d) {
-    var w = (d.measured / 4 * 100).toFixed(1), c = (d.claimed / 4 * 100).toFixed(1);
+    var w = (d.measured / 5 * 100).toFixed(1), c = (d.claimed / 5 * 100).toFixed(1);
     var gap = Math.abs(d.claimed - d.measured) >= 2;
     return '<div class="crow" title="' + d.name + ' — measured ' + d.measured.toFixed(1) +
-      ' of 4, you said ' + d.claimed.toFixed(1) + '">' +
+      ' of 5, you said ' + d.claimed.toFixed(1) + '">' +
       '<div class="cname">' + d.name + (gap ? ' <span style="color:var(--warn)">&#9650;</span>' : '') + '</div>' +
       '<div class="ctrack"><div class="cbar" style="width:' + w + '%"></div>' +
       '<div class="cclaim" style="left:' + c + '%"></div></div>' +
@@ -635,10 +636,10 @@ SCREENS.results =
 
   '<div class="card">' +
     '<h3>Readiness profile</h3>' +
-    '<p class="small" style="margin-top:5px">Maturity 0&ndash;4 across five dimensions</p>' +
+    '<p class="small" style="margin-top:5px">ISO/IEC 33020 capability levels 0&ndash;5, across five dimensions</p>' +
     '<div class="chart">' + chartRows() +
       '<div class="cscale"><span></span><div class="cticks">' +
-        '<span>0</span><span>1</span><span>2</span><span>3</span><span>4</span></div><span></span></div>' +
+        '<span>0</span><span>1</span><span>2</span><span>3</span><span>4</span><span>5</span></div><span></span></div>' +
     '</div>' +
     '<div class="clegend">' +
       '<span><i class="swatch"></i>Assessed level</span>' +
@@ -660,7 +661,7 @@ SCREENS.results =
     '<div class="delta" style="margin-top:13px">' +
       '<div class="ic">!</div><div>' +
         '<h4>Classification</h4>' +
-        '<p>You reported a classification standard applied consistently. 4.2% of elements in the file carry a ' +
+        '<p>You reported that classification coverage is measured and reported per project. 4.2% of elements in the file carry a ' +
         'classification reference. We scored the measurement.</p>' +
         '<div class="vs"><span><b>You said</b>L3 · applied consistently</span>' +
         '<span><b>Measured</b>L1 · 4.2% coverage</span></div>' +
@@ -696,11 +697,11 @@ SCREENS.results =
 
   '<div class="idx2">' +
     '<div class="ix"><span class="who">Can we start?</span>' +
-      '<div class="v">1.6<small> / 4</small></div>' +
+      '<div class="v">1.9<small> / 5</small></div>' +
       '<div style="font-weight:600;font-size:14px">Entry readiness</div>' +
       '<p>The open route is reachable, but not with this model as it stands.</p></div>' +
     '<div class="ix"><span class="who">How exposed are we?</span>' +
-      '<div class="v">3.1<small> / 4</small></div>' +
+      '<div class="v">3.9<small> / 5</small></div>' +
       '<div style="font-weight:600;font-size:14px">Lock-in exposure</div>' +
       '<p>High. No model has been retrieved from your authoring tool and re-opened elsewhere.</p></div>' +
   '</div>' +

--- a/readiness/index.html
+++ b/readiness/index.html
@@ -300,7 +300,7 @@ details.tvwrap summary{cursor:pointer;font-size:13.5px;color:var(--accent-ink);f
     <div class="brandtext">OpenBIM Readiness Assessment Toolkit<small>Research instrument · v0.1 draft</small></div>
     <div class="topspacer"></div>
     <button class="ghostbtn" id="themebtn" type="button">Theme</button>
-    <button class="ghostbtn" id="helpbtn" type="button">? Read more</button>
+    <a class="ghostbtn" id="helpbtn" href="why.html">? Read more</a>
   </div>
 
   <ul class="rail" id="rail" hidden>
@@ -682,11 +682,6 @@ document.addEventListener('click', function (e) {
     var dark = r.getAttribute('data-theme') === 'dark' ||
       (!r.getAttribute('data-theme') && matchMedia('(prefers-color-scheme:dark)').matches);
     r.setAttribute('data-theme', dark ? 'light' : 'dark');
-  }
-  if (e.target.id === 'helpbtn') {
-    alert('MOCKUP — this opens the "Read more" explainer page on GitHub Pages:\n\n' +
-      '· Why open BIM matters (industry)\n· Where you stand (your gap)\n· What to do about it (roadmap)\n\n' +
-      'Charts there use measured or cited data only — never invented figures.');
   }
 });
 

--- a/readiness/index.html
+++ b/readiness/index.html
@@ -351,7 +351,7 @@ var SCREENS = {};
 /* ---------- 1 · INTRO ---------- */
 SCREENS.intro =
   '<p class="eyebrow">Research instrument · open access</p>' +
-  '<h1>You&rsquo;re expected to deliver open BIM.<br>Nothing tells you whether you&rsquo;re ready.</h1>' +
+  '<h1>You&rsquo;re expected to deliver OpenBIM.<br>Nothing tells you whether you&rsquo;re ready.</h1>' +
   '<p class="sub">Twenty questions about how your firm works, plus one IFC file we read inside your browser. ' +
   'You get a checklist of what to fix, in order.</p>' +
 

--- a/readiness/index.html
+++ b/readiness/index.html
@@ -356,10 +356,13 @@ SCREENS.intro =
   'You get a checklist of what to fix, in order.</p>' +
 
   '<div class="card formal">' +
-    '<p><strong>This OpenBIM Readiness Assessment Toolkit</strong> is a research instrument that measures an ' +
-    'organisation&rsquo;s readiness to adopt open BIM standards across five dimensions &mdash; governance, people and ' +
-    'skills, technology, data and standards, and process &mdash; combining self-reported organisational evidence ' +
-    'with metrics computed directly from your own IFC model.</p>' +
+    '<p><strong>This OpenBIM Readiness Assessment Toolkit</strong> is a structured but easy-to-use way for an ' +
+    'organisation to gauge how ready it is to adopt OpenBIM and to see the specific issues standing in its way. ' +
+    'Readiness is assessed across the dimensions most associated with successful adoption: governance, people and ' +
+    'skills, technology, data and standards, and organisational processes.</p>' +
+    '<p>The result shows an organisation where its capability gaps and implementation risks lie, and which areas ' +
+    'to address first before committing to OpenBIM &mdash; combining what you report with metrics computed ' +
+    'directly from your own IFC model.</p>' +
     '<p class="small">It measures readiness and model data quality. It does not certify regulatory compliance, ' +
     'and no software does so in any jurisdiction.</p>' +
   '</div>' +

--- a/readiness/index.html
+++ b/readiness/index.html
@@ -304,8 +304,7 @@ details.tvwrap summary{cursor:pointer;font-size:13.5px;color:var(--accent-ink);f
   </div>
 
   <ul class="rail" id="rail" hidden>
-    <li data-step="1"></li><li data-step="2"></li><li data-step="3"></li>
-    <li data-step="4"></li><li data-step="5"></li>
+    <li></li><li></li><li></li><li></li><li></li><li></li><li></li><li></li><li></li>
   </ul>
   <div class="railcap" id="railcap" hidden><span id="railnow">About you</span><span id="railpct">Step 1 of 5</span></div>
 
@@ -340,10 +339,10 @@ function q(id, title, tip, anchor, list) {
 /* ---------- CANNED RESULTS ---------- */
 var DIMS = [
   { name: 'Governance',        measured: 1.8, claimed: 2.0 },
-  { name: 'People & skills',   measured: 1.3, claimed: 1.5 },
+  { name: 'People and skills',  measured: 1.3, claimed: 1.5 },
   { name: 'Technology',        measured: 2.3, claimed: 2.5 },
-  { name: 'Data & standards',  measured: 0.9, claimed: 2.8 },
-  { name: 'Process',           measured: 1.5, claimed: 1.8 }
+  { name: 'Data and standards', measured: 0.9, claimed: 2.8 },
+  { name: 'Organisational processes', measured: 1.5, claimed: 1.8 }
 ];
 
 var SCREENS = {};
@@ -384,7 +383,7 @@ SCREENS.intro =
 
 /* ---------- 2 · CONTEXT ---------- */
 SCREENS.context =
-  '<p class="eyebrow">Step 1 of 5 · About you</p>' +
+  '<p class="eyebrow">Step 2 of 9 &middot; About you</p>' +
   '<h2>A little context</h2>' +
   '<p class="sub small">None of this identifies you. It selects the right rules for your jurisdiction and ' +
   'places you in a comparable group.</p>' +
@@ -424,67 +423,136 @@ SCREENS.context =
   '</div>' +
 
   '<div class="actions">' +
-    '<button class="btn" data-go="assess">Continue</button>' +
+    '<button class="btn" data-go="dim0">Continue</button>' +
     '<button class="btn sec" data-go="intro">Back</button>' +
   '</div>';
 
-/* ---------- 3 · ASSESSMENT ---------- */
-SCREENS.assess =
-  '<p class="eyebrow">Step 2 of 5 · Governance &nbsp;·&nbsp; 1 of 5 sections</p>' +
-  '<h2>How your firm is set up</h2>' +
-  '<p class="sub small">Each question asks about the <strong>last real instance</strong>, not general practice. ' +
-  'There is no right answer here &mdash; only an accurate one.</p>' +
+/* ---------- THE 20 SCORED ITEMS ---------- */
+/* pre = mockup's canned answer index, chosen to reproduce the results screen. */
+var DIMENSIONS = [
+{ key:'A', name:'Governance', blurb:'How your firm is set up', items:[
+  { id:'A1', pre:2, q:'Is there a written position on open / IFC deliverables?',
+    tip:'A policy that exists but is never checked behaves differently from one that is enforced. We are separating those two, not judging either.',
+    anchor:'ISO 19650 · organisational information requirements',
+    o:['Nothing, and it has not come up','Discussed, nothing written','Written into a policy or BEP template','Written, someone owns it, checked on projects','As above, and non-compliance is escalated'] },
+  { id:'A2', pre:2, q:'Your most recent contract &mdash; what did it say about deliverable format?',
+    tip:'Naming IFC and naming a schema version are different commitments. The second is checkable; the first often is not.',
+    anchor:'ISO 19650 · exchange information requirements',
+    o:['Did not mention format, or I don&rsquo;t know','Named native files only','Named IFC among the deliverables','Named IFC with a schema version','Named IFC with schema and a validation criterion'] },
+  { id:'A3', pre:1, q:'Have you ever taken a finished model out of your BIM software and opened it elsewhere?',
+    tip:'&ldquo;We own our data&rdquo; is a belief until somebody has actually pulled a model out and opened it somewhere else. This is the single strongest signal of lock-in exposure.',
+    anchor:'Vendor lock-in · data portability',
+    o:['Never tried','Tried, it did not work','Once, roughly worked, not repeated','Done on delivery and the result is checked','Routine, archived vendor-neutrally, re-opened periodically'] },
+  { id:'A4', pre:3, q:'For authority submission, what do you actually hand over?',
+    tip:'Submission requirements vary by jurisdiction &mdash; your locale pack adjusts this question. If model-based submission does not exist where you work, choose N/A and it is excluded from scoring rather than counted as a zero.',
+    anchor:'Locale pack · authority submission route',
+    o:['Paper or PDF drawings only','Native model files','IFC alongside other formats','IFC to a schema the authority named','IFC that passes the authority&rsquo;s validation first'], na:true } ]},
 
-  '<div class="card">' +
-    q('A1', 'Is there a written position on open / IFC deliverables?',
-      'A policy that exists but is never checked behaves differently from one that is enforced. We are separating those two, not judging either.',
-      'ISO 19650 · organisational information requirements',
-      ['Nothing, and it has not come up',
-       'Discussed, nothing written',
-       'Written into a policy or BEP template',
-       'Written, someone owns it, checked on projects',
-       'As above, and non-compliance is escalated']) +
+{ key:'B', name:'People and skills', blurb:'Who actually knows this, and what happens without them', items:[
+  { id:'B1', pre:1, q:'Who in the firm could explain what an IFC property set is?',
+    tip:'Not a test of anyone&rsquo;s knowledge. We are finding out whether open-standards understanding sits with one person or is spread &mdash; that difference decides how fragile your capability is.',
+    anchor:'ISO 19650 · information management competence',
+    o:['Nobody','One person','Two or three','Most of the technical team','It is assumed knowledge here'] },
+  { id:'B2', pre:2, q:'Is information or BIM management in anyone&rsquo;s job description?',
+    tip:'Doing the job and being accountable for it are different things. A role with time allocated behaves differently from someone absorbing it on top of their real work.',
+    anchor:'ISO 19650 · Information Manager role',
+    o:['No','One person does it informally','Part of a named role','A defined role with time allocated','A defined role with authority to stop a delivery'] },
+  { id:'B3', pre:1, q:'If that person left tomorrow, what happens?',
+    tip:'The most honest question in this section. Firms often score well on capability and badly here, and it is the best single predictor of whether a BIM programme survives a resignation.',
+    anchor:'BIM maturity · key-person concentration',
+    o:['BIM capability stops','Severely degraded for months','Slowed, but recoverable','Minor disruption, handover is documented','No material impact'] },
+  { id:'B4', pre:2, q:'Has anyone had BIM or open-standards training in the last 12 months?',
+    tip:'Vendor product training and open-standards training are different investments. Learning one application deeply can even increase lock-in &mdash; that is not a criticism, just a different thing.',
+    anchor:'Succar · competency development',
+    o:['None','Self-taught only','Vendor product training','Open-standards training (IFC / ISO 19650)','An ongoing programme with a budget line'] } ]},
 
-    q('A2', 'Your most recent contract &mdash; what did it say about deliverable format?',
-      'Naming IFC and naming a schema version are different commitments. The second is checkable; the first often is not.',
-      'ISO 19650 · exchange information requirements',
-      ['Did not mention format, or I don’t know',
-       'Named native files only',
-       'Named IFC among the deliverables',
-       'Named IFC with a schema version',
-       'Named IFC with schema and a validation criterion']) +
+{ key:'C', name:'Technology', blurb:'What you run, and what it would take to change it', items:[
+  { id:'C1', pre:2, q:'How many BIM authoring tools are in regular use?',
+    tip:'One tool used well is not a failure. We are measuring concentration, not sophistication &mdash; a single-tool firm is efficient and exposed at the same time.',
+    anchor:'Vendor concentration · switching cost',
+    o:['None','Exactly one','One main, one occasional','Two or more in genuine use','Chosen per task; exchange between them is routine'] },
+  { id:'C2', pre:3, q:'Last time you received an IFC from someone else, what happened?',
+    tip:'The most useful answer here is usually &ldquo;geometry fine, data missing&rdquo;. That is the normal state of IFC exchange and worth recording honestly rather than rounding up.',
+    anchor:'buildingSMART · IFC exchange fidelity',
+    o:['Never received one','Opened but unusable','Geometry fine, data missing','Opened and used it for real work','Used it and fed changes back'] },
+  { id:'C3', pre:2, q:'What most limits how many people here use BIM tools?',
+    tip:'If licence cost is the answer, say so. That is the constraint the open route is most likely to relieve, and understating it makes your recommendations less useful.',
+    anchor:'Adoption barriers · licensing',
+    o:['Licence cost, severely','Licence cost, significantly','Hardware or skills','Minor constraints only','Nothing material'] },
+  { id:'C4', pre:3, q:'Has the firm ever evaluated an alternative to its main BIM tool?',
+    tip:'Not a loyalty question. Having tested an alternative is what turns &ldquo;we could move if we had to&rdquo; from a hope into a known quantity.',
+    anchor:'Switching cost · optionality',
+    o:['Never considered it','Discussed only','Someone trialled one','Trialled and costed a switch','Ran a real project on an alternative'] } ]},
 
-    q('A3', 'Have you ever taken a finished model out of your BIM software and opened it elsewhere?',
-      '&ldquo;We own our data&rdquo; is a belief until somebody has actually pulled a model out and opened it somewhere else. This is the single strongest signal of lock-in exposure.',
-      'Vendor lock-in · data portability',
-      ['Never tried',
-       'Tried, it did not work',
-       'Once, roughly worked, not repeated',
-       'Done on delivery and the result is checked',
-       'Routine, archived vendor-neutrally, re-opened periodically']) +
+{ key:'D', name:'Data and standards', blurb:'What is actually inside the model', items:[
+  { id:'D1', pre:3, q:'Do your models use a classification system?',
+    tip:'A file-naming convention is not a classification system. Both are useful and they answer different questions &mdash; the gap analysis needs to know which one you actually have.',
+    anchor:'ISO 12006-2 · Uniclass / OmniClass / MasterFormat',
+    o:['No','A file-naming convention only','A classification standard, partly applied','Applied consistently','Applied and validated before issue'] },
+  { id:'D2', pre:2, q:'Is what the model must contain written down before the project starts?',
+    tip:'This is about information requirements, whatever they are called locally. Written before the project behaves very differently from agreed as you go.',
+    anchor:'ISO 19650 · EIR / AIR',
+    o:['No','Verbally agreed','A written requirement exists','Written and referenced during the project','Written and verified at handover'] },
+  { id:'D3', pre:4, q:'Before sending an IFC out, is it checked?',
+    tip:'Opening it to see whether it looks right is a real answer and a common one. We are separating &ldquo;looked at it&rdquo; from &ldquo;ran it through something that reports errors&rdquo;.',
+    anchor:'buildingSMART · validation service',
+    o:['Never sent one','Not checked','Opened once to eyeball it','Checked against a written expectation','Validated with a checker tool and the result recorded'] },
+  { id:'D4', pre:2, q:'Where will your finished project models be in five years?',
+    tip:'An asset outlives the software that modelled it by decades. This is the question owners eventually ask, and most firms have never been asked it.',
+    anchor:'ISO 19650 · long-term information stewardship',
+    o:['Nowhere specific','Native format on a server somewhere','Deliberately archived, native only','Archived including IFC','Archived, IFC, re-opened periodically to confirm it still reads'] } ]},
 
-    q('A4', 'For authority submission, what do you actually hand over?',
-      'Submission requirements vary by jurisdiction &mdash; your locale pack adjusts this question. If model-based submission does not exist where you work, choose N/A and it is excluded from scoring rather than counted as a zero.',
-      'Locale pack · UAE authority submission',
-      ['Paper or PDF drawings only',
-       'Native model files',
-       'IFC alongside other formats',
-       'IFC to a schema the authority named',
-       'IFC that passes the authority’s validation first']) +
+{ key:'E', name:'Organisational processes', blurb:'How the work actually flows', items:[
+  { id:'E1', pre:2, q:'How is model data shared on a project?',
+    tip:'A shared drive is a real answer. We are distinguishing a place where files sit from an environment that manages versions, status, and who has what.',
+    anchor:'ISO 19650 · Common Data Environment',
+    o:['Email or file transfer','A shared drive','A CDE for documents','A CDE handling models','A CDE handling IFC natively, with issue tracking'] },
+  { id:'E2', pre:2, q:'Are model exchanges scheduled?',
+    tip:'Ad hoc on request is extremely common and not a failure. Scheduled exchange is what lets other disciplines plan around you.',
+    anchor:'ISO 19650 · information delivery planning',
+    o:['Ad hoc, on request','Around milestones, informally','Defined in a plan','Defined and tracked','Defined, tracked, and missed exchanges have consequences'] },
+  { id:'E3', pre:1, q:'After handover, is the model used for anything?',
+    tip:'Most models stop at handover. If yours does, that is the normal case &mdash; and it is the largest unrealised value in the whole lifecycle.',
+    anchor:'Asset information model · FM handover',
+    o:['No','Occasionally referenced','Handed to the client, unclear if used','Used for FM or asset management','Drives O&amp;M with data flowing back to the model'] },
+  { id:'E4', pre:2, q:'Is anything about your BIM work measured?',
+    tip:'Anecdotes count as an honest &ldquo;no&rdquo;. Without measurement there is no way to tell whether a change you make actually worked.',
+    anchor:'Maturity · measurement and improvement',
+    o:['No','Anecdotally','Some metrics collected','Metrics reviewed periodically','Metrics drive changes in how projects run'] } ]}
+];
 
-    '<p class="small" style="margin-top:20px;padding-top:16px;border-top:1px solid var(--rule-soft)">' +
-    'Remaining sections: People &amp; skills · Technology · Data &amp; standards · Process &mdash; four questions each. ' +
-    '<em>Not built in this mockup.</em></p>' +
-  '</div>' +
+function renderItem(it) {
+  var rows = it.o.map(function (t, i) {
+    return '<input type="radio" name="' + it.id + '" id="' + it.id + i + '"' + (i === it.pre ? ' checked' : '') + '>' +
+      '<label for="' + it.id + i + '"><span class="lv">' + LV[i] + '</span><span class="dot"></span><span>' + t + '</span></label>';
+  }).join('');
+  if (it.na) {
+    rows += '<input type="radio" name="' + it.id + '" id="' + it.id + 'na">' +
+      '<label for="' + it.id + 'na"><span class="lv">N/A</span><span class="dot"></span>' +
+      '<span>No model-based submission exists in our market <em class="small">&mdash; excluded from scoring</em></span></label>';
+  }
+  return '<div class="field"><div class="qhead"><span class="qid">' + it.id + '</span><span>' + it.q + '</span>' +
+    TIP(it.tip, it.anchor) + '</div><div class="opts">' + rows + '</div></div>';
+}
 
-  '<div class="actions">' +
-    '<button class="btn" data-go="model">Continue to model check</button>' +
-    '<button class="btn sec" data-go="context">Back</button>' +
-  '</div>';
+function dimScreen(n) {
+  var d = DIMENSIONS[n];
+  return '<p class="eyebrow">Step ' + (n + 2) + ' of 9 &nbsp;&middot;&nbsp; ' + d.name +
+      ' &nbsp;&middot;&nbsp; section ' + (n + 1) + ' of 5</p>' +
+    '<h2>' + d.blurb + '</h2>' +
+    '<p class="sub small">Each question asks about the <strong>last real instance</strong>, not general practice. ' +
+    'There is no right answer here &mdash; only an accurate one. Tap <strong>?</strong> on any question to see why we ask it.</p>' +
+    '<div class="card">' + d.items.map(renderItem).join('') + '</div>' +
+    '<div class="actions">' +
+      '<button class="btn" data-go="' + (n < 4 ? 'dim' + (n + 1) : 'model') + '">' +
+        (n < 4 ? 'Continue to ' + DIMENSIONS[n + 1].name : 'Continue to model check') + '</button>' +
+      '<button class="btn sec" data-go="' + (n > 0 ? 'dim' + (n - 1) : 'context') + '">Back</button>' +
+    '</div>';
+}
 
 /* ---------- 4 · MODEL ---------- */
 SCREENS.model =
-  '<p class="eyebrow">Step 3 of 5 · Your model</p>' +
+  '<p class="eyebrow">Step 8 of 9 &middot; Your model</p>' +
   '<h2>Now let&rsquo;s look at an actual file</h2>' +
   '<p class="sub small">This is the part a questionnaire cannot do. We read the file here, in your browser, and ' +
   'compare what it contains against what you just told us. <strong>The file is never uploaded.</strong></p>' +
@@ -542,7 +610,7 @@ SCREENS.model =
 
   '<div class="actions">' +
     '<button class="btn" data-go="results">See my results</button>' +
-    '<button class="btn sec" data-go="assess">Back</button>' +
+    '<button class="btn sec" data-go="dim4">Back</button>' +
   '</div>';
 
 /* ---------- 5 · RESULTS ---------- */
@@ -560,7 +628,7 @@ function chartRows() {
 }
 
 SCREENS.results =
-  '<p class="eyebrow">Step 5 of 5 · Your results</p>' +
+  '<p class="eyebrow">Step 9 of 9 &middot; Your results</p>' +
   '<h2>Where you stand</h2>' +
   '<p class="sub small">Two numbers per dimension: what your answers claimed, and what the evidence supports. ' +
   'Where they disagree by two levels or more, the measurement is used and the gap is shown.</p>' +
@@ -654,8 +722,15 @@ SCREENS.results =
   'same answers and same versions always produce this same result</p>';
 
 /* ---------- NAV ---------- */
-var ORDER = ['intro', 'context', 'assess', 'model', 'results'];
-var LABELS = { intro: 'Introduction', context: 'About you', assess: 'Your firm', model: 'Your model', results: 'Results' };
+DIMENSIONS.forEach(function (d, i) { SCREENS['dim' + i] = dimScreen(i); });
+
+var ORDER = ['intro', 'context', 'dim0', 'dim1', 'dim2', 'dim3', 'dim4', 'model', 'results'];
+var LABELS = {
+  intro: 'Introduction', context: 'About you',
+  dim0: 'Governance', dim1: 'People and skills', dim2: 'Technology',
+  dim3: 'Data and standards', dim4: 'Organisational processes',
+  model: 'Your model', results: 'Results'
+};
 var host = document.getElementById('screens');
 
 function show(name) {

--- a/readiness/index.html
+++ b/readiness/index.html
@@ -250,6 +250,15 @@ pre.payload{
 .delta .vs{display:flex;gap:20px;margin-top:10px;flex-wrap:wrap;font-size:13px}
 .delta .vs b{display:block;font-family:"IBM Plex Mono",monospace;font-size:11px;color:var(--muted);font-weight:500;letter-spacing:.06em;text-transform:uppercase}
 
+/* ---- RISK REGISTER ---- */
+.risks{list-style:none;padding:0;margin:14px 0 0;display:flex;flex-direction:column;gap:10px}
+.risks li{
+  background:var(--surface-2);border:1px solid var(--rule);border-left:3px solid var(--warn);
+  border-radius:7px;padding:14px 16px
+}
+.risks h4{margin:0 0 4px;font-size:14.5px;font-weight:600;color:var(--warn)}
+.risks p{font-size:13.5px;color:var(--ink-2)}
+
 /* ---- FIX LIST ---- */
 .fixes{list-style:none;padding:0;margin:16px 0;counter-reset:f}
 .fixes li{
@@ -337,12 +346,13 @@ function q(id, title, tip, anchor, list) {
 }
 
 /* ---------- CANNED RESULTS ---------- */
+/* target = proportionate level for an 11-50 firm, engineering, mixed projects (§6.5) */
 var DIMS = [
-  { name: 'Governance',               measured: 2.0, claimed: 2.25 },
-  { name: 'People and skills',        measured: 1.5, claimed: 1.75 },
-  { name: 'Technology',               measured: 2.8, claimed: 3.00 },
-  { name: 'Data and standards',       measured: 1.0, claimed: 3.25 },
-  { name: 'Organisational processes', measured: 1.8, claimed: 2.00 }
+  { name: 'Governance',               measured: 2.0, claimed: 2.25, target: 3 },
+  { name: 'People and skills',        measured: 1.5, claimed: 1.75, target: 2 },
+  { name: 'Technology',               measured: 2.8, claimed: 3.00, target: 3 },
+  { name: 'Data and standards',       measured: 1.0, claimed: 3.25, target: 3 },
+  { name: 'Organisational processes', measured: 1.8, claimed: 2.00, target: 2 }
 ];
 
 var SCREENS = {};
@@ -532,6 +542,9 @@ function renderItem(it) {
       '<label for="' + it.id + 'na"><span class="lv">N/A</span><span class="dot"></span>' +
       '<span>No model-based submission exists in our market <em class="small">&mdash; excluded from scoring</em></span></label>';
   }
+  rows += '<input type="radio" name="' + it.id + '" id="' + it.id + 'dk">' +
+    '<label for="' + it.id + 'dk"><span class="lv">&mdash;</span><span class="dot"></span>' +
+    '<span>Not known to me <em class="small">&mdash; scored as insufficient evidence, never as zero</em></span></label>';
   return '<div class="field"><div class="qhead"><span class="qid">' + it.id + '</span><span>' + it.q + '</span>' +
     TIP(it.tip, it.anchor) + '</div><div class="opts">' + rows + '</div></div>';
 }
@@ -617,14 +630,17 @@ SCREENS.model =
 /* ---------- 5 · RESULTS ---------- */
 function chartRows() {
   return DIMS.map(function (d) {
-    var w = (d.measured / 5 * 100).toFixed(1), c = (d.claimed / 5 * 100).toFixed(1);
-    var gap = Math.abs(d.claimed - d.measured) >= 2;
-    return '<div class="crow" title="' + d.name + ' — measured ' + d.measured.toFixed(1) +
-      ' of 5, you said ' + d.claimed.toFixed(1) + '">' +
-      '<div class="cname">' + d.name + (gap ? ' <span style="color:var(--warn)">&#9650;</span>' : '') + '</div>' +
-      '<div class="ctrack"><div class="cbar" style="width:' + w + '%"></div>' +
-      '<div class="cclaim" style="left:' + c + '%"></div></div>' +
-      '<div class="cval">' + d.measured.toFixed(1) + '</div></div>';
+    var w = (d.measured / 5 * 100).toFixed(1), t = (d.target / 5 * 100).toFixed(1);
+    var met = d.measured >= d.target;
+    var short = (d.target - d.measured);
+    return '<div class="crow" title="' + d.name + ' — assessed ' + d.measured.toFixed(1) +
+      ', proportionate target ' + d.target + '">' +
+      '<div class="cname">' + d.name + '</div>' +
+      '<div class="ctrack"><div class="ctarget" style="width:' + t + '%"></div>' +
+      '<div class="cbar" style="width:' + w + '%"></div>' +
+      '<div class="cclaim" style="left:' + t + '%"></div></div>' +
+      '<div class="cval"' + (met ? ' style="color:var(--accent)"' : '') + '>' +
+      (met ? 'met' : '&minus;' + short.toFixed(1)) + '</div></div>';
   }).join('');
 }
 
@@ -636,22 +652,23 @@ SCREENS.results =
 
   '<div class="card">' +
     '<h3>Readiness profile</h3>' +
-    '<p class="small" style="margin-top:5px">ISO/IEC 33020 capability levels 0&ndash;5, across five dimensions</p>' +
+    '<p class="small" style="margin-top:5px">ISO/IEC 33020 capability levels 0&ndash;5, against a target proportionate to your firm</p>' +
     '<div class="chart">' + chartRows() +
       '<div class="cscale"><span></span><div class="cticks">' +
         '<span>0</span><span>1</span><span>2</span><span>3</span><span>4</span><span>5</span></div><span></span></div>' +
     '</div>' +
     '<div class="clegend">' +
       '<span><i class="swatch"></i>Assessed level</span>' +
-      '<span><i class="swtick"></i>What you said</span>' +
-      '<span style="color:var(--warn)">&#9650; Claim and evidence disagree</span>' +
+      '<span><i class="swtick"></i>Proportionate target for a firm your size</span>' +
+      '<span class="small">Targets follow ISO/IEC 33020 &mdash; capability is meant to suit the risk, not be maximised</span>' +
     '</div>' +
     '<details class="tvwrap"><summary>View as a table</summary>' +
-      '<table class="tv"><thead><tr><th>Dimension</th><th>Assessed</th><th>You said</th><th>Gap</th></tr></thead><tbody>' +
+      '<table class="tv"><thead><tr><th>Dimension</th><th>Assessed</th><th>Target</th><th>Gap</th><th>You said</th></tr></thead><tbody>' +
       DIMS.map(function (d) {
-        var g = (d.claimed - d.measured);
+        var g = d.target - d.measured;
         return '<tr><td>' + d.name + '</td><td class="n">' + d.measured.toFixed(1) + '</td><td class="n">' +
-          d.claimed.toFixed(1) + '</td><td class="n">' + (g >= 2 ? '+' + g.toFixed(1) + ' ▲' : g.toFixed(1)) + '</td></tr>';
+          d.target + '</td><td class="n">' + (g <= 0 ? 'met' : '&minus;' + g.toFixed(1)) + '</td><td class="n">' +
+          d.claimed.toFixed(2) + '</td></tr>';
       }).join('') + '</tbody></table></details>' +
   '</div>' +
 
@@ -676,6 +693,25 @@ SCREENS.results =
       '</div></div>' +
     '<p class="small">This is not a gotcha. Most firms score differently on claim and evidence, and the gap is ' +
     'usually a reporting problem rather than a competence one &mdash; but it is the most useful thing here.</p>' +
+
+    '<h3 style="margin-top:28px">Implementation risks</h3>' +
+    '<p class="small" style="margin-top:5px">Things that can stop a transition regardless of how capable you are. ' +
+    'These are flagged, not scored.</p>' +
+    '<ul class="risks">' +
+      '<li><div><h4>Professional indemnity position is unchecked</h4>' +
+      '<p>You have not confirmed with your insurer or counsel whether delivering on open standards, or ' +
+      'using non-proprietary tooling, affects your cover. <strong>This toolkit cannot answer that and does ' +
+      'not try to.</strong> What it can tell you is that software warranty disclaimers are near-universal ' +
+      '&mdash; proprietary licences carry them too &mdash; and that professional indemnity insures the ' +
+      'professional, not the tool. Put the question to your insurer in writing before it becomes urgent.</p></div></li>' +
+      '<li><div><h4>No named accountable party for information</h4>' +
+      '<p>Governance sits below its proportionate target and no one role carries information management ' +
+      'with authority. Under ISO 19650 that accountability does not disappear &mdash; it defaults upward to ' +
+      'whoever signed.</p></div></li>' +
+      '<li><div><h4>Single-vendor continuity</h4>' +
+      '<p>No model has been retrieved from your authoring tool and opened elsewhere, so the cost and ' +
+      'feasibility of moving is unknown rather than low.</p></div></li>' +
+    '</ul>' +
   '</div>' +
 
   '<div class="card">' +

--- a/readiness/index.html
+++ b/readiness/index.html
@@ -372,8 +372,11 @@ SCREENS.intro =
     '<p>The result shows an organisation where its capability gaps and implementation risks lie, and which areas ' +
     'to address first before committing to OpenBIM &mdash; combining what you report with metrics computed ' +
     'directly from your own IFC model.</p>' +
-    '<p class="small">It measures readiness and model data quality. It does not certify regulatory compliance, ' +
-    'and no software does so in any jurisdiction.</p>' +
+    '<p class="small"><strong>This is only a technical readiness assessment.</strong> It measures ' +
+    'organisational readiness and model data quality &mdash; nothing else. It qualifies nothing and no ' +
+    'one, confers no certification, licence or professional status, and is not evidence of compliance. ' +
+    'Where your regulations or appointment require insurance, indemnity or a formal qualification ' +
+    'process, that remains yours to satisfy directly.</p>' +
   '</div>' +
 
   '<div class="card">' +
@@ -749,14 +752,28 @@ SCREENS.results =
     'asserted.</p>' +
   '</div>' +
 
+  '<div class="card" style="border-left:3px solid var(--warn)">' +
+    '<h3 style="color:var(--warn)">Before you share this</h3>' +
+    '<p class="small" style="margin-top:8px"><strong>This assessment qualifies nothing and no one.</strong> ' +
+    'It confers no certification, accreditation, licence, approval or professional status, and it is not ' +
+    'evidence of compliance with any regulation, standard, code or contract. Do not present it as such &mdash; ' +
+    'to a client, an authority, an insurer, or in a tender.</p>' +
+    '<p class="small">Nothing here is audited or verified. The answers are yours and the measurements come ' +
+    'from a file you supplied; no third party has checked any of it.</p>' +
+    '<p class="small">Where insurance, professional indemnity, licensing or a formal qualification process ' +
+    'is required or applicable under your regulations, contract or client requirements, that obligation is ' +
+    'yours and must be discharged directly with the responsible body. This report substitutes for none of it.</p>' +
+  '</div>' +
+
   '<div class="actions">' +
     '<button class="btn">Download checklist (PDF)</button>' +
     '<button class="btn sec">See these gaps in 3D</button>' +
     '<button class="btn sec" data-go="intro">Start over</button>' +
   '</div>' +
   '<p class="small mono" style="margin-top:20px;padding-top:14px;border-top:1px solid var(--rule)">' +
-  'core-0.1 · locale ae-v1 · toolkit v0.1 · 2026-08-21 · scoring is deterministic &mdash; ' +
-  'same answers and same versions always produce this same result</p>';
+  'core-0.1 · locale ae-v1 · toolkit v0.1 · scope: one office or region · scoring is deterministic &mdash; ' +
+  'same answers and same versions always produce this same result. Technical readiness assessment only: ' +
+  'self-reported, unaudited, qualifies nothing and no one, confers no certification or professional status.</p>';
 
 /* ---------- NAV ---------- */
 DIMENSIONS.forEach(function (d, i) { SCREENS['dim' + i] = dimScreen(i); });

--- a/readiness/index.html
+++ b/readiness/index.html
@@ -587,7 +587,8 @@ SCREENS.results =
   '</div>' +
 
   '<div class="card">' +
-    '<h3>Where your model disagreed with your answers</h3>' +
+    '<h3>Gap analysis</h3>' +
+    '<p class="small" style="margin-top:5px">Capability gaps, implementation risks, and where your model disagreed with your answers</p>' +
     '<div class="delta" style="margin-top:13px">' +
       '<div class="ic">!</div><div>' +
         '<h4>Classification</h4>' +
@@ -609,8 +610,8 @@ SCREENS.results =
   '</div>' +
 
   '<div class="card">' +
-    '<h3>What to fix first</h3>' +
-    '<p class="small" style="margin-top:5px">Ordered by how much each unlocks downstream</p>' +
+    '<h3>Recommendations</h3>' +
+    '<p class="small" style="margin-top:5px">Capability development &middot; standards adoption &middot; implementation planning &mdash; ordered by how much each unlocks downstream</p>' +
     '<ol class="fixes">' +
       '<li><div><h4>Add spaces to the model</h4><p>Zero IfcSpace entities. Rooms are the spine of anything ' +
       'downstream &mdash; FM, area schedules, analysis. Nothing that needs a room can consume this file.</p></div></li>' +

--- a/readiness/why.html
+++ b/readiness/why.html
@@ -415,7 +415,7 @@ footer{
   independently.</p>
 
   <p>The assessment scores each of governance, people and skills, technology, data and standards, and
-  process on the same five-rung ladder. The rungs are deliberately about
+  organisational processes on the same five-rung ladder. The rungs are deliberately about
   <strong>institutionalisation</strong> rather than enthusiasm &mdash; a firm where one keen engineer
   exports IFC by hand is not more mature than one that never tried, it is differently fragile.</p>
 

--- a/readiness/why.html
+++ b/readiness/why.html
@@ -480,6 +480,13 @@ footer{
     <p><strong>Figures on this page are measured from named individual models or cited public sources,
     and are labelled as such.</strong> Single-building measurements are not industry statistics and
     must not be quoted as such. Nothing here is estimated, projected or illustrative.</p>
+    <p><strong>Nothing here is insurance, indemnity or legal advice.</strong> Whether delivering on
+    open standards affects your professional indemnity cover is a question for your insurer and your
+    counsel, and this toolkit neither answers it nor is qualified to. Two facts are worth carrying into
+    that conversation: warranty disclaimers are near-universal in software licensing, proprietary
+    licences included; and professional indemnity insures the professional, not the tool. What an
+    open-standard toolchain can evidence is <em>technical</em> conformance &mdash; schema validity,
+    exchange fidelity, information completeness &mdash; and that is the only claim made here.</p>
     <p><strong>Research instrument, in development.</strong> This is a work in progress supporting
     academic research. Its criteria, thresholds and weightings are subject to expert validation and
     will change.</p>

--- a/readiness/why.html
+++ b/readiness/why.html
@@ -1,0 +1,500 @@
+<title>Why Open BIM Readiness</title>
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Instrument+Sans:wght@400;500;600;700&family=Source+Serif+4:opsz,wght@8..60,400;8..60,600&family=IBM+Plex+Mono:wght@400;500;600&display=swap">
+
+<style>
+:root{
+  --ink:#131e1b; --ink-2:#3a4a45; --muted:#6b7d78; --faint:#9aaba6;
+  --paper:#f5f7f5; --surface:#ffffff; --surface-2:#eaefed; --surface-3:#dbe3e0;
+  --rule:#d3dcd9; --rule-soft:#e4e9e7;
+  --accent:#00897b; --accent-ink:#00695f; --accent-wash:#e0efec;
+  --warn:#a06a00; --warn-wash:#f7efdd;
+  --focus:#00897b;
+  --shadow:0 1px 2px rgba(19,30,27,.05),0 10px 30px -18px rgba(19,30,27,.22);
+}
+@media (prefers-color-scheme:dark){
+  :root:not([data-theme="light"]){
+    --ink:#e9efed; --ink-2:#c3d0cc; --muted:#93a5a0; --faint:#6d7f7a;
+    --paper:#0f1816; --surface:#182421; --surface-2:#1f2d29; --surface-3:#2b3b36;
+    --rule:#2d3e39; --rule-soft:#22302c;
+    --accent:#1f9d87; --accent-ink:#4fc9b0; --accent-wash:#14312b;
+    --warn:#b1811f; --warn-wash:#2f2612;
+    --focus:#4fc9b0;
+    --shadow:0 1px 2px rgba(0,0,0,.35),0 12px 32px -18px rgba(0,0,0,.75);
+  }
+}
+:root[data-theme="dark"]{
+  --ink:#e9efed; --ink-2:#c3d0cc; --muted:#93a5a0; --faint:#6d7f7a;
+  --paper:#0f1816; --surface:#182421; --surface-2:#1f2d29; --surface-3:#2b3b36;
+  --rule:#2d3e39; --rule-soft:#22302c;
+  --accent:#1f9d87; --accent-ink:#4fc9b0; --accent-wash:#14312b;
+  --warn:#b1811f; --warn-wash:#2f2612;
+  --focus:#4fc9b0;
+  --shadow:0 1px 2px rgba(0,0,0,.35),0 12px 32px -18px rgba(0,0,0,.75);
+}
+
+*{box-sizing:border-box}
+body{
+  margin:0;background:var(--paper);color:var(--ink);
+  font-family:"Source Serif 4",Georgia,serif;font-size:17.5px;line-height:1.65;
+  -webkit-font-smoothing:antialiased;
+}
+h1,h2,h3,h4,.ui{font-family:"Instrument Sans",-apple-system,"Segoe UI",Helvetica,Arial,sans-serif}
+h1,h2,h3{margin:0;text-wrap:balance;letter-spacing:-.022em}
+p{margin:0}
+.mono{font-family:"IBM Plex Mono",ui-monospace,Menlo,monospace;font-variant-numeric:tabular-nums}
+a{color:var(--accent-ink);text-underline-offset:2px}
+:focus-visible{outline:2px solid var(--focus);outline-offset:2px;border-radius:3px}
+
+.wrap{max-width:800px;margin:0 auto;padding:0 22px 90px}
+
+/* ---- topbar ---- */
+.topbar{display:flex;align-items:center;gap:13px;padding:18px 0;border-bottom:1px solid var(--rule)}
+.brandmark{
+  width:28px;height:28px;border-radius:6px;background:var(--accent);flex:none;
+  display:grid;place-items:center;color:var(--paper);font-weight:700;font-size:12px;
+  font-family:"IBM Plex Mono",monospace
+}
+.brandtext{font-family:"Instrument Sans",sans-serif;font-size:13.5px;font-weight:600;line-height:1.3}
+.brandtext small{display:block;font-weight:400;font-size:11.5px;color:var(--muted)}
+.topspacer{flex:1}
+.ghostbtn{
+  background:transparent;border:1px solid var(--rule);border-radius:6px;padding:6px 12px;
+  font-family:"Instrument Sans",sans-serif;font-size:13px;cursor:pointer;color:var(--ink-2);
+  text-decoration:none;display:inline-block
+}
+.ghostbtn:hover{background:var(--surface-2);border-color:var(--accent);color:var(--accent-ink)}
+
+/* ---- hero ---- */
+.hero{padding:56px 0 40px;border-bottom:2px solid var(--ink)}
+.eyebrow{
+  font-family:"IBM Plex Mono",monospace;font-size:11px;letter-spacing:.14em;
+  text-transform:uppercase;color:var(--accent-ink);font-weight:600;margin-bottom:16px
+}
+h1{font-family:"Instrument Sans",sans-serif;font-size:clamp(31px,5.2vw,46px);line-height:1.08;font-weight:700}
+.standfirst{font-size:19px;color:var(--ink-2);margin-top:18px;max-width:58ch;line-height:1.55}
+
+/* ---- sections ---- */
+section{margin:64px 0 0;scroll-margin-top:20px}
+.shead{display:flex;gap:14px;align-items:baseline;margin-bottom:10px}
+.snum{
+  font-family:"IBM Plex Mono",monospace;font-size:12px;font-weight:600;color:var(--accent-ink);
+  flex:none;padding-top:5px;letter-spacing:.05em
+}
+h2{font-family:"Instrument Sans",sans-serif;font-size:26px;font-weight:600;line-height:1.2}
+h3{font-family:"Instrument Sans",sans-serif;font-size:16.5px;font-weight:600;margin:30px 0 8px}
+section p{margin:15px 0;max-width:64ch}
+.lede{font-size:18.5px;color:var(--ink-2)}
+strong{font-weight:600;color:var(--ink)}
+
+/* ---- nav chips ---- */
+.jump{display:flex;gap:8px;flex-wrap:wrap;margin:26px 0 0}
+.jump a{
+  font-family:"Instrument Sans",sans-serif;font-size:13px;text-decoration:none;
+  border:1px solid var(--rule);border-radius:20px;padding:7px 14px;color:var(--ink-2);background:var(--surface)
+}
+.jump a:hover{border-color:var(--accent);color:var(--accent-ink);background:var(--accent-wash)}
+
+/* ---- figure ---- */
+figure{
+  margin:26px 0;background:var(--surface);border:1px solid var(--rule);border-radius:10px;
+  padding:22px 24px;box-shadow:var(--shadow)
+}
+figure h4{
+  font-family:"Instrument Sans",sans-serif;font-size:15.5px;font-weight:600;margin:0 0 4px
+}
+figure .fsub{font-family:"Instrument Sans",sans-serif;font-size:13px;color:var(--muted);margin-bottom:18px}
+figcaption{
+  margin-top:16px;padding-top:13px;border-top:1px solid var(--rule-soft);
+  font-family:"Instrument Sans",sans-serif;font-size:12.5px;color:var(--muted);line-height:1.5
+}
+figcaption b{
+  font-family:"IBM Plex Mono",monospace;font-size:10.5px;letter-spacing:.09em;
+  text-transform:uppercase;color:var(--accent-ink);font-weight:600;display:block;margin-bottom:4px
+}
+
+/* ---- stacked bar ---- */
+.stack{display:flex;height:38px;border-radius:6px;overflow:hidden;gap:2px;background:var(--surface)}
+.seg{display:grid;place-items:center;font-family:"IBM Plex Mono",monospace;font-size:12px;font-weight:600;min-width:0}
+.seg.a{background:var(--accent);color:var(--paper)}
+.seg.n{background:var(--surface-3);color:var(--ink-2)}
+.seg.w{background:var(--warn);color:var(--paper)}
+.stacklab{
+  display:flex;justify-content:space-between;margin-top:9px;gap:14px;
+  font-family:"Instrument Sans",sans-serif;font-size:13px;color:var(--ink-2)
+}
+.stacklab span{display:flex;gap:7px;align-items:center}
+.sw{width:12px;height:11px;border-radius:3px;flex:none}
+.sw.a{background:var(--accent)} .sw.n{background:var(--surface-3)} .sw.w{background:var(--warn)}
+
+/* ---- hbars ---- */
+.hb{display:grid;grid-template-columns:150px 1fr 74px;gap:12px;align-items:center;padding:6px 0}
+.hb .n{font-family:"Instrument Sans",sans-serif;font-size:13.5px;text-align:right;color:var(--ink-2);line-height:1.25}
+.hb .t{height:17px;background:var(--surface-3);border-radius:4px;position:relative;overflow:hidden}
+.hb .f{position:absolute;inset:0 auto 0 0;background:var(--accent);border-radius:4px}
+.hb .v{font-family:"IBM Plex Mono",monospace;font-size:12.5px;font-weight:600;color:var(--ink-2)}
+
+/* ---- hero stat ---- */
+.bignum{
+  display:flex;gap:26px;align-items:baseline;flex-wrap:wrap;
+  padding:6px 0 2px
+}
+.bignum .n{
+  font-family:"Instrument Sans",sans-serif;font-size:clamp(46px,9vw,74px);font-weight:700;
+  line-height:.95;letter-spacing:-.04em;color:var(--warn);font-variant-numeric:tabular-nums
+}
+.bignum .n.ok{color:var(--accent)}
+.bignum .t{font-size:16px;color:var(--ink-2);max-width:34ch;font-family:"Instrument Sans",sans-serif;line-height:1.4}
+
+/* ---- matrix ---- */
+.mx{width:100%;border-collapse:collapse;font-family:"Instrument Sans",sans-serif;font-size:13.5px}
+.mx th{
+  text-align:left;font-size:10.5px;letter-spacing:.09em;text-transform:uppercase;color:var(--muted);
+  padding:9px 10px;border-bottom:1px solid var(--rule);font-weight:600
+}
+.mx th.c,.mx td.c{text-align:center;width:88px}
+.mx td{padding:10px;border-bottom:1px solid var(--rule-soft);color:var(--ink-2)}
+.mx tr:last-child td{border-bottom:none}
+.yes{color:var(--accent);font-weight:700}
+.no{color:var(--warn);font-weight:700}
+.mxscroll{overflow-x:auto}
+
+/* ---- bands ---- */
+.bands{display:flex;gap:2px;border-radius:6px;overflow:hidden;margin-top:4px}
+.band{padding:11px 12px;flex:1;font-family:"Instrument Sans",sans-serif;font-size:12.5px;text-align:center;line-height:1.35}
+.band b{display:block;font-family:"IBM Plex Mono",monospace;font-size:14px;margin-bottom:3px}
+.band.g{background:var(--accent-wash);color:var(--accent-ink)}
+.band.m{background:var(--surface-3);color:var(--ink-2)}
+.band.b{background:var(--warn-wash);color:var(--warn)}
+
+/* ---- callout ---- */
+.call{
+  background:var(--surface);border:1px solid var(--rule);border-left:3px solid var(--accent);
+  border-radius:8px;padding:19px 22px;margin:26px 0
+}
+.call.warn{border-left-color:var(--warn)}
+.call .lab{
+  font-family:"IBM Plex Mono",monospace;font-size:10.5px;letter-spacing:.11em;text-transform:uppercase;
+  color:var(--accent-ink);font-weight:600;display:block;margin-bottom:8px
+}
+.call.warn .lab{color:var(--warn)}
+.call p{margin:0 0 11px;max-width:none}
+.call p:last-child{margin-bottom:0}
+
+/* ---- ladder ---- */
+.ladder{display:flex;flex-direction:column;gap:1px;background:var(--rule);border:1px solid var(--rule);border-radius:8px;overflow:hidden;margin:22px 0}
+.rung{background:var(--surface);padding:12px 16px;display:grid;grid-template-columns:38px 1fr;gap:14px;align-items:baseline}
+.rung .l{font-family:"IBM Plex Mono",monospace;font-size:11.5px;font-weight:600;color:var(--accent-ink)}
+.rung b{font-family:"Instrument Sans",sans-serif;font-size:14.5px}
+.rung p{margin:2px 0 0;font-size:14.5px;color:var(--muted);max-width:none}
+
+/* ---- cta ---- */
+.cta{
+  margin:60px 0 0;padding:30px 26px;background:var(--accent-wash);
+  border:1px solid var(--accent);border-radius:12px;text-align:center
+}
+.cta h3{margin:0 0 8px;font-size:20px}
+.cta p{margin:0 auto 20px;max-width:46ch;color:var(--ink-2);font-size:15.5px}
+.btn{
+  background:var(--accent);color:var(--paper);border:1px solid var(--accent);border-radius:8px;
+  padding:12px 24px;font-family:"Instrument Sans",sans-serif;font-size:15.5px;font-weight:600;
+  cursor:pointer;text-decoration:none;display:inline-block
+}
+.btn:hover{filter:brightness(1.08)}
+
+footer{
+  margin:64px 0 0;padding-top:20px;border-top:1px solid var(--rule);
+  font-family:"IBM Plex Mono",monospace;font-size:11.5px;color:var(--faint);line-height:1.8
+}
+
+@media (max-width:600px){
+  .hb{grid-template-columns:96px 1fr 62px;gap:9px}
+  .hb .n{font-size:12.5px}
+  .bands{flex-direction:column}
+  figure{padding:18px 16px}
+}
+@media (prefers-reduced-motion:reduce){*{animation:none!important;transition:none!important}}
+</style>
+
+<div class="wrap">
+
+<div class="topbar">
+  <div class="brandmark">OB</div>
+  <div class="brandtext">OpenBIM Readiness Assessment Toolkit<small>Read more</small></div>
+  <div class="topspacer"></div>
+  <button class="ghostbtn" id="themebtn" type="button">Theme</button>
+  <a class="ghostbtn" href="./">Back to assessment</a>
+</div>
+
+<div class="hero">
+  <p class="eyebrow">Why this exists</p>
+  <h1>Everyone is telling you to open your data. Nobody is telling you what that costs.</h1>
+  <p class="standfirst">Three things worth knowing before you spend money on it: what the industry
+  actually certifies, where models really stand today, and what closing the gap involves.</p>
+  <nav class="jump">
+    <a href="#industry">01 &nbsp;The industry</a>
+    <a href="#gap">02 &nbsp;The gap</a>
+    <a href="#roadmap">03 &nbsp;The roadmap</a>
+    <a href="#offline">Offline copy</a>
+  </nav>
+</div>
+
+<section id="industry">
+  <div class="shead"><span class="snum">01</span><h2>What the industry actually certifies</h2></div>
+  <p class="lede">Start here, because almost everyone has this backwards — including people selling
+  you software.</p>
+
+  <p>BIM moved the industry from drawing to modelling, and the model became the record: geometry
+  carrying data, coordinated across disciplines, outliving the project into operations. That part is
+  settled. What is not settled is who owns the file format that record lives in.</p>
+
+  <p>A small number of vendors own practical BIM today. That bought real maturity, and it charged for
+  it in ways that only surface later — formats one application fully understands and others
+  approximate, licences that scale with headcount, and model data whose readability depends on
+  keeping a subscription alive. The sharpest version belongs to the asset owner: <strong>a building
+  outlives the software that modelled it by decades.</strong></p>
+
+  <p>So it is worth asking what the largest vendor on earth certifies about its own software.</p>
+
+  <figure>
+    <h4>What Autodesk holds certification for</h4>
+    <p class="fsub">buildingSMART certifications vs. local-authority compliance, any jurisdiction</p>
+    <div class="mxscroll">
+      <table class="mx">
+        <thead><tr><th>Certification</th><th class="c">Export</th><th class="c">Import</th></tr></thead>
+        <tbody>
+          <tr><td>IFC4 Architectural Reference Exchange</td><td class="c yes">✓</td><td class="c">&mdash;</td></tr>
+          <tr><td>IFC4 Structural Reference Exchange</td><td class="c yes">✓</td><td class="c">&mdash;</td></tr>
+          <tr><td>IFC2x3 Coordination View 2.0 &mdash; Architecture</td><td class="c yes">✓</td><td class="c yes">✓</td></tr>
+          <tr><td>IFC2x3 Coordination View 2.0 &mdash; Structure</td><td class="c yes">✓</td><td class="c yes">✓</td></tr>
+          <tr><td>IFC2x3 Coordination View 2.0 &mdash; MEP</td><td class="c yes">✓</td><td class="c yes">✓</td></tr>
+          <tr><td><strong>Local-authority building compliance</strong> &mdash; any country</td>
+              <td class="c no">✗</td><td class="c no">✗</td></tr>
+        </tbody>
+      </table>
+    </div>
+    <figcaption><b>Source</b>buildingSMART certification register, as researched 2026-07-31.
+    What buildingSMART verifies is that an application &ldquo;can reliably import and export files in
+    accordance with the relevant IFC standard versions&rdquo; &mdash; a losslessness claim, not a
+    regulatory one.</figcaption>
+  </figure>
+
+  <div class="call">
+    <span class="lab">The conclusion that matters</span>
+    <p>The largest BIM vendor on earth, facing every jurisdiction on earth, certifies
+    <strong>&ldquo;I don&rsquo;t corrupt your data&rdquo;</strong> &mdash; and leaves &ldquo;is this
+    building lawful&rdquo; to the practice.</p>
+    <p>That is not a gap in their product. It is the correct division of responsibility: local-authority
+    compliance sits with the Appointing Party and the Lead Appointed Party. Software is never a legal
+    party to it. Anyone selling you &ldquo;compliance certified&rdquo; software is selling something
+    that does not exist as a category.</p>
+  </div>
+
+  <h3>Meanwhile the mandates arrive anyway</h3>
+  <p>Since <strong>1 July 2025</strong>, BIM is mandatory for Malaysian projects of RM 10 million and
+  above, public and private, under the Construction 4.0 Strategic Plan &mdash; with deliverables
+  expected to follow CIDB BIM Guidelines and hand over LOD 500 models conforming to PeDATA and SKATA.
+  Other jurisdictions are moving on their own timetables.</p>
+
+  <p>Which produces the situation this toolkit exists for: <strong>you are being asked to deliver
+  something specific, the software you own does not promise to deliver it, and nothing tells you how
+  far off you are.</strong></p>
+</section>
+
+<section id="gap">
+  <div class="shead"><span class="snum">02</span><h2>Where models actually stand</h2></div>
+  <p class="lede">Not opinion. Numbers measured from real delivered models, with the building named
+  in each case.</p>
+
+  <h3>A model can be almost entirely missing and still look fine</h3>
+  <p>This is the one to know about, because it fails <em>quietly</em>. Past a 4 GB boundary during
+  export, geometry generation stops. There is no crash and no error message. The file opens. It
+  renders. It looks like a building.</p>
+
+  <figure>
+    <h4>One real truncated export</h4>
+    <p class="fsub">Elements delivered vs. elements silently absent</p>
+    <div class="stack" aria-label="6 percent delivered, 94 percent absent">
+      <div class="seg a" style="flex:6">6%</div>
+      <div class="seg w" style="flex:94">94% absent</div>
+    </div>
+    <div class="stacklab">
+      <span><i class="sw a"></i>3,955 elements delivered</span>
+      <span><i class="sw w"></i>no error shown</span>
+    </div>
+    <figcaption><b>Source</b>Measured export failure documented in the project&rsquo;s own IFC export
+    guide. Export died at element #3,956 of the model and reported success.
+    <strong>A reviewer can sign off on a model that is almost entirely absent.</strong></figcaption>
+  </figure>
+
+  <h3>The expensive part is geometry. The useful part is almost free.</h3>
+  <p>When a model is extracted into a database, it becomes obvious where the weight sits &mdash; and
+  it is not where most delivery effort goes.</p>
+
+  <figure>
+    <h4>Where the bytes go in an extracted model</h4>
+    <p class="fsub">Hospital building, 63,917 elements, ~263 MB database</p>
+    <div class="stack" aria-label="91 percent geometry, 9 percent semantics">
+      <div class="seg a" style="flex:91">91% geometry</div>
+      <div class="seg n" style="flex:9">9%</div>
+    </div>
+    <div class="stacklab">
+      <span><i class="sw a"></i>Component geometry &mdash; 239.1 MB</span>
+      <span><i class="sw n"></i>All semantics, transforms, indexes &mdash; 23.7 MB</span>
+    </div>
+    <figcaption><b>Source</b>Measured with <span class="mono">dbstat</span> on the Hospital extraction.
+    Relationship data &mdash; the part that makes a model queryable rather than merely viewable &mdash;
+    is roughly 0.2% of the file. The industry rations the cheap part.</figcaption>
+  </figure>
+
+  <h3>And the data that should be there, usually isn&rsquo;t</h3>
+
+  <figure>
+    <h4>Classification coverage in one delivered model</h4>
+    <p class="fsub">Hospital building &mdash; elements carrying a classification code</p>
+    <div class="bignum">
+      <span class="n">7.11%</span>
+      <span class="t">of 63,917 elements carry a classification code. Of those that do,
+      <strong>every single one is well-formed</strong> &mdash; zero invalid codes.</span>
+    </div>
+    <figcaption><b>Source</b>Measured on re-extraction of the Hospital model, 2026-07-31.
+    <strong>This is one building&rsquo;s number and must not be read as an industry figure.</strong>
+    It illustrates a pattern worth checking on your own model, which is what the assessment does.
+    Note also what it shows about verdicts: judged on validity alone this model passes perfectly.
+    Judged on coverage it is almost empty. <em>Both numbers have to be read together, which is why
+    this toolkit never reports a single headline score.</em></figcaption>
+  </figure>
+
+  <h3>Even file bulk has a threshold</h3>
+  <figure>
+    <h4>Entities per element &mdash; delivery thresholds</h4>
+    <p class="fsub">A rough measure of whether anyone else can open what you send</p>
+    <div class="bands">
+      <div class="band g"><b>&lt; 50</b>Target &mdash; exports cleanly, opens everywhere</div>
+      <div class="band m"><b>50 &ndash; 200</b>Acceptable &mdash; large but workable</div>
+      <div class="band b"><b>&gt; 200</b>Many tools cannot open it at all</div>
+    </div>
+    <figcaption><b>Source</b>Thresholds published in the project&rsquo;s IFC export guide, derived from
+    measured import behaviour. Driven mostly by exporting tessellated geometry where solids were
+    available, and by exporting property sets nobody contracted for.</figcaption>
+  </figure>
+</section>
+
+<section id="roadmap">
+  <div class="shead"><span class="snum">03</span><h2>What closing the gap involves</h2></div>
+  <p class="lede">Readiness is not one thing you either have or lack. It is five, and they fail
+  independently.</p>
+
+  <p>The assessment scores each of governance, people and skills, technology, data and standards, and
+  process on the same five-rung ladder. The rungs are deliberately about
+  <strong>institutionalisation</strong> rather than enthusiasm &mdash; a firm where one keen engineer
+  exports IFC by hand is not more mature than one that never tried, it is differently fragile.</p>
+
+  <div class="ladder">
+    <div class="rung"><span class="l">L0</span><div><b>Absent</b><p>Not present, and not recognised as something that should be.</p></div></div>
+    <div class="rung"><span class="l">L1</span><div><b>Ad hoc</b><p>Happens through individual initiative, and stops when that individual does.</p></div></div>
+    <div class="rung"><span class="l">L2</span><div><b>Defined</b><p>Written down, but not enforced, resourced or measured.</p></div></div>
+    <div class="rung"><span class="l">L3</span><div><b>Managed</b><p>Enforced and resourced, with named ownership and some measurement.</p></div></div>
+    <div class="rung"><span class="l">L4</span><div><b>Optimising</b><p>Measured outcomes drive change, and the open path is the default rather than the exception.</p></div></div>
+  </div>
+
+  <h3>Jurisdiction rules are data, not code &mdash; and they are being built</h3>
+  <p>Requirements differ by country, so they are carried in swappable rule packs rather than baked
+  into the instrument. That work is partial and the chart says so.</p>
+
+  <figure>
+    <h4>Jurisdiction rule coverage</h4>
+    <p class="fsub">Validation rules implemented against the stated target</p>
+    <div class="hb"><span class="n">Malaysia · UBBL</span><span class="t"><span class="f" style="width:15%"></span></span><span class="v">30</span></div>
+    <div class="hb"><span class="n">SG · UK · AU · US · EU · HK</span><span class="t"><span class="f" style="width:0%"></span></span><span class="v">0</span></div>
+    <div class="hb"><span class="n">Stated target</span><span class="t"><span class="f" style="width:100%;background:var(--surface-3)"></span></span><span class="v">200+</span></div>
+    <figcaption><b>Source</b>Project rule inventory. 30 UBBL rules implemented against a stated target
+    of 200+ across six jurisdictions. <strong>The architecture is proven; the rule population is the
+    work ahead.</strong> Shown here because a roadmap that hides its own gap is marketing.</figcaption>
+  </figure>
+
+  <h3>The industry picture starts empty</h3>
+  <figure>
+    <h4>Assessments completed</h4>
+    <p class="fsub">The benchmark this toolkit builds</p>
+    <div class="bignum">
+      <span class="n ok">0</span>
+      <span class="t">No assessments have been submitted yet. As responses accumulate, this becomes a
+      real industry picture &mdash; built from practitioners rather than asserted.</span>
+    </div>
+    <figcaption><b>Source</b>Live count of submitted assessments. There is deliberately no estimate,
+    no projection and no illustrative figure here. When we do not have a number, the page says so.</figcaption>
+  </figure>
+</section>
+
+<section id="disclaimer">
+  <div class="shead"><span class="snum">&mdash;</span><h2>What this does not do</h2></div>
+
+  <div class="call warn">
+    <span class="lab">Disclaimer</span>
+    <p><strong>Measurement works. Certification does not.</strong> This toolkit can tell you how far a
+    model and an organisation are from carrying compliant, open, well-structured information, with
+    numbers you can reproduce. It cannot certify a model or a firm as compliant with any standard,
+    code or authority requirement &mdash; and it will refuse to pretend otherwise.</p>
+    <p><strong>No regulatory verdict is issued.</strong> Local-authority compliance rests with the
+    Appointing Party and the Lead Appointed Party. No software is a legal party to it, and no BIM
+    vendor holds such certification in any jurisdiction.</p>
+    <p><strong>Coverage is not validity.</strong> A high score on well-formedness says the data present
+    is correctly shaped. It says nothing about whether the right data is present. Both numbers are
+    always reported together, and no single headline score is produced.</p>
+    <p><strong>Self-reported answers are self-reported.</strong> Where measurements from your model
+    contradict them, the measurement is used for scoring and the disagreement is shown to you.</p>
+    <p><strong>Figures on this page are measured from named individual models or cited public sources,
+    and are labelled as such.</strong> Single-building measurements are not industry statistics and
+    must not be quoted as such. Nothing here is estimated, projected or illustrative.</p>
+    <p><strong>Research instrument, in development.</strong> This is a work in progress supporting
+    academic research. Its criteria, thresholds and weightings are subject to expert validation and
+    will change.</p>
+  </div>
+</section>
+
+<section id="offline">
+  <div class="shead"><span class="snum">&mdash;</span><h2>Run it on your own machine</h2></div>
+  <p class="lede">If your IT policy will not let a model near a browser tab, take the whole thing
+  offline instead.</p>
+
+  <p>The assessment is a set of static files with no server, no database and no accounts. That means
+  it can simply be downloaded and opened from your own disk &mdash; the same assessment, the same
+  scoring, with no network involved at any point.</p>
+
+  <p>Useful when your models are commercially sensitive, when your firm works air-gapped, when you are
+  on site with no connection, or when you would simply rather verify for yourself that nothing is
+  being transmitted. Unzip it, open the file, and read the source if you want to.</p>
+
+  <div class="call">
+    <span class="lab">What&rsquo;s in the download</span>
+    <p>A single archive containing the assessment, this page, the rule packs, and a short README.
+    Everything runs from <span class="mono">file://</span> &mdash; no install, no build step, no
+    dependencies to fetch.</p>
+    <p class="mono" style="font-size:13px;color:var(--muted)">openbim-readiness-toolkit-v0.1.zip</p>
+  </div>
+</section>
+
+<div class="cta">
+  <h3>Find out where you actually stand</h3>
+  <p>Twenty questions and one IFC file, read inside your browser. About fifteen minutes.</p>
+  <a class="btn" href="./">Start the assessment</a>
+</div>
+
+<footer>
+  OpenBIM Readiness Assessment Toolkit &middot; v0.1 draft &middot; 2026-08-21<br>
+  Research instrument &mdash; criteria and thresholds subject to expert validation.<br>
+  Every figure on this page is measured from a named model or cited from a public source.
+</footer>
+
+</div>
+
+<script>
+document.getElementById('themebtn').addEventListener('click', function () {
+  var r = document.documentElement;
+  var dark = r.getAttribute('data-theme') === 'dark' ||
+    (!r.getAttribute('data-theme') && matchMedia('(prefers-color-scheme:dark)').matches);
+  r.setAttribute('data-theme', dark ? 'light' : 'dark');
+});
+</script>

--- a/readiness/why.html
+++ b/readiness/why.html
@@ -1,4 +1,4 @@
-<title>Why Open BIM Readiness</title>
+<title>Why OpenBIM Readiness</title>
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
 <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Instrument+Sans:wght@400;500;600;700&family=Source+Serif+4:opsz,wght@8..60,400;8..60,600&family=IBM+Plex+Mono:wght@400;500;600&display=swap">

--- a/readiness/why.html
+++ b/readiness/why.html
@@ -252,6 +252,7 @@ footer{
     <a href="#gap">02 &nbsp;The gap</a>
     <a href="#roadmap">03 &nbsp;The roadmap</a>
     <a href="#offline">Offline copy</a>
+    <a href="disclaimer.html">Disclaimer Notice</a>
   </nav>
 </div>
 
@@ -503,6 +504,8 @@ footer{
     licences included; and professional indemnity insures the professional, not the tool. What an
     open-standard toolchain can evidence is <em>technical</em> conformance &mdash; schema validity,
     exchange fidelity, information completeness &mdash; and that is the only claim made here.</p>
+    <p><a href="disclaimer.html"><strong>Read the full Disclaimer Notice &rarr;</strong></a> &mdash; the
+    canonical version, which applies to the toolkit and every report it produces.</p>
     <p><strong>Research instrument, in development.</strong> This is a work in progress supporting
     academic research. Its criteria, thresholds and weightings are subject to expert validation and
     will change.</p>

--- a/readiness/why.html
+++ b/readiness/why.html
@@ -465,6 +465,22 @@ footer{
 
   <div class="call warn">
     <span class="lab">Disclaimer</span>
+    <p><strong>This is only a technical readiness assessment.</strong> It measures organisational
+    readiness for open-standard working and the data quality of a model you supply. That is its entire
+    scope. It says nothing about the lawfulness, safety, buildability or professional adequacy of
+    anything you produce.</p>
+    <p><strong>It qualifies nothing and no one.</strong> It confers no certification,
+    accreditation, licence, approval or professional status. It is not evidence of compliance with any
+    regulation, standard, code or contract, and must not be presented as such &mdash; to a client, an
+    authority, an insurer, or in a tender.</p>
+    <p><strong>Nothing here is audited or verified.</strong> The inputs are self-reported by the
+    respondent and computed from a file the respondent supplied. No third party has witnessed,
+    checked or attested to any of it.</p>
+    <p><strong>Where regulation or an appointment requires a formal process, you must satisfy it
+    separately.</strong> If insurance, professional indemnity, licensing, certification or a
+    qualification procedure is required or applicable under your regulations, contract or client
+    requirements, that obligation is yours and must be discharged directly with the responsible body.
+    This report substitutes for none of it, in whole or in part.</p>
     <p><strong>Measurement works. Certification does not.</strong> This toolkit can tell you how far a
     model and an organisation are from carrying compliant, open, well-structured information, with
     numbers you can reproduce. It cannot certify a model or a firm as compliant with any standard,

--- a/readiness/why.html
+++ b/readiness/why.html
@@ -168,6 +168,21 @@ figcaption b{
 .band.m{background:var(--surface-3);color:var(--ink-2)}
 .band.b{background:var(--warn-wash);color:var(--warn)}
 
+/* ---- pull quote ---- */
+blockquote.ps{
+  margin:30px 0;padding:24px 26px;background:var(--surface);
+  border:1px solid var(--rule);border-left:3px solid var(--accent);border-radius:8px;
+  box-shadow:var(--shadow)
+}
+blockquote.ps p{margin:0 0 13px;font-size:17px;line-height:1.6;max-width:none}
+blockquote.ps p:last-of-type{margin-bottom:0}
+blockquote.ps .k{font-weight:600;color:var(--ink)}
+blockquote.ps cite{
+  display:block;margin-top:16px;padding-top:13px;border-top:1px solid var(--rule-soft);
+  font-family:"IBM Plex Mono",monospace;font-size:10.5px;letter-spacing:.08em;
+  text-transform:uppercase;color:var(--muted);font-style:normal
+}
+
 /* ---- callout ---- */
 .call{
   background:var(--surface);border:1px solid var(--rule);border-left:3px solid var(--accent);
@@ -244,6 +259,19 @@ footer{
   <div class="shead"><span class="snum">01</span><h2>What the industry actually certifies</h2></div>
   <p class="lede">Start here, because almost everyone has this backwards — including people selling
   you software.</p>
+
+  <blockquote class="ps">
+    <p>As BIM adoption matures, organisations are increasingly expected to move beyond proprietary
+    BIM workflows towards more interoperable OpenBIM practices. This transition requires not only
+    appropriate technologies, but also organisational readiness in areas such as governance, business
+    processes, workforce capabilities, data management, and compliance with open standards.</p>
+    <p class="k">However, there is currently no simple and practical way for organisations to
+    objectively assess their readiness for OpenBIM implementation or to identify the capability gaps
+    that should be addressed before embarking on this transition.</p>
+    <cite>The problem statement &mdash; research proposal, 10 Aug 2026</cite>
+  </blockquote>
+
+  <p>That is what this toolkit is for, and the rest of this page is the evidence behind it.</p>
 
   <p>BIM moved the industry from drawing to modelling, and the model became the record: geometry
   carrying data, coordinated across disciplines, outliving the project into operations. That part is

--- a/readiness/why.html
+++ b/readiness/why.html
@@ -415,16 +415,20 @@ footer{
   independently.</p>
 
   <p>The assessment scores each of governance, people and skills, technology, data and standards, and
-  organisational processes on the same five-rung ladder. The rungs are deliberately about
-  <strong>institutionalisation</strong> rather than enthusiasm &mdash; a firm where one keen engineer
-  exports IFC by hand is not more mature than one that never tried, it is differently fragile.</p>
+  organisational processes on one shared capability ladder. The rungs are not ours: they are the six
+  capability levels defined by <strong>ISO/IEC 33020</strong>, the international standard for process
+  capability measurement, which states it is applicable to any domain.</p>
+  <p>They measure <strong>institutionalisation</strong> rather than enthusiasm. A firm where one keen
+  engineer exports IFC by hand sits at Performed, not higher &mdash; it is not more mature than a firm
+  that never tried, it is differently fragile.</p>
 
   <div class="ladder">
-    <div class="rung"><span class="l">L0</span><div><b>Absent</b><p>Not present, and not recognised as something that should be.</p></div></div>
-    <div class="rung"><span class="l">L1</span><div><b>Ad hoc</b><p>Happens through individual initiative, and stops when that individual does.</p></div></div>
-    <div class="rung"><span class="l">L2</span><div><b>Defined</b><p>Written down, but not enforced, resourced or measured.</p></div></div>
-    <div class="rung"><span class="l">L3</span><div><b>Managed</b><p>Enforced and resourced, with named ownership and some measurement.</p></div></div>
-    <div class="rung"><span class="l">L4</span><div><b>Optimising</b><p>Measured outcomes drive change, and the open path is the default rather than the exception.</p></div></div>
+    <div class="rung"><span class="l">L0</span><div><b>Incomplete</b><p>Not present, or it fails to achieve its purpose.</p></div></div>
+    <div class="rung"><span class="l">L1</span><div><b>Performed</b><p>It happens and achieves its purpose, but unmanaged — through individual initiative.</p></div></div>
+    <div class="rung"><span class="l">L2</span><div><b>Managed</b><p>Planned, controlled and maintained; the work products are kept.</p></div></div>
+    <div class="rung"><span class="l">L3</span><div><b>Established</b><p>A defined standard process, applied across projects rather than per person.</p></div></div>
+    <div class="rung"><span class="l">L4</span><div><b>Predictable</b><p>Measured quantitatively, so performance can be predicted rather than hoped for.</p></div></div>
+    <div class="rung"><span class="l">L5</span><div><b>Innovating</b><p>Those measurements drive continuous change to how the work is done.</p></div></div>
   </div>
 
   <h3>Jurisdiction rules are data, not code &mdash; and they are being built</h3>


### PR DESCRIPTION
Both pages paraphrased the funded proposal's framing. This quotes it instead.

The deliverable is assessed against the grant's own wording, so front door, explainer, and abstract should say the same thing in the same words.

- `why.html` — adds the problem statement as an attributed pull-quote: *"there is currently no simple and practical way for organisations to objectively assess their readiness for OpenBIM implementation or to identify the capability gaps that should be addressed before embarking on this transition"* (research proposal, 10 Aug 2026)
- `index.html` — the formal identification card now uses the proposal's own description of the toolkit and its five dimensions

Follow-up to #1450 and #1451. Still a WIP mockup.

## Verification
Both pages tag-balanced; `node --check` clean on the inline script.

🤖 Generated with [Claude Code](https://claude.com/claude-code)