### PR TITLE
feat(4d): the Gantt refuses edits while the film is recording (§TM_BAKE_LOCK, §S56)

### DIFF
--- a/viewer/sw.js
+++ b/viewer/sw.js
@@ -8,7 +8,7 @@
 // Cache-first for heavy assets (.wasm, images). DB files skip SW (IndexedDB handles them).
 //
 // DEPLOY: bump CACHE_VERSION on every OCI upload. Old caches are purged on activate.
-const CACHE_VERSION = 'v1067';   // bump on each deploy; per-change detail is the git commit message.
+const CACHE_VERSION = 'v1068';   // bump on each deploy; per-change detail is the git commit message.
 // v1064 (2026-08-21) 4D_GANTT_TM_REFACTOR.md §S58 — observability hardening, ADDITIVE LOGGING
 // ONLY, no rule or behaviour changed. (a) the three §GANTT_* proof lines now fire on every
 // model REBUILD instead of once per building, so an edit is auditable (rebuild=N ordinal).

--- a/viewer/tests/witness_gantt_edit_undo.js
+++ b/viewer/tests/witness_gantt_edit_undo.js
@@ -34,7 +34,12 @@ function sliceFn(src, name) {
 }
 
 const tmSrc = fs.readFileSync(path.join(__dirname, '..', 'time_machine.js'), 'utf8');
+  // §S56: commitGanttDrag/generateGanttSchedule now call _tmBusyRecording (the §TM_BAKE_LOCK
+  // guard). Declared here because a sliced function cannot state its own dependencies — the
+  // same undeclared-dep class that killed two witnesses in §S62. Adding the name is the fix;
+  // the suite runner caught the omission the moment the guard landed.
 const sliced = [
+  '_tmBusyRecording',
   'loadOps', '_retimeSpan', 'retimeTaskElements', 'commitGanttDrag', 'undoLastGanttEdit'
 ].map(function (n) { return sliceFn(tmSrc, n); }).join('\n');
 

--- a/viewer/tests/witness_gantt_native_generate.js
+++ b/viewer/tests/witness_gantt_native_generate.js
@@ -41,6 +41,7 @@ const _verMatch = tmSrc.match(/var _GANTT_CACHE_VERSION = (\d+);/);
 if (!_verMatch) throw new Error('_GANTT_CACHE_VERSION not found in time_machine.js');
 const sliced = 'var _GANTT_CACHE_VERSION = ' + _verMatch[1] + ';\n' +
   'var _tmDisplayRemap = function () { return null; };\n' +
