### PR TITLE
feat(readiness): synopsis becomes the front door, assessment moves to assess.html

### DIFF
--- a/readiness/assess.html
+++ b/readiness/assess.html
@@ -1,0 +1,950 @@
+<title>OpenBIM Readiness Toolkit</title>
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Instrument+Sans:wght@400;500;600;700&family=IBM+Plex+Mono:wght@400;500;600&display=swap">
+
+<style>
+:root{
+  --ink:#131e1b; --ink-2:#3a4a45; --muted:#6b7d78; --faint:#9aaba6;
+  --paper:#f5f7f5; --surface:#ffffff; --surface-2:#eaefed; --surface-3:#dfe6e3;
+  --rule:#d3dcd9; --rule-soft:#e4e9e7;
+  --accent:#00897b; --accent-ink:#00695f; --accent-wash:#e0efec;
+  --warn:#a06a00; --warn-wash:#f7efdd;
+  --focus:#00897b;
+  --shadow:0 1px 2px rgba(19,30,27,.05),0 8px 24px -14px rgba(19,30,27,.18);
+}
+@media (prefers-color-scheme:dark){
+  :root:not([data-theme="light"]){
+    --ink:#e9efed; --ink-2:#c3d0cc; --muted:#93a5a0; --faint:#6d7f7a;
+    --paper:#0f1816; --surface:#182421; --surface-2:#1f2d29; --surface-3:#273733;
+    --rule:#2d3e39; --rule-soft:#22302c;
+    --accent:#1f9d87; --accent-ink:#4fc9b0; --accent-wash:#14312b;
+    --warn:#b1811f; --warn-wash:#2f2612;
+    --focus:#4fc9b0;
+    --shadow:0 1px 2px rgba(0,0,0,.35),0 10px 28px -16px rgba(0,0,0,.7);
+  }
+}
+:root[data-theme="dark"]{
+  --ink:#e9efed; --ink-2:#c3d0cc; --muted:#93a5a0; --faint:#6d7f7a;
+  --paper:#0f1816; --surface:#182421; --surface-2:#1f2d29; --surface-3:#273733;
+  --rule:#2d3e39; --rule-soft:#22302c;
+  --accent:#1f9d87; --accent-ink:#4fc9b0; --accent-wash:#14312b;
+  --warn:#b1811f; --warn-wash:#2f2612;
+  --focus:#4fc9b0;
+  --shadow:0 1px 2px rgba(0,0,0,.35),0 10px 28px -16px rgba(0,0,0,.7);
+}
+
+*{box-sizing:border-box}
+body{
+  margin:0;background:var(--paper);color:var(--ink);
+  font-family:"Instrument Sans",-apple-system,"Segoe UI",Helvetica,Arial,sans-serif;
+  font-size:16px;line-height:1.55;-webkit-font-smoothing:antialiased;
+}
+.mono,.num{font-family:"IBM Plex Mono",ui-monospace,Menlo,monospace;font-variant-numeric:tabular-nums}
+h1,h2,h3{margin:0;text-wrap:balance;letter-spacing:-.02em}
+p{margin:0}
+button{font:inherit;color:inherit}
+a{color:var(--accent-ink);text-underline-offset:2px}
+:focus-visible{outline:2px solid var(--focus);outline-offset:2px;border-radius:3px}
+
+/* ---- MOCKUP BANNER ---- */
+.mockbar{
+  background:var(--warn-wash);border-bottom:1px solid var(--warn);
+  padding:7px 16px;font-family:"IBM Plex Mono",monospace;font-size:11px;
+  letter-spacing:.09em;text-transform:uppercase;color:var(--warn);
+  display:flex;gap:12px;align-items:center;justify-content:center;flex-wrap:wrap;text-align:center
+}
+
+/* ---- SHELL ---- */
+.shell{max-width:820px;margin:0 auto;padding:0 22px 80px}
+
+.topbar{display:flex;align-items:center;gap:14px;padding:20px 0 0;flex-wrap:wrap}
+.brandmark{
+  width:30px;height:30px;border-radius:6px;background:var(--accent);flex:none;
+  display:grid;place-items:center;color:#fff;font-weight:700;font-size:13px;
+  font-family:"IBM Plex Mono",monospace
+}
+:root[data-theme="dark"] .brandmark,
+:root:not([data-theme="light"]) .brandmark{color:#0f1816}
+@media (prefers-color-scheme:light){:root:not([data-theme="dark"]) .brandmark{color:#fff}}
+.brandtext{font-size:14px;font-weight:600;letter-spacing:-.01em;line-height:1.25}
+.brandtext small{display:block;font-weight:400;font-size:11.5px;color:var(--muted);letter-spacing:0}
+.topspacer{flex:1}
+.ghostbtn{
+  background:transparent;border:1px solid var(--rule);border-radius:6px;
+  padding:6px 11px;font-size:13px;cursor:pointer;color:var(--ink-2)
+}
+.ghostbtn:hover{background:var(--surface-2);border-color:var(--accent);color:var(--accent-ink)}
+
+/* ---- PROGRESS RAIL ---- */
+.rail{display:flex;gap:5px;margin:20px 0 0;list-style:none;padding:0}
+.rail li{flex:1;height:3px;border-radius:2px;background:var(--rule);transition:background .2s}
+.rail li.done{background:var(--accent)}
+.rail li.now{background:var(--accent);opacity:.45}
+.railcap{
+  display:flex;justify-content:space-between;margin-top:8px;
+  font-family:"IBM Plex Mono",monospace;font-size:10.5px;letter-spacing:.08em;
+  text-transform:uppercase;color:var(--muted)
+}
+
+/* ---- SCREENS ---- */
+.screen{display:none;padding-top:30px}
+.screen.on{display:block;animation:fade .22s ease}
+@keyframes fade{from{opacity:0;transform:translateY(5px)}to{opacity:1;transform:none}}
+@media (prefers-reduced-motion:reduce){*{animation:none!important;transition:none!important}}
+
+/* ---- PRINTED NOTICE (travels with the PDF) ---- */
+.printnotice{
+  border:1.5px solid var(--warn);border-radius:8px;padding:16px 18px;margin:26px 0 0;
+  background:var(--warn-wash)
+}
+.printnotice h4{
+  margin:0 0 8px;font-size:11px;letter-spacing:.11em;text-transform:uppercase;
+  color:var(--warn);font-family:"IBM Plex Mono",monospace;font-weight:600
+}
+.printnotice p{font-size:13px;color:var(--ink-2);line-height:1.55}
+.printnotice p + p{margin-top:9px}
+.printnotice a{color:var(--warn);font-weight:600}
+
+@media print{
+  .mockbar,.topbar,.rail,.railcap,.actions,.tvwrap{display:none!important}
+  body{background:#fff;color:#000;font-size:11pt}
+  .card,.printnotice,figure{break-inside:avoid;box-shadow:none}
+  .printnotice{border:1.5pt solid #000;background:#fff;break-inside:avoid}
+  .printnotice h4,.printnotice a{color:#000}
+  a[href]:after{content:" (" attr(href) ")";font-size:9pt;word-break:break-all}
+}
+
+.eyebrow{
+  font-family:"IBM Plex Mono",monospace;font-size:11px;letter-spacing:.13em;
+  text-transform:uppercase;color:var(--accent-ink);font-weight:600;margin-bottom:14px
+}
+h1{font-size:clamp(27px,4.6vw,38px);line-height:1.12;font-weight:700}
+h2{font-size:21px;font-weight:600;line-height:1.25}
+h3{font-size:15.5px;font-weight:600}
+.sub{font-size:17px;color:var(--ink-2);margin-top:14px;max-width:56ch}
+.small{font-size:14px;color:var(--muted)}
+
+.card{
+  background:var(--surface);border:1px solid var(--rule);border-radius:9px;
+  padding:20px 22px;margin:22px 0;box-shadow:var(--shadow)
+}
+.card.flat{box-shadow:none}
+.card.formal{border-left:3px solid var(--accent)}
+.card p + p{margin-top:12px}
+
+.actions{display:flex;gap:10px;margin-top:26px;flex-wrap:wrap;align-items:center}
+.btn{
+  background:var(--accent);color:#fff;border:1px solid var(--accent);
+  border-radius:7px;padding:11px 20px;font-size:15px;font-weight:600;cursor:pointer
+}
+:root[data-theme="dark"] .btn,:root:not([data-theme="light"]) .btn{color:#0f1816}
+@media (prefers-color-scheme:light){:root:not([data-theme="dark"]) .btn{color:#fff}}
+.btn:hover{filter:brightness(1.08)}
+.btn:disabled{opacity:.42;cursor:not-allowed;filter:none}
+.btn.sec{background:transparent;color:var(--ink-2);border-color:var(--rule)}
+.btn.sec:hover{background:var(--surface-2);filter:none;border-color:var(--accent)}
+.btn.sm{padding:8px 14px;font-size:13.5px}
+
+/* ---- FIELDS ---- */
+.field{margin:18px 0}
+.field > label,.qhead{
+  display:flex;gap:8px;align-items:flex-start;
+  font-size:14.5px;font-weight:600;margin-bottom:9px;line-height:1.4
+}
+.qid{
+  font-family:"IBM Plex Mono",monospace;font-size:11px;color:var(--accent-ink);
+  background:var(--accent-wash);border-radius:3px;padding:2px 6px;flex:none;margin-top:1px;font-weight:600
+}
+select,input[type=text]{
+  width:100%;background:var(--surface);color:var(--ink);
+  border:1px solid var(--rule);border-radius:7px;padding:10px 12px;font:inherit;font-size:15px
+}
+select:hover,input[type=text]:hover{border-color:var(--accent)}
+.grid2{display:grid;grid-template-columns:repeat(auto-fit,minmax(230px,1fr));gap:16px}
+
+/* pill radios (firm size etc) */
+.pills{display:flex;flex-wrap:wrap;gap:7px}
+.pills input{position:absolute;opacity:0;pointer-events:none}
+.pills label{
+  border:1px solid var(--rule);border-radius:20px;padding:7px 14px;
+  font-size:13.5px;cursor:pointer;background:var(--surface);color:var(--ink-2)
+}
+.pills label:hover{border-color:var(--accent)}
+.pills input:checked + label{background:var(--accent-wash);border-color:var(--accent);color:var(--accent-ink);font-weight:600}
+.pills input:focus-visible + label{outline:2px solid var(--focus);outline-offset:2px}
+
+/* level radio list */
+.opts{display:flex;flex-direction:column;gap:1px;background:var(--rule);border:1px solid var(--rule);border-radius:8px;overflow:hidden}
+.opts input{position:absolute;opacity:0;pointer-events:none}
+.opts label{
+  display:grid;grid-template-columns:30px 18px 1fr;gap:11px;align-items:start;
+  background:var(--surface);padding:11px 14px;cursor:pointer;font-size:14.5px;color:var(--ink-2)
+}
+.opts label:hover{background:var(--surface-2)}
+.opts .lv{font-family:"IBM Plex Mono",monospace;font-size:11px;color:var(--faint);font-weight:600;padding-top:3px}
+.opts .dot{width:15px;height:15px;border:1.5px solid var(--rule);border-radius:50%;margin-top:2px}
+.opts input:checked + label{background:var(--accent-wash);color:var(--ink);font-weight:500}
+.opts input:checked + label .dot{border-color:var(--accent);border-width:4.5px}
+.opts input:checked + label .lv{color:var(--accent-ink)}
+.opts input:focus-visible + label{outline:2px solid var(--focus);outline-offset:-2px}
+
+/* checkbox rows */
+.chk{display:flex;gap:10px;align-items:flex-start;font-size:14.5px;color:var(--ink-2);cursor:pointer;margin:9px 0}
+.chk input{width:16px;height:16px;margin:2px 0 0;accent-color:var(--accent);flex:none}
+
+/* ---- TOOLTIP ---- */
+.tip{position:relative;display:inline-flex;flex:none;margin-top:1px}
+.tipbtn{
+  width:17px;height:17px;border-radius:50%;border:1px solid var(--rule);
+  background:var(--surface-2);color:var(--muted);font-size:11px;font-weight:700;
+  cursor:pointer;display:grid;place-items:center;padding:0;line-height:1
+}
+.tipbtn:hover{border-color:var(--accent);color:var(--accent-ink)}
+.tipbody{
+  display:none;position:absolute;z-index:40;top:24px;left:-8px;width:min(310px,78vw);
+  background:var(--surface);border:1px solid var(--accent);border-radius:8px;
+  padding:13px 15px;box-shadow:var(--shadow);font-size:13.5px;font-weight:400;
+  color:var(--ink-2);line-height:1.5;text-align:left
+}
+.tip.open .tipbody{display:block}
+.tipbody .anchor{
+  display:block;margin-top:9px;padding-top:9px;border-top:1px solid var(--rule-soft);
+  font-family:"IBM Plex Mono",monospace;font-size:10.5px;letter-spacing:.05em;
+  text-transform:uppercase;color:var(--muted)
+}
+
+/* ---- DROPZONE ---- */
+.drop{
+  border:2px dashed var(--rule);border-radius:10px;padding:34px 22px;text-align:center;
+  background:var(--surface);cursor:pointer
+}
+.drop:hover{border-color:var(--accent);background:var(--accent-wash)}
+.drop .big{font-size:16px;font-weight:600;margin-bottom:5px}
+.drop.filled{border-style:solid;border-color:var(--accent);text-align:left;padding:18px 20px}
+
+/* ---- PAYLOAD ---- */
+pre.payload{
+  margin:0;background:var(--surface-2);border:1px solid var(--rule);border-radius:7px;
+  padding:14px 16px;overflow-x:auto;font-family:"IBM Plex Mono",monospace;
+  font-size:12px;line-height:1.65;color:var(--ink-2)
+}
+
+/* ---- METRIC GRID ---- */
+.mgrid{display:grid;grid-template-columns:repeat(auto-fit,minmax(158px,1fr));gap:1px;background:var(--rule);border:1px solid var(--rule);border-radius:8px;overflow:hidden}
+.mcell{background:var(--surface);padding:13px 15px}
+.mcell dt{font-family:"IBM Plex Mono",monospace;font-size:10px;letter-spacing:.09em;text-transform:uppercase;color:var(--muted);margin-bottom:6px}
+.mcell dd{margin:0;font-size:17px;font-weight:600;font-variant-numeric:tabular-nums}
+.mcell dd .unit{font-size:12.5px;font-weight:400;color:var(--muted);margin-left:3px}
+.mcell.flag dd{color:var(--warn)}
+
+/* ---- CHART ---- */
+.chart{margin:20px 0 6px}
+.crow{display:grid;grid-template-columns:132px 1fr 42px;gap:13px;align-items:center;padding:7px 0}
+.crow .cname{font-size:14px;font-weight:500;text-align:right;color:var(--ink-2);line-height:1.25}
+.ctrack{position:relative;height:19px;background:var(--surface-3);border-radius:4px}
+.cbar{position:absolute;left:0;top:0;bottom:0;background:var(--accent);border-radius:4px}
+.cclaim{position:absolute;top:-4px;bottom:-4px;width:2px;background:var(--ink);border-radius:1px}
+.cclaim::after{
+  content:"";position:absolute;top:-3px;left:-3px;
+  border-left:4px solid transparent;border-right:4px solid transparent;border-top:5px solid var(--ink)
+}
+.crow .cval{font-family:"IBM Plex Mono",monospace;font-size:13.5px;font-weight:600;font-variant-numeric:tabular-nums}
+.cscale{display:grid;grid-template-columns:132px 1fr 42px;gap:13px;margin-top:4px}
+.cticks{display:flex;justify-content:space-between;font-family:"IBM Plex Mono",monospace;font-size:10.5px;color:var(--faint)}
+.clegend{
+  display:flex;gap:18px;flex-wrap:wrap;margin-top:14px;padding-top:13px;
+  border-top:1px solid var(--rule-soft);font-size:12.5px;color:var(--muted)
+}
+.clegend span{display:flex;gap:7px;align-items:center}
+.swatch{width:13px;height:11px;border-radius:3px;background:var(--accent);flex:none}
+.swtick{width:2px;height:13px;background:var(--ink);flex:none}
+
+/* ---- DELTA ---- */
+.delta{
+  background:var(--warn-wash);border:1px solid var(--warn);border-radius:8px;
+  padding:15px 17px;margin:13px 0;display:grid;grid-template-columns:auto 1fr;gap:13px
+}
+.delta .ic{
+  width:21px;height:21px;border-radius:50%;background:var(--warn);color:var(--paper);
+  display:grid;place-items:center;font-size:13px;font-weight:700;flex:none
+}
+.delta h4{margin:0 0 5px;font-size:14.5px;font-weight:600;color:var(--warn)}
+.delta p{font-size:14px;color:var(--ink-2)}
+.delta .vs{display:flex;gap:20px;margin-top:10px;flex-wrap:wrap;font-size:13px}
+.delta .vs b{display:block;font-family:"IBM Plex Mono",monospace;font-size:11px;color:var(--muted);font-weight:500;letter-spacing:.06em;text-transform:uppercase}
+
+/* ---- RISK REGISTER ---- */
+.risks{list-style:none;padding:0;margin:14px 0 0;display:flex;flex-direction:column;gap:10px}
+.risks li{
+  background:var(--surface-2);border:1px solid var(--rule);border-left:3px solid var(--warn);
+  border-radius:7px;padding:14px 16px
+}
+.risks h4{margin:0 0 4px;font-size:14.5px;font-weight:600;color:var(--warn)}
+.risks p{font-size:13.5px;color:var(--ink-2)}
+
+/* ---- FIX LIST ---- */
+.fixes{list-style:none;padding:0;margin:16px 0;counter-reset:f}
+.fixes li{
+  counter-increment:f;display:grid;grid-template-columns:27px 1fr;gap:13px;
+  padding:13px 0;border-bottom:1px solid var(--rule-soft);align-items:start
+}
+.fixes li:last-child{border-bottom:none}
+.fixes li::before{
+  content:counter(f);font-family:"IBM Plex Mono",monospace;font-size:12px;font-weight:600;
+  color:var(--accent-ink);background:var(--accent-wash);border-radius:5px;
+  height:23px;display:grid;place-items:center
+}
+.fixes h4{margin:0 0 3px;font-size:14.5px;font-weight:600}
+.fixes p{font-size:13.5px;color:var(--muted)}
+
+/* ---- INDICES ---- */
+.idx2{display:grid;grid-template-columns:repeat(auto-fit,minmax(215px,1fr));gap:14px;margin:18px 0}
+.ix{background:var(--surface);border:1px solid var(--rule);border-radius:8px;padding:16px 18px}
+.ix .who{font-family:"IBM Plex Mono",monospace;font-size:10px;letter-spacing:.09em;text-transform:uppercase;color:var(--muted)}
+.ix .v{font-size:27px;font-weight:700;font-variant-numeric:tabular-nums;margin:7px 0 2px}
+.ix .v small{font-size:14px;font-weight:400;color:var(--muted)}
+.ix p{font-size:13px;color:var(--ink-2);margin-top:6px}
+
+table.tv{width:100%;border-collapse:collapse;font-size:13.5px;margin-top:10px}
+table.tv th,table.tv td{text-align:left;padding:8px 10px;border-bottom:1px solid var(--rule-soft)}
+table.tv th{font-size:10.5px;letter-spacing:.08em;text-transform:uppercase;color:var(--muted);font-weight:600}
+table.tv td.n{font-family:"IBM Plex Mono",monospace;font-variant-numeric:tabular-nums}
+details.tvwrap{margin-top:16px}
+details.tvwrap summary{cursor:pointer;font-size:13.5px;color:var(--accent-ink);font-weight:500}
+
+@media (max-width:600px){
+  .crow,.cscale{grid-template-columns:96px 1fr 38px;gap:9px}
+  .crow .cname{font-size:12.5px}
+  .opts label{grid-template-columns:26px 16px 1fr;gap:8px;font-size:14px}
+}
+
+.nav{display:flex;gap:7px;flex-wrap:wrap;margin-left:auto}
+.nav a{font-family:"Instrument Sans",sans-serif;font-size:13px;text-decoration:none;
+  border:1px solid var(--rule);border-radius:6px;padding:6px 12px;color:var(--ink-2);background:transparent}
+.nav a:hover{border-color:var(--accent);color:var(--accent-ink);background:var(--accent-wash)}
+.nav a.on{border-color:var(--accent);color:var(--accent-ink);background:var(--accent-wash);font-weight:600}
+</style>
+
+<div class="mockbar" id="mockbar">
+  <span>⚠ Mockup for review — canned data, nothing wired</span>
+  <span>·</span>
+  <span>v0.1 · 2026-08-21</span>
+</div>
+
+<div class="shell">
+
+  <div class="topbar">
+    <div class="brandmark">OB</div>
+    <div class="brandtext">OpenBIM Readiness Assessment Toolkit<small>Research instrument · v0.1 draft</small></div>
+    <div class="nav"><a href="./">Overview</a><a href="assess.html" class="on">Assessment</a><a href="proposal.html">Proposal</a><a href="why.html">Background</a><a href="faq.html">Basics</a><a href="disclaimer.html">Notice</a></div>
+  </div>
+
+  <ul class="rail" id="rail" hidden>
+    <li></li><li></li><li></li><li></li><li></li><li></li><li></li><li></li><li></li><li></li>
+  </ul>
+  <div class="railcap" id="railcap" hidden><span id="railnow">About you</span><span id="railpct">Step 1 of 5</span></div>
+
+  <div id="screens"></div>
+
+</div>
+
+<script>
+/* ============================================================
+   MOCKUP ONLY — canned data, no scoring, no parsing, no network.
+   Real logic specified in SCORING_SPEC.md; wiring comes later.
+   ============================================================ */
+
+var TIP = function (text, anchor) {
+  return '<span class="tip"><button class="tipbtn" type="button" aria-label="Why we ask this">?</button>' +
+    '<span class="tipbody">' + text +
+    (anchor ? '<span class="anchor">Anchor · ' + anchor + '</span>' : '') + '</span></span>';
+};
+
+var LV = ['L0', 'L1', 'L2', 'L3', 'L4', 'L5'];
+function opts(name, list) {
+  return '<div class="opts">' + list.map(function (t, i) {
+    return '<input type="radio" name="' + name + '" id="' + name + i + '"' + (i === 1 ? ' checked' : '') + '>' +
+      '<label for="' + name + i + '"><span class="lv">' + LV[i] + '</span><span class="dot"></span><span>' + t + '</span></label>';
+  }).join('') + '</div>';
+}
+function q(id, title, tip, anchor, list) {
+  return '<div class="field"><div class="qhead"><span class="qid">' + id + '</span><span>' + title + '</span>' +
+    TIP(tip, anchor) + '</div>' + opts(id, list) + '</div>';
+}
+
+/* ---------- CANNED RESULTS ---------- */
+/* target = proportionate level for an 11-50 firm, engineering, mixed projects (§6.5) */
+var DIMS = [
+  { name: 'Governance',               measured: 2.0, claimed: 2.25, target: 3 },
+  { name: 'People and skills',        measured: 1.5, claimed: 1.75, target: 2 },
+  { name: 'Technology',               measured: 2.8, claimed: 3.00, target: 3 },
+  { name: 'Data and standards',       measured: 1.0, claimed: 3.25, target: 3 },
+  { name: 'Organisational processes', measured: 1.8, claimed: 2.00, target: 2 }
+];
+
+var SCREENS = {};
+
+/* ---------- 1 · INTRO ---------- */
+SCREENS.intro =
+  '<p class="eyebrow">Research instrument · open access</p>' +
+  '<h1>You&rsquo;re expected to deliver OpenBIM.<br>Nothing tells you whether you&rsquo;re ready.</h1>' +
+  '<p class="sub">Twenty questions about how your firm works, plus one IFC file we read inside your browser. ' +
+  'You get a checklist of what to fix, in order.</p>' +
+
+  '<div class="card formal">' +
+    '<p><strong>This OpenBIM Readiness Assessment Toolkit</strong> is a structured but easy-to-use way for an ' +
+    'organisation to gauge how ready it is to adopt OpenBIM and to see the specific issues standing in its way. ' +
+    'Readiness is assessed across the dimensions most associated with successful adoption: governance, people and ' +
+    'skills, technology, data and standards, and organisational processes.</p>' +
+    '<p>The result shows an organisation where its capability gaps and implementation risks lie, and which areas ' +
+    'to address first before committing to OpenBIM &mdash; combining what you report with metrics computed ' +
+    'directly from your own IFC model.</p>' +
+    '<p class="small"><strong>This is only a technical readiness assessment.</strong> It measures ' +
+    'organisational readiness and model data quality &mdash; nothing else. It qualifies nothing and no ' +
+    'one, confers no certification, licence or professional status, and is not evidence of compliance. ' +
+    'Where your regulations or appointment require insurance, indemnity or a formal qualification ' +
+    'process, that remains yours to satisfy directly.</p>' +
+  '</div>' +
+
+  '<div class="card">' +
+    '<h3>Before you start</h3>' +
+    '<p class="small" style="margin-top:9px">It takes about fifteen minutes. Your IFC file is read inside your ' +
+    'browser and is never uploaded &mdash; you can see exactly what would leave your device at any point.</p>' +
+    '<label class="chk" style="margin-top:14px"><input type="checkbox" checked>' +
+      '<span>Answer anonymously. No name, firm, email, or project details are collected.</span></label>' +
+    '<label class="chk"><input type="checkbox">' +
+      '<span>Include my (anonymous) results in the industry benchmark, so I can see how I compare.</span></label>' +
+  '</div>' +
+
+  '<p class="small" style="margin-top:20px">This toolkit is the artifact of a funded research ' +
+  'project. The proposal is published in full: <a href="proposal.html">read it</a>. New to any of ' +
+  'this? <a href="faq.html">Plain answers</a> covers the basics nobody wants to ask about.</p>' +
+
+  '<div class="actions">' +
+    '<button class="btn" data-go="agree">Start assessment</button>' +
+    '<button class="btn sec" data-go="results">Skip to sample results</button>' +
+  '</div>';
+
+/* ---------- 1b · ACKNOWLEDGEMENT GATE ---------- */
+SCREENS.agree =
+  '<p class="eyebrow">Before you begin</p>' +
+  '<h2>What this is, and what it is not</h2>' +
+  '<p class="sub small">Please read this. It takes thirty seconds and it decides how you may use the ' +
+  'result.</p>' +
+
+  '<div class="card" style="border-left:3px solid var(--warn)">' +
+    '<h3>Scope</h3>' +
+    '<p class="small" style="margin-top:8px"><strong>This is only a technical readiness assessment.</strong> ' +
+    'It measures organisational readiness for open-standard working and the data quality of a model you ' +
+    'supply. That is its entire scope. It says nothing about the lawfulness, safety, buildability or ' +
+    'professional adequacy of anything you produce.</p>' +
+
+    '<h3 style="margin-top:22px">It qualifies nothing and no one</h3>' +
+    '<p class="small" style="margin-top:8px">It confers no certification, accreditation, licence, approval ' +
+    'or professional status. It is not evidence of compliance with any regulation, standard, code or ' +
+    'contract, and must not be presented as such &mdash; to a client, an authority, an insurer, or in a ' +
+    'tender.</p>' +
+
+    '<h3 style="margin-top:22px">Nothing here is audited</h3>' +
+    '<p class="small" style="margin-top:8px">Your answers are self-reported and the measurements come from ' +
+    'a file you supply. No third party has witnessed, checked or attested to any of it.</p>' +
+
+    '<h3 style="margin-top:22px">Your obligations remain yours</h3>' +
+    '<p class="small" style="margin-top:8px">Where insurance, professional indemnity, licensing, ' +
+    'certification or a formal qualification process is required or applicable under your regulations, ' +
+    'contract or client requirements, that obligation is yours and must be discharged directly with the ' +
+    'responsible body. This report substitutes for none of it.</p>' +
+
+    '<h3 style="margin-top:22px">Your data</h3>' +
+    '<p class="small" style="margin-top:8px">Any model file you choose is read inside your browser and is ' +
+    'never uploaded. Submitting anonymous results at the end is optional, you will see the exact payload ' +
+    'first, and your checklist is complete either way.</p>' +
+
+    '<h3 style="margin-top:22px">Research instrument</h3>' +
+    '<p class="small" style="margin-top:8px">This is a work in progress supporting academic research. Its ' +
+    'criteria, thresholds and weightings are subject to expert validation and will change.</p>' +
+  '</div>' +
+
+  '<label class="chk" style="font-size:15px;margin:20px 0 0"><input type="checkbox" id="ackbox">' +
+    '<span>I have read and understood the above, and I understand this assessment qualifies nothing ' +
+    'and no one.</span></label>' +
+
+  '<div class="actions">' +
+    '<button class="btn" id="agreebtn" data-go="context" disabled>Agree and continue</button>' +
+    '<button class="btn sec" data-go="declined">I do not agree</button>' +
+  '</div>' +
+  '<p class="small" style="margin-top:16px"><a href="proposal.html">The research proposal</a> &nbsp;&middot;&nbsp; ' +
+  '<a href="faq.html">Plain answers</a> &nbsp;&middot;&nbsp; <a href="disclaimer.html">Read the full Disclaimer Notice ' +
+  '&rarr;</a> &nbsp;&middot;&nbsp; <span class="mono">Terms v0.1 &middot; 22 Aug 2026</span></p>';
+
+/* ---------- 1c · DECLINED ---------- */
+SCREENS.declined =
+  '<p class="eyebrow">No assessment taken</p>' +
+  '<h2>No assessment was taken</h2>' +
+  '<p class="sub">Nothing has been recorded and nothing has left your device. This is a deliberately narrow ' +
+  'instrument, and the limits above are the whole of what it can tell you.</p>' +
+  '<div class="card">' +
+    '<h3>Further reading</h3>' +
+    '<p class="small" style="margin-top:9px">The background covers what the industry certifies, where delivered ' +
+    'models stand, and what closing the gap involves. None of it requires taking the assessment.</p>' +
+  '</div>' +
+  '<div class="actions">' +
+    '<a class="btn" href="why.html">Read the background</a>' +
+    '<a class="btn sec" href="faq.html">Plain answers</a>' +
+    '<button class="btn sec" data-go="agree">Back</button>' +
+  '</div>';
+
+/* ---------- 2 · CONTEXT ---------- */
+SCREENS.context =
+  '<p class="eyebrow">Step 3 of 10 &middot; About you</p>' +
+  '<h2>A little context</h2>' +
+  '<p class="sub small">None of this identifies you. It selects the right rules for your jurisdiction and ' +
+  'places you in a comparable group.</p>' +
+
+  '<div class="card">' +
+    '<div class="grid2">' +
+      '<div class="field"><label for="c1">Country <span class="small">&mdash; sets your locale pack</span></label>' +
+        '<select id="c1">' +
+          '<option>Malaysia</option><option selected>United Arab Emirates</option>' +
+          '<option>Singapore</option><option>United Kingdom</option>' +
+          '<option>Australia</option><option>Other &mdash; drafted live, marked provisional</option>' +
+        '</select></div>' +
+      '<div class="field"><label for="c4">Type of firm</label>' +
+        '<select id="c4">' +
+          '<option>Architecture</option><option selected>Engineering (structural / MEP)</option>' +
+          '<option>Contractor</option><option>Developer / owner</option>' +
+          '<option>Facilities management</option><option>Multidisciplinary consultant</option>' +
+        '</select></div>' +
+    '</div>' +
+
+    '<div class="field"><label>Firm size</label><div class="pills">' +
+      ['1', '2–10', '11–50', '51–200', '200+'].map(function (s, i) {
+        return '<input type="radio" name="c2" id="c2' + i + '"' + (i === 2 ? ' checked' : '') + '>' +
+               '<label for="c2' + i + '">' + s + '</label>';
+      }).join('') + '</div></div>' +
+
+    '<div class="field"><label for="c3">Your role</label>' +
+      '<select id="c3">' +
+        '<option>Principal / owner</option><option selected>Technical or BIM lead</option>' +
+        '<option>Project manager</option><option>Designer / engineer</option>' +
+        '<option>Owner-side / facilities</option><option>Other</option>' +
+      '</select></div>' +
+
+    '<div class="field"><label for="c6">In one sentence, what made you open this? ' +
+      '<span class="small">&mdash; optional, stays on your device</span></label>' +
+      '<input type="text" id="c6" value="A client has started asking for IFC and we are not sure we can deliver it."></div>' +
+  '</div>' +
+
+  '<div class="actions">' +
+    '<button class="btn" data-go="dim0">Continue</button>' +
+    '<button class="btn sec" data-go="agree">Back</button>' +
+  '</div>';
+
+/* ---------- THE 20 SCORED ITEMS ---------- */
+/* pre = mockup's canned answer index, chosen to reproduce the results screen. */
+var DIMENSIONS = [
+{ key:'A', name:'Governance', blurb:'How your firm is set up', items:[
+  { id:'A1', pre:2, q:'Is there a written position on open / IFC deliverables?',
+    tip:'A policy that exists but is never checked behaves differently from one that is enforced. We are separating those two, not judging either.',
+    anchor:'ISO 19650-1 &middot; organisational information requirements',
+    o:['Nothing, and it has not come up','It happens case by case, when someone remembers','Written into a policy or BEP template and kept current','A standard position applied across all projects','Compliance is checked and reported per project','Those reports drive changes to the policy'] },
+  { id:'A2', pre:3, q:'Your most recent contract &mdash; what did it say about deliverable format?',
+    tip:'Naming IFC and naming a schema version are different commitments. The second is checkable; the first often is not.',
+    anchor:'ISO 19650-2 &middot; exchange information requirements',
+    o:['Did not mention format, or I don&rsquo;t know','Format agreed informally, project by project','Named IFC in the appointment documents','A standard clause naming IFC and a schema version, every appointment','Conformance to that clause is verified at handover','Verification findings feed back into the clause'] },
+  { id:'A3', pre:1, q:'Have you ever taken a finished model out of your BIM software and opened it elsewhere?',
+    tip:'&ldquo;We own our data&rdquo; is a belief until somebody has actually pulled a model out and opened it somewhere else. This is the single strongest signal of lock-in exposure.',
+    anchor:'Vendor lock-in &middot; data portability',
+    o:['Never tried','Tried once, ad hoc','Done on delivery and the result is kept','A standard step in every project close-out','Fidelity is measured against the source each time','Those measurements change how we export'] },
+  { id:'A4', pre:3, q:'For authority submission, what do you actually hand over?',
+    tip:'Submission requirements vary by jurisdiction &mdash; your locale pack adjusts this question. If model-based submission does not exist where you work, choose N/A and it is excluded from scoring rather than counted as a zero.',
+    anchor:'Locale pack &middot; authority submission route',
+    o:['Paper or PDF drawings only','Native model files, as asked','IFC alongside other formats','IFC to the authority&rsquo;s named schema, every submission','Validated against the authority&rsquo;s criteria before sending','Validation findings change our authoring templates'], na:true }
+]},
+{ key:'B', name:'People and skills', blurb:'Who actually knows this, and what happens without them', items:[
+  { id:'B1', pre:2, q:'Who in the firm could explain what an IFC property set is?',
+    tip:'Not a test of anyone&rsquo;s knowledge. We are finding out whether open-standards understanding sits with one person or is spread &mdash; that difference decides how fragile your capability is.',
+    anchor:'ISO 19650-1 &middot; information management competence',
+    o:['Nobody','One person, self-taught','One person, and it is written down somewhere','Most of the technical team, through defined onboarding','Competence is assessed and tracked','Assessment results drive the training programme'] },
+  { id:'B2', pre:2, q:'Is information or BIM management in anyone&rsquo;s job description?',
+    tip:'Doing the job and being accountable for it are different things. A role with time allocated behaves differently from someone absorbing it on top of their real work.',
+    anchor:'ISO 19650-1 &middot; Information Manager function',
+    o:['No','Someone does it informally','Part of a named role, with time allocated','A defined role with documented responsibilities','Role performance is measured','Measurement reshapes the role'] },
+  { id:'B3', pre:1, q:'If that person left tomorrow, what happens?',
+    tip:'The most honest question in this section. Firms often score well on capability and badly here, and it is the best single predictor of whether a BIM programme survives a resignation.',
+    anchor:'Key-person concentration &middot; continuity',
+    o:['BIM capability stops','Severely degraded for months','Slowed; some handover notes exist','Documented handover and a defined backup role','Continuity is tested, not assumed','Test results drive succession planning'] },
+  { id:'B4', pre:2, q:'Has anyone had BIM or open-standards training in the last 12 months?',
+    tip:'Vendor product training and open-standards training are different investments. Learning one application deeply can even increase lock-in &mdash; that is not a criticism, just a different thing.',
+    anchor:'Succar &middot; competency development',
+    o:['None','Self-taught only','Vendor product training, when budget allowed','A defined training path including open standards','Training outcomes are measured','Measured outcomes set next year&rsquo;s programme'] }
+]},
+{ key:'C', name:'Technology', blurb:'What you run, and what it would take to change it', items:[
+  { id:'C1', pre:3, q:'How many BIM authoring tools are in regular use?',
+    tip:'One tool used well is not a failure. We are measuring concentration, not sophistication &mdash; a single-tool firm is efficient and exposed at the same time.',
+    anchor:'Vendor concentration &middot; switching cost',
+    o:['None','Exactly one, by default','One main, one occasional','Tool choice is a defined decision per task','Exchange between them is measured for loss','Those measurements drive the toolchain'] },
+  { id:'C2', pre:4, q:'Last time you received an IFC from someone else, what happened?',
+    tip:'The most useful answer here is usually &ldquo;geometry fine, data missing&rdquo;. That is the normal state of IFC exchange and worth recording honestly rather than rounding up.',
+    anchor:'buildingSMART &middot; IFC exchange fidelity',
+    o:['Never received one','Opened but unusable','Geometry fine, data missing','Opened and used within a defined workflow','Import quality is checked and recorded','Findings go back to the sender and the exchange improves'] },
+  { id:'C3', pre:2, q:'What most limits how many people here use BIM tools?',
+    tip:'If licence cost is the answer, say so. That is the constraint the open route is most likely to relieve, and understating it makes your recommendations less useful.',
+    anchor:'Adoption barriers &middot; licensing',
+    o:['Licence cost, severely','Licence cost, significantly','Hardware or skills, being managed','Access is planned and provisioned','Utilisation is measured against need','Measurement drives licensing decisions'] },
+  { id:'C4', pre:3, q:'Has the firm ever evaluated an alternative to its main BIM tool?',
+    tip:'Not a loyalty question. Having tested an alternative is what turns &ldquo;we could move if we had to&rdquo; from a hope into a known quantity.',
+    anchor:'Switching cost &middot; optionality',
+    o:['Never considered it','Discussed only','Someone trialled one','Evaluation is a defined periodic exercise','Switching cost is quantified','That figure informs procurement'] }
+]},
+{ key:'D', name:'Data and standards', blurb:'What is actually inside the model', items:[
+  { id:'D1', pre:4, q:'Do your models use a classification system?',
+    tip:'A file-naming convention is not a classification system. Both are useful and they answer different questions &mdash; the gap analysis needs to know which one you actually have.',
+    anchor:'ISO 12006-2 &middot; Uniclass / OmniClass / MasterFormat',
+    o:['No','A file-naming convention only','A classification standard, partly applied','Applied consistently through a defined process','Coverage is measured and reported per project','Coverage figures drive template changes'] },
+  { id:'D2', pre:3, q:'Is what the model must contain written down before the project starts?',
+    tip:'This is about information requirements, whatever they are called locally. Written before the project behaves very differently from agreed as you go.',
+    anchor:'ISO 19650-2 &middot; EIR / AIR',
+    o:['No','Verbally agreed','A written requirement exists','A standard requirement applied to every project','Compliance is measured at handover','Measurement changes the standard requirement'] },
+  { id:'D3', pre:4, q:'Before sending an IFC out, is it checked?',
+    tip:'Opening it to see whether it looks right is a real answer and a common one. We are separating &ldquo;looked at it&rdquo; from &ldquo;ran it through something that reports errors&rdquo;.',
+    anchor:'buildingSMART &middot; validation service',
+    o:['Never sent one','Not checked','Opened once to eyeball it','Checked against a defined expectation, every issue','Validated with a checker tool and results recorded','Recorded results drive authoring changes'] },
+  { id:'D4', pre:2, q:'Where will your finished project models be in five years?',
+    tip:'An asset outlives the software that modelled it by decades. This is the question owners eventually ask, and most firms have never been asked it.',
+    anchor:'ISO 19650-3 &middot; long-term information stewardship',
+    o:['Nowhere specific','Native format on a server somewhere','Deliberately archived, native only','A defined archive process including IFC','Archive readability is tested periodically','Test results change the archive policy'] }
+]},
+{ key:'E', name:'Organisational processes', blurb:'How the work actually flows', items:[
+  { id:'E1', pre:2, q:'How is model data shared on a project?',
+    tip:'A shared drive is a real answer. We are distinguishing a place where files sit from an environment that manages versions, status, and who has what.',
+    anchor:'ISO 19650-1 &middot; Common Data Environment',
+    o:['Email or file transfer','A shared drive','A CDE for documents','A CDE handling models, with defined states','CDE compliance is measured','Measurement drives CDE configuration'] },
+  { id:'E2', pre:3, q:'Are model exchanges scheduled?',
+    tip:'Ad hoc on request is extremely common and not a failure. Scheduled exchange is what lets other disciplines plan around you.',
+    anchor:'ISO 19650-2 &middot; information delivery planning',
+    o:['Ad hoc, on request','Around milestones, informally','Defined in a plan','A standard delivery plan on every project','Exchange punctuality is measured','Measurement changes the plan'] },
+  { id:'E3', pre:1, q:'After handover, is the model used for anything?',
+    tip:'Most models stop at handover. If yours does, that is the normal case &mdash; and it is the largest unrealised value in the whole lifecycle.',
+    anchor:'ISO 19650-3 &middot; asset information model',
+    o:['No','Occasionally referenced','Handed over, unclear if used','A defined role in FM or asset management','Its operational value is measured','Measurement drives what we model'] },
+  { id:'E4', pre:2, q:'Is anything about your BIM work measured?',
+    tip:'Anecdotes count as an honest &ldquo;no&rdquo;. Without measurement there is no way to tell whether a change you make actually worked.',
+    anchor:'ISO/IEC 33020 &middot; measurement and improvement',
+    o:['No','Anecdotally','Some metrics collected','A defined metric set on every project','Metrics reviewed against targets','Reviews change how projects run'] }
+]}
+];
+
+function renderItem(it) {
+  var rows = it.o.map(function (t, i) {
+    return '<input type="radio" name="' + it.id + '" id="' + it.id + i + '"' + (i === it.pre ? ' checked' : '') + '>' +
+      '<label for="' + it.id + i + '"><span class="lv">' + LV[i] + '</span><span class="dot"></span><span>' + t + '</span></label>';
+  }).join('');
+  if (it.na) {
+    rows += '<input type="radio" name="' + it.id + '" id="' + it.id + 'na">' +
+      '<label for="' + it.id + 'na"><span class="lv">N/A</span><span class="dot"></span>' +
+      '<span>No model-based submission exists in our market <em class="small">&mdash; excluded from scoring</em></span></label>';
+  }
+  rows += '<input type="radio" name="' + it.id + '" id="' + it.id + 'dk">' +
+    '<label for="' + it.id + 'dk"><span class="lv">&mdash;</span><span class="dot"></span>' +
+    '<span>Not known to me <em class="small">&mdash; scored as insufficient evidence, never as zero</em></span></label>';
+  return '<div class="field"><div class="qhead"><span class="qid">' + it.id + '</span><span>' + it.q + '</span>' +
+    TIP(it.tip, it.anchor) + '</div><div class="opts">' + rows + '</div></div>';
+}
+
+function dimScreen(n) {
+  var d = DIMENSIONS[n];
+  return '<p class="eyebrow">Step ' + (n + 4) + ' of 10 &nbsp;&middot;&nbsp; ' + d.name +
+      ' &nbsp;&middot;&nbsp; section ' + (n + 1) + ' of 5</p>' +
+    '<h2>' + d.blurb + '</h2>' +
+    '<p class="sub small">Each question asks about the <strong>last real instance</strong>, not general practice. ' +
+    'Answer from what you know. Tap <strong>?</strong> on any question to see why it is asked.</p>' +
+    '<div class="card">' + d.items.map(renderItem).join('') + '</div>' +
+    '<div class="actions">' +
+      '<button class="btn" data-go="' + (n < 4 ? 'dim' + (n + 1) : 'model') + '">' +
+        (n < 4 ? 'Continue to ' + DIMENSIONS[n + 1].name : 'Continue to model check') + '</button>' +
+      '<button class="btn sec" data-go="' + (n > 0 ? 'dim' + (n - 1) : 'context') + '">Back</button>' +
+    '</div>';
+}
+
+/* ---------- 4 · MODEL ---------- */
+SCREENS.model =
+  '<p class="eyebrow">Step 9 of 10 &middot; Your model</p>' +
+  '<h2>Now let&rsquo;s look at an actual file</h2>' +
+  '<p class="sub small">This is the part a questionnaire cannot do. We read the file here, in your browser, and ' +
+  'compare what it contains against what you just told us. <strong>The file is never uploaded.</strong></p>' +
+
+  '<div class="drop filled" id="drop">' +
+    '<div style="display:flex;gap:13px;align-items:center;flex-wrap:wrap">' +
+      '<div class="brandmark" style="background:var(--accent-wash);color:var(--accent-ink)">IFC</div>' +
+      '<div style="flex:1;min-width:170px">' +
+        '<div style="font-weight:600;font-size:15px">Tower_ARC_Rev04.ifc</div>' +
+        '<div class="small mono">IFC2X3 · 84.2 MB · read locally · 12,847 elements</div>' +
+      '</div>' +
+      '<button class="btn sec sm" type="button">Choose a different file</button>' +
+    '</div>' +
+  '</div>' +
+
+  '<div class="card">' +
+    '<h3>What we found in it</h3>' +
+    '<dl class="mgrid" style="margin-top:13px">' +
+      '<div class="mcell"><dt>Schema</dt><dd class="mono">IFC2X3</dd></div>' +
+      '<div class="mcell"><dt>Elements</dt><dd class="mono">12,847</dd></div>' +
+      '<div class="mcell"><dt>Spatial chain</dt><dd>Complete</dd></div>' +
+      '<div class="mcell flag"><dt>Spaces (rooms)</dt><dd class="mono">0</dd></div>' +
+      '<div class="mcell flag"><dt>Classified</dt><dd class="mono">4.2<span class="unit">%</span></dd></div>' +
+      '<div class="mcell flag"><dt>Property sets</dt><dd class="mono">39<span class="unit">%</span></dd></div>' +
+      '<div class="mcell flag"><dt>Quantities</dt><dd>Absent</dd></div>' +
+      '<div class="mcell flag"><dt>Duplicate GUIDs</dt><dd class="mono">47</dd></div>' +
+    '</dl>' +
+    '<p class="small" style="margin-top:14px">Counted from the file directly, not from anything we stored &mdash; ' +
+    'so these are your model&rsquo;s numbers, not our extractor&rsquo;s view of it.</p>' +
+  '</div>' +
+
+  '<div class="card">' +
+    '<h3>Exactly what would leave your browser</h3>' +
+    '<p class="small" style="margin:9px 0 13px">Numbers and fixed categories only. No file, no names, no GUIDs, ' +
+    'no coordinates, no free text.</p>' +
+    '<pre class="payload">{\n' +
+      '  "locale":        "AE",\n' +
+      '  "firm_size":     "11-50",\n' +
+      '  "firm_type":     "engineering",\n' +
+      '  "answers":       [1,2,0,1, 1,1,2,1, 2,2,3,2, 3,1,4,0, 1,2,1,1],\n' +
+      '  "schema":        "IFC2X3",\n' +
+      '  "elements":      12847,\n' +
+      '  "spaces":        0,\n' +
+      '  "classified_pc": 4.2,\n' +
+      '  "psets_pc":      39.0,\n' +
+      '  "quantities":    false,\n' +
+      '  "georef":        true,\n' +
+      '  "dup_guids":     47,\n' +
+      '  "exporter":      "other",\n' +
+      '  "toolkit":       "v0.1",\n' +
+      '  "kb":            "core-0.1 / ae-v1"\n}</pre>' +
+    '<label class="chk" style="margin-top:14px"><input type="checkbox">' +
+      '<span>Send this. Optional &mdash; your checklist is complete either way.</span></label>' +
+  '</div>' +
+
+  '<div class="actions">' +
+    '<button class="btn" data-go="results">See my results</button>' +
+    '<button class="btn sec" data-go="dim4">Back</button>' +
+  '</div>';
+
+/* ---------- 5 · RESULTS ---------- */
+function chartRows() {
+  return DIMS.map(function (d) {
+    var w = (d.measured / 5 * 100).toFixed(1), t = (d.target / 5 * 100).toFixed(1);
+    var met = d.measured >= d.target;
+    var short = (d.target - d.measured);
+    return '<div class="crow" title="' + d.name + ' — assessed ' + d.measured.toFixed(1) +
+      ', proportionate target ' + d.target + '">' +
+      '<div class="cname">' + d.name + '</div>' +
+      '<div class="ctrack"><div class="ctarget" style="width:' + t + '%"></div>' +
+      '<div class="cbar" style="width:' + w + '%"></div>' +
+      '<div class="cclaim" style="left:' + t + '%"></div></div>' +
+      '<div class="cval"' + (met ? ' style="color:var(--accent)"' : '') + '>' +
+      (met ? 'met' : '&minus;' + short.toFixed(1)) + '</div></div>';
+  }).join('');
+}
+
+SCREENS.results =
+  '<p class="eyebrow">Step 10 of 10 &middot; Your results</p>' +
+  '<h2>Where you stand</h2>' +
+  '<p class="sub small">Two numbers per dimension: what your answers claimed, and what the evidence supports. ' +
+  'Where they disagree by two levels or more, the measurement is used and the gap is shown.</p>' +
+
+  '<div class="card">' +
+    '<h3>Readiness profile</h3>' +
+    '<p class="small" style="margin-top:5px">ISO/IEC 33020 capability levels 0&ndash;5, against a target proportionate to your firm</p>' +
+    '<div class="chart">' + chartRows() +
+      '<div class="cscale"><span></span><div class="cticks">' +
+        '<span>0</span><span>1</span><span>2</span><span>3</span><span>4</span><span>5</span></div><span></span></div>' +
+    '</div>' +
+    '<div class="clegend">' +
+      '<span><i class="swatch"></i>Assessed level</span>' +
+      '<span><i class="swtick"></i>Proportionate target for a firm your size</span>' +
+      '<span class="small">Targets follow ISO/IEC 33020 &mdash; capability is meant to suit the risk, not be maximised</span>' +
+    '</div>' +
+    '<details class="tvwrap"><summary>View as a table</summary>' +
+      '<table class="tv"><thead><tr><th>Dimension</th><th>Assessed</th><th>Target</th><th>Gap</th><th>You said</th></tr></thead><tbody>' +
+      DIMS.map(function (d) {
+        var g = d.target - d.measured;
+        return '<tr><td>' + d.name + '</td><td class="n">' + d.measured.toFixed(1) + '</td><td class="n">' +
+          d.target + '</td><td class="n">' + (g <= 0 ? 'met' : '&minus;' + g.toFixed(1)) + '</td><td class="n">' +
+          d.claimed.toFixed(2) + '</td></tr>';
+      }).join('') + '</tbody></table></details>' +
+  '</div>' +
+
+  '<div class="card">' +
+    '<h3>Gap analysis</h3>' +
+    '<p class="small" style="margin-top:5px">Capability gaps, implementation risks, and where your model disagreed with your answers</p>' +
+    '<div class="delta" style="margin-top:13px">' +
+      '<div class="ic">!</div><div>' +
+        '<h4>Classification</h4>' +
+        '<p>You reported that classification coverage is measured and reported per project. 4.2% of elements in the file carry a ' +
+        'classification reference. We scored the measurement.</p>' +
+        '<div class="vs"><span><b>You said</b>L3 · applied consistently</span>' +
+        '<span><b>Measured</b>L1 · 4.2% coverage</span></div>' +
+      '</div></div>' +
+    '<div class="delta">' +
+      '<div class="ic">!</div><div>' +
+        '<h4>Quality checking before issue</h4>' +
+        '<p>You reported validating IFC with a checker tool before sending. The file carries 47 duplicate GUIDs, ' +
+        'which a checker would have caught.</p>' +
+        '<div class="vs"><span><b>You said</b>L4 · validated with a tool</span>' +
+        '<span><b>Measured</b>L1 · 47 duplicate GUIDs</span></div>' +
+      '</div></div>' +
+    '<p class="small">A gap between claim and evidence is usually a reporting problem rather than a competence one. ' +
+    'It is also the most actionable finding in this report.</p>' +
+
+    '<h3 style="margin-top:28px">Implementation risks</h3>' +
+    '<p class="small" style="margin-top:5px">Things that can stop a transition regardless of how capable you are. ' +
+    'These are flagged, not scored.</p>' +
+    '<ul class="risks">' +
+      '<li><div><h4>Professional indemnity position is unchecked</h4>' +
+      '<p>You have not confirmed with your insurer or counsel whether delivering on open standards, or ' +
+      'using non-proprietary tooling, affects your cover. <strong>This toolkit cannot answer that and does ' +
+      'not try to.</strong> What it can tell you is that software warranty disclaimers are near-universal ' +
+      '&mdash; proprietary licences carry them too &mdash; and that professional indemnity insures the ' +
+      'professional, not the tool. Put the question to your insurer in writing before it becomes urgent.</p></div></li>' +
+      '<li><div><h4>No named accountable party for information</h4>' +
+      '<p>Governance sits below its proportionate target and no one role carries information management ' +
+      'with authority. Under ISO 19650 that accountability does not disappear &mdash; it defaults upward to ' +
+      'whoever signed.</p></div></li>' +
+      '<li><div><h4>Single-vendor continuity</h4>' +
+      '<p>No model has been retrieved from your authoring tool and opened elsewhere, so the cost and ' +
+      'feasibility of moving is unknown rather than low.</p></div></li>' +
+    '</ul>' +
+  '</div>' +
+
+  '<div class="card">' +
+    '<h3>Recommendations</h3>' +
+    '<p class="small" style="margin-top:5px">Capability development &middot; standards adoption &middot; implementation planning &mdash; ordered by how much each unlocks downstream</p>' +
+    '<ol class="fixes">' +
+      '<li><div><h4>Add spaces to the model</h4><p>Zero IfcSpace entities. Rooms are the spine of anything ' +
+      'downstream &mdash; FM, area schedules, analysis. Nothing that needs a room can consume this file.</p></div></li>' +
+      '<li><div><h4>Classify at type level, not element level</h4><p>234 of 339 types carry no code. Coding types ' +
+      'rather than 12,847 elements is roughly a day of work instead of a month.</p></div></li>' +
+      '<li><div><h4>Resolve 47 duplicate GUIDs before the next issue</h4><p>Duplicates break round-tripping and ' +
+      'change tracking silently.</p></div></li>' +
+      '<li><div><h4>Turn on quantity export</h4><p>No IfcElementQuantity present, so nothing downstream can do ' +
+      'cost or carbon from this model.</p></div></li>' +
+      '<li><div><h4>Write down what the model must contain, before the next project starts</h4>' +
+      '<p>Your lowest-scoring governance item, and the cheapest to fix.</p></div></li>' +
+    '</ol>' +
+  '</div>' +
+
+  '<div class="idx2">' +
+    '<div class="ix"><span class="who">Can we start?</span>' +
+      '<div class="v">1.9<small> / 5</small></div>' +
+      '<div style="font-weight:600;font-size:14px">Entry readiness</div>' +
+      '<p>The open route is reachable, but not with this model as it stands.</p></div>' +
+    '<div class="ix"><span class="who">How exposed are we?</span>' +
+      '<div class="v">3.9<small> / 5</small></div>' +
+      '<div style="font-weight:600;font-size:14px">Lock-in exposure</div>' +
+      '<p>High. No model has been retrieved from your authoring tool and re-opened elsewhere.</p></div>' +
+  '</div>' +
+
+  '<div class="card flat" style="background:var(--surface-2)">' +
+    '<h3>Compare yourself to others</h3>' +
+    '<p class="small" style="margin-top:8px">No assessments have been submitted yet &mdash; yours would be the ' +
+    'first. As responses accumulate this becomes a real industry picture, built from practitioners rather than ' +
+    'asserted.</p>' +
+  '</div>' +
+
+  '<div class="card" style="border-left:3px solid var(--warn)">' +
+    '<h3 style="color:var(--warn)">Before you share this</h3>' +
+    '<p class="small" style="margin-top:8px"><strong>This assessment qualifies nothing and no one.</strong> ' +
+    'It confers no certification, accreditation, licence, approval or professional status, and it is not ' +
+    'evidence of compliance with any regulation, standard, code or contract. Do not present it as such &mdash; ' +
+    'to a client, an authority, an insurer, or in a tender.</p>' +
+    '<p class="small">Nothing here is audited or verified. The answers are yours and the measurements come ' +
+    'from a file you supplied; no third party has checked any of it.</p>' +
+    '<p class="small">Where insurance, professional indemnity, licensing or a formal qualification process ' +
+    'is required or applicable under your regulations, contract or client requirements, that obligation is ' +
+    'yours and must be discharged directly with the responsible body. This report substitutes for none of it.</p>' +
+    '<p class="small"><a href="disclaimer.html">Read the full Disclaimer Notice &rarr;</a></p>' +
+  '</div>' +
+
+  '<div class="printnotice">' +
+    '<h4>Notice &mdash; printed with every copy of this report</h4>' +
+    '<p><strong>This is only a technical readiness assessment. It qualifies nothing and no one.</strong> ' +
+    'It confers no certification, accreditation, licence, approval or professional status, and is not ' +
+    'evidence of compliance with any regulation, standard, code or contract. Do not present it as such ' +
+    '&mdash; to a client, an authority, an insurer, or in a tender.</p>' +
+    '<p>Answers are self-reported and measurements come from a file supplied by the respondent. Nothing ' +
+    'here has been audited or verified by any third party. Where insurance, professional indemnity, ' +
+    'licensing or a formal qualification process is required or applicable under your regulations or ' +
+    'appointment, that obligation is yours and this report substitutes for none of it.</p>' +
+    '<p><a href="disclaimer.html">Read the full Disclaimer Notice &rarr;</a> &nbsp;&middot;&nbsp; ' +
+    '<span class="mono">Notice v0.1 &middot; 22 Aug 2026</span></p>' +
+  '</div>' +
+
+  '<div class="actions">' +
+    '<button class="btn">Download checklist (PDF)</button>' +
+    '<button class="btn sec">See these gaps in 3D</button>' +
+    '<button class="btn sec" data-go="intro">Start over</button>' +
+  '</div>' +
+  '<p class="small mono" style="margin-top:20px;padding-top:14px;border-top:1px solid var(--rule)">' +
+  'core-0.1 · locale ae-v1 · toolkit v0.1 · terms v0.1 acknowledged · scope: one office or region · scoring is deterministic &mdash; ' +
+  'same answers and same versions always produce this same result. Technical readiness assessment only: ' +
+  'self-reported, unaudited, qualifies nothing and no one, confers no certification or professional status.</p>';
+
+/* ---------- NAV ---------- */
+DIMENSIONS.forEach(function (d, i) { SCREENS['dim' + i] = dimScreen(i); });
+
+var ORDER = ['intro', 'agree', 'context', 'dim0', 'dim1', 'dim2', 'dim3', 'dim4', 'model', 'results'];
+var LABELS = {
+  intro: 'Introduction', agree: 'Before you begin', declined: 'No assessment taken', context: 'About you',
+  dim0: 'Governance', dim1: 'People and skills', dim2: 'Technology',
+  dim3: 'Data and standards', dim4: 'Organisational processes',
+  model: 'Your model', results: 'Results'
+};
+var host = document.getElementById('screens');
+
+function show(name) {
+  host.innerHTML = '<div class="screen on">' + SCREENS[name] + '</div>';
+  var i = ORDER.indexOf(name);
+  if (i < 0) { window.scrollTo({ top: 0, behavior: 'instant' }); return; }
+  var rail = document.getElementById('rail'), cap = document.getElementById('railcap');
+  rail.hidden = cap.hidden = (name === 'intro' || name === 'agree' || name === 'declined');
+  [].forEach.call(rail.children, function (li, n) {
+    li.className = n < i ? 'done' : (n === i ? 'now' : '');
+  });
+  document.getElementById('railnow').textContent = LABELS[name];
+  document.getElementById('railpct').textContent = 'Step ' + (i + 1) + ' of ' + ORDER.length;
+  window.scrollTo({ top: 0, behavior: 'instant' });
+}
+
+document.addEventListener('change', function (e) {
+  if (e.target.id === 'ackbox') {
+    document.getElementById('agreebtn').disabled = !e.target.checked;
+  }
+});
+
+document.addEventListener('click', function (e) {
+  var go = e.target.closest('[data-go]');
+  if (go && go.disabled) return;
+  if (go) { show(go.dataset.go); return; }
+
+  var tb = e.target.closest('.tipbtn');
+  document.querySelectorAll('.tip.open').forEach(function (t) {
+    if (!tb || t !== tb.parentNode) t.classList.remove('open');
+  });
+  if (tb) { tb.parentNode.classList.toggle('open'); return; }
+
+  if (e.target.id === 'themebtn') {
+    var r = document.documentElement;
+    var dark = r.getAttribute('data-theme') === 'dark' ||
+      (!r.getAttribute('data-theme') && matchMedia('(prefers-color-scheme:dark)').matches);
+    r.setAttribute('data-theme', dark ? 'light' : 'dark');
+  }
+});
+
+document.addEventListener('keydown', function (e) {
+  if (e.key === 'Escape') document.querySelectorAll('.tip.open').forEach(function (t) { t.classList.remove('open'); });
+});
+
+show('intro');
+</script>

--- a/readiness/disclaimer.html
+++ b/readiness/disclaimer.html
@@ -230,16 +230,19 @@ footer{
   figure{padding:18px 16px}
 }
 @media (prefers-reduced-motion:reduce){*{animation:none!important;transition:none!important}}
+
+.nav{display:flex;gap:7px;flex-wrap:wrap;margin-left:auto}
+.nav a{font-family:"Instrument Sans",sans-serif;font-size:13px;text-decoration:none;
+  border:1px solid var(--rule);border-radius:6px;padding:6px 12px;color:var(--ink-2);background:transparent}
+.nav a:hover{border-color:var(--accent);color:var(--accent-ink);background:var(--accent-wash)}
+.nav a.on{border-color:var(--accent);color:var(--accent-ink);background:var(--accent-wash);font-weight:600}
 </style>
 <div class="wrap">
 
 <div class="topbar">
   <div class="brandmark">OB</div>
   <div class="brandtext">OpenBIM Readiness Assessment Toolkit<small>Disclaimer Notice</small></div>
-  <div class="topspacer"></div>
-  <button class="ghostbtn" id="themebtn" type="button">Theme</button>
-  <a class="ghostbtn" href="proposal.html">Proposal</a>
-  <a class="ghostbtn" href="./">Back to assessment</a>
+  <div class="nav"><a href="./">Overview</a><a href="assess.html">Assessment</a><a href="proposal.html">Proposal</a><a href="why.html">Background</a><a href="faq.html">Basics</a><a href="disclaimer.html" class="on">Notice</a></div>
 </div>
 
 <div class="hero">
@@ -328,10 +331,9 @@ footer{
   in the UAE. The full proposal is reproduced at <a href="proposal.html">The research proposal</a>.</p>
 
   <h3>Funding</h3>
-  <p>Supported by a research grant awarded to Mohd Faizal Bin Yusof at
-  <strong>[institution]</strong>, reference <strong>[grant reference]</strong>, value US$5,000.
-  Software development was contracted separately to REFREX SDN BHD under quotation
-  QTN.KFK.260703-01.</p>
+  <p>Supported by a research grant awarded to Mohd Faizal Bin Yusof, value US$5,000. Software
+  development was contracted separately to REFREX SDN BHD under quotation QTN.KFK.260703-01. Full
+  award details are published with the first citable release.</p>
   <p>The funder had no role in the design of the assessment framework, the collection or analysis of
   responses, the writing of any report, or the decision to submit for publication.</p>
 
@@ -361,8 +363,9 @@ footer{
   it will be optional and anonymous, with the exact payload shown before sending.</p>
 
   <h3>Ethics</h3>
-  <p><strong>[Ethics position to be stated by the researcher.]</strong> The toolkit collects no
-  participant data in its current version.</p>
+  <p>The toolkit collects no participant data in its current version. Any ethics determination for
+  the wider study rests with the researcher's institution and is published with the first citable
+  release.</p>
 
   <h3>Use of generative AI</h3>
   <p>Generative AI was used in developing this toolkit and in preparing its documentation. All
@@ -373,9 +376,9 @@ footer{
   a respondent&rsquo;s behalf.</p>
 
   <h3>Licence and citation</h3>
-  <p>Source code: <strong>[licence to be selected]</strong>, available at
-  <span class="mono">github.com/red1oon/bim-ootb</span> under <span class="mono">readiness/</span>.
-  Cite as <strong>[DOI to be minted on the tagged release]</strong>.</p>
+  <p>Source code is available at <span class="mono">github.com/red1oon/bim-ootb</span> under
+  <span class="mono">readiness/</span>. Licence terms and a citable DOI are issued with the first
+  tagged release; until then this is a pre-release draft and should not be cited.</p>
 
   <h3>Status</h3>
   <p>Research instrument in development. Criteria, thresholds and weightings are subject to expert

--- a/readiness/faq.html
+++ b/readiness/faq.html
@@ -1,4 +1,4 @@
-<title>Plain Answers</title>
+<title>OpenBIM Basics</title>
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
 <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Instrument+Sans:wght@400;500;600;700&family=Source+Serif+4:opsz,wght@8..60,400;8..60,600&family=IBM+Plex+Mono:wght@400;500;600&display=swap">
@@ -253,42 +253,45 @@ footer{
 .gterm dt{font-family:"Instrument Sans",sans-serif;font-weight:600;font-size:14.5px;color:var(--ink);margin:0}
 .gterm dd{margin:0;font-size:15px;color:var(--ink-2);line-height:1.55}
 @media (max-width:600px){.gterm{grid-template-columns:1fr;gap:5px}}
+
+.nav{display:flex;gap:7px;flex-wrap:wrap;margin-left:auto}
+.nav a{font-family:"Instrument Sans",sans-serif;font-size:13px;text-decoration:none;
+  border:1px solid var(--rule);border-radius:6px;padding:6px 12px;color:var(--ink-2);background:transparent}
+.nav a:hover{border-color:var(--accent);color:var(--accent-ink);background:var(--accent-wash)}
+.nav a.on{border-color:var(--accent);color:var(--accent-ink);background:var(--accent-wash);font-weight:600}
 </style>
 <div class="wrap">
 
 <div class="topbar">
   <div class="brandmark">OB</div>
-  <div class="brandtext">OpenBIM Readiness Assessment Toolkit<small>Plain answers</small></div>
-  <div class="topspacer"></div>
-  <button class="ghostbtn" id="themebtn" type="button">Theme</button>
-  <a class="ghostbtn" href="./">Back to assessment</a>
+  <div class="brandtext">OpenBIM Readiness Assessment Toolkit<small>Basics</small></div>
+  <div class="nav"><a href="./">Overview</a><a href="assess.html">Assessment</a><a href="proposal.html">Proposal</a><a href="why.html">Background</a><a href="faq.html" class="on">Basics</a><a href="disclaimer.html">Notice</a></div>
 </div>
 
 <div class="hero">
-  <p class="eyebrow">Plain answers</p>
-  <h1>The questions people feel they should already know the answer to.</h1>
-  <p class="standfirst">Nobody asks these out loud. They are all reasonable questions, several of them
-  are the whole point, and one of them is answered wrongly by most of the industry.</p>
+  <p class="eyebrow">Basics</p>
+  <h1>What OpenBIM is, and what this assessment does.</h1>
+  <p class="standfirst">Short answers to the questions that come up most often, and the terms the
+  assessment uses.</p>
 </div>
 
 <section>
   <div class="shead"><span class="snum">01</span><h2>The basics</h2></div>
   <div class="qa">
-<details><summary>What is OpenBIM?</summary><div class="a"><p>BIM is <strong>building information modelling</strong> — designing with a model that carries data, not just lines. OpenBIM is doing that using <strong>open, published file formats</strong> so the information is not locked inside one company's software.</p><p>That is the whole idea. It is not a product, a brand, or a piece of software.</p></div></details><details><summary>Is OpenBIM something I buy?</summary><div class="a"><p>No. It is an approach and a set of published standards. Nobody owns it and nobody sells it. You can work this way with software you already have.</p></div></details><details><summary>What is IFC?</summary><div class="a"><p><strong>IFC</strong> — Industry Foundation Classes — is the main open file format for building information. It is published by buildingSMART, an international non-profit, and any software can read or write it without asking permission or paying a licence.</p><p>If you have ever been asked to \u201cdeliver in IFC\u201d, this is what was meant.</p></div></details><details><summary>My software already has an \u201cexport to IFC\u201d button. Isn't that it?</summary><div class="a"><p>That button is where it starts, not where it ends. Almost every BIM tool has one. The question is whether what comes out is <em>usable</em> by anyone else — whether it carries the rooms, the classifications, the quantities and the properties that make it worth receiving.</p><p><strong>That gap is exactly what this assessment measures.</strong> Most exports open fine and carry far less than the sender assumes.</p></div></details><details><summary>Do I have to stop using the software I have?</summary><div class="a"><p>No, and this assessment will not tell you to. OpenBIM is about what you <em>deliver and archive</em>, not what you author in. Plenty of firms work openly using entirely proprietary tools.</p><p>What changes is that your information stays readable when the software, the subscription or the vendor does not.</p></div></details>
+<details><summary>What is OpenBIM?</summary><div class="a"><p>BIM is <strong>building information modelling</strong> — designing with a model that carries data, not just lines. OpenBIM is doing that using <strong>open, published file formats</strong> so the information is not locked inside one company's software.</p><p>That is the whole idea. It is not a product, a brand, or a piece of software.</p></div></details><details><summary>Is OpenBIM something I buy?</summary><div class="a"><p>No. It is an approach and a set of published standards. Nobody owns it and nobody sells it. You can work this way with software you already have.</p></div></details><details><summary>What is IFC?</summary><div class="a"><p><strong>IFC</strong> — Industry Foundation Classes — is the main open file format for building information. It is published by buildingSMART, an international non-profit, and any software can read or write it without asking permission or paying a licence.</p><p>If you have ever been asked to \u201cdeliver in IFC\u201d, this is what was meant.</p></div></details><details><summary>My software already has an \u201cexport to IFC\u201d button. Isn't that it?</summary><div class="a"><p>That button is where it starts, not where it ends. Almost every BIM tool has one. The question is whether what comes out is <em>usable</em> by anyone else — whether it carries the rooms, the classifications, the quantities and the properties that make it worth receiving.</p><p>Most exports open fine and carry far less than the sender assumes. That gap is what this assessment measures.</p></div></details><details><summary>Do I have to stop using the software I have?</summary><div class="a"><p>No. OpenBIM is about what you <em>deliver and archive</em>, not what you author in. Plenty of firms work openly using entirely proprietary tools.</p><p>What changes is that your information stays readable when the software, the subscription or the vendor does not.</p></div></details>
   </div>
 </section>
 
 <section>
   <div class="shead"><span class="snum">02</span><h2>About this assessment</h2></div>
   <div class="qa">
-<details><summary>What do I need before I start?</summary><div class="a"><p>About fifteen minutes. Optionally one IFC file. No account, no sign-up, no API key, no payment.</p></div></details><details><summary>What if I don't have an IFC file?</summary><div class="a"><p>You can still take it. You get the organisational half of the assessment, and the report says plainly that the model half was not measured — it does not guess, and it does not score you down for the absence.</p></div></details><details><summary>Will you see my model?</summary><div class="a"><p>No. The file is read <strong>inside your browser</strong> and is never uploaded. There is no server to upload it to. If you choose to submit results at the end, you are shown the exact payload first, and it contains only numbers and fixed categories — no file, no names, no coordinates.</p></div></details><details><summary>What is the catch? Who is paying for this?</summary><div class="a"><p>It is a research instrument, developed under an academic research grant, and free to use. The platform it references as a worked example is open source. The full proposal is published at <a href="proposal.html">The research proposal</a>.</p><p>The honest commercial disclosure: the people who built it also build that open-source platform. That is why the assessment scores you against <em>published standards</em> rather than against any product, and why it can return \u201cthe open route is not viable for you yet\u201d.</p></div></details><details><summary>Am I too small for this?</summary><div class="a"><p>No. Targets are proportionate to firm size and project type — a four-person practice is not measured against what a 200-person firm should be doing. That was a deliberate design decision.</p></div></details><details><summary>Is this only for BIM managers?</summary><div class="a"><p>No. It is for anyone who delivers or receives building information — principals, project managers, contractors, owners, facilities teams. If you have ever been asked for a model, or been handed one, the questions will make sense.</p></div></details><details><summary>What do I get at the end?</summary><div class="a"><p>A readiness profile across five areas, a gap analysis showing where you stand against a proportionate target, an ordered set of recommendations, and — if you supplied a file — the places where your model disagreed with your answers. Downloadable as a PDF.</p></div></details>
+<details><summary>What do I need before I start?</summary><div class="a"><p>About fifteen minutes. Optionally one IFC file. No account, no sign-up, no API key, no payment.</p></div></details><details><summary>What if I don't have an IFC file?</summary><div class="a"><p>You can still take it. You get the organisational half of the assessment, and the report says plainly that the model half was not measured — it does not guess, and it does not score you down for the absence.</p></div></details><details><summary>Will you see my model?</summary><div class="a"><p>No. The file is read <strong>inside your browser</strong> and is never uploaded. There is no server to upload it to. If you choose to submit results at the end, you are shown the exact payload first, and it contains only numbers and fixed categories — no file, no names, no coordinates.</p></div></details><details><summary>What is the catch? Who is paying for this?</summary><div class="a"><p>It is a research instrument, developed under an academic research grant, and free to use. The platform it references as a worked example is open source. The full proposal is published at <a href="proposal.html">The research proposal</a>.</p><p>The people who built it also build that open-source platform. That is why the assessment scores you against <em>published standards</em> rather than against any product, and why it can return \u201cthe open route is not viable for you yet\u201d.</p></div></details><details><summary>Am I too small for this?</summary><div class="a"><p>No. Targets are proportionate to firm size and project type. A four-person practice is not measured against what a 200-person firm should be doing.</p></div></details><details><summary>Is this only for BIM managers?</summary><div class="a"><p>No. It is for anyone who delivers or receives building information — principals, project managers, contractors, owners, facilities teams. If you have ever been asked for a model, or been handed one, the questions will make sense.</p></div></details><details><summary>What do I get at the end?</summary><div class="a"><p>A readiness profile across five areas, a gap analysis showing where you stand against a proportionate target, an ordered set of recommendations, and — if you supplied a file — the places where your model disagreed with your answers. Downloadable as a PDF.</p></div></details>
   </div>
 </section>
 
 <section>
   <div class="shead"><span class="snum">03</span><h2>Words the assessment uses</h2></div>
-  <p class="lede">If a question uses a term you do not use day to day, it is here. Not knowing these
-  is not a failing — several are UK or ISO vocabulary that never travelled.</p>
+  <p class="lede">Terms used in the assessment questions.</p>
   <dl class="gloss">
     <div class="gterm"><dt>IFC</dt><dd>The open file format for building information. Published by buildingSMART; readable by any tool.</dd></div>
     <div class="gterm"><dt>IFC schema version</dt><dd>Which edition of IFC a file uses — IFC2x3, IFC4, IFC4x3. They differ in what can be expressed, which is why contracts increasingly name one.</dd></div>
@@ -305,14 +308,14 @@ footer{
 </section>
 
 <div class="cta">
-  <h3>Still nothing here that answers it?</h3>
+  <h3>Not covered here?</h3>
   <p>The background reading goes deeper on why any of this matters, and the Disclaimer Notice covers
   what this assessment can and cannot be used for.</p>
   <a class="btn" href="./">Take the assessment</a>
 </div>
 
 <footer>
-  Plain answers &middot; OpenBIM Readiness Assessment Toolkit v0.1<br>
+  Basics &middot; OpenBIM Readiness Assessment Toolkit v0.1<br>
   <a href="proposal.html">The research proposal</a> &middot; <a href="why.html">Background reading</a> &middot; <a href="disclaimer.html">Disclaimer Notice</a>
 </footer>
 

--- a/readiness/index.html
+++ b/readiness/index.html
@@ -1,949 +1,311 @@
-<title>OpenBIM Readiness Toolkit</title>
+<title>OpenBIM Readiness</title>
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-<link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Instrument+Sans:wght@400;500;600;700&family=IBM+Plex+Mono:wght@400;500;600&display=swap">
+<link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Instrument+Sans:wght@400;500;600;700&family=Source+Serif+4:opsz,wght@8..60,400;8..60,600&family=IBM+Plex+Mono:wght@400;500;600&display=swap">
 
 <style>
 :root{
   --ink:#131e1b; --ink-2:#3a4a45; --muted:#6b7d78; --faint:#9aaba6;
-  --paper:#f5f7f5; --surface:#ffffff; --surface-2:#eaefed; --surface-3:#dfe6e3;
+  --paper:#f5f7f5; --surface:#ffffff; --surface-2:#eaefed; --surface-3:#dbe3e0;
   --rule:#d3dcd9; --rule-soft:#e4e9e7;
   --accent:#00897b; --accent-ink:#00695f; --accent-wash:#e0efec;
   --warn:#a06a00; --warn-wash:#f7efdd;
   --focus:#00897b;
-  --shadow:0 1px 2px rgba(19,30,27,.05),0 8px 24px -14px rgba(19,30,27,.18);
+  --shadow:0 1px 2px rgba(19,30,27,.05),0 10px 30px -18px rgba(19,30,27,.22);
 }
 @media (prefers-color-scheme:dark){
   :root:not([data-theme="light"]){
     --ink:#e9efed; --ink-2:#c3d0cc; --muted:#93a5a0; --faint:#6d7f7a;
-    --paper:#0f1816; --surface:#182421; --surface-2:#1f2d29; --surface-3:#273733;
+    --paper:#0f1816; --surface:#182421; --surface-2:#1f2d29; --surface-3:#2b3b36;
     --rule:#2d3e39; --rule-soft:#22302c;
     --accent:#1f9d87; --accent-ink:#4fc9b0; --accent-wash:#14312b;
     --warn:#b1811f; --warn-wash:#2f2612;
     --focus:#4fc9b0;
-    --shadow:0 1px 2px rgba(0,0,0,.35),0 10px 28px -16px rgba(0,0,0,.7);
+    --shadow:0 1px 2px rgba(0,0,0,.35),0 12px 32px -18px rgba(0,0,0,.75);
   }
 }
 :root[data-theme="dark"]{
   --ink:#e9efed; --ink-2:#c3d0cc; --muted:#93a5a0; --faint:#6d7f7a;
-  --paper:#0f1816; --surface:#182421; --surface-2:#1f2d29; --surface-3:#273733;
+  --paper:#0f1816; --surface:#182421; --surface-2:#1f2d29; --surface-3:#2b3b36;
   --rule:#2d3e39; --rule-soft:#22302c;
   --accent:#1f9d87; --accent-ink:#4fc9b0; --accent-wash:#14312b;
   --warn:#b1811f; --warn-wash:#2f2612;
   --focus:#4fc9b0;
-  --shadow:0 1px 2px rgba(0,0,0,.35),0 10px 28px -16px rgba(0,0,0,.7);
+  --shadow:0 1px 2px rgba(0,0,0,.35),0 12px 32px -18px rgba(0,0,0,.75);
 }
 
 *{box-sizing:border-box}
 body{
   margin:0;background:var(--paper);color:var(--ink);
-  font-family:"Instrument Sans",-apple-system,"Segoe UI",Helvetica,Arial,sans-serif;
-  font-size:16px;line-height:1.55;-webkit-font-smoothing:antialiased;
+  font-family:"Source Serif 4",Georgia,serif;font-size:17.5px;line-height:1.65;
+  -webkit-font-smoothing:antialiased;
 }
-.mono,.num{font-family:"IBM Plex Mono",ui-monospace,Menlo,monospace;font-variant-numeric:tabular-nums}
-h1,h2,h3{margin:0;text-wrap:balance;letter-spacing:-.02em}
+h1,h2,h3,h4,.ui{font-family:"Instrument Sans",-apple-system,"Segoe UI",Helvetica,Arial,sans-serif}
+h1,h2,h3{margin:0;text-wrap:balance;letter-spacing:-.022em}
 p{margin:0}
-button{font:inherit;color:inherit}
+.mono{font-family:"IBM Plex Mono",ui-monospace,Menlo,monospace;font-variant-numeric:tabular-nums}
 a{color:var(--accent-ink);text-underline-offset:2px}
 :focus-visible{outline:2px solid var(--focus);outline-offset:2px;border-radius:3px}
 
-/* ---- MOCKUP BANNER ---- */
-.mockbar{
-  background:var(--warn-wash);border-bottom:1px solid var(--warn);
-  padding:7px 16px;font-family:"IBM Plex Mono",monospace;font-size:11px;
-  letter-spacing:.09em;text-transform:uppercase;color:var(--warn);
-  display:flex;gap:12px;align-items:center;justify-content:center;flex-wrap:wrap;text-align:center
-}
+.wrap{max-width:800px;margin:0 auto;padding:0 22px 90px}
 
-/* ---- SHELL ---- */
-.shell{max-width:820px;margin:0 auto;padding:0 22px 80px}
-
-.topbar{display:flex;align-items:center;gap:14px;padding:20px 0 0;flex-wrap:wrap}
+/* ---- topbar ---- */
+.topbar{display:flex;align-items:center;gap:13px;padding:18px 0;border-bottom:1px solid var(--rule)}
 .brandmark{
-  width:30px;height:30px;border-radius:6px;background:var(--accent);flex:none;
-  display:grid;place-items:center;color:#fff;font-weight:700;font-size:13px;
+  width:28px;height:28px;border-radius:6px;background:var(--accent);flex:none;
+  display:grid;place-items:center;color:var(--paper);font-weight:700;font-size:12px;
   font-family:"IBM Plex Mono",monospace
 }
-:root[data-theme="dark"] .brandmark,
-:root:not([data-theme="light"]) .brandmark{color:#0f1816}
-@media (prefers-color-scheme:light){:root:not([data-theme="dark"]) .brandmark{color:#fff}}
-.brandtext{font-size:14px;font-weight:600;letter-spacing:-.01em;line-height:1.25}
-.brandtext small{display:block;font-weight:400;font-size:11.5px;color:var(--muted);letter-spacing:0}
+.brandtext{font-family:"Instrument Sans",sans-serif;font-size:13.5px;font-weight:600;line-height:1.3}
+.brandtext small{display:block;font-weight:400;font-size:11.5px;color:var(--muted)}
 .topspacer{flex:1}
 .ghostbtn{
-  background:transparent;border:1px solid var(--rule);border-radius:6px;
-  padding:6px 11px;font-size:13px;cursor:pointer;color:var(--ink-2)
+  background:transparent;border:1px solid var(--rule);border-radius:6px;padding:6px 12px;
+  font-family:"Instrument Sans",sans-serif;font-size:13px;cursor:pointer;color:var(--ink-2);
+  text-decoration:none;display:inline-block
 }
 .ghostbtn:hover{background:var(--surface-2);border-color:var(--accent);color:var(--accent-ink)}
 
-/* ---- PROGRESS RAIL ---- */
-.rail{display:flex;gap:5px;margin:20px 0 0;list-style:none;padding:0}
-.rail li{flex:1;height:3px;border-radius:2px;background:var(--rule);transition:background .2s}
-.rail li.done{background:var(--accent)}
-.rail li.now{background:var(--accent);opacity:.45}
-.railcap{
-  display:flex;justify-content:space-between;margin-top:8px;
-  font-family:"IBM Plex Mono",monospace;font-size:10.5px;letter-spacing:.08em;
-  text-transform:uppercase;color:var(--muted)
-}
-
-/* ---- SCREENS ---- */
-.screen{display:none;padding-top:30px}
-.screen.on{display:block;animation:fade .22s ease}
-@keyframes fade{from{opacity:0;transform:translateY(5px)}to{opacity:1;transform:none}}
-@media (prefers-reduced-motion:reduce){*{animation:none!important;transition:none!important}}
-
-/* ---- PRINTED NOTICE (travels with the PDF) ---- */
-.printnotice{
-  border:1.5px solid var(--warn);border-radius:8px;padding:16px 18px;margin:26px 0 0;
-  background:var(--warn-wash)
-}
-.printnotice h4{
-  margin:0 0 8px;font-size:11px;letter-spacing:.11em;text-transform:uppercase;
-  color:var(--warn);font-family:"IBM Plex Mono",monospace;font-weight:600
-}
-.printnotice p{font-size:13px;color:var(--ink-2);line-height:1.55}
-.printnotice p + p{margin-top:9px}
-.printnotice a{color:var(--warn);font-weight:600}
-
-@media print{
-  .mockbar,.topbar,.rail,.railcap,.actions,.tvwrap{display:none!important}
-  body{background:#fff;color:#000;font-size:11pt}
-  .card,.printnotice,figure{break-inside:avoid;box-shadow:none}
-  .printnotice{border:1.5pt solid #000;background:#fff;break-inside:avoid}
-  .printnotice h4,.printnotice a{color:#000}
-  a[href]:after{content:" (" attr(href) ")";font-size:9pt;word-break:break-all}
-}
-
+/* ---- hero ---- */
+.hero{padding:56px 0 40px;border-bottom:2px solid var(--ink)}
 .eyebrow{
-  font-family:"IBM Plex Mono",monospace;font-size:11px;letter-spacing:.13em;
-  text-transform:uppercase;color:var(--accent-ink);font-weight:600;margin-bottom:14px
+  font-family:"IBM Plex Mono",monospace;font-size:11px;letter-spacing:.14em;
+  text-transform:uppercase;color:var(--accent-ink);font-weight:600;margin-bottom:16px
 }
-h1{font-size:clamp(27px,4.6vw,38px);line-height:1.12;font-weight:700}
-h2{font-size:21px;font-weight:600;line-height:1.25}
-h3{font-size:15.5px;font-weight:600}
-.sub{font-size:17px;color:var(--ink-2);margin-top:14px;max-width:56ch}
-.small{font-size:14px;color:var(--muted)}
+h1{font-family:"Instrument Sans",sans-serif;font-size:clamp(31px,5.2vw,46px);line-height:1.08;font-weight:700}
+.standfirst{font-size:19px;color:var(--ink-2);margin-top:18px;max-width:58ch;line-height:1.55}
 
-.card{
-  background:var(--surface);border:1px solid var(--rule);border-radius:9px;
-  padding:20px 22px;margin:22px 0;box-shadow:var(--shadow)
+/* ---- sections ---- */
+section{margin:64px 0 0;scroll-margin-top:20px}
+.shead{display:flex;gap:14px;align-items:baseline;margin-bottom:10px}
+.snum{
+  font-family:"IBM Plex Mono",monospace;font-size:12px;font-weight:600;color:var(--accent-ink);
+  flex:none;padding-top:5px;letter-spacing:.05em
 }
-.card.flat{box-shadow:none}
-.card.formal{border-left:3px solid var(--accent)}
-.card p + p{margin-top:12px}
+h2{font-family:"Instrument Sans",sans-serif;font-size:26px;font-weight:600;line-height:1.2}
+h3{font-family:"Instrument Sans",sans-serif;font-size:16.5px;font-weight:600;margin:30px 0 8px}
+section p{margin:15px 0;max-width:64ch}
+.lede{font-size:18.5px;color:var(--ink-2)}
+strong{font-weight:600;color:var(--ink)}
 
-.actions{display:flex;gap:10px;margin-top:26px;flex-wrap:wrap;align-items:center}
+/* ---- nav chips ---- */
+.jump{display:flex;gap:8px;flex-wrap:wrap;margin:26px 0 0}
+.jump a{
+  font-family:"Instrument Sans",sans-serif;font-size:13px;text-decoration:none;
+  border:1px solid var(--rule);border-radius:20px;padding:7px 14px;color:var(--ink-2);background:var(--surface)
+}
+.jump a:hover{border-color:var(--accent);color:var(--accent-ink);background:var(--accent-wash)}
+
+/* ---- figure ---- */
+figure{
+  margin:26px 0;background:var(--surface);border:1px solid var(--rule);border-radius:10px;
+  padding:22px 24px;box-shadow:var(--shadow)
+}
+figure h4{
+  font-family:"Instrument Sans",sans-serif;font-size:15.5px;font-weight:600;margin:0 0 4px
+}
+figure .fsub{font-family:"Instrument Sans",sans-serif;font-size:13px;color:var(--muted);margin-bottom:18px}
+figcaption{
+  margin-top:16px;padding-top:13px;border-top:1px solid var(--rule-soft);
+  font-family:"Instrument Sans",sans-serif;font-size:12.5px;color:var(--muted);line-height:1.5
+}
+figcaption b{
+  font-family:"IBM Plex Mono",monospace;font-size:10.5px;letter-spacing:.09em;
+  text-transform:uppercase;color:var(--accent-ink);font-weight:600;display:block;margin-bottom:4px
+}
+
+/* ---- stacked bar ---- */
+.stack{display:flex;height:38px;border-radius:6px;overflow:hidden;gap:2px;background:var(--surface)}
+.seg{display:grid;place-items:center;font-family:"IBM Plex Mono",monospace;font-size:12px;font-weight:600;min-width:0}
+.seg.a{background:var(--accent);color:var(--paper)}
+.seg.n{background:var(--surface-3);color:var(--ink-2)}
+.seg.w{background:var(--warn);color:var(--paper)}
+.stacklab{
+  display:flex;justify-content:space-between;margin-top:9px;gap:14px;
+  font-family:"Instrument Sans",sans-serif;font-size:13px;color:var(--ink-2)
+}
+.stacklab span{display:flex;gap:7px;align-items:center}
+.sw{width:12px;height:11px;border-radius:3px;flex:none}
+.sw.a{background:var(--accent)} .sw.n{background:var(--surface-3)} .sw.w{background:var(--warn)}
+
+/* ---- hbars ---- */
+.hb{display:grid;grid-template-columns:150px 1fr 74px;gap:12px;align-items:center;padding:6px 0}
+.hb .n{font-family:"Instrument Sans",sans-serif;font-size:13.5px;text-align:right;color:var(--ink-2);line-height:1.25}
+.hb .t{height:17px;background:var(--surface-3);border-radius:4px;position:relative;overflow:hidden}
+.hb .f{position:absolute;inset:0 auto 0 0;background:var(--accent);border-radius:4px}
+.hb .v{font-family:"IBM Plex Mono",monospace;font-size:12.5px;font-weight:600;color:var(--ink-2)}
+
+/* ---- hero stat ---- */
+.bignum{
+  display:flex;gap:26px;align-items:baseline;flex-wrap:wrap;
+  padding:6px 0 2px
+}
+.bignum .n{
+  font-family:"Instrument Sans",sans-serif;font-size:clamp(46px,9vw,74px);font-weight:700;
+  line-height:.95;letter-spacing:-.04em;color:var(--warn);font-variant-numeric:tabular-nums
+}
+.bignum .n.ok{color:var(--accent)}
+.bignum .t{font-size:16px;color:var(--ink-2);max-width:34ch;font-family:"Instrument Sans",sans-serif;line-height:1.4}
+
+/* ---- matrix ---- */
+.mx{width:100%;border-collapse:collapse;font-family:"Instrument Sans",sans-serif;font-size:13.5px}
+.mx th{
+  text-align:left;font-size:10.5px;letter-spacing:.09em;text-transform:uppercase;color:var(--muted);
+  padding:9px 10px;border-bottom:1px solid var(--rule);font-weight:600
+}
+.mx th.c,.mx td.c{text-align:center;width:88px}
+.mx td{padding:10px;border-bottom:1px solid var(--rule-soft);color:var(--ink-2)}
+.mx tr:last-child td{border-bottom:none}
+.yes{color:var(--accent);font-weight:700}
+.no{color:var(--warn);font-weight:700}
+.mxscroll{overflow-x:auto}
+
+/* ---- bands ---- */
+.bands{display:flex;gap:2px;border-radius:6px;overflow:hidden;margin-top:4px}
+.band{padding:11px 12px;flex:1;font-family:"Instrument Sans",sans-serif;font-size:12.5px;text-align:center;line-height:1.35}
+.band b{display:block;font-family:"IBM Plex Mono",monospace;font-size:14px;margin-bottom:3px}
+.band.g{background:var(--accent-wash);color:var(--accent-ink)}
+.band.m{background:var(--surface-3);color:var(--ink-2)}
+.band.b{background:var(--warn-wash);color:var(--warn)}
+
+/* ---- pull quote ---- */
+blockquote.ps{
+  margin:30px 0;padding:24px 26px;background:var(--surface);
+  border:1px solid var(--rule);border-left:3px solid var(--accent);border-radius:8px;
+  box-shadow:var(--shadow)
+}
+blockquote.ps p{margin:0 0 13px;font-size:17px;line-height:1.6;max-width:none}
+blockquote.ps p:last-of-type{margin-bottom:0}
+blockquote.ps .k{font-weight:600;color:var(--ink)}
+blockquote.ps cite{
+  display:block;margin-top:16px;padding-top:13px;border-top:1px solid var(--rule-soft);
+  font-family:"IBM Plex Mono",monospace;font-size:10.5px;letter-spacing:.08em;
+  text-transform:uppercase;color:var(--muted);font-style:normal
+}
+
+/* ---- callout ---- */
+.call{
+  background:var(--surface);border:1px solid var(--rule);border-left:3px solid var(--accent);
+  border-radius:8px;padding:19px 22px;margin:26px 0
+}
+.call.warn{border-left-color:var(--warn)}
+.call .lab{
+  font-family:"IBM Plex Mono",monospace;font-size:10.5px;letter-spacing:.11em;text-transform:uppercase;
+  color:var(--accent-ink);font-weight:600;display:block;margin-bottom:8px
+}
+.call.warn .lab{color:var(--warn)}
+.call p{margin:0 0 11px;max-width:none}
+.call p:last-child{margin-bottom:0}
+
+/* ---- ladder ---- */
+.ladder{display:flex;flex-direction:column;gap:1px;background:var(--rule);border:1px solid var(--rule);border-radius:8px;overflow:hidden;margin:22px 0}
+.rung{background:var(--surface);padding:12px 16px;display:grid;grid-template-columns:38px 1fr;gap:14px;align-items:baseline}
+.rung .l{font-family:"IBM Plex Mono",monospace;font-size:11.5px;font-weight:600;color:var(--accent-ink)}
+.rung b{font-family:"Instrument Sans",sans-serif;font-size:14.5px}
+.rung p{margin:2px 0 0;font-size:14.5px;color:var(--muted);max-width:none}
+
+/* ---- cta ---- */
+.cta{
+  margin:60px 0 0;padding:30px 26px;background:var(--accent-wash);
+  border:1px solid var(--accent);border-radius:12px;text-align:center
+}
+.cta h3{margin:0 0 8px;font-size:20px}
+.cta p{margin:0 auto 20px;max-width:46ch;color:var(--ink-2);font-size:15.5px}
 .btn{
-  background:var(--accent);color:#fff;border:1px solid var(--accent);
-  border-radius:7px;padding:11px 20px;font-size:15px;font-weight:600;cursor:pointer
+  background:var(--accent);color:var(--paper);border:1px solid var(--accent);border-radius:8px;
+  padding:12px 24px;font-family:"Instrument Sans",sans-serif;font-size:15.5px;font-weight:600;
+  cursor:pointer;text-decoration:none;display:inline-block
 }
-:root[data-theme="dark"] .btn,:root:not([data-theme="light"]) .btn{color:#0f1816}
-@media (prefers-color-scheme:light){:root:not([data-theme="dark"]) .btn{color:#fff}}
 .btn:hover{filter:brightness(1.08)}
-.btn:disabled{opacity:.42;cursor:not-allowed;filter:none}
-.btn.sec{background:transparent;color:var(--ink-2);border-color:var(--rule)}
-.btn.sec:hover{background:var(--surface-2);filter:none;border-color:var(--accent)}
-.btn.sm{padding:8px 14px;font-size:13.5px}
 
-/* ---- FIELDS ---- */
-.field{margin:18px 0}
-.field > label,.qhead{
-  display:flex;gap:8px;align-items:flex-start;
-  font-size:14.5px;font-weight:600;margin-bottom:9px;line-height:1.4
+footer{
+  margin:64px 0 0;padding-top:20px;border-top:1px solid var(--rule);
+  font-family:"IBM Plex Mono",monospace;font-size:11.5px;color:var(--faint);line-height:1.8
 }
-.qid{
-  font-family:"IBM Plex Mono",monospace;font-size:11px;color:var(--accent-ink);
-  background:var(--accent-wash);border-radius:3px;padding:2px 6px;flex:none;margin-top:1px;font-weight:600
-}
-select,input[type=text]{
-  width:100%;background:var(--surface);color:var(--ink);
-  border:1px solid var(--rule);border-radius:7px;padding:10px 12px;font:inherit;font-size:15px
-}
-select:hover,input[type=text]:hover{border-color:var(--accent)}
-.grid2{display:grid;grid-template-columns:repeat(auto-fit,minmax(230px,1fr));gap:16px}
-
-/* pill radios (firm size etc) */
-.pills{display:flex;flex-wrap:wrap;gap:7px}
-.pills input{position:absolute;opacity:0;pointer-events:none}
-.pills label{
-  border:1px solid var(--rule);border-radius:20px;padding:7px 14px;
-  font-size:13.5px;cursor:pointer;background:var(--surface);color:var(--ink-2)
-}
-.pills label:hover{border-color:var(--accent)}
-.pills input:checked + label{background:var(--accent-wash);border-color:var(--accent);color:var(--accent-ink);font-weight:600}
-.pills input:focus-visible + label{outline:2px solid var(--focus);outline-offset:2px}
-
-/* level radio list */
-.opts{display:flex;flex-direction:column;gap:1px;background:var(--rule);border:1px solid var(--rule);border-radius:8px;overflow:hidden}
-.opts input{position:absolute;opacity:0;pointer-events:none}
-.opts label{
-  display:grid;grid-template-columns:30px 18px 1fr;gap:11px;align-items:start;
-  background:var(--surface);padding:11px 14px;cursor:pointer;font-size:14.5px;color:var(--ink-2)
-}
-.opts label:hover{background:var(--surface-2)}
-.opts .lv{font-family:"IBM Plex Mono",monospace;font-size:11px;color:var(--faint);font-weight:600;padding-top:3px}
-.opts .dot{width:15px;height:15px;border:1.5px solid var(--rule);border-radius:50%;margin-top:2px}
-.opts input:checked + label{background:var(--accent-wash);color:var(--ink);font-weight:500}
-.opts input:checked + label .dot{border-color:var(--accent);border-width:4.5px}
-.opts input:checked + label .lv{color:var(--accent-ink)}
-.opts input:focus-visible + label{outline:2px solid var(--focus);outline-offset:-2px}
-
-/* checkbox rows */
-.chk{display:flex;gap:10px;align-items:flex-start;font-size:14.5px;color:var(--ink-2);cursor:pointer;margin:9px 0}
-.chk input{width:16px;height:16px;margin:2px 0 0;accent-color:var(--accent);flex:none}
-
-/* ---- TOOLTIP ---- */
-.tip{position:relative;display:inline-flex;flex:none;margin-top:1px}
-.tipbtn{
-  width:17px;height:17px;border-radius:50%;border:1px solid var(--rule);
-  background:var(--surface-2);color:var(--muted);font-size:11px;font-weight:700;
-  cursor:pointer;display:grid;place-items:center;padding:0;line-height:1
-}
-.tipbtn:hover{border-color:var(--accent);color:var(--accent-ink)}
-.tipbody{
-  display:none;position:absolute;z-index:40;top:24px;left:-8px;width:min(310px,78vw);
-  background:var(--surface);border:1px solid var(--accent);border-radius:8px;
-  padding:13px 15px;box-shadow:var(--shadow);font-size:13.5px;font-weight:400;
-  color:var(--ink-2);line-height:1.5;text-align:left
-}
-.tip.open .tipbody{display:block}
-.tipbody .anchor{
-  display:block;margin-top:9px;padding-top:9px;border-top:1px solid var(--rule-soft);
-  font-family:"IBM Plex Mono",monospace;font-size:10.5px;letter-spacing:.05em;
-  text-transform:uppercase;color:var(--muted)
-}
-
-/* ---- DROPZONE ---- */
-.drop{
-  border:2px dashed var(--rule);border-radius:10px;padding:34px 22px;text-align:center;
-  background:var(--surface);cursor:pointer
-}
-.drop:hover{border-color:var(--accent);background:var(--accent-wash)}
-.drop .big{font-size:16px;font-weight:600;margin-bottom:5px}
-.drop.filled{border-style:solid;border-color:var(--accent);text-align:left;padding:18px 20px}
-
-/* ---- PAYLOAD ---- */
-pre.payload{
-  margin:0;background:var(--surface-2);border:1px solid var(--rule);border-radius:7px;
-  padding:14px 16px;overflow-x:auto;font-family:"IBM Plex Mono",monospace;
-  font-size:12px;line-height:1.65;color:var(--ink-2)
-}
-
-/* ---- METRIC GRID ---- */
-.mgrid{display:grid;grid-template-columns:repeat(auto-fit,minmax(158px,1fr));gap:1px;background:var(--rule);border:1px solid var(--rule);border-radius:8px;overflow:hidden}
-.mcell{background:var(--surface);padding:13px 15px}
-.mcell dt{font-family:"IBM Plex Mono",monospace;font-size:10px;letter-spacing:.09em;text-transform:uppercase;color:var(--muted);margin-bottom:6px}
-.mcell dd{margin:0;font-size:17px;font-weight:600;font-variant-numeric:tabular-nums}
-.mcell dd .unit{font-size:12.5px;font-weight:400;color:var(--muted);margin-left:3px}
-.mcell.flag dd{color:var(--warn)}
-
-/* ---- CHART ---- */
-.chart{margin:20px 0 6px}
-.crow{display:grid;grid-template-columns:132px 1fr 42px;gap:13px;align-items:center;padding:7px 0}
-.crow .cname{font-size:14px;font-weight:500;text-align:right;color:var(--ink-2);line-height:1.25}
-.ctrack{position:relative;height:19px;background:var(--surface-3);border-radius:4px}
-.cbar{position:absolute;left:0;top:0;bottom:0;background:var(--accent);border-radius:4px}
-.cclaim{position:absolute;top:-4px;bottom:-4px;width:2px;background:var(--ink);border-radius:1px}
-.cclaim::after{
-  content:"";position:absolute;top:-3px;left:-3px;
-  border-left:4px solid transparent;border-right:4px solid transparent;border-top:5px solid var(--ink)
-}
-.crow .cval{font-family:"IBM Plex Mono",monospace;font-size:13.5px;font-weight:600;font-variant-numeric:tabular-nums}
-.cscale{display:grid;grid-template-columns:132px 1fr 42px;gap:13px;margin-top:4px}
-.cticks{display:flex;justify-content:space-between;font-family:"IBM Plex Mono",monospace;font-size:10.5px;color:var(--faint)}
-.clegend{
-  display:flex;gap:18px;flex-wrap:wrap;margin-top:14px;padding-top:13px;
-  border-top:1px solid var(--rule-soft);font-size:12.5px;color:var(--muted)
-}
-.clegend span{display:flex;gap:7px;align-items:center}
-.swatch{width:13px;height:11px;border-radius:3px;background:var(--accent);flex:none}
-.swtick{width:2px;height:13px;background:var(--ink);flex:none}
-
-/* ---- DELTA ---- */
-.delta{
-  background:var(--warn-wash);border:1px solid var(--warn);border-radius:8px;
-  padding:15px 17px;margin:13px 0;display:grid;grid-template-columns:auto 1fr;gap:13px
-}
-.delta .ic{
-  width:21px;height:21px;border-radius:50%;background:var(--warn);color:var(--paper);
-  display:grid;place-items:center;font-size:13px;font-weight:700;flex:none
-}
-.delta h4{margin:0 0 5px;font-size:14.5px;font-weight:600;color:var(--warn)}
-.delta p{font-size:14px;color:var(--ink-2)}
-.delta .vs{display:flex;gap:20px;margin-top:10px;flex-wrap:wrap;font-size:13px}
-.delta .vs b{display:block;font-family:"IBM Plex Mono",monospace;font-size:11px;color:var(--muted);font-weight:500;letter-spacing:.06em;text-transform:uppercase}
-
-/* ---- RISK REGISTER ---- */
-.risks{list-style:none;padding:0;margin:14px 0 0;display:flex;flex-direction:column;gap:10px}
-.risks li{
-  background:var(--surface-2);border:1px solid var(--rule);border-left:3px solid var(--warn);
-  border-radius:7px;padding:14px 16px
-}
-.risks h4{margin:0 0 4px;font-size:14.5px;font-weight:600;color:var(--warn)}
-.risks p{font-size:13.5px;color:var(--ink-2)}
-
-/* ---- FIX LIST ---- */
-.fixes{list-style:none;padding:0;margin:16px 0;counter-reset:f}
-.fixes li{
-  counter-increment:f;display:grid;grid-template-columns:27px 1fr;gap:13px;
-  padding:13px 0;border-bottom:1px solid var(--rule-soft);align-items:start
-}
-.fixes li:last-child{border-bottom:none}
-.fixes li::before{
-  content:counter(f);font-family:"IBM Plex Mono",monospace;font-size:12px;font-weight:600;
-  color:var(--accent-ink);background:var(--accent-wash);border-radius:5px;
-  height:23px;display:grid;place-items:center
-}
-.fixes h4{margin:0 0 3px;font-size:14.5px;font-weight:600}
-.fixes p{font-size:13.5px;color:var(--muted)}
-
-/* ---- INDICES ---- */
-.idx2{display:grid;grid-template-columns:repeat(auto-fit,minmax(215px,1fr));gap:14px;margin:18px 0}
-.ix{background:var(--surface);border:1px solid var(--rule);border-radius:8px;padding:16px 18px}
-.ix .who{font-family:"IBM Plex Mono",monospace;font-size:10px;letter-spacing:.09em;text-transform:uppercase;color:var(--muted)}
-.ix .v{font-size:27px;font-weight:700;font-variant-numeric:tabular-nums;margin:7px 0 2px}
-.ix .v small{font-size:14px;font-weight:400;color:var(--muted)}
-.ix p{font-size:13px;color:var(--ink-2);margin-top:6px}
-
-table.tv{width:100%;border-collapse:collapse;font-size:13.5px;margin-top:10px}
-table.tv th,table.tv td{text-align:left;padding:8px 10px;border-bottom:1px solid var(--rule-soft)}
-table.tv th{font-size:10.5px;letter-spacing:.08em;text-transform:uppercase;color:var(--muted);font-weight:600}
-table.tv td.n{font-family:"IBM Plex Mono",monospace;font-variant-numeric:tabular-nums}
-details.tvwrap{margin-top:16px}
-details.tvwrap summary{cursor:pointer;font-size:13.5px;color:var(--accent-ink);font-weight:500}
 
 @media (max-width:600px){
-  .crow,.cscale{grid-template-columns:96px 1fr 38px;gap:9px}
-  .crow .cname{font-size:12.5px}
-  .opts label{grid-template-columns:26px 16px 1fr;gap:8px;font-size:14px}
+  .hb{grid-template-columns:96px 1fr 62px;gap:9px}
+  .hb .n{font-size:12.5px}
+  .bands{flex-direction:column}
+  figure{padding:18px 16px}
 }
-</style>
+@media (prefers-reduced-motion:reduce){*{animation:none!important;transition:none!important}}
 
-<div class="mockbar" id="mockbar">
-  <span>⚠ Mockup for review — canned data, nothing wired</span>
-  <span>·</span>
-  <span>v0.1 · 2026-08-21</span>
+.proposal p{font-size:17px;line-height:1.72;margin:0 0 18px;max-width:68ch}
+.proposal p:last-child{margin-bottom:0}
+.corr{border-bottom:1px dotted var(--warn);cursor:help}
+.dtable{width:100%;border-collapse:collapse;font-family:"Instrument Sans",sans-serif;font-size:14.5px;margin:20px 0}
+.dtable th{text-align:left;font-size:10.5px;letter-spacing:.09em;text-transform:uppercase;color:var(--muted);padding:10px 12px;border-bottom:1px solid var(--rule);font-weight:600}
+.dtable td{padding:11px 12px;border-bottom:1px solid var(--rule-soft);color:var(--ink-2);vertical-align:top}
+.dtable tr:last-child td{border-bottom:none}
+.dtable td.n{font-family:"IBM Plex Mono",monospace;color:var(--muted);white-space:nowrap}
+.dscroll{overflow-x:auto;border:1px solid var(--rule);border-radius:9px;background:var(--surface);margin:20px 0}
+.dscroll .dtable{margin:0}
+
+.nav{display:flex;gap:7px;flex-wrap:wrap;margin-left:auto}
+.nav a{font-family:"Instrument Sans",sans-serif;font-size:13px;text-decoration:none;
+  border:1px solid var(--rule);border-radius:6px;padding:6px 12px;color:var(--ink-2);background:transparent}
+.nav a:hover{border-color:var(--accent);color:var(--accent-ink);background:var(--accent-wash)}
+.nav a.on{border-color:var(--accent);color:var(--accent-ink);background:var(--accent-wash);font-weight:600}
+.startbar{margin:34px 0 0;padding:26px;background:var(--accent-wash);border:1px solid var(--accent);
+  border-radius:12px;display:flex;gap:20px;align-items:center;flex-wrap:wrap}
+.startbar div{flex:1;min-width:220px}
+.startbar h3{margin:0 0 5px;font-size:19px}
+.startbar p{margin:0;font-size:15px;color:var(--ink-2);max-width:46ch}
+</style>
+<div class="wrap">
+
+<div class="topbar">
+  <div class="brandmark">OB</div>
+  <div class="brandtext">OpenBIM Readiness Assessment Toolkit<small>Digital Infrastructure Management</small></div>
+  <div class="nav">
+    <a href="./" class="on">Overview</a>
+    <a href="assess.html">Assessment</a>
+    <a href="proposal.html">Proposal</a>
+    <a href="why.html">Background</a>
+    <a href="faq.html">Basics</a>
+    <a href="disclaimer.html">Notice</a>
+  </div>
 </div>
 
-<div class="shell">
+<div class="hero">
+  <p class="eyebrow">Research funding request &middot; 10 August 2026 &middot; Mohd Faizal Bin Yusof</p>
+  <h1>Development of an OpenBIM Readiness Assessment Toolkit for Digital Infrastructure Management</h1>
+</div>
 
-  <div class="topbar">
-    <div class="brandmark">OB</div>
-    <div class="brandtext">OpenBIM Readiness Assessment Toolkit<small>Research instrument · v0.1 draft</small></div>
-    <div class="topspacer"></div>
-    <button class="ghostbtn" id="themebtn" type="button">Theme</button>
-    <a class="ghostbtn" href="faq.html">Plain answers</a>
-    <a class="ghostbtn" id="helpbtn" href="why.html">? Read more</a>
+<section>
+  <div class="shead"><span class="snum">&mdash;</span><h2>Synopsis</h2></div>
+  <div class="proposal">
+<p>Digital transformation is reshaping how infrastructure assets are planned, delivered, operated, and maintained. In the UAE, Building Information Modelling (BIM) has become an increasingly important enabler of this transformation, supporting more integrated and data-driven approaches to infrastructure development and lifecycle management. OpenBIM strengthens this capability by adopting vendor-neutral open standards, principally the Industry Foundation Classes (IFC), enabling infrastructure information to be exchanged, integrated, and managed across diverse software platforms without dependence on proprietary systems. The benefits are well recognised, including improved interoperability, reduced software lock-in, and more effective collaboration among stakeholders throughout the asset lifecycle.</p><p>As BIM adoption matures, organisations are increasingly expected to move beyond proprietary BIM workflows towards more interoperable OpenBIM practices. This is also applicable in various <span class="corr" title="Corrected from &quot;third word countries&quot; in the source document.">third world countries</span>. This transition requires not only appropriate technologies, but also organisational readiness in areas such as governance, business processes, workforce capabilities, data management, and compliance with open standards. However, there is currently no simple and practical way for organisations to objectively assess their readiness for OpenBIM implementation or to identify the capability gaps that should be addressed before embarking on this transition.</p><p>This project addresses that gap by developing an OpenBIM Readiness Assessment Toolkit for Digital Infrastructure Management, a structured but easy-to-use way for an organisation to gauge how ready it is to adopt OpenBIM and to see the specific issues standing in its way. Readiness is assessed across the dimensions most associated with successful adoption: governance, people and skills, technology, data and standards, and organisational processes. The result shows an organisation where its capability gaps and implementation risks lie, and which areas to address first before committing to OpenBIM.</p><p>It helps to be precise about how the toolkit works and where its information comes from, because three roles are easily confused. First, a large language model (LLM) acts as the interviewer: instead of filling in a static questionnaire, a practitioner has a guided conversation with the LLM, which asks about the organisation's current practices, constraints, and concerns. Second, the practitioner is the source of evidence: the picture of industry readiness is built entirely from what real people in real organisations report, the LLM does not, and cannot, observe the industry on its own. Third, the toolkit measures those answers against a reference benchmark of OpenBIM good practice (described below), then scores readiness and produces tailored, vendor-neutral recommendations for capability development, standards adoption, and implementation planning.</p><p>That benchmark is provided by an existing open-source, browser-based OpenBIM platform that extracts and compiles IFC models, renders them directly in a standard web browser with no server-side dependency, and extends into asset, operations, and lifecycle management. The platform is not the subject of the study; it serves as a concrete, working example of what an open-standard BIM environment can deliver, giving the toolkit's recommendations a demonstrable reference point rather than an abstract ideal. Alongside it, a knowledge base of OpenBIM standards, readiness criteria, and implementation guidance supports the LLM's reasoning, and automated reporting turns each assessment into a readiness profile, gap analysis, and set of recommendations.</p>
   </div>
 
-  <ul class="rail" id="rail" hidden>
-    <li></li><li></li><li></li><li></li><li></li><li></li><li></li><li></li><li></li><li></li>
-  </ul>
-  <div class="railcap" id="railcap" hidden><span id="railnow">About you</span><span id="railpct">Step 1 of 5</span></div>
+  <div class="startbar">
+    <div>
+      <h3>Take the assessment</h3>
+      <p>Twenty questions and, optionally, one IFC file read inside your browser. About fifteen minutes.</p>
+    </div>
+    <a class="btn" href="assess.html">Start here</a>
+  </div>
+</section>
 
-  <div id="screens"></div>
+<section>
+  <div class="shead"><span class="snum">&mdash;</span><h2>Read further</h2></div>
+  <div class="dscroll"><table class="dtable"><tbody>
+    <tr><td class="n"><a href="proposal.html">The proposal</a></td><td>The funded proposal in full — research design, methodology, outsource requirements, deliverables and project plan.</td></tr>
+    <tr><td class="n"><a href="why.html">Background</a></td><td>What the industry actually certifies, where delivered models stand, and what closing the gap involves.</td></tr>
+    <tr><td class="n"><a href="faq.html">Basics</a></td><td>What OpenBIM is, what IFC is, and the terms the assessment uses.</td></tr>
+    <tr><td class="n"><a href="disclaimer.html">Disclaimer Notice</a></td><td>What this assessment can and cannot be used for, and the research declarations.</td></tr>
+  </tbody></table></div>
+</section>
+
+<footer>
+  OpenBIM Readiness Assessment Toolkit &middot; research instrument in development, v0.1<br>
+  Synopsis reproduced verbatim from the research funding request dated 10 August 2026, with one
+  typographical correction marked.
+</footer>
 
 </div>
 
 <script>
-/* ============================================================
-   MOCKUP ONLY — canned data, no scoring, no parsing, no network.
-   Real logic specified in SCORING_SPEC.md; wiring comes later.
-   ============================================================ */
-
-var TIP = function (text, anchor) {
-  return '<span class="tip"><button class="tipbtn" type="button" aria-label="Why we ask this">?</button>' +
-    '<span class="tipbody">' + text +
-    (anchor ? '<span class="anchor">Anchor · ' + anchor + '</span>' : '') + '</span></span>';
-};
-
-var LV = ['L0', 'L1', 'L2', 'L3', 'L4', 'L5'];
-function opts(name, list) {
-  return '<div class="opts">' + list.map(function (t, i) {
-    return '<input type="radio" name="' + name + '" id="' + name + i + '"' + (i === 1 ? ' checked' : '') + '>' +
-      '<label for="' + name + i + '"><span class="lv">' + LV[i] + '</span><span class="dot"></span><span>' + t + '</span></label>';
-  }).join('') + '</div>';
-}
-function q(id, title, tip, anchor, list) {
-  return '<div class="field"><div class="qhead"><span class="qid">' + id + '</span><span>' + title + '</span>' +
-    TIP(tip, anchor) + '</div>' + opts(id, list) + '</div>';
-}
-
-/* ---------- CANNED RESULTS ---------- */
-/* target = proportionate level for an 11-50 firm, engineering, mixed projects (§6.5) */
-var DIMS = [
-  { name: 'Governance',               measured: 2.0, claimed: 2.25, target: 3 },
-  { name: 'People and skills',        measured: 1.5, claimed: 1.75, target: 2 },
-  { name: 'Technology',               measured: 2.8, claimed: 3.00, target: 3 },
-  { name: 'Data and standards',       measured: 1.0, claimed: 3.25, target: 3 },
-  { name: 'Organisational processes', measured: 1.8, claimed: 2.00, target: 2 }
-];
-
-var SCREENS = {};
-
-/* ---------- 1 · INTRO ---------- */
-SCREENS.intro =
-  '<p class="eyebrow">Research instrument · open access</p>' +
-  '<h1>You&rsquo;re expected to deliver OpenBIM.<br>Nothing tells you whether you&rsquo;re ready.</h1>' +
-  '<p class="sub">Twenty questions about how your firm works, plus one IFC file we read inside your browser. ' +
-  'You get a checklist of what to fix, in order.</p>' +
-
-  '<div class="card formal">' +
-    '<p><strong>This OpenBIM Readiness Assessment Toolkit</strong> is a structured but easy-to-use way for an ' +
-    'organisation to gauge how ready it is to adopt OpenBIM and to see the specific issues standing in its way. ' +
-    'Readiness is assessed across the dimensions most associated with successful adoption: governance, people and ' +
-    'skills, technology, data and standards, and organisational processes.</p>' +
-    '<p>The result shows an organisation where its capability gaps and implementation risks lie, and which areas ' +
-    'to address first before committing to OpenBIM &mdash; combining what you report with metrics computed ' +
-    'directly from your own IFC model.</p>' +
-    '<p class="small"><strong>This is only a technical readiness assessment.</strong> It measures ' +
-    'organisational readiness and model data quality &mdash; nothing else. It qualifies nothing and no ' +
-    'one, confers no certification, licence or professional status, and is not evidence of compliance. ' +
-    'Where your regulations or appointment require insurance, indemnity or a formal qualification ' +
-    'process, that remains yours to satisfy directly.</p>' +
-  '</div>' +
-
-  '<div class="card">' +
-    '<h3>Before you start</h3>' +
-    '<p class="small" style="margin-top:9px">It takes about fifteen minutes. Your IFC file is read inside your ' +
-    'browser and is never uploaded &mdash; you can see exactly what would leave your device at any point.</p>' +
-    '<label class="chk" style="margin-top:14px"><input type="checkbox" checked>' +
-      '<span>Answer anonymously. No name, firm, email, or project details are collected.</span></label>' +
-    '<label class="chk"><input type="checkbox">' +
-      '<span>Include my (anonymous) results in the industry benchmark, so I can see how I compare.</span></label>' +
-  '</div>' +
-
-  '<p class="small" style="margin-top:20px">This toolkit is the artifact of a funded research ' +
-  'project. The proposal is published in full: <a href="proposal.html">read it</a>. New to any of ' +
-  'this? <a href="faq.html">Plain answers</a> covers the basics nobody wants to ask about.</p>' +
-
-  '<div class="actions">' +
-    '<button class="btn" data-go="agree">Start assessment</button>' +
-    '<button class="btn sec" data-go="results">Skip to sample results</button>' +
-  '</div>';
-
-/* ---------- 1b · ACKNOWLEDGEMENT GATE ---------- */
-SCREENS.agree =
-  '<p class="eyebrow">Before you begin</p>' +
-  '<h2>What this is, and what it is not</h2>' +
-  '<p class="sub small">Please read this. It takes thirty seconds and it decides how you may use the ' +
-  'result.</p>' +
-
-  '<div class="card" style="border-left:3px solid var(--warn)">' +
-    '<h3>Scope</h3>' +
-    '<p class="small" style="margin-top:8px"><strong>This is only a technical readiness assessment.</strong> ' +
-    'It measures organisational readiness for open-standard working and the data quality of a model you ' +
-    'supply. That is its entire scope. It says nothing about the lawfulness, safety, buildability or ' +
-    'professional adequacy of anything you produce.</p>' +
-
-    '<h3 style="margin-top:22px">It qualifies nothing and no one</h3>' +
-    '<p class="small" style="margin-top:8px">It confers no certification, accreditation, licence, approval ' +
-    'or professional status. It is not evidence of compliance with any regulation, standard, code or ' +
-    'contract, and must not be presented as such &mdash; to a client, an authority, an insurer, or in a ' +
-    'tender.</p>' +
-
-    '<h3 style="margin-top:22px">Nothing here is audited</h3>' +
-    '<p class="small" style="margin-top:8px">Your answers are self-reported and the measurements come from ' +
-    'a file you supply. No third party has witnessed, checked or attested to any of it.</p>' +
-
-    '<h3 style="margin-top:22px">Your obligations remain yours</h3>' +
-    '<p class="small" style="margin-top:8px">Where insurance, professional indemnity, licensing, ' +
-    'certification or a formal qualification process is required or applicable under your regulations, ' +
-    'contract or client requirements, that obligation is yours and must be discharged directly with the ' +
-    'responsible body. This report substitutes for none of it.</p>' +
-
-    '<h3 style="margin-top:22px">Your data</h3>' +
-    '<p class="small" style="margin-top:8px">Any model file you choose is read inside your browser and is ' +
-    'never uploaded. Submitting anonymous results at the end is optional, you will see the exact payload ' +
-    'first, and your checklist is complete either way.</p>' +
-
-    '<h3 style="margin-top:22px">Research instrument</h3>' +
-    '<p class="small" style="margin-top:8px">This is a work in progress supporting academic research. Its ' +
-    'criteria, thresholds and weightings are subject to expert validation and will change.</p>' +
-  '</div>' +
-
-  '<label class="chk" style="font-size:15px;margin:20px 0 0"><input type="checkbox" id="ackbox">' +
-    '<span>I have read and understood the above, and I understand this assessment qualifies nothing ' +
-    'and no one.</span></label>' +
-
-  '<div class="actions">' +
-    '<button class="btn" id="agreebtn" data-go="context" disabled>Agree and continue</button>' +
-    '<button class="btn sec" data-go="declined">I do not agree</button>' +
-  '</div>' +
-  '<p class="small" style="margin-top:16px"><a href="proposal.html">The research proposal</a> &nbsp;&middot;&nbsp; ' +
-  '<a href="faq.html">Plain answers</a> &nbsp;&middot;&nbsp; <a href="disclaimer.html">Read the full Disclaimer Notice ' +
-  '&rarr;</a> &nbsp;&middot;&nbsp; <span class="mono">Terms v0.1 &middot; 22 Aug 2026</span></p>';
-
-/* ---------- 1c · DECLINED ---------- */
-SCREENS.declined =
-  '<p class="eyebrow">No assessment taken</p>' +
-  '<h2>That is a legitimate answer</h2>' +
-  '<p class="sub">Nothing has been recorded and nothing has left your device. If the limits on what this ' +
-  'can tell you make it not worth your time, that is a reasonable read &mdash; it is a narrow instrument ' +
-  'by design.</p>' +
-  '<div class="card">' +
-    '<h3>You may still find these useful</h3>' +
-    '<p class="small" style="margin-top:9px">The background reading covers what the industry actually ' +
-    'certifies, where delivered models really stand, and what closing the gap involves. None of it ' +
-    'requires taking the assessment.</p>' +
-  '</div>' +
-  '<div class="actions">' +
-    '<a class="btn" href="why.html">Read the background</a>' +
-    '<a class="btn sec" href="faq.html">Plain answers</a>' +
-    '<button class="btn sec" data-go="agree">Back</button>' +
-  '</div>';
-
-/* ---------- 2 · CONTEXT ---------- */
-SCREENS.context =
-  '<p class="eyebrow">Step 3 of 10 &middot; About you</p>' +
-  '<h2>A little context</h2>' +
-  '<p class="sub small">None of this identifies you. It selects the right rules for your jurisdiction and ' +
-  'places you in a comparable group.</p>' +
-
-  '<div class="card">' +
-    '<div class="grid2">' +
-      '<div class="field"><label for="c1">Country <span class="small">&mdash; sets your locale pack</span></label>' +
-        '<select id="c1">' +
-          '<option>Malaysia</option><option selected>United Arab Emirates</option>' +
-          '<option>Singapore</option><option>United Kingdom</option>' +
-          '<option>Australia</option><option>Other &mdash; drafted live, marked provisional</option>' +
-        '</select></div>' +
-      '<div class="field"><label for="c4">Type of firm</label>' +
-        '<select id="c4">' +
-          '<option>Architecture</option><option selected>Engineering (structural / MEP)</option>' +
-          '<option>Contractor</option><option>Developer / owner</option>' +
-          '<option>Facilities management</option><option>Multidisciplinary consultant</option>' +
-        '</select></div>' +
-    '</div>' +
-
-    '<div class="field"><label>Firm size</label><div class="pills">' +
-      ['1', '2–10', '11–50', '51–200', '200+'].map(function (s, i) {
-        return '<input type="radio" name="c2" id="c2' + i + '"' + (i === 2 ? ' checked' : '') + '>' +
-               '<label for="c2' + i + '">' + s + '</label>';
-      }).join('') + '</div></div>' +
-
-    '<div class="field"><label for="c3">Your role</label>' +
-      '<select id="c3">' +
-        '<option>Principal / owner</option><option selected>Technical or BIM lead</option>' +
-        '<option>Project manager</option><option>Designer / engineer</option>' +
-        '<option>Owner-side / facilities</option><option>Other</option>' +
-      '</select></div>' +
-
-    '<div class="field"><label for="c6">In one sentence, what made you open this? ' +
-      '<span class="small">&mdash; optional, stays on your device</span></label>' +
-      '<input type="text" id="c6" value="A client has started asking for IFC and we are not sure we can deliver it."></div>' +
-  '</div>' +
-
-  '<div class="actions">' +
-    '<button class="btn" data-go="dim0">Continue</button>' +
-    '<button class="btn sec" data-go="agree">Back</button>' +
-  '</div>';
-
-/* ---------- THE 20 SCORED ITEMS ---------- */
-/* pre = mockup's canned answer index, chosen to reproduce the results screen. */
-var DIMENSIONS = [
-{ key:'A', name:'Governance', blurb:'How your firm is set up', items:[
-  { id:'A1', pre:2, q:'Is there a written position on open / IFC deliverables?',
-    tip:'A policy that exists but is never checked behaves differently from one that is enforced. We are separating those two, not judging either.',
-    anchor:'ISO 19650-1 &middot; organisational information requirements',
-    o:['Nothing, and it has not come up','It happens case by case, when someone remembers','Written into a policy or BEP template and kept current','A standard position applied across all projects','Compliance is checked and reported per project','Those reports drive changes to the policy'] },
-  { id:'A2', pre:3, q:'Your most recent contract &mdash; what did it say about deliverable format?',
-    tip:'Naming IFC and naming a schema version are different commitments. The second is checkable; the first often is not.',
-    anchor:'ISO 19650-2 &middot; exchange information requirements',
-    o:['Did not mention format, or I don&rsquo;t know','Format agreed informally, project by project','Named IFC in the appointment documents','A standard clause naming IFC and a schema version, every appointment','Conformance to that clause is verified at handover','Verification findings feed back into the clause'] },
-  { id:'A3', pre:1, q:'Have you ever taken a finished model out of your BIM software and opened it elsewhere?',
-    tip:'&ldquo;We own our data&rdquo; is a belief until somebody has actually pulled a model out and opened it somewhere else. This is the single strongest signal of lock-in exposure.',
-    anchor:'Vendor lock-in &middot; data portability',
-    o:['Never tried','Tried once, ad hoc','Done on delivery and the result is kept','A standard step in every project close-out','Fidelity is measured against the source each time','Those measurements change how we export'] },
-  { id:'A4', pre:3, q:'For authority submission, what do you actually hand over?',
-    tip:'Submission requirements vary by jurisdiction &mdash; your locale pack adjusts this question. If model-based submission does not exist where you work, choose N/A and it is excluded from scoring rather than counted as a zero.',
-    anchor:'Locale pack &middot; authority submission route',
-    o:['Paper or PDF drawings only','Native model files, as asked','IFC alongside other formats','IFC to the authority&rsquo;s named schema, every submission','Validated against the authority&rsquo;s criteria before sending','Validation findings change our authoring templates'], na:true }
-]},
-{ key:'B', name:'People and skills', blurb:'Who actually knows this, and what happens without them', items:[
-  { id:'B1', pre:2, q:'Who in the firm could explain what an IFC property set is?',
-    tip:'Not a test of anyone&rsquo;s knowledge. We are finding out whether open-standards understanding sits with one person or is spread &mdash; that difference decides how fragile your capability is.',
-    anchor:'ISO 19650-1 &middot; information management competence',
-    o:['Nobody','One person, self-taught','One person, and it is written down somewhere','Most of the technical team, through defined onboarding','Competence is assessed and tracked','Assessment results drive the training programme'] },
-  { id:'B2', pre:2, q:'Is information or BIM management in anyone&rsquo;s job description?',
-    tip:'Doing the job and being accountable for it are different things. A role with time allocated behaves differently from someone absorbing it on top of their real work.',
-    anchor:'ISO 19650-1 &middot; Information Manager function',
-    o:['No','Someone does it informally','Part of a named role, with time allocated','A defined role with documented responsibilities','Role performance is measured','Measurement reshapes the role'] },
-  { id:'B3', pre:1, q:'If that person left tomorrow, what happens?',
-    tip:'The most honest question in this section. Firms often score well on capability and badly here, and it is the best single predictor of whether a BIM programme survives a resignation.',
-    anchor:'Key-person concentration &middot; continuity',
-    o:['BIM capability stops','Severely degraded for months','Slowed; some handover notes exist','Documented handover and a defined backup role','Continuity is tested, not assumed','Test results drive succession planning'] },
-  { id:'B4', pre:2, q:'Has anyone had BIM or open-standards training in the last 12 months?',
-    tip:'Vendor product training and open-standards training are different investments. Learning one application deeply can even increase lock-in &mdash; that is not a criticism, just a different thing.',
-    anchor:'Succar &middot; competency development',
-    o:['None','Self-taught only','Vendor product training, when budget allowed','A defined training path including open standards','Training outcomes are measured','Measured outcomes set next year&rsquo;s programme'] }
-]},
-{ key:'C', name:'Technology', blurb:'What you run, and what it would take to change it', items:[
-  { id:'C1', pre:3, q:'How many BIM authoring tools are in regular use?',
-    tip:'One tool used well is not a failure. We are measuring concentration, not sophistication &mdash; a single-tool firm is efficient and exposed at the same time.',
-    anchor:'Vendor concentration &middot; switching cost',
-    o:['None','Exactly one, by default','One main, one occasional','Tool choice is a defined decision per task','Exchange between them is measured for loss','Those measurements drive the toolchain'] },
-  { id:'C2', pre:4, q:'Last time you received an IFC from someone else, what happened?',
-    tip:'The most useful answer here is usually &ldquo;geometry fine, data missing&rdquo;. That is the normal state of IFC exchange and worth recording honestly rather than rounding up.',
-    anchor:'buildingSMART &middot; IFC exchange fidelity',
-    o:['Never received one','Opened but unusable','Geometry fine, data missing','Opened and used within a defined workflow','Import quality is checked and recorded','Findings go back to the sender and the exchange improves'] },
-  { id:'C3', pre:2, q:'What most limits how many people here use BIM tools?',
-    tip:'If licence cost is the answer, say so. That is the constraint the open route is most likely to relieve, and understating it makes your recommendations less useful.',
-    anchor:'Adoption barriers &middot; licensing',
-    o:['Licence cost, severely','Licence cost, significantly','Hardware or skills, being managed','Access is planned and provisioned','Utilisation is measured against need','Measurement drives licensing decisions'] },
-  { id:'C4', pre:3, q:'Has the firm ever evaluated an alternative to its main BIM tool?',
-    tip:'Not a loyalty question. Having tested an alternative is what turns &ldquo;we could move if we had to&rdquo; from a hope into a known quantity.',
-    anchor:'Switching cost &middot; optionality',
-    o:['Never considered it','Discussed only','Someone trialled one','Evaluation is a defined periodic exercise','Switching cost is quantified','That figure informs procurement'] }
-]},
-{ key:'D', name:'Data and standards', blurb:'What is actually inside the model', items:[
-  { id:'D1', pre:4, q:'Do your models use a classification system?',
-    tip:'A file-naming convention is not a classification system. Both are useful and they answer different questions &mdash; the gap analysis needs to know which one you actually have.',
-    anchor:'ISO 12006-2 &middot; Uniclass / OmniClass / MasterFormat',
-    o:['No','A file-naming convention only','A classification standard, partly applied','Applied consistently through a defined process','Coverage is measured and reported per project','Coverage figures drive template changes'] },
-  { id:'D2', pre:3, q:'Is what the model must contain written down before the project starts?',
-    tip:'This is about information requirements, whatever they are called locally. Written before the project behaves very differently from agreed as you go.',
-    anchor:'ISO 19650-2 &middot; EIR / AIR',
-    o:['No','Verbally agreed','A written requirement exists','A standard requirement applied to every project','Compliance is measured at handover','Measurement changes the standard requirement'] },
-  { id:'D3', pre:4, q:'Before sending an IFC out, is it checked?',
-    tip:'Opening it to see whether it looks right is a real answer and a common one. We are separating &ldquo;looked at it&rdquo; from &ldquo;ran it through something that reports errors&rdquo;.',
-    anchor:'buildingSMART &middot; validation service',
-    o:['Never sent one','Not checked','Opened once to eyeball it','Checked against a defined expectation, every issue','Validated with a checker tool and results recorded','Recorded results drive authoring changes'] },
-  { id:'D4', pre:2, q:'Where will your finished project models be in five years?',
-    tip:'An asset outlives the software that modelled it by decades. This is the question owners eventually ask, and most firms have never been asked it.',
-    anchor:'ISO 19650-3 &middot; long-term information stewardship',
-    o:['Nowhere specific','Native format on a server somewhere','Deliberately archived, native only','A defined archive process including IFC','Archive readability is tested periodically','Test results change the archive policy'] }
-]},
-{ key:'E', name:'Organisational processes', blurb:'How the work actually flows', items:[
-  { id:'E1', pre:2, q:'How is model data shared on a project?',
-    tip:'A shared drive is a real answer. We are distinguishing a place where files sit from an environment that manages versions, status, and who has what.',
-    anchor:'ISO 19650-1 &middot; Common Data Environment',
-    o:['Email or file transfer','A shared drive','A CDE for documents','A CDE handling models, with defined states','CDE compliance is measured','Measurement drives CDE configuration'] },
-  { id:'E2', pre:3, q:'Are model exchanges scheduled?',
-    tip:'Ad hoc on request is extremely common and not a failure. Scheduled exchange is what lets other disciplines plan around you.',
-    anchor:'ISO 19650-2 &middot; information delivery planning',
-    o:['Ad hoc, on request','Around milestones, informally','Defined in a plan','A standard delivery plan on every project','Exchange punctuality is measured','Measurement changes the plan'] },
-  { id:'E3', pre:1, q:'After handover, is the model used for anything?',
-    tip:'Most models stop at handover. If yours does, that is the normal case &mdash; and it is the largest unrealised value in the whole lifecycle.',
-    anchor:'ISO 19650-3 &middot; asset information model',
-    o:['No','Occasionally referenced','Handed over, unclear if used','A defined role in FM or asset management','Its operational value is measured','Measurement drives what we model'] },
-  { id:'E4', pre:2, q:'Is anything about your BIM work measured?',
-    tip:'Anecdotes count as an honest &ldquo;no&rdquo;. Without measurement there is no way to tell whether a change you make actually worked.',
-    anchor:'ISO/IEC 33020 &middot; measurement and improvement',
-    o:['No','Anecdotally','Some metrics collected','A defined metric set on every project','Metrics reviewed against targets','Reviews change how projects run'] }
-]}
-];
-
-function renderItem(it) {
-  var rows = it.o.map(function (t, i) {
-    return '<input type="radio" name="' + it.id + '" id="' + it.id + i + '"' + (i === it.pre ? ' checked' : '') + '>' +
-      '<label for="' + it.id + i + '"><span class="lv">' + LV[i] + '</span><span class="dot"></span><span>' + t + '</span></label>';
-  }).join('');
-  if (it.na) {
-    rows += '<input type="radio" name="' + it.id + '" id="' + it.id + 'na">' +
-      '<label for="' + it.id + 'na"><span class="lv">N/A</span><span class="dot"></span>' +
-      '<span>No model-based submission exists in our market <em class="small">&mdash; excluded from scoring</em></span></label>';
-  }
-  rows += '<input type="radio" name="' + it.id + '" id="' + it.id + 'dk">' +
-    '<label for="' + it.id + 'dk"><span class="lv">&mdash;</span><span class="dot"></span>' +
-    '<span>Not known to me <em class="small">&mdash; scored as insufficient evidence, never as zero</em></span></label>';
-  return '<div class="field"><div class="qhead"><span class="qid">' + it.id + '</span><span>' + it.q + '</span>' +
-    TIP(it.tip, it.anchor) + '</div><div class="opts">' + rows + '</div></div>';
-}
-
-function dimScreen(n) {
-  var d = DIMENSIONS[n];
-  return '<p class="eyebrow">Step ' + (n + 4) + ' of 10 &nbsp;&middot;&nbsp; ' + d.name +
-      ' &nbsp;&middot;&nbsp; section ' + (n + 1) + ' of 5</p>' +
-    '<h2>' + d.blurb + '</h2>' +
-    '<p class="sub small">Each question asks about the <strong>last real instance</strong>, not general practice. ' +
-    'There is no right answer here &mdash; only an accurate one. Tap <strong>?</strong> on any question to see why we ask it.</p>' +
-    '<div class="card">' + d.items.map(renderItem).join('') + '</div>' +
-    '<div class="actions">' +
-      '<button class="btn" data-go="' + (n < 4 ? 'dim' + (n + 1) : 'model') + '">' +
-        (n < 4 ? 'Continue to ' + DIMENSIONS[n + 1].name : 'Continue to model check') + '</button>' +
-      '<button class="btn sec" data-go="' + (n > 0 ? 'dim' + (n - 1) : 'context') + '">Back</button>' +
-    '</div>';
-}
-
-/* ---------- 4 · MODEL ---------- */
-SCREENS.model =
-  '<p class="eyebrow">Step 9 of 10 &middot; Your model</p>' +
-  '<h2>Now let&rsquo;s look at an actual file</h2>' +
-  '<p class="sub small">This is the part a questionnaire cannot do. We read the file here, in your browser, and ' +
-  'compare what it contains against what you just told us. <strong>The file is never uploaded.</strong></p>' +
-
-  '<div class="drop filled" id="drop">' +
-    '<div style="display:flex;gap:13px;align-items:center;flex-wrap:wrap">' +
-      '<div class="brandmark" style="background:var(--accent-wash);color:var(--accent-ink)">IFC</div>' +
-      '<div style="flex:1;min-width:170px">' +
-        '<div style="font-weight:600;font-size:15px">Tower_ARC_Rev04.ifc</div>' +
-        '<div class="small mono">IFC2X3 · 84.2 MB · read locally · 12,847 elements</div>' +
-      '</div>' +
-      '<button class="btn sec sm" type="button">Choose a different file</button>' +
-    '</div>' +
-  '</div>' +
-
-  '<div class="card">' +
-    '<h3>What we found in it</h3>' +
-    '<dl class="mgrid" style="margin-top:13px">' +
-      '<div class="mcell"><dt>Schema</dt><dd class="mono">IFC2X3</dd></div>' +
-      '<div class="mcell"><dt>Elements</dt><dd class="mono">12,847</dd></div>' +
-      '<div class="mcell"><dt>Spatial chain</dt><dd>Complete</dd></div>' +
-      '<div class="mcell flag"><dt>Spaces (rooms)</dt><dd class="mono">0</dd></div>' +
-      '<div class="mcell flag"><dt>Classified</dt><dd class="mono">4.2<span class="unit">%</span></dd></div>' +
-      '<div class="mcell flag"><dt>Property sets</dt><dd class="mono">39<span class="unit">%</span></dd></div>' +
-      '<div class="mcell flag"><dt>Quantities</dt><dd>Absent</dd></div>' +
-      '<div class="mcell flag"><dt>Duplicate GUIDs</dt><dd class="mono">47</dd></div>' +
-    '</dl>' +
-    '<p class="small" style="margin-top:14px">Counted from the file directly, not from anything we stored &mdash; ' +
-    'so these are your model&rsquo;s numbers, not our extractor&rsquo;s view of it.</p>' +
-  '</div>' +
-
-  '<div class="card">' +
-    '<h3>Exactly what would leave your browser</h3>' +
-    '<p class="small" style="margin:9px 0 13px">Numbers and fixed categories only. No file, no names, no GUIDs, ' +
-    'no coordinates, no free text.</p>' +
-    '<pre class="payload">{\n' +
-      '  "locale":        "AE",\n' +
-      '  "firm_size":     "11-50",\n' +
-      '  "firm_type":     "engineering",\n' +
-      '  "answers":       [1,2,0,1, 1,1,2,1, 2,2,3,2, 3,1,4,0, 1,2,1,1],\n' +
-      '  "schema":        "IFC2X3",\n' +
-      '  "elements":      12847,\n' +
-      '  "spaces":        0,\n' +
-      '  "classified_pc": 4.2,\n' +
-      '  "psets_pc":      39.0,\n' +
-      '  "quantities":    false,\n' +
-      '  "georef":        true,\n' +
-      '  "dup_guids":     47,\n' +
-      '  "exporter":      "other",\n' +
-      '  "toolkit":       "v0.1",\n' +
-      '  "kb":            "core-0.1 / ae-v1"\n}</pre>' +
-    '<label class="chk" style="margin-top:14px"><input type="checkbox">' +
-      '<span>Send this. Optional &mdash; your checklist is complete either way.</span></label>' +
-  '</div>' +
-
-  '<div class="actions">' +
-    '<button class="btn" data-go="results">See my results</button>' +
-    '<button class="btn sec" data-go="dim4">Back</button>' +
-  '</div>';
-
-/* ---------- 5 · RESULTS ---------- */
-function chartRows() {
-  return DIMS.map(function (d) {
-    var w = (d.measured / 5 * 100).toFixed(1), t = (d.target / 5 * 100).toFixed(1);
-    var met = d.measured >= d.target;
-    var short = (d.target - d.measured);
-    return '<div class="crow" title="' + d.name + ' — assessed ' + d.measured.toFixed(1) +
-      ', proportionate target ' + d.target + '">' +
-      '<div class="cname">' + d.name + '</div>' +
-      '<div class="ctrack"><div class="ctarget" style="width:' + t + '%"></div>' +
-      '<div class="cbar" style="width:' + w + '%"></div>' +
-      '<div class="cclaim" style="left:' + t + '%"></div></div>' +
-      '<div class="cval"' + (met ? ' style="color:var(--accent)"' : '') + '>' +
-      (met ? 'met' : '&minus;' + short.toFixed(1)) + '</div></div>';
-  }).join('');
-}
-
-SCREENS.results =
-  '<p class="eyebrow">Step 10 of 10 &middot; Your results</p>' +
-  '<h2>Where you stand</h2>' +
-  '<p class="sub small">Two numbers per dimension: what your answers claimed, and what the evidence supports. ' +
-  'Where they disagree by two levels or more, the measurement is used and the gap is shown.</p>' +
-
-  '<div class="card">' +
-    '<h3>Readiness profile</h3>' +
-    '<p class="small" style="margin-top:5px">ISO/IEC 33020 capability levels 0&ndash;5, against a target proportionate to your firm</p>' +
-    '<div class="chart">' + chartRows() +
-      '<div class="cscale"><span></span><div class="cticks">' +
-        '<span>0</span><span>1</span><span>2</span><span>3</span><span>4</span><span>5</span></div><span></span></div>' +
-    '</div>' +
-    '<div class="clegend">' +
-      '<span><i class="swatch"></i>Assessed level</span>' +
-      '<span><i class="swtick"></i>Proportionate target for a firm your size</span>' +
-      '<span class="small">Targets follow ISO/IEC 33020 &mdash; capability is meant to suit the risk, not be maximised</span>' +
-    '</div>' +
-    '<details class="tvwrap"><summary>View as a table</summary>' +
-      '<table class="tv"><thead><tr><th>Dimension</th><th>Assessed</th><th>Target</th><th>Gap</th><th>You said</th></tr></thead><tbody>' +
-      DIMS.map(function (d) {
-        var g = d.target - d.measured;
-        return '<tr><td>' + d.name + '</td><td class="n">' + d.measured.toFixed(1) + '</td><td class="n">' +
-          d.target + '</td><td class="n">' + (g <= 0 ? 'met' : '&minus;' + g.toFixed(1)) + '</td><td class="n">' +
-          d.claimed.toFixed(2) + '</td></tr>';
-      }).join('') + '</tbody></table></details>' +
-  '</div>' +
-
-  '<div class="card">' +
-    '<h3>Gap analysis</h3>' +
-    '<p class="small" style="margin-top:5px">Capability gaps, implementation risks, and where your model disagreed with your answers</p>' +
-    '<div class="delta" style="margin-top:13px">' +
-      '<div class="ic">!</div><div>' +
-        '<h4>Classification</h4>' +
-        '<p>You reported that classification coverage is measured and reported per project. 4.2% of elements in the file carry a ' +
-        'classification reference. We scored the measurement.</p>' +
-        '<div class="vs"><span><b>You said</b>L3 · applied consistently</span>' +
-        '<span><b>Measured</b>L1 · 4.2% coverage</span></div>' +
-      '</div></div>' +
-    '<div class="delta">' +
-      '<div class="ic">!</div><div>' +
-        '<h4>Quality checking before issue</h4>' +
-        '<p>You reported validating IFC with a checker tool before sending. The file carries 47 duplicate GUIDs, ' +
-        'which a checker would have caught.</p>' +
-        '<div class="vs"><span><b>You said</b>L4 · validated with a tool</span>' +
-        '<span><b>Measured</b>L1 · 47 duplicate GUIDs</span></div>' +
-      '</div></div>' +
-    '<p class="small">This is not a gotcha. Most firms score differently on claim and evidence, and the gap is ' +
-    'usually a reporting problem rather than a competence one &mdash; but it is the most useful thing here.</p>' +
-
-    '<h3 style="margin-top:28px">Implementation risks</h3>' +
-    '<p class="small" style="margin-top:5px">Things that can stop a transition regardless of how capable you are. ' +
-    'These are flagged, not scored.</p>' +
-    '<ul class="risks">' +
-      '<li><div><h4>Professional indemnity position is unchecked</h4>' +
-      '<p>You have not confirmed with your insurer or counsel whether delivering on open standards, or ' +
-      'using non-proprietary tooling, affects your cover. <strong>This toolkit cannot answer that and does ' +
-      'not try to.</strong> What it can tell you is that software warranty disclaimers are near-universal ' +
-      '&mdash; proprietary licences carry them too &mdash; and that professional indemnity insures the ' +
-      'professional, not the tool. Put the question to your insurer in writing before it becomes urgent.</p></div></li>' +
-      '<li><div><h4>No named accountable party for information</h4>' +
-      '<p>Governance sits below its proportionate target and no one role carries information management ' +
-      'with authority. Under ISO 19650 that accountability does not disappear &mdash; it defaults upward to ' +
-      'whoever signed.</p></div></li>' +
-      '<li><div><h4>Single-vendor continuity</h4>' +
-      '<p>No model has been retrieved from your authoring tool and opened elsewhere, so the cost and ' +
-      'feasibility of moving is unknown rather than low.</p></div></li>' +
-    '</ul>' +
-  '</div>' +
-
-  '<div class="card">' +
-    '<h3>Recommendations</h3>' +
-    '<p class="small" style="margin-top:5px">Capability development &middot; standards adoption &middot; implementation planning &mdash; ordered by how much each unlocks downstream</p>' +
-    '<ol class="fixes">' +
-      '<li><div><h4>Add spaces to the model</h4><p>Zero IfcSpace entities. Rooms are the spine of anything ' +
-      'downstream &mdash; FM, area schedules, analysis. Nothing that needs a room can consume this file.</p></div></li>' +
-      '<li><div><h4>Classify at type level, not element level</h4><p>234 of 339 types carry no code. Coding types ' +
-      'rather than 12,847 elements is roughly a day of work instead of a month.</p></div></li>' +
-      '<li><div><h4>Resolve 47 duplicate GUIDs before the next issue</h4><p>Duplicates break round-tripping and ' +
-      'change tracking silently.</p></div></li>' +
-      '<li><div><h4>Turn on quantity export</h4><p>No IfcElementQuantity present, so nothing downstream can do ' +
-      'cost or carbon from this model.</p></div></li>' +
-      '<li><div><h4>Write down what the model must contain, before the next project starts</h4>' +
-      '<p>Your lowest-scoring governance item, and the cheapest to fix.</p></div></li>' +
-    '</ol>' +
-  '</div>' +
-
-  '<div class="idx2">' +
-    '<div class="ix"><span class="who">Can we start?</span>' +
-      '<div class="v">1.9<small> / 5</small></div>' +
-      '<div style="font-weight:600;font-size:14px">Entry readiness</div>' +
-      '<p>The open route is reachable, but not with this model as it stands.</p></div>' +
-    '<div class="ix"><span class="who">How exposed are we?</span>' +
-      '<div class="v">3.9<small> / 5</small></div>' +
-      '<div style="font-weight:600;font-size:14px">Lock-in exposure</div>' +
-      '<p>High. No model has been retrieved from your authoring tool and re-opened elsewhere.</p></div>' +
-  '</div>' +
-
-  '<div class="card flat" style="background:var(--surface-2)">' +
-    '<h3>Compare yourself to others</h3>' +
-    '<p class="small" style="margin-top:8px">No assessments have been submitted yet &mdash; yours would be the ' +
-    'first. As responses accumulate this becomes a real industry picture, built from practitioners rather than ' +
-    'asserted.</p>' +
-  '</div>' +
-
-  '<div class="card" style="border-left:3px solid var(--warn)">' +
-    '<h3 style="color:var(--warn)">Before you share this</h3>' +
-    '<p class="small" style="margin-top:8px"><strong>This assessment qualifies nothing and no one.</strong> ' +
-    'It confers no certification, accreditation, licence, approval or professional status, and it is not ' +
-    'evidence of compliance with any regulation, standard, code or contract. Do not present it as such &mdash; ' +
-    'to a client, an authority, an insurer, or in a tender.</p>' +
-    '<p class="small">Nothing here is audited or verified. The answers are yours and the measurements come ' +
-    'from a file you supplied; no third party has checked any of it.</p>' +
-    '<p class="small">Where insurance, professional indemnity, licensing or a formal qualification process ' +
-    'is required or applicable under your regulations, contract or client requirements, that obligation is ' +
-    'yours and must be discharged directly with the responsible body. This report substitutes for none of it.</p>' +
-    '<p class="small"><a href="disclaimer.html">Read the full Disclaimer Notice &rarr;</a></p>' +
-  '</div>' +
-
-  '<div class="printnotice">' +
-    '<h4>Notice &mdash; printed with every copy of this report</h4>' +
-    '<p><strong>This is only a technical readiness assessment. It qualifies nothing and no one.</strong> ' +
-    'It confers no certification, accreditation, licence, approval or professional status, and is not ' +
-    'evidence of compliance with any regulation, standard, code or contract. Do not present it as such ' +
-    '&mdash; to a client, an authority, an insurer, or in a tender.</p>' +
-    '<p>Answers are self-reported and measurements come from a file supplied by the respondent. Nothing ' +
-    'here has been audited or verified by any third party. Where insurance, professional indemnity, ' +
-    'licensing or a formal qualification process is required or applicable under your regulations or ' +
-    'appointment, that obligation is yours and this report substitutes for none of it.</p>' +
-    '<p><a href="disclaimer.html">Read the full Disclaimer Notice &rarr;</a> &nbsp;&middot;&nbsp; ' +
-    '<span class="mono">Notice v0.1 &middot; 22 Aug 2026</span></p>' +
-  '</div>' +
-
-  '<div class="actions">' +
-    '<button class="btn">Download checklist (PDF)</button>' +
-    '<button class="btn sec">See these gaps in 3D</button>' +
-    '<button class="btn sec" data-go="intro">Start over</button>' +
-  '</div>' +
-  '<p class="small mono" style="margin-top:20px;padding-top:14px;border-top:1px solid var(--rule)">' +
-  'core-0.1 · locale ae-v1 · toolkit v0.1 · terms v0.1 acknowledged · scope: one office or region · scoring is deterministic &mdash; ' +
-  'same answers and same versions always produce this same result. Technical readiness assessment only: ' +
-  'self-reported, unaudited, qualifies nothing and no one, confers no certification or professional status.</p>';
-
-/* ---------- NAV ---------- */
-DIMENSIONS.forEach(function (d, i) { SCREENS['dim' + i] = dimScreen(i); });
-
-var ORDER = ['intro', 'agree', 'context', 'dim0', 'dim1', 'dim2', 'dim3', 'dim4', 'model', 'results'];
-var LABELS = {
-  intro: 'Introduction', agree: 'Before you begin', declined: 'No assessment taken', context: 'About you',
-  dim0: 'Governance', dim1: 'People and skills', dim2: 'Technology',
-  dim3: 'Data and standards', dim4: 'Organisational processes',
-  model: 'Your model', results: 'Results'
-};
-var host = document.getElementById('screens');
-
-function show(name) {
-  host.innerHTML = '<div class="screen on">' + SCREENS[name] + '</div>';
-  var i = ORDER.indexOf(name);
-  if (i < 0) { window.scrollTo({ top: 0, behavior: 'instant' }); return; }
-  var rail = document.getElementById('rail'), cap = document.getElementById('railcap');
-  rail.hidden = cap.hidden = (name === 'intro' || name === 'agree' || name === 'declined');
-  [].forEach.call(rail.children, function (li, n) {
-    li.className = n < i ? 'done' : (n === i ? 'now' : '');
-  });
-  document.getElementById('railnow').textContent = LABELS[name];
-  document.getElementById('railpct').textContent = 'Step ' + (i + 1) + ' of ' + ORDER.length;
-  window.scrollTo({ top: 0, behavior: 'instant' });
-}
-
-document.addEventListener('change', function (e) {
-  if (e.target.id === 'ackbox') {
-    document.getElementById('agreebtn').disabled = !e.target.checked;
-  }
-});
-
-document.addEventListener('click', function (e) {
-  var go = e.target.closest('[data-go]');
-  if (go && go.disabled) return;
-  if (go) { show(go.dataset.go); return; }
-
-  var tb = e.target.closest('.tipbtn');
-  document.querySelectorAll('.tip.open').forEach(function (t) {
-    if (!tb || t !== tb.parentNode) t.classList.remove('open');
-  });
-  if (tb) { tb.parentNode.classList.toggle('open'); return; }
-
-  if (e.target.id === 'themebtn') {
-    var r = document.documentElement;
-    var dark = r.getAttribute('data-theme') === 'dark' ||
-      (!r.getAttribute('data-theme') && matchMedia('(prefers-color-scheme:dark)').matches);
-    r.setAttribute('data-theme', dark ? 'light' : 'dark');
-  }
-});
-
-document.addEventListener('keydown', function (e) {
-  if (e.key === 'Escape') document.querySelectorAll('.tip.open').forEach(function (t) { t.classList.remove('open'); });
-});
-
-show('intro');
+document.getElementById('themebtn') && document.getElementById('themebtn').addEventListener('click', function () {});
 </script>

--- a/readiness/proposal.html
+++ b/readiness/proposal.html
@@ -241,15 +241,19 @@ footer{
 .dtable td.n{font-family:"IBM Plex Mono",monospace;color:var(--muted);white-space:nowrap}
 .dscroll{overflow-x:auto;border:1px solid var(--rule);border-radius:9px;background:var(--surface);margin:20px 0}
 .dscroll .dtable{margin:0}
+
+.nav{display:flex;gap:7px;flex-wrap:wrap;margin-left:auto}
+.nav a{font-family:"Instrument Sans",sans-serif;font-size:13px;text-decoration:none;
+  border:1px solid var(--rule);border-radius:6px;padding:6px 12px;color:var(--ink-2);background:transparent}
+.nav a:hover{border-color:var(--accent);color:var(--accent-ink);background:var(--accent-wash)}
+.nav a.on{border-color:var(--accent);color:var(--accent-ink);background:var(--accent-wash);font-weight:600}
 </style>
 <div class="wrap">
 
 <div class="topbar">
   <div class="brandmark">OB</div>
   <div class="brandtext">OpenBIM Readiness Assessment Toolkit<small>The research proposal</small></div>
-  <div class="topspacer"></div>
-  <button class="ghostbtn" id="themebtn" type="button">Theme</button>
-  <a class="ghostbtn" href="./">Back to assessment</a>
+  <div class="nav"><a href="./">Overview</a><a href="assess.html">Assessment</a><a href="proposal.html" class="on">Proposal</a><a href="why.html">Background</a><a href="faq.html">Basics</a><a href="disclaimer.html">Notice</a></div>
 </div>
 
 <div class="hero">

--- a/readiness/why.html
+++ b/readiness/why.html
@@ -230,6 +230,12 @@ footer{
   figure{padding:18px 16px}
 }
 @media (prefers-reduced-motion:reduce){*{animation:none!important;transition:none!important}}
+
+.nav{display:flex;gap:7px;flex-wrap:wrap;margin-left:auto}
+.nav a{font-family:"Instrument Sans",sans-serif;font-size:13px;text-decoration:none;
+  border:1px solid var(--rule);border-radius:6px;padding:6px 12px;color:var(--ink-2);background:transparent}
+.nav a:hover{border-color:var(--accent);color:var(--accent-ink);background:var(--accent-wash)}
+.nav a.on{border-color:var(--accent);color:var(--accent-ink);background:var(--accent-wash);font-weight:600}
 </style>
 
 <div class="wrap">
@@ -237,16 +243,14 @@ footer{
 <div class="topbar">
   <div class="brandmark">OB</div>
   <div class="brandtext">OpenBIM Readiness Assessment Toolkit<small>Read more</small></div>
-  <div class="topspacer"></div>
-  <button class="ghostbtn" id="themebtn" type="button">Theme</button>
-  <a class="ghostbtn" href="./">Back to assessment</a>
+  <div class="nav"><a href="./">Overview</a><a href="assess.html">Assessment</a><a href="proposal.html">Proposal</a><a href="why.html" class="on">Background</a><a href="faq.html">Basics</a><a href="disclaimer.html">Notice</a></div>
 </div>
 
 <div class="hero">
   <p class="eyebrow">Why this exists</p>
   <h1>Everyone is telling you to open your data. Nobody is telling you what that costs.</h1>
-  <p class="standfirst">Three things worth knowing before you spend money on it: what the industry
-  actually certifies, where models really stand today, and what closing the gap involves.</p>
+  <p class="standfirst">What the industry actually certifies, where delivered models stand today, and
+  what closing the gap involves.</p>
   <nav class="jump">
     <a href="#industry">01 &nbsp;The industry</a>
     <a href="#gap">02 &nbsp;The gap</a>
@@ -260,8 +264,7 @@ footer{
 
 <section id="industry">
   <div class="shead"><span class="snum">01</span><h2>What the industry actually certifies</h2></div>
-  <p class="lede">Start here, because almost everyone has this backwards — including people selling
-  you software.</p>
+  <p class="lede">Worth establishing first, because it is commonly misunderstood.</p>
 
   <blockquote class="ps">
     <p>As BIM adoption matures, organisations are increasingly expected to move beyond proprietary
@@ -312,7 +315,7 @@ footer{
   </figure>
 
   <div class="call">
-    <span class="lab">The conclusion that matters</span>
+    <span class="lab">What follows from that</span>
     <p>The largest BIM vendor on earth, facing every jurisdiction on earth, certifies
     <strong>&ldquo;I don&rsquo;t corrupt your data&rdquo;</strong> &mdash; and leaves &ldquo;is this
     building lawful&rdquo; to the practice.</p>
@@ -339,8 +342,7 @@ footer{
   in each case.</p>
 
   <h3>A model can be almost entirely missing and still look fine</h3>
-  <p>This is the one to know about, because it fails <em>quietly</em>. Past a 4 GB boundary during
-  export, geometry generation stops. There is no crash and no error message. The file opens. It
+  <p>Past a 4 GB boundary during export, geometry generation stops. There is no crash and no error message. The file opens. It
   renders. It looks like a building.</p>
 
   <figure>
@@ -446,7 +448,7 @@ footer{
     <div class="hb"><span class="n">Stated target</span><span class="t"><span class="f" style="width:100%;background:var(--surface-3)"></span></span><span class="v">200+</span></div>
     <figcaption><b>Source</b>Project rule inventory. 30 UBBL rules implemented against a stated target
     of 200+ across six jurisdictions. <strong>The architecture is proven; the rule population is the
-    work ahead.</strong> Shown here because a roadmap that hides its own gap is marketing.</figcaption>
+    work ahead.</strong></figcaption>
   </figure>
 
   <h3>The industry picture starts empty</h3>
@@ -458,8 +460,8 @@ footer{
       <span class="t">No assessments have been submitted yet. As responses accumulate, this becomes a
       real industry picture &mdash; built from practitioners rather than asserted.</span>
     </div>
-    <figcaption><b>Source</b>Live count of submitted assessments. There is deliberately no estimate,
-    no projection and no illustrative figure here. When we do not have a number, the page says so.</figcaption>
+    <figcaption><b>Source</b>Live count of submitted assessments. No estimate, projection or illustrative figure is
+    shown in its place.</figcaption>
   </figure>
 </section>
 


### PR DESCRIPTION
## Structure

The proposal synopsis is now the landing page. It states what the project is in its own funded words, so a reviewer checking conformance to their criteria has nothing to interpret, and a newcomer has context before meeting the tool.

```
/readiness/              synopsis + Start Here
/readiness/assess.html   the toolkit (was index.html)
/readiness/proposal.html the proposal in full
/readiness/why.html      background
/readiness/faq.html      basics + glossary
/readiness/disclaimer.html  notice + declarations
```

The assessment itself is unchanged — its own intro screen greets a newcomer rather than repeating the pitch, which is the right job for that screen.

## Also, from a self-audit of what had already shipped

- **Shared header nav on all six pages.** Previously the proposal was reachable only via one sentence under the buttons, which is how it got missed.
- **Removed bracketed placeholders from the live Disclaimer Notice.** `[institution]`, `[grant reference]`, `[licence to be selected]` were publicly visible on the page whose job is establishing credibility. Pending facts now read as *"published with the first citable release"*.
- **Stripped self-narrating phrasing across the set** — "nobody asks these out loud", "this is not a gotcha", "the honest commercial disclosure", "that is a legitimate answer", "a roadmap that hides its own gap is marketing". Narrating candour instead of just stating facts.
- **Rewrote the basics page flat.** Substance kept, arch framing dropped.

## Verification
All six pages served locally; every internal link on every page checked and resolving 200; nav present on all six; tags balanced; `node --check` clean on the assessment script.

Still a WIP mockup — no scoring, no parsing, no network.

🤖 Generated with [Claude Code](https://claude.com/claude-code)