### PR TITLE
docs(readiness): restore the front-page title, shortened (relands #1466 over #1465)

### DIFF
--- a/readiness/index.html
+++ b/readiness/index.html
@@ -70,7 +70,7 @@ a{color:var(--accent-ink);text-underline-offset:2px}
 .hero{padding:30px 0 18px;border-bottom:2px solid var(--ink)}
 .eyebrow{
   font-family:"IBM Plex Mono",monospace;font-size:11px;letter-spacing:.14em;
-  text-transform:uppercase;color:var(--accent-ink);font-weight:600;margin-bottom:0
+  text-transform:uppercase;color:var(--accent-ink);font-weight:600;margin-bottom:10px
 }
 h1{font-family:"Instrument Sans",sans-serif;font-size:clamp(31px,5.2vw,46px);line-height:1.08;font-weight:700}
 .standfirst{font-size:19px;color:var(--ink-2);margin-top:18px;max-width:58ch;line-height:1.55}
@@ -270,6 +270,7 @@ footer{
 
 <div class="hero">
   <p class="eyebrow">Research funding request &middot; 10 August 2026 &middot; Mohd Faizal Bin Yusof</p>
+  <h1>Readiness Assessment Toolkit for Digital Infrastructure Management</h1>
 </div>
 
 <section>


### PR DESCRIPTION
Your live page had **no title at all** — that is what "still not there" was.

## What actually happened
Two changes disagreed, and the second silently won:

| PR | intent | outcome |
|---|---|---|
| **#1465** (merged) | *drop the repeated project title* — deleted the front-page `<h1>` entirely | landed |
| **#1466** (open) | **reword** that same `<h1>`, dropping only the *"Development of an OpenBIM"* prefix | **could not merge** — #1465 deleted the line it patches (`mergeable=CONFLICTING`, `DIRTY`). Its checks were green; the conflict is why it sat there. |

## Verified before touching anything
- served page: **0** `<h1>` elements — the hero renders as the eyebrow line alone
- live bytes **byte-identical** to `origin/main`, and all six readiness pages return **200**

So the deploy was current and the Pages workflow was fine. The content was the problem.

## This PR
Relands #1466's intent on fresh main (never reusing a DIRTY branch): the title returns with its wording — **Readiness Assessment Toolkit for Digital Infrastructure Management**.

Also restores the eyebrow's bottom gap `0 → 10px`. #1465 zeroed it and tightened `.hero` padding *because* there was no title underneath; with the title back they would sit flush. The tightened padding is kept — only the gap the title needs is returned. One value to change if it reads wrong to you.

**#1466 can be closed as superseded** — its branch cannot merge as-is.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