+  sliceFn(tmSrc, '_tmBusyRecording') + '\n' +   // §S56: the §TM_BAKE_LOCK guard the verb now calls
   sliceFn(tmSrc, 'generateGanttSchedule');
 
 function loadRules() {

--- a/viewer/tests/witness_tm_bake_lock.js
+++ b/viewer/tests/witness_tm_bake_lock.js
@@ -1,0 +1,109 @@
+#!/usr/bin/env node
+/**
+ * witness_tm_bake_lock.js — the Gantt refuses edits while the film is recording (§TM_BAKE_LOCK).
+ *
+ * Implementing bim-compiler prompts/SCRIPT_LENGTH_REFACTOR_SEAMS.md §S56 — Witness: W-TBL
+ *
+ * THE ISSUE EACH CHECK PROVES OR DISPROVES. The user's separation-of-concern rule is that the movie
+ * bake PLAYS the Time Machine and nobody should edit the schedule while it records. Before this
+ * change that rule existed only as discipline: cinema_maxq.js sets A._maxqActive and dlod_nav.js /
+ * panels.js honour it, but time_machine.js — the thing being recorded — never read it, so a drag or
+ * a re-generate mid-bake would mutate the timeline the recorder was mid-way through playing.
+ *
+ * These checks are RELATIVE, not absolute: each asserts that the edit verb DID NOT reach its engine
+ * call while a flag is set, and DID reach it when no flag is set. A guard that refuses everything
+ * would pass the first half and fail the second — that pairing is the point.
+ */
+'use strict';
+const fs = require('fs');
+const path = require('path');
+const vm = require('vm');
+
+let pass = 0, fail = 0;
+function assert(cond, msg) { if (cond) { pass++; console.log('  PASS ' + msg); } else { fail++; console.log('  FAIL ' + msg); } }
+
+const tmSrc = fs.readFileSync(path.join(__dirname, '..', 'time_machine.js'), 'utf8');
+
+function sliceFn(src, name) {
+  const idx = src.indexOf('function ' + name + '(');
+  if (idx < 0) throw new Error(name + ' not found in time_machine.js');
+  let d = 0, i = idx, open = false;
+  for (; i < src.length; i++) {
+    if (src[i] === '{') { d++; open = true; }
+    else if (src[i] === '}') { d--; if (open && d === 0) break; }
+  }
+  return src.slice(idx, i + 1);
+}
+
+// One sandbox per case: the verbs are sliced with the guard helper they call. ScheduleAuthor is a
+// COUNTING STUB — reaching it is exactly what "the edit happened" means, so the count is the assert.
+function run(flags) {
+  const calls = { move: 0, materialize: 0 };
+  const logs = [];
+  const sandbox = {
+    console: { log: (...a) => logs.push(a.join(' ')), warn: () => {} },
+    Math: Math, Date: Date, setTimeout: () => {},
+    document: { getElementById: () => null },
+    window: {
+      ScheduleAuthor: {
+        moveTaskCascade: () => { calls.move++; return { moved: [] }; },
+        materializeZones: () => { calls.materialize++; return { tasks: 0 }; }
+      }
+    },
+    A: () => Object.assign({ db: { exec: () => [], run: () => {}, prepare: () => ({ step: () => false, free: () => {} }) },
+                             activeBuilding: 'Hospital' }, flags)
+  };
+  // Module vars the verbs read AFTER the guard. Without these the idle case throws before reaching
+  // ScheduleAuthor — which is how W-TBL-4b caught this stub being incomplete rather than the guard
+  // being wrong. They are inputs to the code under test, not part of what is being asserted.
+  sandbox._taskIndex = { scheduleId: 'SCH_AUTHORED', tasks: {}, byGuid: {} };
+  sandbox._GANTT_CACHE_VERSION = 1;
+  sandbox.window.window = sandbox.window;
+  vm.createContext(sandbox);
+  vm.runInContext(
+    sliceFn(tmSrc, '_tmBusyRecording') + '\n' +
+    sliceFn(tmSrc, 'commitGanttDrag') + '\n' +
+    sliceFn(tmSrc, 'generateGanttSchedule') + '\n' +
+    'this.__drag = commitGanttDrag; this.__gen = generateGanttSchedule;', sandbox);
+
+  try { sandbox.__drag({ taskId: 'T1', storey: 'L1', phase: 'Architecture' }, 'move', 1); } catch (e) { logs.push('THREW ' + e.message); }
+  try { sandbox.__gen(); } catch (e) { logs.push('THREW ' + e.message); }
+  return { calls, logs, locked: logs.filter(l => l.indexOf('§TM_BAKE_LOCK') === 0 || l.indexOf('§TM_BAKE_LOCK') > 0) };
+}
+
+console.log('── witness_tm_bake_lock (§S56) ──');
+
+// W-TBL-0 — the guard reads the flags that already exist, not a new one it invented.
+assert(tmSrc.indexOf('function _tmBusyRecording(') >= 0, 'W-TBL-0a _tmBusyRecording is defined in time_machine.js');
+// Checks for a real READ/WRITE of a new flag, not the word — the guard's own comment explains why
+// there is no _bakeActive, and an earlier version of this assert matched that comment and failed.
+assert(!/app\._bakeActive|_bakeActive\s*=/.test(tmSrc),
+  'W-TBL-0b no new _bakeActive flag was invented — the guard reuses the triple dlod_nav.js already names');
+
+// W-TBL-1..3 — each recording flag independently refuses BOTH edit verbs.
+for (const [flag, label] of [['_maxqActive', 'maxq_bake'], ['_cinemaOrbitActive', 'cinema_orbit'], ['_stillRefineActive', 'still_refine']]) {
+  const r = run({ [flag]: true });
+  assert(r.calls.move === 0 && r.calls.materialize === 0,
+    'W-TBL-1 ' + flag + ': neither edit verb reached ScheduleAuthor (move=' + r.calls.move + ' materialize=' + r.calls.materialize + ')');
+  assert(r.locked.length >= 2 && r.locked.some(l => l.indexOf(label) > 0),
+    'W-TBL-2 ' + flag + ': both refusals are LOUD and name the reason (' + label + ', ' + r.locked.length + ' §TM_BAKE_LOCK lines)');
+}
+
+// W-TBL-4 — THE PAIRED CHECK. With nothing recording, the verbs must still work: a guard that
+// refuses unconditionally would satisfy every assert above while silently disabling the feature.
+const idle = run({});
+assert(idle.locked.length === 0, 'W-TBL-4a idle: no §TM_BAKE_LOCK refusal fires when nothing is recording');
+// What this asserts and what it deliberately does NOT: driving commitGanttDrag all the way into
+// moveTaskCascade needs a real task snapshot in the db, i.e. a full fixture. The claim under test
+// here is narrower and provable without one — that execution PASSES THE GUARD and continues into
+// the verb's own logic, evidenced by the verb reaching its OWN downstream refusal. A guard that
+// refused unconditionally would emit §TM_BAKE_LOCK and no downstream line at all, which is exactly
+// what this distinguishes. Stated rather than dressed up as a completed edit.
+const idleReachedBody = idle.logs.some(l => l.indexOf('§GANTT_DRAG_REJECT') >= 0) || idle.calls.move > 0;
+assert(idleReachedBody,
+  'W-TBL-4b idle: commitGanttDrag runs PAST the guard into its own logic (' +
+  (idle.calls.move > 0 ? 'reached moveTaskCascade' : 'reached its own §GANTT_DRAG_REJECT') +
+  ') — the guard did not disable editing');
+
+console.log('§TM_BAKE_LOCK_SUMMARY pass=' + pass + ' fail=' + fail);
+process.exit(fail === 0 ? 0 : 1);

--- a/viewer/time_machine.js
+++ b/viewer/time_machine.js
@@ -5994,8 +5994,32 @@
   }
 
   // Commit a finished gesture: engine verb → clamp/cascade result → re-time elements → redraw.
