### PR TITLE
refactor(4d): extract the zone-index builder into viewer/zone_index.js (§S62), retiring a dead witness

### DIFF
--- a/eslint.globals.json
+++ b/eslint.globals.json
@@ -18,6 +18,7 @@
   "CostPanel": "readonly",
   "CpmSchedule": "readonly",
   "SupportSweep": "readonly",
+  "ZoneIndex": "readonly",
   "DB_URL": "readonly",
   "DISC_COLORS": "readonly",
   "DimChains": "readonly",

--- a/scripts/probe_captured_floating.js
+++ b/scripts/probe_captured_floating.js
@@ -469,6 +469,7 @@ async function main() {
   // are the current answer to the same question. ════════════════════════════════════════════════
   {
     const vm = require('vm');
+const ZoneIndex = require(path.join(__dirname, '..', 'viewer', 'zone_index.js'));   // §S62
     function sliceAt(src, name, which, optional) {
       let from = 0;
       for (let pass = 0; pass <= (which || 0); pass++) {
@@ -494,6 +495,7 @@ async function main() {
     const sandbox = { console: { log: () => {}, warn: () => {} }, performance: { now: () => Date.now() },
       window: { SEQUENCE_RULES: RATES.SEQUENCE_RULES, SEQUENCE_DEFAULT: RATES.SEQUENCE_DEFAULT,
         SEQUENCE_NAME_OVERRIDES: RATES.SEQUENCE_NAME_OVERRIDES, LABOR_RATES: RATES.LABOR_RATES },
+      ZoneIndex: ZoneIndex,
       ScheduleGate: ScheduleGate, Math: Math, A: () => ({ db: db }),
       URLSearchParams: URLSearchParams, CpmSchedule: CpmScheduleMod };
     vm.createContext(sandbox);

--- a/tests/audit_section_refs.js
+++ b/tests/audit_section_refs.js
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 /**
- * audit_section_refs.js — every `prompts/X.md` pointer in the code resolves to a real file.
+ * audit_section_refs.js — every `prompts/<NAME>.md` pointer in the code resolves to a real file.
  *
  * Implementing bim-compiler prompts/SCRIPT_LENGTH_REFACTOR_SEAMS.md §S62 — Witness: W-REF-RESOLVE
  *
@@ -57,7 +57,7 @@ if (!sidecarPresent) {
               ' — refs that would resolve there are reported NO-SIDECAR, not failed');
 }
 
-function resolveRef(rel) {           // rel is like 'prompts/FOO.md'
+function resolveRef(rel) {           // rel is like 'prompts/<NAME>.md'
   const base = path.basename(rel);
   const cands = [path.join(ROOT, rel), path.join(ROOT, 'prompts', 'archive', base)];
   if (sidecarPresent) cands.push(path.join(SIDECAR, base), path.join(SIDECAR, 'archive', base));
@@ -75,7 +75,7 @@ try {
   else { console.log('§REF_AUDIT FAIL: git grep failed — ' + e.message); process.exit(1); }
 }
 
-const refs = new Map();              // 'prompts/X.md' -> [{file, line}]
+const refs = new Map();              // 'prompts/<NAME>.md' -> [{file, line}]
 for (const row of hits.split('\n')) {
   if (!row) continue;
   const m = row.match(/^([^:]+):(\d+):(.*)$/); if (!m) continue;

--- a/tests/run_witness_suite.js
+++ b/tests/run_witness_suite.js
@@ -76,8 +76,10 @@ const KNOWN_RED = {
   // A — stale-slice crash: a source-text slice of time_machine.js calls a module-scope helper the
   // vm sandbox was never given. The §S53.5 class (it killed witness_zone_display_authoring for four
   // days). §S58's support_sweep.js extraction retires this class outright.
-  'witness_big_element_support_coverage.js': 'A — ReferenceError: _zoneIndex is not defined, crashes AFTER its first PASS line so its head reads healthy',
-  'witness_tm_geo_order_cycles.js':          'A — ReferenceError: _zoneIndex is not defined, after §TMREPRO_SLICE',
+  // §S62: no longer a crash — it RUNS now, and on its first live run in 9+ days it reports a real
+  // drift: W-TMREPRO-5 locks Terminal's floating tail at 8, measured 12. cycles=0 is clean.
+  // The lock was set when the witness last ran; nothing has checked it since. Not chased here.
+  'witness_tm_geo_order_cycles.js':          'C — W-TMREPRO-5 Terminal floating tail 12, locked at 8 (cycles=0). Real drift, newly visible.',
   // B — environment assumption baked into the file.
   'witness_zone_index.js':                   'B — ENOENT: hardcodes /tmp/vw/time_machine.js instead of resolving from __dirname. One-line fix.',
   // C — real assertion reds, reproducible every run.

--- a/viewer/sw.js
+++ b/viewer/sw.js
@@ -8,7 +8,7 @@
 // Cache-first for heavy assets (.wasm, images). DB files skip SW (IndexedDB handles them).
 //
 // DEPLOY: bump CACHE_VERSION on every OCI upload. Old caches are purged on activate.
-const CACHE_VERSION = 'v1066';   // bump on each deploy; per-change detail is the git commit message.
+const CACHE_VERSION = 'v1067';   // bump on each deploy; per-change detail is the git commit message.
 // v1064 (2026-08-21) 4D_GANTT_TM_REFACTOR.md §S58 — observability hardening, ADDITIVE LOGGING
 // ONLY, no rule or behaviour changed. (a) the three §GANTT_* proof lines now fire on every
 // model REBUILD instead of once per building, so an edit is auditable (rebuild=N ordinal).
@@ -399,6 +399,7 @@ const PRECACHE_ASSETS = [
   'location_axis.js',       // §S50 — rooms injection; lib/room_walker.js is network-first below
   'cpm_schedule.js',
   'gantt_model.js',      // §S53 (F3) — the Gantt bar model, extracted from time_machine.js
+  'zone_index.js',       // §S62 — median-Z storey banding, extracted from time_machine.js
   'support_sweep.js',    // §S58 — support-order physics, extracted from time_machine.js
   'time_machine.js',
   'dlod_nav.js',

--- a/viewer/tests/witness_big_element_support_coverage.js
+++ b/viewer/tests/witness_big_element_support_coverage.js
@@ -32,6 +32,7 @@
 const fs = require('fs');
 const path = require('path');
 const vm = require('vm');
+const ZoneIndex = require(path.join(__dirname, '..', 'zone_index.js'));   // §S62
 const initSqlJs = require(path.join(__dirname, '..', '..', 'modeller', 'lib', 'sql-wasm.js'));
 
 let pass = 0, fail = 0;
@@ -116,6 +117,15 @@ const BUILDINGS = [
 
   const names = ['_buildXrayElements'];
   if (tmSrc.indexOf('function _promoteRoofLoadPath(') >= 0) names.unshift('_promoteRoofLoadPath');
+  // §S62: _buildXrayElements' real dependency closure. It calls _classifyRule (which calls
+  // _classifyNameOverride) and _zoneIndex — none of which were in this slice set, so the witness
+  // died on ReferenceError before its first assertion. _zoneIndex now comes from the zone_index.js
+  // module via the sandbox; these two are still text slices, added here the same way
+  // witness_midair_zero.js:136 already does it. Each name added is a dependency that was
+  // ALWAYS required and never declared — the text-slice pattern cannot state its own needs.
+  for (const dep of ['_classifyNameOverride', '_classifyRule']) {
+    if (tmSrc.indexOf('function ' + dep + '(') >= 0) names.push(dep);
+  }
   let sliced;
   try { sliced = names.map(n => sliceFn(tmSrc, n)).join('\n'); }
   catch (e) { assert(false, 'W-BIGSUP-SLICE failed: ' + e.message); finish(); return; }
@@ -133,6 +143,12 @@ const BUILDINGS = [
       performance: { now: () => Date.now() },
       window: { SEQUENCE_RULES: rulesJson.SEQUENCE_RULES, SEQUENCE_DEFAULT: rulesJson.SEQUENCE_DEFAULT, SEQUENCE_NAME_OVERRIDES: rulesJson.SEQUENCE_NAME_OVERRIDES || rulesJson.NAME_OVERRIDES || [] },
       A: function () { return { db: db }; },
+      // §S62: _buildXrayElements calls _zoneIndex(), which was in NEITHER the slice set nor the
+      // sandbox — this witness died on `ReferenceError: _zoneIndex is not defined` before its first
+      // assertion. The builder is a real module now, so the accessor is provided here (no memo
+      // needed: one build per run) instead of hoping a text slice happens to include it.
+      ZoneIndex: ZoneIndex,
+      _zoneIndex: function () { return ZoneIndex.build(db); },
     };
     vm.createContext(sandbox);
     vm.runInContext(sliced + '\nthis.__bxe = _buildXrayElements;', sandbox);

--- a/viewer/tests/witness_curtain_wall_opening.js
+++ b/viewer/tests/witness_curtain_wall_opening.js
@@ -83,6 +83,7 @@
 const fs = require('fs');
 const path = require('path');
 const vm = require('vm');
+const ZoneIndex = require(path.join(__dirname, '..', 'zone_index.js'));   // §S62: sliced _zoneIndexBuild delegates to it
 const SupportSweep = require(path.join(__dirname, '..', 'support_sweep.js'));   // §S58: required, never sliced
 const HOME = require('os').homedir();
 const VIEWER_DIR = path.join(__dirname, '..');
@@ -228,6 +229,7 @@ function countEarly(pairs, getS, getE, sccOf) {
     // real per-resource caps instead of running crew-unconstrained.
     const sandbox = { console: { log: () => {}, warn: () => {} }, performance: { now: () => Date.now() },
       window: { SEQUENCE_RULES: SR, SEQUENCE_DEFAULT: SD, SEQUENCE_NAME_OVERRIDES: NO, LABOR_RATES: RATES.LABOR_RATES },
+      ZoneIndex: ZoneIndex,
       ScheduleGate: ScheduleGate, SupportSweep: SupportSweep, Math: Math, RegExp: RegExp, Object: Object, Infinity: Infinity,
       URLSearchParams: URLSearchParams, CpmSchedule: CpmSchedule,
       A: () => ({ db: db, activeBuilding: bld, _metaGen: 0 }) };

--- a/viewer/tests/witness_gantt_lock_integrity.js
+++ b/viewer/tests/witness_gantt_lock_integrity.js
@@ -27,6 +27,7 @@
 const fs = require('fs');
 const path = require('path');
 const vm = require('vm');
+const ZoneIndex = require(path.join(__dirname, '..', 'zone_index.js'));   // §S62: sliced _zoneIndexBuild delegates to it
 const { execSync } = require('child_process');
 const initSqlJs = require(path.join(__dirname, '..', '..', 'modeller', 'lib', 'sql-wasm.js'));
 
@@ -160,8 +161,10 @@ const BLD_DIR = process.env.BLD_DIR || path.join(require('os').homedir(), 'bim-o
   const sandbox = {
     console: console,
     performance: { now: () => Date.now() },
+    ZoneIndex: ZoneIndex,
     ScheduleGate: ScheduleGate,
     window: { SEQUENCE_RULES: rulesJson.SEQUENCE_RULES, SEQUENCE_DEFAULT: rulesJson.SEQUENCE_DEFAULT, SEQUENCE_NAME_OVERRIDES: rulesJson.SEQUENCE_NAME_OVERRIDES || rulesJson.NAME_OVERRIDES || [] },
+    ZoneIndex: ZoneIndex,
     A: function () { return { db: db }; },
     _ops: [],
     URLSearchParams: URLSearchParams,

--- a/viewer/tests/witness_hosted_before_host.js
+++ b/viewer/tests/witness_hosted_before_host.js
@@ -72,6 +72,7 @@
 const fs = require('fs');
 const path = require('path');
 const vm = require('vm');
+const ZoneIndex = require(path.join(__dirname, '..', 'zone_index.js'));   // §S62: sliced _zoneIndexBuild delegates to it
 const SupportSweep = require(path.join(__dirname, '..', 'support_sweep.js'));   // §S58: required, never sliced
 const HOME = require('os').homedir();
 const VIEWER_DIR = path.join(__dirname, '..');
@@ -196,6 +197,7 @@ function countEarly(pairs, get) {
     // real per-resource caps instead of running crew-unconstrained.
     const sandbox = { console: { log: () => {}, warn: () => {} }, performance: { now: () => Date.now() },
       window: { SEQUENCE_RULES: SR, SEQUENCE_DEFAULT: SD, SEQUENCE_NAME_OVERRIDES: NO, LABOR_RATES: RATES.LABOR_RATES },
+      ZoneIndex: ZoneIndex,
       ScheduleGate: ScheduleGate, SupportSweep: SupportSweep, Math: Math, RegExp: RegExp, Object: Object, Infinity: Infinity,
       URLSearchParams: URLSearchParams, CpmSchedule: CpmSchedule,
       A: () => ({ db: db, activeBuilding: bld, _metaGen: 0 }) };

--- a/viewer/tests/witness_kernel_ops_sched_version.js
+++ b/viewer/tests/witness_kernel_ops_sched_version.js
@@ -44,6 +44,7 @@
 const fs = require('fs');
 const path = require('path');
 const vm = require('vm');
+const ZoneIndex = require(path.join(__dirname, '..', 'zone_index.js'));   // §S62: sliced _zoneIndexBuild delegates to it
 const SupportSweep = require(path.join(__dirname, '..', 'support_sweep.js'));   // §S58: required, never sliced
 const initSqlJs = require(path.join(__dirname, '..', '..', 'modeller', 'lib', 'sql-wasm.js'));
 
@@ -159,6 +160,7 @@ function loadRatesTable() {
     const sandbox = {
       console: { log: () => {}, warn: () => {} }, performance: { now: () => Date.now() },
       window: { SEQUENCE_RULES: SR, SEQUENCE_DEFAULT: SD, SEQUENCE_NAME_OVERRIDES: NO, LABOR_RATES: RATES.LABOR_RATES },
+      ZoneIndex: ZoneIndex,
       ScheduleGate: ScheduleGate, SupportSweep: SupportSweep, Math: Math, A: () => ({ db: db }),
       URLSearchParams: URLSearchParams, CpmSchedule: CpmSchedule
     };

--- a/viewer/tests/witness_midair_zero.js
+++ b/viewer/tests/witness_midair_zero.js
@@ -83,6 +83,7 @@
 const fs = require('fs');
 const path = require('path');
 const vm = require('vm');
+const ZoneIndex = require(path.join(__dirname, '..', 'zone_index.js'));   // §S62: sliced _zoneIndexBuild delegates to it
 const initSqlJs = require(path.join(__dirname, '..', '..', 'modeller', 'lib', 'sql-wasm.js'));
 const ScheduleGate = require(path.join(__dirname, '..', 'schedule_gate.js'));
 const ScheduleAuthor = require(path.join(__dirname, '..', 'schedule_author.js'));
@@ -372,6 +373,7 @@ function census(items) {
     const sandbox = { console: { log: () => {}, warn: () => {} }, performance: { now: () => Date.now() },
       window: { SEQUENCE_RULES: SR, SEQUENCE_DEFAULT: SD, SEQUENCE_NAME_OVERRIDES: NO,
                 LABOR_RATES: RATES.LABOR_RATES, GanttModel: GanttModel },   // §S53: sliced code's delegates read window.GanttModel
+      ZoneIndex: ZoneIndex,
       ScheduleGate: ScheduleGate, SupportSweep: SupportSweep, Math: Math, A: () => ({ db: db }),   // §S58
       URLSearchParams: URLSearchParams, CpmSchedule: CpmSchedule };
     vm.createContext(sandbox);

--- a/viewer/tests/witness_s50_cell_engine.js
+++ b/viewer/tests/witness_s50_cell_engine.js
@@ -7,6 +7,7 @@
 const fs = require('fs');
 const path = require('path');
 const vm = require('vm');
+const ZoneIndex = require(path.join(__dirname, '..', 'zone_index.js'));   // §S62: sliced _zoneIndexBuild delegates to it
 const initSqlJs = require(path.join(__dirname, '..', '..', 'modeller', 'lib', 'sql-wasm.js'));
 const ScheduleGate = require(path.join(__dirname, '..', 'schedule_gate.js'));
 const ScheduleAuthor = require(path.join(__dirname, '..', 'schedule_author.js'));
@@ -66,6 +67,7 @@ const BUILDINGS = (process.env.ONLY || 'Clinic,Duplex').split(',');
     const db = new SQL.Database(fs.readFileSync(dbPath));
     const sandbox = { console: { log: () => {}, warn: () => {} }, performance: { now: () => Date.now() },
       window: { SEQUENCE_RULES: SR, SEQUENCE_DEFAULT: SD, SEQUENCE_NAME_OVERRIDES: NO, LABOR_RATES: RATES.LABOR_RATES },
+      ZoneIndex: ZoneIndex,
       ScheduleGate: ScheduleGate, Math: Math, A: () => ({ db: db }), URLSearchParams: URLSearchParams };
     vm.createContext(sandbox);
     vm.runInContext(sliced + '\nthis.__bxe = _buildXrayElements;', sandbox);

--- a/viewer/tests/witness_s55_identity_vs_cell.js
+++ b/viewer/tests/witness_s55_identity_vs_cell.js
@@ -53,6 +53,7 @@
 const fs = require('fs');
 const path = require('path');
 const vm = require('vm');
+const ZoneIndex = require(path.join(__dirname, '..', 'zone_index.js'));   // §S62: sliced _zoneIndexBuild delegates to it
 const initSqlJs = require(path.join(__dirname, '..', '..', 'modeller', 'lib', 'sql-wasm.js'));
 const ScheduleGate = require(path.join(__dirname, '..', 'schedule_gate.js'));
 const ScheduleAuthor = require(path.join(__dirname, '..', 'schedule_author.js'));
@@ -144,6 +145,7 @@ function authoredRowCounts(db) {
       const sandbox = { console: { log: () => {}, warn: () => {} }, performance: { now: () => Date.now() },
         window: { SEQUENCE_RULES: SR, SEQUENCE_DEFAULT: SD, SEQUENCE_NAME_OVERRIDES: NO,
                   LABOR_RATES: RATES.LABOR_RATES, GanttModel: GanttModel },
+        ZoneIndex: ZoneIndex,
         ScheduleGate: ScheduleGate, SupportSweep: SupportSweep, Math: Math, A: () => ({ db: db }),
         URLSearchParams: URLSearchParams, CpmSchedule: CpmSchedule };
       vm.createContext(sandbox);

--- a/viewer/tests/witness_tm_geo_order_cycles.js
+++ b/viewer/tests/witness_tm_geo_order_cycles.js
@@ -44,6 +44,7 @@
 const fs = require('fs');
 const path = require('path');
 const vm = require('vm');
+const ZoneIndex = require(path.join(__dirname, '..', 'zone_index.js'));   // §S62
 const initSqlJs = require(path.join(__dirname, '..', '..', 'modeller', 'lib', 'sql-wasm.js'));
 
 let pass = 0, fail = 0;
@@ -72,6 +73,15 @@ const BLD_DIR = process.env.BLD_DIR || path.join(require('os').homedir(), 'bim-o
   const names = ['_buildXrayElements'];
   const hasPromote = tmSrc.indexOf('function _promoteRoofLoadPath(') >= 0;
   if (hasPromote) names.unshift('_promoteRoofLoadPath');
+  // §S62: _buildXrayElements' real dependency closure. It calls _classifyRule (which calls
+  // _classifyNameOverride) and _zoneIndex — none of which were in this slice set, so the witness
+  // died on ReferenceError before its first assertion. _zoneIndex now comes from the zone_index.js
+  // module via the sandbox; these two are still text slices, added here the same way
+  // witness_midair_zero.js:136 already does it. Each name added is a dependency that was
+  // ALWAYS required and never declared — the text-slice pattern cannot state its own needs.
+  for (const dep of ['_classifyNameOverride', '_classifyRule']) {
+    if (tmSrc.indexOf('function ' + dep + '(') >= 0) names.push(dep);
+  }
   console.log('§TMREPRO_SLICE state=' + (hasPromote ? 'post-refactor (shared _promoteRoofLoadPath)' : 'pre-refactor (inline copy)'));
   let sliced;
   try {
@@ -89,6 +99,12 @@ const BLD_DIR = process.env.BLD_DIR || path.join(require('os').homedir(), 'bim-o
     performance: { now: () => Date.now() },
     window: { SEQUENCE_RULES: rulesJson.SEQUENCE_RULES, SEQUENCE_DEFAULT: rulesJson.SEQUENCE_DEFAULT, SEQUENCE_NAME_OVERRIDES: rulesJson.SEQUENCE_NAME_OVERRIDES || rulesJson.NAME_OVERRIDES || [] },
     A: function () { return { db: db }; },
+    // §S62: _buildXrayElements calls _zoneIndex(), which was in NEITHER the slice set nor the
+    // sandbox — this witness died on `ReferenceError: _zoneIndex is not defined` before its first
+    // assertion. The builder is a real module now, so the accessor is provided here (no memo
+    // needed: one build per run) instead of hoping a text slice happens to include it.
+    ZoneIndex: ZoneIndex,
+    _zoneIndex: function () { return ZoneIndex.build(db); },
   };
   vm.createContext(sandbox);
   vm.runInContext(sliced + '\nthis.__bxe = _buildXrayElements;', sandbox);

--- a/viewer/tests/witness_zone_display_authoring.js
+++ b/viewer/tests/witness_zone_display_authoring.js
@@ -28,6 +28,7 @@
 const fs = require('fs');
 const path = require('path');
 const vm = require('vm');
+const ZoneIndex = require(path.join(__dirname, '..', 'zone_index.js'));   // §S62: sliced _zoneIndexBuild delegates to it
 const initSqlJs = require(path.join(__dirname, '..', '..', 'modeller', 'lib', 'sql-wasm.js'));
 const ScheduleGate = require(path.join(__dirname, '..', 'schedule_gate.js'));
 const ScheduleAuthor = require(path.join(__dirname, '..', 'schedule_author.js'));
@@ -97,6 +98,7 @@ const sliced = ["var _TIER1_ORDER = ['Substructure', 'Superstructure', 'Architec
   sliceFn(tmSrc, '_tmDisplayRemap')].join('\n');
 const _rlines = [];
 const sandbox = { console: { log: (...a) => _rlines.push(a.join(' ')), warn: () => {} }, performance: { now: () => Date.now() },
+  ZoneIndex: ZoneIndex,
   ScheduleGate: ScheduleGate, SupportSweep: SupportSweep, Math: Math, URLSearchParams: URLSearchParams,
   CpmSchedule: require(path.join(__dirname, '..', 'cpm_schedule.js')),
   GanttModel: require(path.join(__dirname, '..', 'gantt_model.js')) };   // §S53: the drawer's bar-trim envelope, as a real module
@@ -225,6 +227,7 @@ async function main() {
     // display timeline through the SAME hook (proves the wiring, not just the module).
     console.log = quiet;
     const cpmSandbox = { console: { log: () => {}, warn: () => {} }, performance: { now: () => Date.now() },
+      ZoneIndex: ZoneIndex,
       ScheduleGate: ScheduleGate, SupportSweep: SupportSweep, Math: Math, URLSearchParams: URLSearchParams,
       CpmSchedule: require(path.join(__dirname, '..', 'cpm_schedule.js')),
       GanttModel: require(path.join(__dirname, '..', 'gantt_model.js')) };   // §S53, same as the sandbox above

--- a/viewer/time_machine.js
+++ b/viewer/time_machine.js
@@ -3557,73 +3557,10 @@
   // not with a refactor that has to prove itself byte-identical.
   var _zoneMemo = [];   // 2-slot, most-recent first — same discipline as §XRAY_CACHE_MEMO
 
-  function _zoneIndexBuild(db) {
-    var t0 = performance.now();
-    var r;
-    // Same population filter both former copies used, so the index is exactly their union.
-    try {
-      r = db.exec('SELECT m.guid, m.storey, COALESCE(t.center_z, 0) as cz ' +
-        'FROM elements_meta m LEFT JOIN element_transforms t ON t.guid = m.guid ' +
-        "WHERE m.ifc_class != 'IfcOpeningElement' AND m.ifc_class != 'IfcSpace'");
-    } catch (e) { return null; }
-    if (!r.length || !r[0].values.length) return null;
-    var rows = r[0].values;
-
-    var zvals = {}, unknownN = 0;
-    for (var i = 0; i < rows.length; i++) {
-      var st = rows[i][1] || '_UNKNOWN';
-      if (st === '_UNKNOWN' || /^unknown$/i.test(st)) { unknownN++; continue; }
-      (zvals[st] || (zvals[st] = [])).push(rows[i][2] || 0);
-    }
-    var medianZ = {};
-    for (var sk in zvals) {
-      var vals = zvals[sk].sort(function (a, b) { return a - b; });
-      var mid = Math.floor(vals.length / 2);
-      medianZ[sk] = vals.length % 2 !== 0 ? vals[mid] : (vals[mid - 1] + vals[mid]) / 2;
-    }
-    var names = Object.keys(medianZ).sort(function (a, b) { return medianZ[a] - medianZ[b]; });
-    var band = {};
-    for (var bi = 0; bi < names.length; bi++) band[names[bi]] = bi;
-
-    // Tie audit: the two former copies fed their maps in DIFFERENT row orders (injectGantt's SELECT
-    // carries ORDER BY cz, _buildXrayElements' does not). Sorting by medianZ is only order-stable
-    // when no two storeys SHARE a median — so a tie is the one condition under which the old pair
-    // could legitimately have disagreed with each other, and under which this consolidation would
-    // be picking a winner rather than preserving both. Counted and logged, never silently assumed.
-    var tiesN = 0;
-    for (var ti = 1; ti < names.length; ti++) if (medianZ[names[ti]] === medianZ[names[ti - 1]]) tiesN++;
-
-    // Optional finest level — present only where the extractor produced it (Terminal today).
-    var spaceOf = null, spaceN = 0;
-    try {
-      var sr = db.exec('SELECT element_guid, space_guid FROM rel_contained_in_space');
-      if (sr.length && sr[0].values.length) {
-        spaceOf = {};
-        for (var si = 0; si < sr[0].values.length; si++) spaceOf[sr[0].values[si][0]] = sr[0].values[si][1];
-        spaceN = sr[0].values.length;
-      }
-    } catch (e) { spaceOf = null; }   // table absent — expected on 6 of 7 buildings, not an error
-
-    var level = spaceOf ? 'space' : (names.length > 1 ? 'band' : (names.length === 1 ? 'storey' : 'single'));
-    return {
-      medianZ: medianZ, names: names, band: band, spaceOf: spaceOf,
-      level: level, tiesN: tiesN, unknownN: unknownN, spaceN: spaceN,
-      totalN: rows.length, buildMs: performance.now() - t0,
-      // The reassignment both former copies performed, verbatim — an element with no real storey
-      // is placed on the nearest real one by |cz - medianZ|, first-wins on an exact distance tie
-      // (loop keeps the earlier name on `<`), which is the previous behaviour exactly.
-      assign: function (storey, cz) {
-        if (storey !== '_UNKNOWN' && !/^unknown$/i.test(storey)) return storey;
-        if (!names.length) return storey;
-        var best = names[0], bd = Infinity;
-        for (var ai = 0; ai < names.length; ai++) {
-          var d = Math.abs(cz - medianZ[names[ai]]);
-          if (d < bd) { bd = d; best = names[ai]; }
-        }
-        return best;
-      }
-    };
-  }
+  // §S62: the builder moved VERBATIM to viewer/zone_index.js (pure: db in, index out). The memo,
+  // the key and the §ZONE_INDEX log below stay here — state and reporting are the parent's job.
+  // Name kept so every caller and the __tmZoneProbe hook read unchanged.
+  function _zoneIndexBuild(db) { return ZoneIndex.build(db); }
 
   // Memoized accessor. Key mirrors §XRAY_CACHE_MEMO: over-invalidating on _metaGen is the safe
   // direction (a miss costs one rebuild; a false hit is a wrong-zone bug).

--- a/viewer/viewer.html
+++ b/viewer/viewer.html
@@ -946,8 +946,11 @@ html.bim-embedded, html.bim-embedded body { background: #0b0b0b; }
 <!-- §S58: support-order physics (sweep / judge parity / window rescale), extracted out of
      time_machine.js. Must load BEFORE time_machine.js — its _ogSupportSweep/_cjpJudgeParity/
      _contactGraph/_designatedSupport/_midairAudit/_capWindowRescale wrappers call it. -->
+<!-- §S62: median-Z storey banding index (pure builder), extracted out of time_machine.js.
+     Must load BEFORE time_machine.js — its _zoneIndexBuild wrapper calls it. -->
+<script src="zone_index.js?v=1" onerror="console.warn('§LOAD_FAIL zone_index.js — storey banding unavailable (zone inference falls back to declared storey)')"></script>
 <script src="support_sweep.js?v=1" onerror="console.warn('§LOAD_FAIL support_sweep.js — support-order physics unavailable (schedule repair, judge parity, lock-gate midair audit)')"></script>
-<script src="time_machine.js?v=72" onerror="console.warn('§LOAD_FAIL time_machine.js')"></script>
+<script src="time_machine.js?v=73" onerror="console.warn('§LOAD_FAIL time_machine.js')"></script>
 <script src="dlod_nav.js?v=2" onerror="console.warn('§LOAD_FAIL dlod_nav.js')"></script>
 <script src="schedule_author.js?v=14" onerror="console.warn('§LOAD_FAIL schedule_author.js')"></script>
 <script src="schedule_sync.js?v=3" onerror="console.warn('§LOAD_FAIL schedule_sync.js')"></script>

--- a/viewer/zone_index.js
+++ b/viewer/zone_index.js
@@ -1,0 +1,92 @@
+// zone_index.js — the median-Z storey banding index, extracted from time_machine.js (§S62)
+//
+// Implementing bim-compiler prompts/SCRIPT_LENGTH_REFACTOR_SEAMS.md §S62
+// Witness: witness_big_element_support_coverage / witness_tm_geo_order_cycles — both were RED with
+// `ReferenceError: _zoneIndex is not defined` before this move (2 of the suite's 8 known reds).
+//
+// PURE. build(db) reads nothing but its argument: no app object, no memo, no DOM, no § log.
+// time_machine.js keeps _zoneMemo, the _zoneIndex() accessor that owns the memo key and the
+// §ZONE_INDEX log line, and the __tmZoneProbe test hook — that is state and reporting, the
+// parent's half of the split. Same contract as gantt_model.js (§S53) and support_sweep.js (§S58).
+//
+// WHY IT WAS EXTRACTED, stated so the next reader does not have to reconstruct it: two witnesses
+// slice _buildXrayElements out of time_machine.js by source text, and _buildXrayElements calls
+// _zoneIndex(). Neither the accessor nor this builder was ever in their slice set, so both died
+// before their first assertion — the same failure class that hid a dead witness for four days
+// (§S53.5). A require() cannot half-import a function; a text slice can and did.
+'use strict';
+(function (global) {
+
+  function _zoneIndexBuild(db) {
+    var t0 = performance.now();
+    var r;
+    // Same population filter both former copies used, so the index is exactly their union.
+    try {
+      r = db.exec('SELECT m.guid, m.storey, COALESCE(t.center_z, 0) as cz ' +
+        'FROM elements_meta m LEFT JOIN element_transforms t ON t.guid = m.guid ' +
+        "WHERE m.ifc_class != 'IfcOpeningElement' AND m.ifc_class != 'IfcSpace'");
+    } catch (e) { return null; }
+    if (!r.length || !r[0].values.length) return null;
+    var rows = r[0].values;
+
+    var zvals = {}, unknownN = 0;
+    for (var i = 0; i < rows.length; i++) {
+      var st = rows[i][1] || '_UNKNOWN';
+      if (st === '_UNKNOWN' || /^unknown$/i.test(st)) { unknownN++; continue; }
+      (zvals[st] || (zvals[st] = [])).push(rows[i][2] || 0);
+    }
+    var medianZ = {};
+    for (var sk in zvals) {
+      var vals = zvals[sk].sort(function (a, b) { return a - b; });
+      var mid = Math.floor(vals.length / 2);
+      medianZ[sk] = vals.length % 2 !== 0 ? vals[mid] : (vals[mid - 1] + vals[mid]) / 2;
+    }
+    var names = Object.keys(medianZ).sort(function (a, b) { return medianZ[a] - medianZ[b]; });
+    var band = {};
+    for (var bi = 0; bi < names.length; bi++) band[names[bi]] = bi;
+
+    // Tie audit: the two former copies fed their maps in DIFFERENT row orders (injectGantt's SELECT
+    // carries ORDER BY cz, _buildXrayElements' does not). Sorting by medianZ is only order-stable
+    // when no two storeys SHARE a median — so a tie is the one condition under which the old pair
+    // could legitimately have disagreed with each other, and under which this consolidation would
+    // be picking a winner rather than preserving both. Counted and logged, never silently assumed.
+    var tiesN = 0;
+    for (var ti = 1; ti < names.length; ti++) if (medianZ[names[ti]] === medianZ[names[ti - 1]]) tiesN++;
+
+    // Optional finest level — present only where the extractor produced it (Terminal today).
+    var spaceOf = null, spaceN = 0;
+    try {
+      var sr = db.exec('SELECT element_guid, space_guid FROM rel_contained_in_space');
+      if (sr.length && sr[0].values.length) {
+        spaceOf = {};
+        for (var si = 0; si < sr[0].values.length; si++) spaceOf[sr[0].values[si][0]] = sr[0].values[si][1];
+        spaceN = sr[0].values.length;
+      }
+    } catch (e) { spaceOf = null; }   // table absent — expected on 6 of 7 buildings, not an error
+
+    var level = spaceOf ? 'space' : (names.length > 1 ? 'band' : (names.length === 1 ? 'storey' : 'single'));
+    return {
+      medianZ: medianZ, names: names, band: band, spaceOf: spaceOf,
+      level: level, tiesN: tiesN, unknownN: unknownN, spaceN: spaceN,
+      totalN: rows.length, buildMs: performance.now() - t0,
+      // The reassignment both former copies performed, verbatim — an element with no real storey
+      // is placed on the nearest real one by |cz - medianZ|, first-wins on an exact distance tie
+      // (loop keeps the earlier name on `<`), which is the previous behaviour exactly.
+      assign: function (storey, cz) {
+        if (storey !== '_UNKNOWN' && !/^unknown$/i.test(storey)) return storey;
+        if (!names.length) return storey;
+        var best = names[0], bd = Infinity;
+        for (var ai = 0; ai < names.length; ai++) {
+          var d = Math.abs(cz - medianZ[names[ai]]);
+          if (d < bd) { bd = d; best = names[ai]; }
+        }
+        return best;
+      }
+    };
+  }
+
+  var API = { build: _zoneIndexBuild };
+  global.ZoneIndex = API;
+  if (typeof module !== 'undefined' && module.exports) module.exports = API;
+
+})(typeof window !== 'undefined' ? window : (typeof globalThis !== 'undefined' ? globalThis : this));


### PR DESCRIPTION
**Justified by a live failure, not by line count.** `witness_big_element_support_coverage` and `witness_tm_geo_order_cycles` were both RED on main with `ReferenceError: _zoneIndex is not defined` — 2 of the suite's 8 known reds, the same stale-slice class that hid a dead witness for four days (§S53.5).

| | before | after |
|---|---|---|
| `time_machine.js` | 8,706 | **8,643** (−63) |
| `zone_index.js` | — | 92 |
| suite | green=34 known_red=8 | **green=35 known_red=7**, new_red=0 |

`_zoneIndexBuild(db)` is param-complete (no app object, no memo, no DOM) so it moves. `_zoneMemo`, the `_zoneIndex()` accessor owning the memo key and the `§ZONE_INDEX` log, `_zoneOf` and `__tmZoneProbe` all **stay** — state and reporting are the parent's half, same contract as `gantt_model.js` and `support_sweep.js`.

## Two real findings, neither fixed here
1. `witness_big_element_support_coverage` now **runs and passes** — retired from `KNOWN_RED`.
2. `witness_tm_geo_order_cycles` runs for the first time in **9+ days** and immediately reports a drift: **W-TMREPRO-5 locks Terminal's floating tail at 8, measured 12** (cycles=0, clean). The lock was set when the witness last ran; nothing has checked it since. Its `KNOWN_RED` entry is re-labelled from *crash* to that measured cause.

## The extraction alone did not fix the crash
`_buildXrayElements`' real dependency closure is `_zoneIndex` + `_classifyRule` + `_classifyNameOverride`, and **none** were declared by the slicing witnesses. `_zoneIndex` now comes from the module; the classify pair are added as text slices the same way `witness_midair_zero.js:136` already does it. **The text-slice pattern cannot state its own needs** — that is the argument for the module, restated with evidence.

## I broke three witnesses first
9 witnesses/probes slice `_zoneIndexBuild` and needed `ZoneIndex` in their sandbox. Migrating them, I missed three — `midair_zero`, `s50_cell_engine`, `s55_identity_vs_cell` all went new-red — and **the suite runner caught it in one command**. Precisely the accumulation it exists to prevent.

## Wiring, same commit
`viewer.html` loads `zone_index.js` before `time_machine.js` (`?v=72→73`) with `§LOAD_FAIL`; `sw.js` PRECACHE + `CACHE_VERSION` **v1066 → v1067**; `ZoneIndex` declared in `eslint.globals.json` (CI's no-undef gate catches this; local runs do not).

Also: `audit_section_refs.js` flagged its **own** doc examples as dead refs. Fixed by making the examples non-matching rather than excluding the file — the audit still checks itself.

Audits green: precache 141/0 · script tags 148/148 · refs 100 resolved, 0 DEAD.

🤖 Generated with [Claude Code](https://claude.com/claude-code)