### PR TITLE
docs(readiness): drop the repeated project title from the front page

### DIFF
--- a/readiness/index.html
+++ b/readiness/index.html
@@ -67,10 +67,10 @@ a{color:var(--accent-ink);text-underline-offset:2px}
 .ghostbtn:hover{background:var(--surface-2);border-color:var(--accent);color:var(--accent-ink)}
 
 /* ---- hero ---- */
-.hero{padding:56px 0 40px;border-bottom:2px solid var(--ink)}
+.hero{padding:30px 0 18px;border-bottom:2px solid var(--ink)}
 .eyebrow{
   font-family:"IBM Plex Mono",monospace;font-size:11px;letter-spacing:.14em;
-  text-transform:uppercase;color:var(--accent-ink);font-weight:600;margin-bottom:16px
+  text-transform:uppercase;color:var(--accent-ink);font-weight:600;margin-bottom:0
 }
 h1{font-family:"Instrument Sans",sans-serif;font-size:clamp(31px,5.2vw,46px);line-height:1.08;font-weight:700}
 .standfirst{font-size:19px;color:var(--ink-2);margin-top:18px;max-width:58ch;line-height:1.55}
@@ -270,7 +270,6 @@ footer{
 
 <div class="hero">
   <p class="eyebrow">Research funding request &middot; 10 August 2026 &middot; Mohd Faizal Bin Yusof</p>
-  <h1>Development of an OpenBIM Readiness Assessment Toolkit for Digital Infrastructure Management</h1>
 </div>
 
 <section>


### PR DESCRIPTION
The page header already names the toolkit. Restating the full proposal title as a headline above the synopsis added nothing — it's understood from context.

Removed the `<h1>`, tightened the hero spacing that had been sized around it. The provenance line (funding request, date, applicant) and the synopsis are unchanged.

Verified locally: page serves 200, all five synopsis paragraphs present, provenance line intact, Start Here still resolves.

🤖 Generated with [Claude Code](https://claude.com/claude-code)