### PR TITLE
feat(readiness): publish the research proposal in full, declarations, and plain answers

### DIFF
--- a/readiness/faq.html
+++ b/readiness/faq.html
@@ -1,4 +1,4 @@
-<title>Disclaimer Notice</title>
+<title>Plain Answers</title>
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
 <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Instrument+Sans:wght@400;500;600;700&family=Source+Serif+4:opsz,wght@8..60,400;8..60,600&family=IBM+Plex+Mono:wght@400;500;600&display=swap">
@@ -230,169 +230,90 @@ footer{
   figure{padding:18px 16px}
 }
 @media (prefers-reduced-motion:reduce){*{animation:none!important;transition:none!important}}
+
+/* ---- Q&A ---- */
+.qa{margin:26px 0;display:flex;flex-direction:column;gap:1px;background:var(--rule);
+  border:1px solid var(--rule);border-radius:10px;overflow:hidden}
+.qa details{background:var(--surface)}
+.qa summary{
+  cursor:pointer;padding:15px 20px;font-family:"Instrument Sans",sans-serif;font-weight:600;
+  font-size:15.5px;list-style:none;display:flex;gap:12px;align-items:baseline
+}
+.qa summary::-webkit-details-marker{display:none}
+.qa summary::before{content:"+";color:var(--accent-ink);font-weight:700;flex:none;width:12px}
+.qa details[open] summary::before{content:"\2212"}
+.qa summary:hover{background:var(--surface-2)}
+.qa .a{padding:0 20px 18px 44px;font-size:16px;color:var(--ink-2);line-height:1.6}
+.qa .a p+p{margin-top:12px}
+.qa .a strong{color:var(--ink)}
+/* ---- glossary ---- */
+.gloss{display:flex;flex-direction:column;gap:1px;background:var(--rule);border:1px solid var(--rule);
+  border-radius:10px;overflow:hidden;margin:24px 0}
+.gterm{background:var(--surface);padding:15px 20px;display:grid;grid-template-columns:172px 1fr;gap:18px}
+.gterm dt{font-family:"Instrument Sans",sans-serif;font-weight:600;font-size:14.5px;color:var(--ink);margin:0}
+.gterm dd{margin:0;font-size:15px;color:var(--ink-2);line-height:1.55}
+@media (max-width:600px){.gterm{grid-template-columns:1fr;gap:5px}}
 </style>
 <div class="wrap">
 
 <div class="topbar">
   <div class="brandmark">OB</div>
-  <div class="brandtext">OpenBIM Readiness Assessment Toolkit<small>Disclaimer Notice</small></div>
+  <div class="brandtext">OpenBIM Readiness Assessment Toolkit<small>Plain answers</small></div>
   <div class="topspacer"></div>
   <button class="ghostbtn" id="themebtn" type="button">Theme</button>
-  <a class="ghostbtn" href="proposal.html">Proposal</a>
   <a class="ghostbtn" href="./">Back to assessment</a>
 </div>
 
 <div class="hero">
-  <p class="eyebrow">Disclaimer Notice &middot; v0.1 &middot; 22 August 2026</p>
-  <h1>What this assessment is, and what it is not.</h1>
-  <p class="standfirst">This notice applies to the OpenBIM Readiness Assessment Toolkit, to every
-  assessment taken with it, and to every report, checklist or record it produces.</p>
+  <p class="eyebrow">Plain answers</p>
+  <h1>The questions people feel they should already know the answer to.</h1>
+  <p class="standfirst">Nobody asks these out loud. They are all reasonable questions, several of them
+  are the whole point, and one of them is answered wrongly by most of the industry.</p>
 </div>
 
 <section>
-  <div class="shead"><span class="snum">01</span><h2>Scope</h2></div>
-  <p><strong>This is only a technical readiness assessment.</strong> It measures organisational
-  readiness for open-standard working, and the data quality of a model file supplied by the
-  respondent. That is its entire scope.</p>
-  <p>It says nothing about the lawfulness, safety, structural adequacy, buildability, fitness for
-  purpose or professional adequacy of any design, model, building or asset. It does not assess the
-  respondent, their competence, or their standing to practise.</p>
+  <div class="shead"><span class="snum">01</span><h2>The basics</h2></div>
+  <div class="qa">
+<details><summary>What is OpenBIM?</summary><div class="a"><p>BIM is <strong>building information modelling</strong> — designing with a model that carries data, not just lines. OpenBIM is doing that using <strong>open, published file formats</strong> so the information is not locked inside one company's software.</p><p>That is the whole idea. It is not a product, a brand, or a piece of software.</p></div></details><details><summary>Is OpenBIM something I buy?</summary><div class="a"><p>No. It is an approach and a set of published standards. Nobody owns it and nobody sells it. You can work this way with software you already have.</p></div></details><details><summary>What is IFC?</summary><div class="a"><p><strong>IFC</strong> — Industry Foundation Classes — is the main open file format for building information. It is published by buildingSMART, an international non-profit, and any software can read or write it without asking permission or paying a licence.</p><p>If you have ever been asked to \u201cdeliver in IFC\u201d, this is what was meant.</p></div></details><details><summary>My software already has an \u201cexport to IFC\u201d button. Isn't that it?</summary><div class="a"><p>That button is where it starts, not where it ends. Almost every BIM tool has one. The question is whether what comes out is <em>usable</em> by anyone else — whether it carries the rooms, the classifications, the quantities and the properties that make it worth receiving.</p><p><strong>That gap is exactly what this assessment measures.</strong> Most exports open fine and carry far less than the sender assumes.</p></div></details><details><summary>Do I have to stop using the software I have?</summary><div class="a"><p>No, and this assessment will not tell you to. OpenBIM is about what you <em>deliver and archive</em>, not what you author in. Plenty of firms work openly using entirely proprietary tools.</p><p>What changes is that your information stays readable when the software, the subscription or the vendor does not.</p></div></details>
+  </div>
 </section>
 
 <section>
