### PR TITLE
test(4d): §S63 — close the three handover reds; Terminal's floating tail bisected, not absorbed

### DIFF
--- a/tests/run_witness_suite.js
+++ b/tests/run_witness_suite.js
@@ -73,18 +73,19 @@ const BLD_DIR = process.env.BLD_DIR || path.join(require('os').homedir(), 'bim-o
 // retires it). B = hardcoded path. C = real product red. D = needs a live server/browser this run
 // did not have — NOT proven healthy, just not proven red.
 const KNOWN_RED = {
-  // A — stale-slice crash: a source-text slice of time_machine.js calls a module-scope helper the
-  // vm sandbox was never given. The §S53.5 class (it killed witness_zone_display_authoring for four
-  // days). §S58's support_sweep.js extraction retires this class outright.
-  // §S62: no longer a crash — it RUNS now, and on its first live run in 9+ days it reports a real
-  // drift: W-TMREPRO-5 locks Terminal's floating tail at 8, measured 12. cycles=0 is clean.
-  // The lock was set when the witness last ran; nothing has checked it since. Not chased here.
-  'witness_tm_geo_order_cycles.js':          'C — W-TMREPRO-5 Terminal floating tail 12, locked at 8 (cycles=0). Real drift, newly visible.',
-  // B — environment assumption baked into the file.
-  'witness_zone_index.js':                   'B — ENOENT: hardcodes /tmp/vw/time_machine.js instead of resolving from __dirname. One-line fix.',
+  // DRAINED 2026-08-22 (§S63) — all three were fixed and are green in the same PR that removed them:
+  //   witness_tm_geo_order_cycles.js — the 8 -> 12 drift was BISECTED (18 runs over schedule_gate.js
+  //     history), isolated to a2c30ee (#1345 §STAIR_FLIGHT_GRID_VISIBILITY) and MEASURED: the 4 added
+  //     floaters are stair flights caught by the scheduler/audit asymmetry that commit deliberately
+  //     left open, deficit 0.01d. Re-locked at 12 AND its class composition. Cause: 4D_SCHEDULE_PERFECTION §S63.
+  //   witness_zone_index.js — was not a path bug: OLD is a prior REVISION, not a sibling file. Now
+  //     derived from git at 475373b^, plus the two undeclared slice deps §S62 exposed. 5/5, 267,274
+  //     elements compared across 7 buildings, mismatch=0.
+  //   witness_zone_display_authoring.js — W-ZDA-4a re-locked to per-building baselines in
+  //     baselines/midair.json (Duplex 22->37, HHS 894->1839). The inequality it replaced was
+  //     permanently false, i.e. it gated nothing.
   // C — real assertion reds, reproducible every run.
   'witness_gantt_lock_integrity.js':         'C — G-LI-2e, self-declared KNOWN PRE-EXISTING BUG in its own assert message',
-  'witness_zone_display_authoring.js':       'C — W-ZDA-4a x2 (§S53.5): decision pending, re-lock as per-building baselines rather than a threshold',
   'witness_door_window_host_wall.js':        'C — assertion red, UNTRIAGED',
   // Reproducible reds whose cause has NOT been established. Labelled honestly rather than guessed:
   // an earlier pass called these "browser/server not up", which was wrong — both are headless.

--- a/viewer/tests/baselines/midair.json
+++ b/viewer/tests/baselines/midair.json
@@ -11,6 +11,12 @@
     "Terminal": 684, "Hospital": 218, "Duplex": 0, "HHS_Office_Federated": 0,
     "Clinic": 422, "LTU_AHouse": 0, "JKR": 0
   },
+  "zda_display_float": {
+    "_what": "W-ZDA-4a — the floating census under DISPLAY-AUTHORED windows vs the raw-authored baseline, from witness_zone_display_authoring.js. The display path IS measurably worse and always has been; this locks the exact pair so a CHANGE reddens, replacing an inequality assert that shipped permanently red. base = raw-authored windows + shipped rescale/sweep/parity; display = display-authored windows, rescale + parity, no sweep. Deliberately NOT a % threshold — that judge transfer was tried and retracted.",
+    "_measured": "2026-08-22 on origin/main 6ec0dcc (§S63)",
+    "Duplex_extracted":               { "base": 22,  "display": 37 },
+    "HHS_Office_Federated_extracted": { "base": 894, "display": 1839 }
+  },
   "orphans": {
     "_what": "W-MZ-4 — elements touching nothing in the model. Purely geometric (never reads .s/.e), so independent of which display-authoring path produced the times. An extraction limit, reported never gated.",
     "Terminal": 25, "Hospital": 35, "Duplex": 1, "HHS_Office_Federated": 36,

--- a/viewer/tests/witness_big_element_support_coverage.js
+++ b/viewer/tests/witness_big_element_support_coverage.js
@@ -79,6 +79,11 @@ const BUILDINGS = [
   //   Duplex   big=49   unchecked=6   (IfcSlab:4,IfcWallStandardCase:2)     floating=0 (HELD)
   //   HHS      big=239  unchecked=13  (IfcSlab:5,IfcFlowSegment:3,…)        floating=0 (HELD)
   //   Clinic   big=442  unchecked=22  (IfcWallStandardCase:15,IfcMember:3,…) floating=1 (HELD)
+  // The floating column above is COMMENTARY (this witness asserts `unchecked`, never floating) and
+  // has drifted since. Re-measured 2026-08-22 (§S63, this witness's own green run): Terminal=12
+  // Hospital=0 Duplex=0 HHS=9 Clinic=1 LTU_AHouse=360 JKR=80. Terminal 8->12 is bisected and
+  // explained in witness_tm_geo_order_cycles.js (which DOES lock it, count + composition); the rest
+  // are recorded here so the next reader compares against a real number, not a stale one.
   // RE-MEASURED 2026-08-11 (closure pass, bigsup_after_fix.log) after the
   // 'slab_on_grade_substructure' name-override (rates.js/sequence_rules.json — slab-on-grade is
   // the 1c spec's own named ground-bearing class, pattern measured to exactly Duplex 4 + Clinic 4

--- a/viewer/tests/witness_tm_geo_order_cycles.js
+++ b/viewer/tests/witness_tm_geo_order_cycles.js
@@ -15,8 +15,10 @@
 //     for slabs EMBEDDED metres below the wall's top. Fix: contained support must live in the
 //     consumer's LOWER HALF; a wall carries a promoted slab only AT ITS TOP (wallCarries, ±GAP).
 //     Terminal: cycles 37,927→0, §DEQ_REPAIR shifts 251→0, floating 45→8 (37 were cycle-fallback
-//     ordering artifacts; the 8 remain a separate, named, open tail). This witness now ASSERTS
-//     cycles=0 and floating=8 so any regression screams.
+//     ordering artifacts; the 8 remain a separate, named, open tail). This witness ASSERTS
+//     cycles=0 plus the floating tail's COUNT AND COMPOSITION so any regression screams. The tail
+//     is 12 since #1345 (§S63, 2026-08-22 — bisected, isolated to one file, cause measured; see the
+//     block at W-TMREPRO-5). It was 8 from 2026-08-10 to #1345.
 //
 //   ISSUE 2 (refactor invariance): the roof/load-path promotion classifier existed as two copies in
 //     time_machine.js (_buildXrayElements inline + injectGantt inline). Direct verification proved
@@ -138,16 +140,45 @@ const BLD_DIR = process.env.BLD_DIR || path.join(require('os').homedir(), 'bim-o
   assert(cycles >= 0, 'W-TMREPRO-2 §SUPPORT_CYCLE reported by canonical computeSchedule (cycles=' + cycles + ')');
   assert(typeof floating === 'number' && floating >= 0, 'W-TMREPRO-3 auditFloating returns a count (floating=' + floating + ')');
   // §TM_GEO_ORDER_CYCLES fix bar (2026-08-10): the DAG is acyclic on Terminal under load-path
-  // promotion. floating=8 is the EXACT remaining tail (was 45; 37 were cycle-fallback artifacts) —
+  // promotion. The floating tail is the EXACT remainder (was 45; 37 were cycle-fallback artifacts) —
   // if it moves EITHER way, that is a real behavior change to examine, not to absorb silently.
+  //
+  // §S63 (2026-08-22) — the tail moved 8 -> 12 and the lock was re-measured, not absorbed. Bisected
+  // over every schedule_gate.js commit since the lock was set (268a85f..HEAD, 18 runs, this witness
+  // unchanged, only viewer/{schedule_gate,time_machine}.js + rates/sequence_rules.json swapped):
+  // constant 8 through 2463ff1, 12 from a2c30ee onward. Isolated to ONE file — a2c30ee's
+  // schedule_gate.js alone over the 2463ff1 tree gives 12; a2c30ee's time_machine.js alone gives 8.
+  // a2c30ee = #1345 §STAIR_FLIGHT_GRID_VISIBILITY, which added isStairFlight() to the SCHEDULER's
+  // support pool (now supportPool(), schedule_gate.js:1246) and deliberately did NOT mirror it into
+  // auditFloating's structGrid (:1076 still admits seq<=4 or promoted IfcSlab only).
+  //
+  // The 4 added floaters are all IfcStairFlight, and they are that asymmetry, measured:
+  //   flight ...UjZp  base_z 18.892 top_z 20.864, ZERO bearing-below supports -> audited on the HANG
+  //   path against the landing above it (IfcSlab seq=4 @20.864 + 2x IfcMember seq=3 @20.564).
+  //   Scheduler side, the same pair runs the OTHER way: the flight is now a pool member BELOW those
+  //   carriers (geoGate's `below` has no top-proximity bound), so carrier ...UjXu's gate IS the
+  //   flight — start day 1.1083 == flight end day 1.1083 (next candidate down ends day 0.3139).
+  //   Pre-#1345 those carriers finished day 0.25 and the flight started day 1.15, 0.89d clear.
+  //   Now the flight starts 0.01d (~14 min) before its audited carrier ends -> flagged.
+  // So this is the audit/scheduler asymmetry disagreeing about one pair, not a physics regression:
+  // the deficit is a rounding-scale 0.01d, and #1345 already tried and reverted mirroring flights
+  // into auditFloating (it surfaced an unrelated _twoTierRemap weakness). Closing the asymmetry is
+  // a named open item, NOT this witness's job — see prompts/4D_SCHEDULE_PERFECTION.md §S63.
+  //
+  // The lock is therefore 12 AND its composition: count alone would let a swap through.
   assert(cycles === 0, 'W-TMREPRO-4 Terminal support DAG is acyclic under load-path promotion (cycles=' + cycles + ', fix: lower-half contained + wallCarries)');
-  assert(floating === 8, 'W-TMREPRO-5 floating tail exactly 8 (measured after cycle fix; was 45) — got ' + floating);
+  var _byG = new Map(geoEls.map(function (e) { return [e.guid, e]; }));
+  var _tail = {};
+  collector.forEach(function (g) { var e = _byG.get(g); var c = e ? e.cls : 'NOT-IN-geoEls'; _tail[c] = (_tail[c] || 0) + 1; });
+  var tailSig = Object.keys(_tail).sort().map(function (k) { return k + ':' + _tail[k]; }).join(',');
+  assert(floating === 12, 'W-TMREPRO-5 floating tail exactly 12 (8 promoted roof slabs since 2026-08-10 + 4 stair flights since #1345, §S63) — got ' + floating);
+  assert(tailSig === 'IfcSlab:8,IfcStairFlight:4', 'W-TMREPRO-5b floating tail COMPOSITION unchanged (a swap that keeps the count still reddens) — got ' + tailSig);
 
   // THE line. Must be numerically identical pre vs post the _promoteRoofLoadPath refactor
   // (diffed across the two commits' logs — see header ISSUE 2). Numbers only; slice state is on
   // the separate §TMREPRO_SLICE line above so this one diffs clean.
   console.log('§TM_GEO_ORDER_CYCLES_REPRO cycles=' + cycles + ' floating=' + floating +
-    ' n=' + geoEls.length + '/' + els.length + ' promotedRoofSlabs=' + promoted +
+    ' n=' + geoEls.length + '/' + els.length + ' promotedRoofSlabs=' + promoted + ' tail=' + tailSig +
     ' (Terminal_extracted.db; resource/installSecs approximated — structural cycle count unaffected)');
   console.log('§TMREPRO_DRIFT_FLAG planning-session 2026-08-10 got cycles=37927 floating=45; doc earlier recorded cycles=24353 floating=33/48428 — divergence unexplained, neither number overwritten (see header)');
   if (collector.length) console.log('§TMREPRO_FLOATING_SAMPLE [' + collector.slice(0, 5).join(',') + ']');

--- a/viewer/tests/witness_zone_display_authoring.js
+++ b/viewer/tests/witness_zone_display_authoring.js
@@ -37,6 +37,14 @@ const ScheduleAuthor = require(path.join(__dirname, '..', 'schedule_author.js'))
 const SupportSweep = require(path.join(__dirname, '..', 'support_sweep.js'));
 const tmSrc = fs.readFileSync(path.join(__dirname, '..', 'time_machine.js'), 'utf8');
 
+// W-ZDA-4a's locked pair, same file + same discipline as witness_midair_zero.js's baselines
+// (data in baselines/midair.json, the WHY here). §S63, 2026-08-22.
+const ZDA_LOCK = (function () {
+  const j = JSON.parse(fs.readFileSync(path.join(__dirname, 'baselines', 'midair.json'), 'utf8'));
+  if (!j.zda_display_float) throw new Error('baselines/midair.json missing group "zda_display_float"');
+  return j.zda_display_float;
+})();
+
 let pass = 0, fail = 0;
 function assert(cond, msg) { if (cond) { pass++; console.log('  PASS ' + msg); } else { fail++; console.log('  FAIL ' + msg); } }
 
@@ -221,7 +229,22 @@ async function main() {
     console.log = ql;
     console.log('  §ZDA_WITNESS ' + B + ' floating ' + baseFloat + ' -> ' + nextFloat +
       ' outWindow ' + baseWin.outW + ' -> ' + nextWin.outW);
-    assert(nextFloat <= baseFloat, 'W-ZDA-4a floating not worse under display-authored windows (' + baseFloat + ' -> ' + nextFloat + ')');
+    // W-ZDA-4a — §S63 (2026-08-22). WAS `nextFloat <= baseFloat`, which had shipped PERMANENTLY RED:
+    // the display-authored path is genuinely worse on both buildings (Duplex 22->37, HHS 894->1839),
+    // so the inequality was false on every run and gated nothing — it only taught readers to skip the
+    // file. Locked per building instead, exactly like witness_midair_zero.js's baselines: a CHANGE
+    // either way is red, a re-lock is a data edit in baselines/midair.json with a named cause, and the
+    // trade stays visible on the §ZDA_WITNESS line above. NOT a % threshold — that judge transfer was
+    // tried and retracted. The trade itself is still an OPEN item, not blessed by being locked.
+    const lock = ZDA_LOCK[B];
+    if (!lock) {
+      assert(false, 'W-ZDA-4a no locked baseline for ' + B + ' in baselines/midair.json — measured ' +
+        baseFloat + ' -> ' + nextFloat + '; record it there with the run that produced it');
+    } else {
+      assert(baseFloat === lock.base && nextFloat === lock.display,
+        'W-ZDA-4a floating pair at its locked baseline for ' + B + ' (locked ' + lock.base + ' -> ' +
+        lock.display + ', got ' + baseFloat + ' -> ' + nextFloat + ')');
+    }
     assert(nextWin.outW <= baseWin.outW, 'W-ZDA-4b window fidelity not worse (outWindow ' + baseWin.outW + ' -> ' + nextWin.outW + ')');
     // W-ZDA-6 (§CPM_DISPLAY, 2026-08-16): the CPM branch of _displayTimeline authors a 0-midair
     // display timeline through the SAME hook (proves the wiring, not just the module).

--- a/viewer/tests/witness_zone_index.js
+++ b/viewer/tests/witness_zone_index.js
@@ -34,18 +34,37 @@
 //   G-ZONE-MEMO    the index is built ONCE across repeated consumers, not once per consumer.
 //
 // Command (from the worktree root):
-//   OLD=/tmp/vw/time_machine.js BLD_DIR=~/bim-ootb/buildings node viewer/tests/witness_zone_index.js
+//   BLD_DIR=~/bim-ootb/buildings node viewer/tests/witness_zone_index.js
+//   (the OLD baseline is derived from git at 475373b^; OLD=<path> / OLD_REV=<rev> override)
 'use strict';
 const fs = require('fs');
 const path = require('path');
 const vm = require('vm');
 const HOME = require('os').homedir();
 const NEW_TM = process.env.NEW_TM || path.join(__dirname, '..', 'time_machine.js');
-const OLD_TM = process.env.OLD || '/tmp/vw/time_machine.js';
+// The OLD side is not a sibling FILE, it is a prior REVISION: the last commit before §ZONE_INDEX
+// (#1313, 475373b) consolidated the two inline banding copies. The original run staged it by hand at
+// /tmp/vw/time_machine.js, which then ENOENT-crashed this witness for everyone else (§S61.3 class B).
+// Derive it from git instead, cached under the OS temp dir; `OLD=<path>` still overrides.
+const OLD_REV = process.env.OLD_REV || '475373b^';                 // pre-§ZONE_INDEX baseline
+function resolveOldTm() {
+  if (process.env.OLD) return process.env.OLD;
+  const cache = path.join(require('os').tmpdir(), 'witness_zone_index_old_' + OLD_REV.replace(/[^a-zA-Z0-9]/g, '_') + '.js');
+  if (fs.existsSync(cache) && fs.statSync(cache).size > 0) return cache;
+  try {
+    const src = require('child_process').execFileSync('git',
+      ['-C', path.join(__dirname, '..', '..'), 'show', OLD_REV + ':viewer/time_machine.js'],
+      { encoding: 'utf8', maxBuffer: 64 * 1024 * 1024, stdio: ['ignore', 'pipe', 'ignore'] });
+    fs.writeFileSync(cache, src);
+    return cache;
+  } catch (e) { return null; }
+}
+const OLD_TM = resolveOldTm();
 const BLD_DIR = process.env.BLD_DIR || path.join(HOME, 'bim-ootb', 'buildings');
 const VIEWER_DIR = path.join(__dirname, '..');
 const SQLJS_DIR = process.env.SQLJS_DIR || path.join(HOME, 'bim-ootb', 'modeller', 'lib');
 const initSqlJs = require(path.join(SQLJS_DIR, 'sql-wasm.js'));
+const ZoneIndex = require(path.join(VIEWER_DIR, 'zone_index.js'));   // §S62
 const DB_FILE = { LTU_AHouse: 'LTU_AHouse_meta.db' };
 const BUILDINGS = (process.env.ONLY || 'Terminal,Hospital,Duplex,HHS_Office_Federated,Clinic,LTU_AHouse,JKR').split(',');
 
@@ -70,7 +89,13 @@ function sliceFn(src, name, which) {
 function makeCtx(src, db, bld, counters) {
   const parts = [
     sliceFn(src, '_promoteRoofLoadPath'),
-    sliceFn(src, '_buildXrayElements')
+    sliceFn(src, '_buildXrayElements'),
+    // §S62 follow-on: _buildXrayElements' real dependency closure — matchRule() calls _classifyRule,
+    // which calls _classifyNameOverride. Neither was ever in this slice set (the same undeclared-
+    // dependency class as the ZoneIndex miss above); added conditionally so a revision that predates
+    // either name still slices cleanly.
+    sliceFn(src, '_classifyRule'),
+    sliceFn(src, '_classifyNameOverride')
   ];
   const zb = sliceFn(src, '_zoneIndexBuild');
   const zi = sliceFn(src, '_zoneIndex');
@@ -81,6 +106,12 @@ function makeCtx(src, db, bld, counters) {
     performance: { now: () => Date.now() },
     window: {},
     Math: Math, RegExp: RegExp, Object: Object, Infinity: Infinity,
+    // §S62 (#1459) moved the builder body out to viewer/zone_index.js, so the NEW side's sliced
+    // _zoneIndexBuild is now a one-line `return ZoneIndex.build(db)` wrapper and the sandbox has to
+    // supply the module. Same pattern as witness_tm_geo_order_cycles.js. Without it the witness
+    // died on `ReferenceError: ZoneIndex is not defined` — a sliced function cannot state its own
+    // dependencies. The OLD side has the banding inline and never touches this.
+    ZoneIndex: ZoneIndex,
     A: () => ({ db: db, activeBuilding: bld, _metaGen: 0 })
   };
   vm.createContext(sandbox);
@@ -99,6 +130,11 @@ function gate(name, pass, detail) {
 (async () => {
   const SQL = await initSqlJs({ wasmBinary: fs.readFileSync(path.join(SQLJS_DIR, 'sql-wasm.wasm')) });
   const newSrc = fs.readFileSync(NEW_TM, 'utf8');
+  if (!OLD_TM || !fs.existsSync(OLD_TM)) {
+    console.log('§ZONE_INDEX_SKIP baseline revision ' + OLD_REV + ' unavailable (not a git checkout, or the ' +
+      'revision is not fetched). Set OLD=<path to a pre-§ZONE_INDEX time_machine.js> to run. Skipping, not failing.');
+    process.exit(0);
+  }
   const oldSrc = fs.readFileSync(OLD_TM, 'utf8');
   const rulesJson = JSON.parse(fs.readFileSync(path.join(VIEWER_DIR, 'rates', 'sequence_rules.json'), 'utf8'));
 


### PR DESCRIPTION
Implementing bim-compiler `prompts/SCRIPT_LENGTH_REFACTOR_SEAMS.md` §S63 (+ `4D_SCHEDULE_PERFECTION.md` §S63).

**Tests + one baseline JSON only — ZERO product-code lines**, so no `sw.js` `CACHE_VERSION` bump applies (nothing a user's browser caches moved).

## 1. `witness_tm_geo_order_cycles` — the 8-vs-12 disagreement, bisected not absorbed

`W-TMREPRO-5` locked Terminal's floating tail at 8; the witness (revived by §S62 after 9+ days dead) measured **12**, cycles=0.

**Bisected** — witness held at HEAD, only `viewer/{schedule_gate,time_machine}.js` + `rates/sequence_rules.json` swapped across every commit that touched `schedule_gate.js` since the lock was set. 18 runs on the real `Terminal_extracted.db` (n=48428):

| range | floating |
|---|---|
| `268a85f` (#1276, lock set) → `2463ff1` (#1333) | **8**, constant |
| `a2c30ee` (#1345) → `HEAD` | **12**, constant |

**Isolated** — over the `2463ff1` tree, `a2c30ee`'s `schedule_gate.js` ALONE gives 12; its `time_machine.js` alone gives 8.

`a2c30ee` = #1345 §STAIR_FLIGHT_GRID_VISIBILITY. The 4 added floaters are all `IfcStairFlight`, and the mechanism is measured to the day: #1345 made flights scheduler support-pool members, and `geoGate`'s `below` has no top-proximity bound, so a flight now gates the landing members **1.7 m above it** (carrier start day 1.1083 == flight end day 1.1083; next candidate down ends day 0.3139). `auditFloating` — deliberately unchanged by #1345 — still audits that flight as **hanging from** those same members. Deficit **0.01 d (~14 min)**.

Also measured: the mirror #1345 tried and reverted (flights into `auditFloating`'s `structGrid`) **does not fix it** — still 12, same composition.

Re-locked at 12, plus a new `W-TMREPRO-5b` on the **class composition** (`IfcSlab:8,IfcStairFlight:4`) so a swap that keeps the count still reddens.

**Proven red 3 ways:** pre-#1345 `schedule_gate.js` → `got 8` / `IfcSlab:8`; `isStairFlight → false` at HEAD → same; pre-fix `edgeContained` → `cycles=38254`, `floating=50`, `IfcColumn:8,IfcMember:30,IfcSlab:8,IfcStairFlight:4` (all three assertions red at once).

The remaining asymmetry is a **named ⛔ open item** in `4D_SCHEDULE_PERFECTION.md` §S63 — not fixed here.

## 2. `witness_zone_index` — the predicted "one-line fix" was wrong about the bug

§S61.3 classified it "hardcodes `/tmp/vw/time_machine.js`, resolve from `__dirname`". That would not have worked: `OLD` is a prior **revision** (the last commit before §ZONE_INDEX #1313 consolidated the two inline banding copies), not a sibling file — there is nothing in the tree to resolve to.

Now derived from git at `475373b^`, cached under the OS temp dir, `OLD=`/`OLD_REV=` still overriding, and a **clean skip** (exit 0, `§ZONE_INDEX_SKIP`) when the revision cannot be produced (shallow clone) instead of a crash. Two undeclared slice deps §S62 exposed fixed in the same pass (`ZoneIndex` into the sandbox; `_classifyRule`/`_classifyNameOverride` into the slice set).

**5/5 gates, 7 buildings, 267,274 elements compared guid-by-guid, mismatch=0** — the §ZONE_INDEX consolidation is still provably a no-op today. Proven red by reversing `zone_index.js`'s band sort (`G-ZONE-BANDS` FAIL); skip path proven with `OLD_REV=deadbeef1234`.

## 3. `W-ZDA-4a` — an inequality that was permanently false

`assert(nextFloat <= baseFloat)` had shipped RED on every run: the display path IS worse (Duplex 22→37, HHS 894→1839). An assertion false on every run gates nothing.

Replaced with an exact per-building lock in `viewer/tests/baselines/midair.json` (new `zda_display_float` group — same file and discipline as `witness_midair_zero.js`'s baselines: data in the JSON, the WHY in the witness). **No % threshold** — that judge transfer was tried and retracted.

**Proven red 3 ways:** lock 36 vs measured 37; building missing from the group; group missing entirely (loud throw, never a silent pass). Green 18/0. The trade stays **open** — locking makes a CHANGE visible, it does not bless 1839.

## Housekeeping in the same PR (the runner's own contract)

- `run_witness_suite.js` `KNOWN_RED` drained of all three. Suite: **green=40 new_red=0 known_red=4 flaky=0 total=44** (was green=37 known_red=7).
- `witness_big_element_support_coverage.js`'s floating commentary was stale (said Terminal=8, HHS=0). Re-measured off its own green run and dated: Terminal=12 Hospital=0 Duplex=0 HHS=9 Clinic=1 LTU_AHouse=360 JKR=80. That witness asserts `unchecked`, never floating — its Terminal=12 is an **independent confirmation** of item 1's number.

`audit_section_refs` 0 DEAD · `audit_sw_precache` 141 found/0 missing + 115 precached/0 unlisted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)