### PR TITLE
docs(readiness): front page title reads 'Readiness Assessment Toolkit for Digital Infrastructure Management'

### DIFF
--- a/readiness/index.html
+++ b/readiness/index.html
@@ -67,7 +67,7 @@ a{color:var(--accent-ink);text-underline-offset:2px}
 .ghostbtn:hover{background:var(--surface-2);border-color:var(--accent);color:var(--accent-ink)}
 
 /* ---- hero ---- */
-.hero{padding:56px 0 40px;border-bottom:2px solid var(--ink)}
+.hero{padding:44px 0 34px;border-bottom:2px solid var(--ink)}
 .eyebrow{
   font-family:"IBM Plex Mono",monospace;font-size:11px;letter-spacing:.14em;
   text-transform:uppercase;color:var(--accent-ink);font-weight:600;margin-bottom:16px
@@ -270,7 +270,7 @@ footer{
 
 <div class="hero">
   <p class="eyebrow">Research funding request &middot; 10 August 2026 &middot; Mohd Faizal Bin Yusof</p>
-  <h1>Development of an OpenBIM Readiness Assessment Toolkit for Digital Infrastructure Management</h1>
+  <h1>Readiness Assessment Toolkit for Digital Infrastructure Management</h1>
 </div>
 
 <section>

--- a/readiness/index.html
+++ b/readiness/index.html
@@ -67,7 +67,7 @@ a{color:var(--accent-ink);text-underline-offset:2px}
 .ghostbtn:hover{background:var(--surface-2);border-color:var(--accent);color:var(--accent-ink)}
 
 /* ---- hero ---- */
-.hero{padding:44px 0 34px;border-bottom:2px solid var(--ink)}
+.hero{padding:56px 0 40px;border-bottom:2px solid var(--ink)}
 .eyebrow{
   font-family:"IBM Plex Mono",monospace;font-size:11px;letter-spacing:.14em;
   text-transform:uppercase;color:var(--accent-ink);font-weight:600;margin-bottom:16px


### PR DESCRIPTION
Trims the proposal's *'Development of an OpenBIM'* prefix — document framing rather than a greeting — and avoids repeating OpenBIM, already in the page header. Keeps the domain scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)