-  <div class="shead"><span class="snum">02</span><h2>It qualifies nothing and no one</h2></div>
-  <p>This assessment and any report produced from it confer <strong>no certification, accreditation,
-  licence, approval, registration, endorsement or professional status</strong> of any kind, on any
-  person or organisation.</p>
-  <p>They are <strong>not evidence of compliance</strong> with any regulation, building code,
-  standard, mandate, contract, appointment or client requirement, and must not be presented as such
-  &mdash; to a client, an authority having jurisdiction, an insurer, a certifying body, or in a
-  tender or prequalification submission.</p>
-  <p>No BIM software holds local-authority compliance certification in any jurisdiction. Compliance
-  rests with the Appointing Party and the Lead Appointed Party. Software is never a legal party to it.</p>
+  <div class="shead"><span class="snum">02</span><h2>About this assessment</h2></div>
+  <div class="qa">
+<details><summary>What do I need before I start?</summary><div class="a"><p>About fifteen minutes. Optionally one IFC file. No account, no sign-up, no API key, no payment.</p></div></details><details><summary>What if I don't have an IFC file?</summary><div class="a"><p>You can still take it. You get the organisational half of the assessment, and the report says plainly that the model half was not measured — it does not guess, and it does not score you down for the absence.</p></div></details><details><summary>Will you see my model?</summary><div class="a"><p>No. The file is read <strong>inside your browser</strong> and is never uploaded. There is no server to upload it to. If you choose to submit results at the end, you are shown the exact payload first, and it contains only numbers and fixed categories — no file, no names, no coordinates.</p></div></details><details><summary>What is the catch? Who is paying for this?</summary><div class="a"><p>It is a research instrument, developed under an academic research grant, and free to use. The platform it references as a worked example is open source. The full proposal is published at <a href="proposal.html">The research proposal</a>.</p><p>The honest commercial disclosure: the people who built it also build that open-source platform. That is why the assessment scores you against <em>published standards</em> rather than against any product, and why it can return \u201cthe open route is not viable for you yet\u201d.</p></div></details><details><summary>Am I too small for this?</summary><div class="a"><p>No. Targets are proportionate to firm size and project type — a four-person practice is not measured against what a 200-person firm should be doing. That was a deliberate design decision.</p></div></details><details><summary>Is this only for BIM managers?</summary><div class="a"><p>No. It is for anyone who delivers or receives building information — principals, project managers, contractors, owners, facilities teams. If you have ever been asked for a model, or been handed one, the questions will make sense.</p></div></details><details><summary>What do I get at the end?</summary><div class="a"><p>A readiness profile across five areas, a gap analysis showing where you stand against a proportionate target, an ordered set of recommendations, and — if you supplied a file — the places where your model disagreed with your answers. Downloadable as a PDF.</p></div></details>
+  </div>
 </section>
 
 <section>