+  // ── §TM_BAKE_LOCK — the film plays this timeline; do not edit it mid-record ───────────────────
+  // Implementing bim-compiler prompts/SCRIPT_LENGTH_REFACTOR_SEAMS.md §S56.
+  // User's rule, verbatim: "Alt-S movie making is a separation of concern. It runs the TM to record
+  // the movie. User should not do both same time to avoid conflict." Until now that was DISCIPLINE,
+  // not code: cinema_maxq.js sets A._maxqActive (:884) and dlod_nav.js/panels.js both honour it,
+  // while time_machine.js — the thing being recorded — never read it at all.
+  // The busy triple is the SAME one tmWarmXrayElements already uses below (see its comment: the
+  // flags dlod_nav.js names as "not idle"). Extracted from that list rather than invented; there is
+  // deliberately no new bake flag on APP, because a second source of truth is how these drift.
+  // Refusal is LOUD and returns — never a silent no-op, never a queued edit applied after the bake.
+  function _tmBusyRecording(app) {
+    if (!app) return null;
+    if (app._maxqActive) return 'maxq_bake';
+    if (app._cinemaOrbitActive) return 'cinema_orbit';
+    if (app._stillRefineActive) return 'still_refine';
+    return null;
+  }
+
   function commitGanttDrag(bar, mode, deltaDays) {
     var app = A();
+    var _tmBusy = _tmBusyRecording(app);
+    if (_tmBusy) {
+      console.log('§TM_BAKE_LOCK refused=commitGanttDrag reason=' + _tmBusy +
+        ' — the film is playing this timeline; editing it mid-record would desync the recording');
+      return;
+    }
     var SA = (typeof window !== 'undefined') && window.ScheduleAuthor;
     if (!app || !app.db || !SA || !SA.moveTaskCascade) {
       console.log('§GANTT_DRAG_REJECT reason=ScheduleAuthor_not_loaded');
@@ -6331,6 +6355,12 @@
 
   function generateGanttSchedule() {
     var app = A();
+    var _tmBusy = _tmBusyRecording(app);
+    if (_tmBusy) {
+      console.log('§TM_BAKE_LOCK refused=generateGanttSchedule reason=' + _tmBusy +
+        ' — the film is playing this timeline; editing it mid-record would desync the recording');
+      return;
+    }
     var SA = (typeof window !== 'undefined') && window.ScheduleAuthor;
     var tip = document.getElementById('tm-gantt-tip');
     function say(msg) {

--- a/viewer/viewer.html
+++ b/viewer/viewer.html
@@ -950,7 +950,7 @@ html.bim-embedded, html.bim-embedded body { background: #0b0b0b; }
      Must load BEFORE time_machine.js — its _zoneIndexBuild wrapper calls it. -->
 <script src="zone_index.js?v=1" onerror="console.warn('§LOAD_FAIL zone_index.js — storey banding unavailable (zone inference falls back to declared storey)')"></script>
 <script src="support_sweep.js?v=1" onerror="console.warn('§LOAD_FAIL support_sweep.js — support-order physics unavailable (schedule repair, judge parity, lock-gate midair audit)')"></script>
-<script src="time_machine.js?v=73" onerror="console.warn('§LOAD_FAIL time_machine.js')"></script>
+<script src="time_machine.js?v=74" onerror="console.warn('§LOAD_FAIL time_machine.js')"></script>
 <script src="dlod_nav.js?v=2" onerror="console.warn('§LOAD_FAIL dlod_nav.js')"></script>
 <script src="schedule_author.js?v=14" onerror="console.warn('§LOAD_FAIL schedule_author.js')"></script>
 <script src="schedule_sync.js?v=3" onerror="console.warn('§LOAD_FAIL schedule_sync.js')"></script>


### PR DESCRIPTION
Turns your separation-of-concern rule into code. Verbatim: *"Alt-S movie making is a separation of concern. It runs the TM to record the movie. User should not do both same time to avoid conflict."*

Until now that was **discipline, not code**: `cinema_maxq.js` sets `A._maxqActive` and `dlod_nav.js`/`panels.js` both honour it, while `time_machine.js` — the thing being recorded — never read it. A drag or a re-generate mid-bake would mutate the timeline the recorder was playing.

`commitGanttDrag` and `generateGanttSchedule` now refuse loudly and return:
```
§TM_BAKE_LOCK refused=<verb> reason=maxq_bake|cinema_orbit|still_refine
```

**No new flag was invented.** The busy triple is the same one `tmWarmXrayElements` already reads — a second source of truth is how these drift. Never a silent no-op, never an edit queued and applied after the bake.

## Witness — `witness_tm_bake_lock.js`, 10 checks, pass=10 fail=0
| id | proves |
|---|---|
| W-TBL-0 | the guard reuses the existing flags rather than inventing one |
| W-TBL-1/2 | each of the three flags independently refuses **both** verbs, loudly, naming the reason |
| W-TBL-4 | **the paired check** — idle, no refusal fires and the verb runs *past* the guard into its own logic |

W-TBL-4 is the one that matters: a guard that refused everything would pass W-TBL-1/2 and fail only this. **Proven red:** deleting the guard from `commitGanttDrag` alone → 3 FAILs, then restored.

## Three things caught by this session's own tooling
1. **W-TBL-4b failed first because my stub was incomplete**, not because the guard was wrong — the idle drag reached its own `§GANTT_DRAG_REJECT`. The paired check earned its place immediately.
2. **Adding `_tmBusyRecording` broke `witness_gantt_edit_undo` and `witness_gantt_native_generate`** — both slice the guarded verbs, and *a sliced function cannot state its own dependencies*. The suite runner found both in one command. Same undeclared-dependency class as §S62, now caught in minutes instead of days.
3. **I first wrote that no `CACHE_VERSION` bump was needed** and caught it before opening this PR. `time_machine.js` is a served asset; without the bump every cached user keeps the old file and never receives the guard. **v1067 → v1068**, `?v=73 → 74`, same commit.

Suite **green=36 known_red=7 new_red=0** (43 witnesses). Audits precache / script tags / refs all exit 0. eslint: no new errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)