### PR TITLE
docs(4d): code-side pointers for the midair judge divergence (ref §S58.5)

### DIFF
--- a/viewer/support_sweep.js
+++ b/viewer/support_sweep.js
@@ -486,6 +486,17 @@
   // close support exists (verified: scripts/probe_e3_synthetic.js CASE7) — this check still finds
   // and uses that real support via _designatedSupport()'s own narrowing, it just no longer treats
   // "something built on top of me, which depends on ME" as a thing I should be waiting for.
+  // ⛔ OPEN — ref: bim-compiler prompts/4D_GANTT_TM_REFACTOR.md §S58.5 (already tracked there; this
+  // is the code-side pointer, not a second record). That item asks: "measure whether the two judges
+  // still agree per element, or only in aggregate." MEASURED 2026-08-22 during the §S58 extraction,
+  // and the answer is worse than aggregate-only agreement: weakening THIS judge by 86,400,000x
+  // (the `items[sIdx].s > items[i].s + 1` threshold raised to + 86400000) produces ZERO failures
+  // across witness_midair_zero, witness_hosted_before_host, witness_kernel_ops_sched_version and
+  // witness_curtain_wall_opening. witness_midair_zero locks midair with its OWN census() (see the
+  // matching note there), which mirrors _contactGraph's symmetric carrier clause and did NOT follow
+  // this judge when #1435 made it directional. So the function that names the lane's core metric
+  // has no test that goes red when it breaks. Do not "fix" that by deleting census() — it is a
+  // deliberate independent judge; the open question is whether the two still describe one physics.
   function _midairAudit(items) {
     var out = { midair: 0, orphans: 0, guids: [], ok: true };
     if (!items || !items.length) return out;

--- a/viewer/tests/witness_midair_zero.js
+++ b/viewer/tests/witness_midair_zero.js
@@ -298,6 +298,12 @@ const CELL = ScheduleGate.CELL, EPS = ScheduleGate.EPS, GAP = ScheduleGate.GAP;
 const D = 86400000;
 
 // ── the INDEPENDENT judge (deliberately not the shipped repair's own helpers) ──
+// ⛔ OPEN — ref: bim-compiler prompts/4D_GANTT_TM_REFACTOR.md §S58.5 (tracked there; pointer only).
+// This census() is an INDEPENDENT judge by design, but it no longer encodes the same rule as the
+// shipped judge: it mirrors _contactGraph's symmetric carrier clause, while SupportSweep.midairAudit
+// went DIRECTIONAL in #1435. Measured 2026-08-22: breaking the shipped judge by 86,400,000x leaves
+// this witness at pass=49 fail=0 — the lock does not track the engine. Green here is not evidence
+// that midairAudit works. See the matching note at viewer/support_sweep.js _midairAudit.
 function census(items) {
   const grid = {};
   const cellsOf = e => { const o = [];


### PR DESCRIPTION
**Checked first whether this was already tracked — it is.** `prompts/4D_GANTT_TM_REFACTOR.md` **§S58.5** already carries it: *"measure whether the two judges still agree per element, or only in aggregate."* This adds **pointers** at the two code sites, not a competing record.

## The measurement §S58.5 asked for
Taken during the §S58 extraction. Weakening `SupportSweep.midairAudit` by 86,400,000× (its `+1` threshold raised to `+86400000`) produces **zero** failures across `witness_midair_zero`, `witness_hosted_before_host`, `witness_kernel_ops_sched_version` and `witness_curtain_wall_opening`.

The answer is worse than aggregate-only agreement: **the shipped judge has no test that reddens when it breaks.**

`witness_midair_zero`'s `census()` mirrors `_contactGraph`'s **symmetric** carrier clause; the shipped judge went **directional** in #1435. Both notes say so, and both say `census()` must **not** be deleted to "fix" it — the independence is deliberate. Whether the two still describe one physics is the open question, and it stays open.

## Convention used
House marker `⛔` (18 uses in-tree; `TODO` 10, no `FIXME`), each notice carrying the prompts file **and** the section number so the ref resolves.

Verified: `witness_midair_zero` still `pass=49 fail=0`. Comments only — no behaviour change, no `CACHE_VERSION` bump needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)