-  <div class="shead"><span class="snum">03</span><h2>Nothing here is audited or verified</h2></div>
-  <p>The inputs are <strong>self-reported by the respondent</strong> and computed from a file the
-  respondent supplies. No third party has witnessed, inspected, checked or attested to any answer,
-  measurement or result.</p>
-  <p>Results reflect what the respondent reported and what their file contained at the moment of
-  assessment, at the scope they declared. They are not a statement of fact about the organisation.</p>
-</section>
-
-<section>
-  <div class="shead"><span class="snum">04</span><h2>Your obligations remain yours</h2></div>
-  <p>Where <strong>insurance, professional indemnity, licensing, certification, registration or any
-  formal qualification process</strong> is required or applicable under the respondent&rsquo;s
-  regulations, contract, appointment or client requirements, that obligation is the
-  respondent&rsquo;s and must be discharged directly with the responsible body.</p>
-  <p><strong>This report substitutes for none of it, in whole or in part.</strong></p>
-  <p>Nothing in this toolkit or its outputs is insurance, indemnity, legal, regulatory or
-  professional advice. Whether working to open standards affects any cover or obligation is a matter
-  for the respondent&rsquo;s insurer and legal counsel. Two facts are offered only as context for that
-  conversation: warranty disclaimers are near-universal in software licensing, proprietary licences
-  included; and professional indemnity insures the professional, not the tool.</p>
-</section>
-
-<section>
-  <div class="shead"><span class="snum">05</span><h2>Figures and measurements</h2></div>
-  <p>Figures published by this toolkit are either measured from a named individual model, cited from
-  a public source, or aggregated from assessments taken &mdash; and are labelled accordingly. A
-  measurement from one building is not an industry statistic and must not be quoted as one.</p>
-  <p>Coverage and validity are reported as separate figures. A result showing well-formed data says
-  nothing about whether the right data is present. No single headline score is produced.</p>
-</section>
-
-<section>
-  <div class="shead"><span class="snum">06</span><h2>Research instrument, in development</h2></div>
-  <p>This toolkit supports academic research and is a work in progress. Its readiness dimensions,
-  assessment criteria, capability thresholds and weightings are subject to expert validation and
-  pilot testing, and <strong>will change</strong>. Results produced under one version are not
-  directly comparable with results produced under another.</p>
-  <p>Each report states the versions under which it was produced. Quote them whenever you quote a
-  result.</p>
-</section>
-
-
-<section id="declarations">
-  <div class="shead"><span class="snum">07</span><h2>About this research</h2></div>
-  <p class="lede">Standard declarations. Blanks are marked and will be completed before any release
-  is cited.</p>
-
-  <h3>The toolkit</h3>
-  <p>The OpenBIM Readiness Assessment Toolkit is a research instrument developed under the project
-  <em>Development of an OpenBIM Readiness Assessment Toolkit for Digital Infrastructure
-  Management</em>. It assesses readiness across governance, people and skills, technology, data and
-  standards, and organisational processes. The study is set in the context of infrastructure delivery
-  in the UAE. The full proposal is reproduced at <a href="proposal.html">The research proposal</a>.</p>
-
-  <h3>Funding</h3>
-  <p>Supported by a research grant awarded to Mohd Faizal Bin Yusof at
-  <strong>[institution]</strong>, reference <strong>[grant reference]</strong>, value US$5,000.
-  Software development was contracted separately to REFREX SDN BHD under quotation
-  QTN.KFK.260703-01.</p>
-  <p>The funder had no role in the design of the assessment framework, the collection or analysis of
-  responses, the writing of any report, or the decision to submit for publication.</p>
-
-  <h3>Declaration of competing interests</h3>
-  <p>The proposal describes the reference benchmark as <em>&ldquo;an existing open-source,
-  browser-based OpenBIM platform&rdquo;</em> and states that <em>&ldquo;the platform is not the
-  subject of the study&rdquo;</em>. That platform is <strong>BIM OOTB</strong>.
-  <strong>The developers contracted to build this toolkit are also the developers of that
-  platform.</strong> This is declared as a competing interest.</p>
-  <p>Three measures address it, and each can be checked rather than taken on trust:</p>
-  <p>1. Assessment criteria are anchored to published standards &mdash; ISO 19650, ISO 12006-2,
-  buildingSMART IFC &mdash; and the capability ladder is taken verbatim from ISO/IEC 33020. The
-  platform appears as what the proposal itself calls <em>&ldquo;a concrete, working example &hellip;
-  rather than an abstract ideal&rdquo;</em>.</p>
-  <p>2. Scoring is a deterministic function of the responses. Any third party can reproduce a score
-  from the same inputs and the same published versions.</p>
-  <p>3. The instrument can return a negative result for the open route, including that it is not yet
-  viable for a given organisation&rsquo;s regulatory or capability position.</p>
-  <p>No commercial relationship arises between a respondent and either party as a result of taking an
-  assessment. The platform is free and open source; the toolkit is free to use and requires no
-  account.</p>
-
-  <h3>Data availability</h3>
-  <p>No personal data is collected. Model files supplied by respondents are processed entirely in the
-  respondent&rsquo;s browser and are never transmitted. Version 0.1 has no submission endpoint, so no
-  response data is collected or stored by any party. Where submission is offered in a future version
-  it will be optional and anonymous, with the exact payload shown before sending.</p>
-
-  <h3>Ethics</h3>
-  <p><strong>[Ethics position to be stated by the researcher.]</strong> The toolkit collects no
-  participant data in its current version.</p>
-
-  <h3>Use of generative AI</h3>
-  <p>Generative AI was used in developing this toolkit and in preparing its documentation. All
-  assessment criteria, capability thresholds and scoring logic were reviewed and trace to the cited
-  standards.</p>
-  <p>Separately and by design, the instrument invites the respondent to use <em>their own</em> AI
-  service to conduct the interview. The toolkit bundles no language model and makes no model calls on
-  a respondent&rsquo;s behalf.</p>
-
-  <h3>Licence and citation</h3>
-  <p>Source code: <strong>[licence to be selected]</strong>, available at
-  <span class="mono">github.com/red1oon/bim-ootb</span> under <span class="mono">readiness/</span>.
-  Cite as <strong>[DOI to be minted on the tagged release]</strong>.</p>
-
-  <h3>Status</h3>
-  <p>Research instrument in development. Criteria, thresholds and weightings are subject to expert
-  validation and will change. Results produced under different versions are not directly comparable;
-  each report states the versions under which it was produced.</p>
+  <div class="shead"><span class="snum">03</span><h2>Words the assessment uses</h2></div>
+  <p class="lede">If a question uses a term you do not use day to day, it is here. Not knowing these
+  is not a failing — several are UK or ISO vocabulary that never travelled.</p>
+  <dl class="gloss">
+    <div class="gterm"><dt>IFC</dt><dd>The open file format for building information. Published by buildingSMART; readable by any tool.</dd></div>
+    <div class="gterm"><dt>IFC schema version</dt><dd>Which edition of IFC a file uses — IFC2x3, IFC4, IFC4x3. They differ in what can be expressed, which is why contracts increasingly name one.</dd></div>
+    <div class="gterm"><dt>Property set</dt><dd>A named group of data attached to an element — a wall's fire rating, a door's acoustic performance. Geometry without property sets is a shape, not information.</dd></div>
+    <div class="gterm"><dt>Classification</dt><dd>A standard code identifying what a thing <em>is</em>, from a published system such as Uniclass, OmniClass or MasterFormat. A file-naming convention is not classification.</dd></div>
+    <div class="gterm"><dt>IfcSpace</dt><dd>A room or space as an object in the model, rather than as a gap between walls. Almost everything downstream — areas, FM, analysis — needs these to exist.</dd></div>
+    <div class="gterm"><dt>CDE</dt><dd>Common Data Environment. The agreed place project information lives, with versions and status — not simply a shared drive.</dd></div>
+    <div class="gterm"><dt>EIR / AIR</dt><dd>Exchange and Asset Information Requirements: what the client says the model must contain, written down before the work starts.</dd></div>
+    <div class="gterm"><dt>Federated model</dt><dd>Discipline models combined for review without being merged into one file, so each stays owned by its author.</dd></div>
+    <div class="gterm"><dt>buildingSMART</dt><dd>The international non-profit that publishes IFC and certifies software for data-exchange fidelity — not for regulatory compliance.</dd></div>
+    <div class="gterm"><dt>ISO 19650</dt><dd>The international standard for managing information using BIM. It sets requirements; it does not define a maturity ladder.</dd></div>
+    <div class="gterm"><dt>Capability level</dt><dd>How reliably and repeatably your organisation does something, on the ISO/IEC 33020 scale of 0 to 5. It is not a grade, and it is not a compliance measure.</dd></div>
+  </dl>
 </section>
 
 <div class="cta">
-  <h3>Understood?</h3>
-  <p>You can take the assessment, or read the background on why any of this matters.</p>
-  <a class="btn" href="./">Go to the assessment</a>
+  <h3>Still nothing here that answers it?</h3>
+  <p>The background reading goes deeper on why any of this matters, and the Disclaimer Notice covers
+  what this assessment can and cannot be used for.</p>
+  <a class="btn" href="./">Take the assessment</a>
 </div>
 
 <footer>
-  Disclaimer Notice v0.1 &middot; 22 August 2026<br>
-  OpenBIM Readiness Assessment Toolkit &middot; applies to the toolkit and every output it produces.<br>
-  <a href="proposal.html">The research proposal</a> &middot; <a href="why.html">Background reading</a> &middot; <a href="faq.html">Plain answers</a>
+  Plain answers &middot; OpenBIM Readiness Assessment Toolkit v0.1<br>
+  <a href="proposal.html">The research proposal</a> &middot; <a href="why.html">Background reading</a> &middot; <a href="disclaimer.html">Disclaimer Notice</a>
 </footer>
 
 </div>

--- a/readiness/index.html
+++ b/readiness/index.html
@@ -44,6 +44,7 @@ body{
 h1,h2,h3{margin:0;text-wrap:balance;letter-spacing:-.02em}
 p{margin:0}
 button{font:inherit;color:inherit}
+a{color:var(--accent-ink);text-underline-offset:2px}
 :focus-visible{outline:2px solid var(--focus);outline-offset:2px;border-radius:3px}
 
 /* ---- MOCKUP BANNER ---- */
@@ -332,6 +333,7 @@ details.tvwrap summary{cursor:pointer;font-size:13.5px;color:var(--accent-ink);f
     <div class="brandtext">OpenBIM Readiness Assessment Toolkit<small>Research instrument · v0.1 draft</small></div>
     <div class="topspacer"></div>
     <button class="ghostbtn" id="themebtn" type="button">Theme</button>
+    <a class="ghostbtn" href="faq.html">Plain answers</a>
     <a class="ghostbtn" id="helpbtn" href="why.html">? Read more</a>
   </div>
 
@@ -412,6 +414,10 @@ SCREENS.intro =
       '<span>Include my (anonymous) results in the industry benchmark, so I can see how I compare.</span></label>' +
   '</div>' +
 
+  '<p class="small" style="margin-top:20px">This toolkit is the artifact of a funded research ' +
+  'project. The proposal is published in full: <a href="proposal.html">read it</a>. New to any of ' +
+  'this? <a href="faq.html">Plain answers</a> covers the basics nobody wants to ask about.</p>' +
+
   '<div class="actions">' +
     '<button class="btn" data-go="agree">Start assessment</button>' +
     '<button class="btn sec" data-go="results">Skip to sample results</button>' +
@@ -465,7 +471,8 @@ SCREENS.agree =
     '<button class="btn" id="agreebtn" data-go="context" disabled>Agree and continue</button>' +
     '<button class="btn sec" data-go="declined">I do not agree</button>' +
   '</div>' +
-  '<p class="small" style="margin-top:16px"><a href="disclaimer.html">Read the full Disclaimer Notice ' +
+  '<p class="small" style="margin-top:16px"><a href="proposal.html">The research proposal</a> &nbsp;&middot;&nbsp; ' +
+  '<a href="faq.html">Plain answers</a> &nbsp;&middot;&nbsp; <a href="disclaimer.html">Read the full Disclaimer Notice ' +
   '&rarr;</a> &nbsp;&middot;&nbsp; <span class="mono">Terms v0.1 &middot; 22 Aug 2026</span></p>';
 
 /* ---------- 1c · DECLINED ---------- */
@@ -483,6 +490,7 @@ SCREENS.declined =
   '</div>' +
   '<div class="actions">' +
     '<a class="btn" href="why.html">Read the background</a>' +
+    '<a class="btn sec" href="faq.html">Plain answers</a>' +
     '<button class="btn sec" data-go="agree">Back</button>' +
   '</div>';
 

--- a/readiness/proposal.html
+++ b/readiness/proposal.html
@@ -1,4 +1,4 @@
-<title>Disclaimer Notice</title>
+<title>The Research Proposal</title>
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
 <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Instrument+Sans:wght@400;500;600;700&family=Source+Serif+4:opsz,wght@8..60,400;8..60,600&family=IBM+Plex+Mono:wght@400;500;600&display=swap">
@@ -230,169 +230,102 @@ footer{
   figure{padding:18px 16px}
 }
 @media (prefers-reduced-motion:reduce){*{animation:none!important;transition:none!important}}
+
+.proposal p{font-size:17px;line-height:1.72;margin:0 0 18px;max-width:68ch}
+.proposal p:last-child{margin-bottom:0}
+.corr{border-bottom:1px dotted var(--warn);cursor:help}
+.dtable{width:100%;border-collapse:collapse;font-family:"Instrument Sans",sans-serif;font-size:14.5px;margin:20px 0}
+.dtable th{text-align:left;font-size:10.5px;letter-spacing:.09em;text-transform:uppercase;color:var(--muted);padding:10px 12px;border-bottom:1px solid var(--rule);font-weight:600}
+.dtable td{padding:11px 12px;border-bottom:1px solid var(--rule-soft);color:var(--ink-2);vertical-align:top}
+.dtable tr:last-child td{border-bottom:none}
+.dtable td.n{font-family:"IBM Plex Mono",monospace;color:var(--muted);white-space:nowrap}
+.dscroll{overflow-x:auto;border:1px solid var(--rule);border-radius:9px;background:var(--surface);margin:20px 0}
+.dscroll .dtable{margin:0}
 </style>
 <div class="wrap">
 
 <div class="topbar">
   <div class="brandmark">OB</div>
-  <div class="brandtext">OpenBIM Readiness Assessment Toolkit<small>Disclaimer Notice</small></div>
+  <div class="brandtext">OpenBIM Readiness Assessment Toolkit<small>The research proposal</small></div>
   <div class="topspacer"></div>
   <button class="ghostbtn" id="themebtn" type="button">Theme</button>
-  <a class="ghostbtn" href="proposal.html">Proposal</a>
   <a class="ghostbtn" href="./">Back to assessment</a>
 </div>
 
 <div class="hero">
-  <p class="eyebrow">Disclaimer Notice &middot; v0.1 &middot; 22 August 2026</p>
-  <h1>What this assessment is, and what it is not.</h1>
-  <p class="standfirst">This notice applies to the OpenBIM Readiness Assessment Toolkit, to every
-  assessment taken with it, and to every report, checklist or record it produces.</p>
+  <p class="eyebrow">Research funding request &middot; 10 August 2026</p>
+  <h1>Development of an OpenBIM Readiness Assessment Toolkit for Digital Infrastructure Management</h1>
+  <p class="standfirst">The funded proposal, reproduced in full. This toolkit is the artifact it
+  describes, and this page is the authoritative statement of its scope.</p>
 </div>
 
 <section>
-  <div class="shead"><span class="snum">01</span><h2>Scope</h2></div>
-  <p><strong>This is only a technical readiness assessment.</strong> It measures organisational
-  readiness for open-standard working, and the data quality of a model file supplied by the
-  respondent. That is its entire scope.</p>
-  <p>It says nothing about the lawfulness, safety, structural adequacy, buildability, fitness for
-  purpose or professional adequacy of any design, model, building or asset. It does not assess the
-  respondent, their competence, or their standing to practise.</p>
+  <div class="shead"><span class="snum">&mdash;</span><h2>Project information</h2></div>
+  <div class="dscroll"><table class="dtable"><tbody>
+    <tr><td class="n">Name</td><td>Mohd Faizal Bin Yusof</td></tr>
+    <tr><td class="n">Date</td><td>10 August 2026</td></tr>
+    <tr><td class="n">Project title</td><td>Development of an OpenBIM Readiness Assessment Toolkit for Digital Infrastructure Management</td></tr>
+  </tbody></table></div>
 </section>
 
 <section>
-  <div class="shead"><span class="snum">02</span><h2>It qualifies nothing and no one</h2></div>
-  <p>This assessment and any report produced from it confer <strong>no certification, accreditation,
-  licence, approval, registration, endorsement or professional status</strong> of any kind, on any
-  person or organisation.</p>
-  <p>They are <strong>not evidence of compliance</strong> with any regulation, building code,
-  standard, mandate, contract, appointment or client requirement, and must not be presented as such
-  &mdash; to a client, an authority having jurisdiction, an insurer, a certifying body, or in a
-  tender or prequalification submission.</p>
-  <p>No BIM software holds local-authority compliance certification in any jurisdiction. Compliance
-  rests with the Appointing Party and the Lead Appointed Party. Software is never a legal party to it.</p>
+  <div class="shead"><span class="snum">01</span><h2>Synopsis</h2></div>
+  <div class="proposal">
+<p>Digital transformation is reshaping how infrastructure assets are planned, delivered, operated, and maintained. In the UAE, Building Information Modelling (BIM) has become an increasingly important enabler of this transformation, supporting more integrated and data-driven approaches to infrastructure development and lifecycle management. OpenBIM strengthens this capability by adopting vendor-neutral open standards, principally the Industry Foundation Classes (IFC), enabling infrastructure information to be exchanged, integrated, and managed across diverse software platforms without dependence on proprietary systems. The benefits are well recognised, including improved interoperability, reduced software lock-in, and more effective collaboration among stakeholders throughout the asset lifecycle.</p><p>As BIM adoption matures, organisations are increasingly expected to move beyond proprietary BIM workflows towards more interoperable OpenBIM practices. This is also applicable in various <span class="corr" title="Corrected from &quot;third word countries&quot; in the source document.">third world countries</span>. This transition requires not only appropriate technologies, but also organisational readiness in areas such as governance, business processes, workforce capabilities, data management, and compliance with open standards. However, there is currently no simple and practical way for organisations to objectively assess their readiness for OpenBIM implementation or to identify the capability gaps that should be addressed before embarking on this transition.</p><p>This project addresses that gap by developing an OpenBIM Readiness Assessment Toolkit for Digital Infrastructure Management, a structured but easy-to-use way for an organisation to gauge how ready it is to adopt OpenBIM and to see the specific issues standing in its way. Readiness is assessed across the dimensions most associated with successful adoption: governance, people and skills, technology, data and standards, and organisational processes. The result shows an organisation where its capability gaps and implementation risks lie, and which areas to address first before committing to OpenBIM.</p><p>It helps to be precise about how the toolkit works and where its information comes from, because three roles are easily confused. First, a large language model (LLM) acts as the interviewer: instead of filling in a static questionnaire, a practitioner has a guided conversation with the LLM, which asks about the organisation's current practices, constraints, and concerns. Second, the practitioner is the source of evidence: the picture of industry readiness is built entirely from what real people in real organisations report, the LLM does not, and cannot, observe the industry on its own. Third, the toolkit measures those answers against a reference benchmark of OpenBIM good practice (described below), then scores readiness and produces tailored, vendor-neutral recommendations for capability development, standards adoption, and implementation planning.</p><p>That benchmark is provided by an existing open-source, browser-based OpenBIM platform that extracts and compiles IFC models, renders them directly in a standard web browser with no server-side dependency, and extends into asset, operations, and lifecycle management. The platform is not the subject of the study; it serves as a concrete, working example of what an open-standard BIM environment can deliver, giving the toolkit's recommendations a demonstrable reference point rather than an abstract ideal. Alongside it, a knowledge base of OpenBIM standards, readiness criteria, and implementation guidance supports the LLM's reasoning, and automated reporting turns each assessment into a readiness profile, gap analysis, and set of recommendations.</p>
+  </div>
 </section>
 
 <section>
-  <div class="shead"><span class="snum">03</span><h2>Nothing here is audited or verified</h2></div>
-  <p>The inputs are <strong>self-reported by the respondent</strong> and computed from a file the
-  respondent supplies. No third party has witnessed, inspected, checked or attested to any answer,
-  measurement or result.</p>
-  <p>Results reflect what the respondent reported and what their file contained at the moment of
-  assessment, at the scope they declared. They are not a statement of fact about the organisation.</p>
+  <div class="shead"><span class="snum">02</span><h2>Research design</h2></div>
+  <div class="proposal"><p>The study's evidence comes from practitioners, not from the LLM's own knowledge. Participants are professionals engaged in Digital Infrastructure Management who complete an assessment through the conversational tool; their responses are the primary data on industry preparedness and on the barriers to BIM adoption. The open-source OpenBIM platform is used throughout as the reference benchmark against which readiness is judged. The toolkit itself is then validated by a panel of subject-matter experts and through pilot use, who judge whether its assessments are accurate and its recommendations useful. Data is gathered through these expert reviews, pilot sessions, and usability evaluations, and analysed to test the toolkit's reliability, practicality, and effectiveness.</p></div>
 </section>
 
 <section>
-  <div class="shead"><span class="snum">04</span><h2>Your obligations remain yours</h2></div>
-  <p>Where <strong>insurance, professional indemnity, licensing, certification, registration or any
-  formal qualification process</strong> is required or applicable under the respondent&rsquo;s
-  regulations, contract, appointment or client requirements, that obligation is the
-  respondent&rsquo;s and must be discharged directly with the responsible body.</p>
-  <p><strong>This report substitutes for none of it, in whole or in part.</strong></p>
-  <p>Nothing in this toolkit or its outputs is insurance, indemnity, legal, regulatory or
-  professional advice. Whether working to open standards affects any cover or obligation is a matter
-  for the respondent&rsquo;s insurer and legal counsel. Two facts are offered only as context for that
-  conversation: warranty disclaimers are near-universal in software licensing, proprietary licences
-  included; and professional indemnity insures the professional, not the tool.</p>
+  <div class="shead"><span class="snum">03</span><h2>Research methodology</h2></div>
+  <div class="proposal"><p>The work follows a Design Science Research (DSR) approach: build a working artifact, then evaluate it with real users. The requirements phase reviews OpenBIM standards, existing BIM maturity and readiness models, and Digital Infrastructure Management practice to fix the readiness dimensions, the assessment criteria, and the issues that affect preparedness. The development phase produces the toolkit, assessment framework, conversational LLM engine, scoring model, recommendation engine, and reporting module. The evaluation phase tests it through the expert validation and pilot implementation described above. The project concludes with a publication reporting the readiness dimensions, the toolkit's design, the assessment method, and the validation result.</p></div>
 </section>
 
 <section>
-  <div class="shead"><span class="snum">05</span><h2>Figures and measurements</h2></div>
-  <p>Figures published by this toolkit are either measured from a named individual model, cited from
-  a public source, or aggregated from assessments taken &mdash; and are labelled accordingly. A
-  measurement from one building is not an industry statistic and must not be quoted as one.</p>
-  <p>Coverage and validity are reported as separate figures. A result showing well-formed data says
-  nothing about whether the right data is present. No single headline score is produced.</p>
+  <div class="shead"><span class="snum">04</span><h2>Outsource requirements</h2></div>
+  <div class="proposal"><p>The project builds on existing open-source technologies and large language model platforms. Development support will be outsourced to implement the conversational interface, the assessment and recommendation engines, the reporting module, and the pilot deployment environment, together with knowledge base integration and usability testing. The outsourced scope is limited to technical development and deployment; the research design, data analysis, and reporting remain with the researcher.</p></div>
 </section>
 
 <section>
-  <div class="shead"><span class="snum">06</span><h2>Research instrument, in development</h2></div>
-  <p>This toolkit supports academic research and is a work in progress. Its readiness dimensions,
-  assessment criteria, capability thresholds and weightings are subject to expert validation and
-  pilot testing, and <strong>will change</strong>. Results produced under one version are not
-  directly comparable with results produced under another.</p>
-  <p>Each report states the versions under which it was produced. Quote them whenever you quote a
-  result.</p>
+  <div class="shead"><span class="snum">05</span><h2>Deliverables</h2></div>
+  <div class="dscroll"><table class="dtable">
+    <thead><tr><th>#</th><th>Type</th><th>Title / topic</th><th>Target publication</th><th>Quartile</th></tr></thead>
+    <tbody><tr><td class="n">1</td><td>Research paper</td>
+      <td>Development and Validation of an OpenBIM Readiness Assessment Framework for Digital Infrastructure Management</td>
+      <td>Automation in Construction (Elsevier)</td><td class="n">Q1</td></tr></tbody>
+  </table></div>
 </section>
 
-
-<section id="declarations">
-  <div class="shead"><span class="snum">07</span><h2>About this research</h2></div>
-  <p class="lede">Standard declarations. Blanks are marked and will be completed before any release
-  is cited.</p>
-
-  <h3>The toolkit</h3>
-  <p>The OpenBIM Readiness Assessment Toolkit is a research instrument developed under the project
-  <em>Development of an OpenBIM Readiness Assessment Toolkit for Digital Infrastructure
-  Management</em>. It assesses readiness across governance, people and skills, technology, data and
-  standards, and organisational processes. The study is set in the context of infrastructure delivery
-  in the UAE. The full proposal is reproduced at <a href="proposal.html">The research proposal</a>.</p>
-
-  <h3>Funding</h3>
-  <p>Supported by a research grant awarded to Mohd Faizal Bin Yusof at
-  <strong>[institution]</strong>, reference <strong>[grant reference]</strong>, value US$5,000.
-  Software development was contracted separately to REFREX SDN BHD under quotation
-  QTN.KFK.260703-01.</p>
-  <p>The funder had no role in the design of the assessment framework, the collection or analysis of
-  responses, the writing of any report, or the decision to submit for publication.</p>
-
-  <h3>Declaration of competing interests</h3>
-  <p>The proposal describes the reference benchmark as <em>&ldquo;an existing open-source,
-  browser-based OpenBIM platform&rdquo;</em> and states that <em>&ldquo;the platform is not the
-  subject of the study&rdquo;</em>. That platform is <strong>BIM OOTB</strong>.
-  <strong>The developers contracted to build this toolkit are also the developers of that
-  platform.</strong> This is declared as a competing interest.</p>
-  <p>Three measures address it, and each can be checked rather than taken on trust:</p>
-  <p>1. Assessment criteria are anchored to published standards &mdash; ISO 19650, ISO 12006-2,
-  buildingSMART IFC &mdash; and the capability ladder is taken verbatim from ISO/IEC 33020. The
-  platform appears as what the proposal itself calls <em>&ldquo;a concrete, working example &hellip;
-  rather than an abstract ideal&rdquo;</em>.</p>
-  <p>2. Scoring is a deterministic function of the responses. Any third party can reproduce a score
-  from the same inputs and the same published versions.</p>
-  <p>3. The instrument can return a negative result for the open route, including that it is not yet
-  viable for a given organisation&rsquo;s regulatory or capability position.</p>
-  <p>No commercial relationship arises between a respondent and either party as a result of taking an
-  assessment. The platform is free and open source; the toolkit is free to use and requires no
-  account.</p>
-
-  <h3>Data availability</h3>
-  <p>No personal data is collected. Model files supplied by respondents are processed entirely in the
-  respondent&rsquo;s browser and are never transmitted. Version 0.1 has no submission endpoint, so no
-  response data is collected or stored by any party. Where submission is offered in a future version
-  it will be optional and anonymous, with the exact payload shown before sending.</p>
-
-  <h3>Ethics</h3>
-  <p><strong>[Ethics position to be stated by the researcher.]</strong> The toolkit collects no
-  participant data in its current version.</p>
-
-  <h3>Use of generative AI</h3>
-  <p>Generative AI was used in developing this toolkit and in preparing its documentation. All
-  assessment criteria, capability thresholds and scoring logic were reviewed and trace to the cited
-  standards.</p>
-  <p>Separately and by design, the instrument invites the respondent to use <em>their own</em> AI
-  service to conduct the interview. The toolkit bundles no language model and makes no model calls on
-  a respondent&rsquo;s behalf.</p>
-
-  <h3>Licence and citation</h3>
-  <p>Source code: <strong>[licence to be selected]</strong>, available at
-  <span class="mono">github.com/red1oon/bim-ootb</span> under <span class="mono">readiness/</span>.
-  Cite as <strong>[DOI to be minted on the tagged release]</strong>.</p>
-
-  <h3>Status</h3>
-  <p>Research instrument in development. Criteria, thresholds and weightings are subject to expert
-  validation and will change. Results produced under different versions are not directly comparable;
-  each report states the versions under which it was produced.</p>
+<section>
+  <div class="shead"><span class="snum">06</span><h2>Project plan</h2></div>
+  <div class="dscroll"><table class="dtable">
+    <thead><tr><th>Phase</th><th>Milestones / activities</th><th>Target date</th></tr></thead>
+    <tbody>
+      <tr><td>Problem analysis</td><td>Finalise research requirements and identify OpenBIM readiness dimensions and assessment criteria for Digital Infrastructure Management.</td><td class="n">10 Aug 2026</td></tr>
+      <tr><td>Artifact development</td><td>Design and develop the OpenBIM Readiness Assessment Toolkit, including the assessment framework, scoring model, and recommendation mechanism. Develop the toolkit, comprising the assessment framework, conversational LLM assessment engine, scoring model, recommendation engine, and reporting module.</td><td class="n">7 Sep 2026</td></tr>
+      <tr><td>Technology assessment</td><td>Conduct expert validation and pilot testing with practitioners; evaluate and refine the toolkit based on feedback.</td><td class="n">1 Oct 2026</td></tr>
+      <tr><td>Publication</td><td>Analyse findings and prepare research article for publication.</td><td class="n">10 Oct 2026</td></tr>
+    </tbody>
+  </table></div>
 </section>
 
 <div class="cta">
-  <h3>Understood?</h3>
-  <p>You can take the assessment, or read the background on why any of this matters.</p>
+  <h3>This is the artifact that proposal describes</h3>
+  <p>The assessment implements the framework set out above. The Disclaimer Notice states what it can
+  and cannot be used for.</p>
   <a class="btn" href="./">Go to the assessment</a>
 </div>
 
 <footer>
-  Disclaimer Notice v0.1 &middot; 22 August 2026<br>
-  OpenBIM Readiness Assessment Toolkit &middot; applies to the toolkit and every output it produces.<br>
-  <a href="proposal.html">The research proposal</a> &middot; <a href="why.html">Background reading</a> &middot; <a href="faq.html">Plain answers</a>
+  Reproduced from the research funding request dated 10 August 2026.<br>
+  Text is verbatim, with one obvious typographical correction marked in the Synopsis. Budget,
+  reviewer assessment and endorsement sections are the funding institution's internal process and
+  are not reproduced here.<br>
+  <a href="disclaimer.html">Disclaimer Notice</a> &middot; <a href="why.html">Background reading</a> &middot; <a href="faq.html">Plain answers</a>
 </footer>
 
 </div>

--- a/readiness/why.html
+++ b/readiness/why.html
@@ -252,6 +252,8 @@ footer{
     <a href="#gap">02 &nbsp;The gap</a>
     <a href="#roadmap">03 &nbsp;The roadmap</a>
     <a href="#offline">Offline copy</a>
+    <a href="proposal.html">The proposal</a>
+    <a href="faq.html">Plain answers</a>
     <a href="disclaimer.html">Disclaimer Notice</a>
   </nav>
 </div>


### PR DESCRIPTION
Adds three pages to `readiness/` and cross-links all five.

## Why
The reviewer approving this work is checking conformance to their own criteria, not judging how good the toolkit is. So the proposal goes up **in full and verbatim** — one place, no ambiguity, section headings mirroring the funding form.

## `proposal.html` — the funded proposal, in full
Synopsis (all five paragraphs), Research Design, Research Methodology, Outsource Requirements, Deliverables and Project Plan. Verbatim.

One typographical correction is made and marked inline with a hover note (`third word` → `third world` in the synopsis). Budget, reviewer assessment and endorsement sections are the funding institution's internal process and are not reproduced — stated in the footer.

## `disclaimer.html` — standard declarations appended
Funding, competing interests, data availability, ethics, generative AI, licence and citation, status. Blanks marked where facts are pending (institution, grant reference, ethics position, licence, DOI).

The competing interest is declared plainly: the proposal describes the benchmark as *"an existing open-source, browser-based OpenBIM platform"*, that platform is BIM OOTB, and **the developers contracted to build this toolkit also develop it**. Three checkable mitigations follow. An undeclared interest a reviewer discovers is fatal; a declared one is a fact about the study.

## `faq.html` — plain answers
The questions professionals feel they should already know the answer to and therefore never ask: what OpenBIM is, what IFC is, whether the export button is enough, whether they must stop using current software, what the catch is. Plus an 11-term glossary. Twelve questions.

## Verification
All five pages served locally, every internal link across all five checked and resolving 200, tags balanced, `node --check` clean on the inline script.

Still a WIP mockup — no scoring, no parsing, no network.

🤖 Generated with [Claude Code](https://claude.com/claude-code)