### PR TITLE
fix(4d): §S64 — auditFloating disagreed with the gate it claims to mirror; fleet floating 462 → 362

### DIFF
--- a/scripts/probe_support_asymmetry.js
+++ b/scripts/probe_support_asymmetry.js
@@ -1,0 +1,178 @@
+#!/usr/bin/env node
+// probe_support_asymmetry.js — §S64 (bim-compiler prompts/4D_SCHEDULE_PERFECTION.md §S63's ⛔ open item).
+//
+// ISSUE THIS PROVES OR DISPROVES: computeSchedule and auditFloating are supposed to test the SAME
+// physics (auditFloating's own header: "scheduler and auditor now test the same thing"; the hang
+// guard's comment: "mirrors the scheduler's hangGate pool rule, so audit and scheduler agree").
+// §S63 measured one pair where they do NOT agree. This probe asks the general question: across all
+// 7 shipped buildings, for EVERY element auditFloating reports as floating, WHICH side disagrees,
+// and by how much.
+//
+// It never re-implements physics it can import: computeSchedule/auditFloating come from the shipped
+// module. The per-element route reconstruction below mirrors auditFloating's own scan verbatim
+// (schedule_gate.js:1076-1130) so a classification can be attributed to a named predicate.
+//
+// Reads ONLY. Changes nothing. Command:
+//   BLD_DIR=~/bim-ootb/buildings node scripts/probe_support_asymmetry.js
+'use strict';
+const fs = require('fs'), path = require('path'), vm = require('vm');
+const initSqlJs = require(path.join(__dirname, '..', 'modeller', 'lib', 'sql-wasm.js'));
+const SG = require(path.join(__dirname, '..', 'viewer', 'schedule_gate.js'));
+const ZoneIndex = require(path.join(__dirname, '..', 'viewer', 'zone_index.js'));
+const tmSrc = fs.readFileSync(path.join(__dirname, '..', 'viewer', 'time_machine.js'), 'utf8');
+
+function sliceFn(src, name) {
+  const idx = src.indexOf('function ' + name + '(');
+  if (idx < 0) throw new Error(name + ' not found');
+  let d = 0, i = idx, o = false;
+  for (; i < src.length; i++) { if (src[i] === '{') { d++; o = true; } else if (src[i] === '}') { d--; if (o && d === 0) return src.slice(idx, i + 1); } }
+  throw new Error('unbalanced ' + name);
+}
+const BLD_DIR = process.env.BLD_DIR || path.join(require('os').homedir(), 'bim-ootb', 'buildings');
+const BUILDINGS = (process.env.ONLY || 'Terminal,Hospital,Duplex,HHS_Office_Federated,Clinic,LTU_AHouse,JKR').split(',');
+const DB_FILE = { LTU_AHouse: 'LTU_AHouse_meta.db' };
+const CELL = SG.CELL, EPS = SG.EPS, GAP = SG.GAP, BIG = SG.BIG_ELEMENT_VOL, DAY = 86400000;
+function cellsOf(e) { const o = []; for (let i = Math.floor(e.x0 / CELL); i <= Math.floor(e.x1 / CELL); i++) for (let j = Math.floor(e.y0 / CELL); j <= Math.floor(e.y1 / CELL); j++) o.push(i + ',' + j); return o; }
+function overlap(a, b) { return a.x0 <= b.x1 && a.x1 >= b.x0 && a.y0 <= b.y1 && a.y1 >= b.y0; }
+function vol(e) { return (e.x1 - e.x0) * (e.y1 - e.y0) * (e.top_z - e.base_z); }
+
+// ── the two membership tests, written where they can be compared side by side ──────────────────
+const schedPool = e => SG.supportPool(e);                                  // schedule_gate.js:1246
+const auditPool = e => e.seq <= 4 || (e.cls === 'IfcSlab' && e.seq > 4);    // schedule_gate.js:1077
+const schedElPool = e => (e.cls === 'IfcSlab' && e.seq > 4) || e.cls === 'IfcStairFlight';  // hangGate:611
+const auditTPool = e => e.cls === 'IfcSlab' && e.seq > 4;                   // auditFloating:1106
+
+(async () => {
+  const names = ['_buildXrayElements'];
+  if (tmSrc.indexOf('function _promoteRoofLoadPath(') >= 0) names.unshift('_promoteRoofLoadPath');
+  for (const d of ['_classifyNameOverride', '_classifyRule']) if (tmSrc.indexOf('function ' + d + '(') >= 0) names.push(d);
+  const sliced = names.map(n => sliceFn(tmSrc, n)).join('\n');
+  const SQL = await initSqlJs({ wasmBinary: fs.readFileSync(path.join(__dirname, '..', 'modeller', 'lib', 'sql-wasm.wasm')) });
+  const rulesJson = JSON.parse(fs.readFileSync(path.join(__dirname, '..', 'viewer', 'rates', 'sequence_rules.json'), 'utf8'));
+  const totals = { floating: 0 };
+
+  for (const B of BUILDINGS) {
+    const dbPath = path.join(BLD_DIR, DB_FILE[B] || (B + '_extracted.db'));
+    if (!fs.existsSync(dbPath)) { console.log('§ASYM_SKIP ' + B + ' fixture missing'); continue; }
+    const db = new SQL.Database(fs.readFileSync(dbPath));
+    const sandbox = { console: { log: () => {}, warn: () => {} }, performance: { now: () => Date.now() },
+      window: { SEQUENCE_RULES: rulesJson.SEQUENCE_RULES, SEQUENCE_DEFAULT: rulesJson.SEQUENCE_DEFAULT, SEQUENCE_NAME_OVERRIDES: rulesJson.SEQUENCE_NAME_OVERRIDES || rulesJson.NAME_OVERRIDES || [] },
+      A: () => ({ db: db }), ZoneIndex: ZoneIndex, _zoneIndex: () => ZoneIndex.build(db) };
+    vm.createContext(sandbox);
+    vm.runInContext(sliced + '\nthis.__bxe = _buildXrayElements;', sandbox);
+    const els = sandbox.__bxe(); db.close();
+    const geoEls = els.filter(e => !(e.x0 === e.x1 && e.y0 === e.y1 && e.base_z === e.top_z));
+    geoEls.forEach(e => { e.resource = e.cls; e.installSecs = 120; });
+
+    const ol = console.log; const engineLines = [];
+    console.log = function () { engineLines.push(Array.prototype.map.call(arguments, String).join(' ')); };
+    const sched = SG.computeSchedule(geoEls, 0, 1);
+    const floaters = [];
+    const floating = SG.auditFloating(geoEls, sched, null, floaters);
+    console.log = ol;
+
+    // membership disagreement, counted over the whole model (not just floaters)
+    const gridDiff = geoEls.filter(e => schedPool(e) !== auditPool(e));
+    const poolDiff = geoEls.filter(e => e.seq > 4 && schedElPool(e) !== auditTPool(e));
+    const byCls = {}; gridDiff.forEach(e => { byCls[e.cls] = (byCls[e.cls] || 0) + 1; });
+
+    // rebuild auditFloating's TWO grids so each floater's route can be attributed. The wall grid
+    // matters: auditFloating offers [structGrid, wallGrid] to a promoted slab and [structGrid] to
+    // everything else (schedule_gate.js:1096) — a reconstruction that scans only structGrid
+    // mis-attributes every promoted-slab floater.
+    const structGrid = {}, wallGrid = {};
+    for (const e of geoEls) {
+      if (auditPool(e)) { for (const c of cellsOf(e)) (structGrid[c] = structGrid[c] || []).push(e); }
+      else if (e.cls.indexOf('IfcWall') === 0) { for (const c of cellsOf(e)) (wallGrid[c] = wallGrid[c] || []).push(e); }
+    }
+    const byG = new Map(geoEls.map(e => [e.guid, e]));
+    // The SCHEDULER's own grid + its own `below` relation, evaluated at FINAL times. computeSchedule
+    // promises (via the §DEQ_REPAIR fixpoint) that no element starts before max(geoGate,…) — but that
+    // loop iterates `nonst` (seq>4) ONLY (schedule_gate.js:951). If this is violated for a floater,
+    // the disagreement is NOT audit-vs-scheduler: the scheduler is contradicting itself.
+    const schedGrid = {};
+    for (const e of geoEls) if (schedPool(e)) for (const c of cellsOf(e)) (schedGrid[c] = schedGrid[c] || []).push(e);
+    function schedBelowGate(T) {
+      let g = 0, sn = {};
+      for (const c of cellsOf(T)) { const arr = schedGrid[c]; if (!arr) continue;
+        for (const S of arr) { if (sn[S.guid] || S.guid === T.guid) continue; sn[S.guid] = 1;
+          if (S.base_z < T.base_z - EPS && overlap(S, T)) { const en = sched[S.guid].end; if (en > g) g = en; } } }
+      return g;
+    }
+    let selfViol = 0, selfViolByClass = {};
+    const cycSet = new Set(global.__PROBE_CYCLE_GUIDS || []);
+    let cycViol = 0, cycFloat = 0;
+    const t0 = Math.min(...Object.values(sched).map(s => s.start));
+    const KEYS = ['A1', 'A2', 'A3a', 'A3a_passA_vs_passB', 'A3b', 'A3c', 'A4'];
+    const cls = {}, samples = {}; KEYS.forEach(k => { cls[k] = 0; samples[k] = []; });
+    let worstDeficit = 0;
+
+    for (const g of floaters) {
+      const T = byG.get(g); if (!T) continue;
+      const cs = cellsOf(T);
+      let route = null, se = 0, seen = {}, seS = null, seFromWall = false;
+      const isPromo = T.cls === 'IfcSlab' && T.seq > 4;
+      const pools = isPromo ? [structGrid, wallGrid] : [structGrid];
+      for (let pi = 0; pi < pools.length; pi++) {
+        for (const c of cs) { const arr = pools[pi][c]; if (!arr) continue;
+          for (const S of arr) { if (seen[S.guid] || S.guid === T.guid) continue; seen[S.guid] = 1;
+            if (S.base_z < T.base_z - EPS && S.top_z >= T.base_z - GAP && overlap(S, T)) {
+              route = 'bearing'; const en = sched[S.guid].end;
+              if (en > se) { se = en; seS = S; seFromWall = (pi === 1); } } } }
+      }
+      const tPool = auditTPool(T), tWall = T.cls.indexOf('IfcWall') === 0;
+      if (!route && T.seq > 4) {
+        const sh = {};
+        for (const c of cs) { const arr = structGrid[c]; if (!arr) continue;
+          for (const S of arr) { if (sh[S.guid] || S.guid === T.guid) continue; sh[S.guid] = 1;
+            if (S.base_z >= T.top_z - GAP && S.base_z <= T.top_z + GAP && S.top_z > T.top_z + EPS &&
+                !(tPool && T.base_z < S.base_z - EPS) &&
+                !(tWall && S.cls === 'IfcSlab' && S.seq > 4 && T.base_z < S.base_z - EPS && T.top_z >= S.base_z - GAP) &&
+                overlap(S, T)) { route = 'hang'; const eh = sched[S.guid].end; if (eh > se) se = eh; } } }
+        if (!route && !tPool && !tWall && vol(T) > BIG) route = 'hangNearest';
+      }
+      const deficit = (se - sched[T.guid].start) / DAY;
+      if (deficit > worstDeficit) worstDeficit = deficit;
+      // A1 — the §S63 class: T is a SCHEDULER pool member (its hangGate refuses to hang it on what
+      //      it sits below of) but NOT an audit tPool member, so the audit hangs it there anyway.
+      // A2 — T is audited on the hang route and IS tPool-consistent: a genuine carrier disagreement.
+      // A3 — bearing route: audit and scheduler use the SAME predicate (edgeBearing), so the start
+      //      really is early relative to a support both sides recognise.
+      // A4 — hangNearest route, or nothing reconstructed.
+      // A3 splits on WHICH grid set `se`, and on whether the scheduler's own wallGate would have
+      // waited for that wall at all. wallGate is BOUNDED at the top (S.top_z <= T.base_z + GAP,
+      // schedule_gate.js:684 — the §TM_GEO_ORDER_CYCLES carry-at-top rule); the audit's bearing test
+      // over wallGrid has NO upper bound. A wall whose crown rises metres past the slab's underside
+      // is therefore audit-support the scheduler never gated on.
+      let k;
+      if (route === 'hang' && schedElPool(T) && !auditTPool(T)) k = 'A1';
+      else if (route === 'hang') k = 'A2';
+      else if (route === 'bearing' && seFromWall && seS && !(seS.top_z <= T.base_z + GAP)) k = 'A3b';
+      else if (route === 'bearing' && seFromWall) k = 'A3c';
+      else if (route === 'bearing') k = (T.seq <= 4 && seS && seS.seq > 4) ? 'A3a_passA_vs_passB' : 'A3a';
+      else k = 'A4';
+      cls[k]++;
+      const sg = schedBelowGate(T);
+      if (sg > sched[T.guid].start + 1) { selfViol++; selfViolByClass[k] = (selfViolByClass[k] || 0) + 1;
+        if (cycSet.has(T.guid)) cycViol++; }
+      if (cycSet.has(T.guid)) cycFloat++;
+      if (samples[k].length < 3) samples[k].push(T.cls + ' seq=' + T.seq + ' bz=' + T.base_z.toFixed(2) + ' deficit=' + deficit.toFixed(3) + 'd' + (seS ? ' via=' + seS.cls + '/seq' + seS.seq + (seFromWall ? '(wallGrid,top=' + seS.top_z.toFixed(2) + ' vs myBase=' + T.base_z.toFixed(2) + ')' : '') : ''));
+    }
+    totals.floating += floating; KEYS.forEach(k => totals[k] = (totals[k] || 0) + cls[k]);
+
+    console.log('§ASYM ' + B + ' n=' + geoEls.length + ' floating=' + floating +
+      ' | A1_tPool_not_mirrored=' + cls.A1 + ' A2_hang_carrier=' + cls.A2 +
+      ' A3a_bearing_struct=' + cls.A3a + ' A3aPassAvsB=' + cls.A3a_passA_vs_passB + ' A3b_wall_above_bound=' + cls.A3b +
+      ' A3c_wall_in_bound=' + cls.A3c + ' A4_nearest/none=' + cls.A4 +
+      ' worstDeficitD=' + worstDeficit.toFixed(2));
+    console.log('      gridMembershipDiff=' + gridDiff.length + ' ' + JSON.stringify(byCls) +
+      ' hangPoolDiff(seq>4)=' + poolDiff.length);
+    console.log('      cycleSet=' + cycSet.size + ' floatersInCycleSet=' + cycFloat + ' selfViolInCycleSet=' + cycViol + '/' + selfViol);
+    console.log('      SCHEDULER-SELF-CONTRADICTION among floaters: ' + selfViol + '/' + floaters.length +
+      ' ' + JSON.stringify(selfViolByClass) + '  (element starts before its OWN geoGate `below` support ends, at final times)');
+    for (const k of KEYS) if (samples[k].length) console.log('      ' + k + ': ' + samples[k].join(' | '));
+    engineLines.filter(l => /§SUPPORT_CYCLE|§DEQ_REPAIR|§GEO_ORDER /.test(l)).forEach(l => console.log('      engine| ' + l.slice(0, 150)));
+  }
+  console.log('§ASYM_TOTAL floating=' + totals.floating + ' ' +
+    ['A1', 'A2', 'A3a', 'A3a_passA_vs_passB', 'A3b', 'A3c', 'A4'].map(k => k + '=' + (totals[k] || 0)).join(' '));
+})();

--- a/viewer/schedule_gate.js
+++ b/viewer/schedule_gate.js
@@ -1096,14 +1096,32 @@
       for (var p = 0; p < pools.length; p++) {
         for (c = 0; c < cs.length; c++) { arr = pools[p][cs[c]]; if (!arr) continue;
           for (k = 0; k < arr.length; k++) { S = arr[k]; if (seen[S.guid] || S.guid === T.guid) continue; seen[S.guid] = 1;
+            // §S64 (2026-08-22) — the WALL pool (p===1, offered only to a promoted slab) must carry
+            // the same CARRY-AT-TOP bound the scheduler puts on the identical relation: wallGate
+            // (:684) and the DAG's wallCarries (:797) both require S.top_z <= T.base_z + GAP, the
+            // §TM_GEO_ORDER_CYCLES rule that "a wall carries a promoted slab AT ITS TOP, never one
+            // embedded metres below its crown". Without it the audit counted a wall the scheduler
+            // never gated on — measured: Terminal IfcWall top 37.06 against a slab base 30.57,
+            // LTU_AHouse 10.80 against 8.60 — 73 fleet-wide false "floating" verdicts (Terminal 8,
+            // Clinic 1, LTU_AHouse 64). structGrid (p===0) is unbounded here as before: that pool's
+            // bearing test is edgeBearing's exact twin and already agrees with the gate.
+            if (p === 1 && !(S.top_z <= T.base_z + GAP)) continue;
             if (S.base_z < T.base_z - EPS && S.top_z >= T.base_z - GAP && overlap(S, T)) {
               hasBearing = true;
               var en = sched[S.guid].end; if (en > se) se = en; } } }
       }
       if (!hasBearing && T.seq > 4) {      // hangs — audit against its carrier above instead
-        // §GEOMETRIC_SUPPORT_ORDER: a pool member (promoted slab) never hangs from what it sits
-        // BELOW of — mirrors the scheduler's hangGate pool rule, so audit and scheduler agree
-        var tPool = T.cls === 'IfcSlab' && T.seq > 4;
+        // §GEOMETRIC_SUPPORT_ORDER: a pool member never hangs from what it sits BELOW of —
+        // mirrors the scheduler's hangGate pool rule, so audit and scheduler agree.
+        // §S64 (2026-08-22, bim-compiler prompts/4D_SCHEDULE_PERFECTION.md — Witness:
+        // witness_tm_geo_order_cycles.js W-TMREPRO-5/5b, scripts/probe_support_asymmetry.js):
+        // this line STOPPED mirroring at #1345, which added isStairFlight() to hangGate's elPool
+        // (:611) and to the scheduler's whole support pool (supportPool(), :1246) without touching
+        // the audit twin here. Result, measured on 3 of 7 buildings: the scheduler REFUSES to hang
+        // a stair flight on the landing it sits below, and the audit hangs it there anyway — 17
+        // fleet-wide false "floating" verdicts (Terminal 4, HHS 4, LTU_AHouse 9), deficits as small
+        // as 0.006 d. elPool's exact test, one concept, both sides.
+        var tPool = (T.cls === 'IfcSlab' && T.seq > 4) || T.cls === 'IfcStairFlight';
         var tWall = T.cls.indexOf('IfcWall') === 0;
         var seenH = {};
         for (c = 0; c < cs.length; c++) { arr = structGrid[cs[c]]; if (!arr) continue;

--- a/viewer/sw.js
+++ b/viewer/sw.js
@@ -8,7 +8,7 @@
 // Cache-first for heavy assets (.wasm, images). DB files skip SW (IndexedDB handles them).
 //
 // DEPLOY: bump CACHE_VERSION on every OCI upload. Old caches are purged on activate.
-const CACHE_VERSION = 'v1068';   // bump on each deploy; per-change detail is the git commit message.
+const CACHE_VERSION = 'v1069';   // bump on each deploy; per-change detail is the git commit message.
 // v1064 (2026-08-21) 4D_GANTT_TM_REFACTOR.md §S58 — observability hardening, ADDITIVE LOGGING
 // ONLY, no rule or behaviour changed. (a) the three §GANTT_* proof lines now fire on every
 // model REBUILD instead of once per building, so an edit is auditable (rebuild=N ordinal).

--- a/viewer/tests/baselines/midair.json
+++ b/viewer/tests/baselines/midair.json
@@ -1,10 +1,10 @@
 {
   "_readme": "Locked regression baselines for viewer/tests/witness_midair_zero.js. DATA ONLY — the WHY for every number stays in the witness's own comment blocks, which cite the prompts/4D_GANTT_TM_REFACTOR.md section that measured it. Split out of the witness source 2026-08-21 so a re-lock is a data edit with a readable diff, and so adding an eighth building never edits test code. Re-lock discipline is unchanged: first run with placeholder -1s, read the real numbers off the FAIL lines, re-run to PASS. Never hand-write a number you have not seen a run produce.",
-  "_relocked": "2026-08-21 — §S50 cell-grain schedule (bim-ootb #1442), carried unchanged through §S51 (#1444)",
+  "_relocked": "2026-08-21 — §S50 cell-grain schedule (bim-ootb #1442), carried unchanged through §S51 (#1444). float_after_cpm ONLY re-locked 2026-08-22 (§S64): HHS 889->884, LTU_AHouse 5023->4998, JKR 1222->1212 — auditFloating shed false positives when its tPool was made to mirror hangGate's elPool and its wall pool given wallCarries' carry-at-top bound. NO schedule time changed (both fixes are inside auditFloating, which no gate reads); midair and orphans are byte-identical on all 7, which is the proof this was the audit and not the engine.",
   "float_after_cpm": {
     "_what": "W-MZ-8 — ScheduleGate.auditFloating AFTER _displayTimeline. The measured TRADE: a dependent may start before its support FINISHES. Deliberate and named, never silent.",
-    "Terminal": 554, "Hospital": 935, "Duplex": 44, "HHS_Office_Federated": 889,
-    "Clinic": 324, "LTU_AHouse": 5023, "JKR": 1222
+    "Terminal": 554, "Hospital": 935, "Duplex": 44, "HHS_Office_Federated": 884,
+    "Clinic": 324, "LTU_AHouse": 4998, "JKR": 1212
   },
   "midair": {
     "_what": "W-MZ-2 — this witness's own census(): elements appearing before the first thing they touch. Non-zero ONLY on the CELL-path buildings (the §S26.11 leg-4 exception surface); GRAPH-path buildings stay at 0. W-MZ-7 is the proof this judge can go red.",

--- a/viewer/tests/witness_big_element_support_coverage.js
+++ b/viewer/tests/witness_big_element_support_coverage.js
@@ -84,6 +84,18 @@ const BUILDINGS = [
   // Hospital=0 Duplex=0 HHS=9 Clinic=1 LTU_AHouse=360 JKR=80. Terminal 8->12 is bisected and
   // explained in witness_tm_geo_order_cycles.js (which DOES lock it, count + composition); the rest
   // are recorded here so the next reader compares against a real number, not a stale one.
+  //
+  // RE-LOCKED 2026-08-22 (§S64, bim-compiler prompts/4D_SCHEDULE_PERFECTION.md §S64) — Terminal 32->36,
+  // HHS 13->17, LTU_AHouse 626 (was 611). Three baselines moved UP and that is the INTENDED trade,
+  // not a regression: auditFloating stopped handing a stair flight a false hang-carrier above it
+  // (its tPool now mirrors hangGate's elPool) and stopped counting a wall whose crown rises past a
+  // promoted slab's underside (its wall pool now carries wallCarries' carry-at-top bound). An
+  // element that was being given a support it never had is now an HONEST §SUPPORT_UNCHECKED finding
+  // — named, counted, warn-only, never a gate. The exchange is exact: floating fell 462->362
+  // fleet-wide while unchecked rose 863->886, and every added warn is one of the elements whose
+  // false carrier was removed. Floating re-measured the same day: Terminal=0 Hospital=0 Duplex=0
+  // HHS=5 Clinic=0 LTU_AHouse=277 JKR=80 (the 350 remaining are the §SUPPORT_CYCLE fallback on
+  // JKR+LTU_AHouse — 350/350 measured cycle-set membership, an upstream modelling fact).
   // RE-MEASURED 2026-08-11 (closure pass, bigsup_after_fix.log) after the
   // 'slab_on_grade_substructure' name-override (rates.js/sequence_rules.json — slab-on-grade is
   // the 1c spec's own named ground-bearing class, pattern measured to exactly Duplex 4 + Clinic 4
@@ -94,10 +106,10 @@ const BUILDINGS = [
   // IfcPile SEQUENCE_RULES entry added the same pass (Gap A close) changed nothing anywhere —
   // latent by construction (no shipped building models the class; Terminal's real piles arrive
   // via the IfcSlab name-override). TOTAL 250→246.
-  { file: 'Terminal_extracted.db',             name: 'Terminal', bms: true,  expectedUnchecked: 32 },   // was bms:false/279
+  { file: 'Terminal_extracted.db',             name: 'Terminal', bms: true,  expectedUnchecked: 36 },   // was bms:false/279; 32->36 §S64
   { file: 'Hospital_extracted.db',             name: 'Hospital', bms: true,  expectedUnchecked: 177 },  // was 503
   { file: 'Duplex_extracted.db',               name: 'Duplex',   bms: true,  expectedUnchecked: 2 },    // was 6 — SoG override, see above
-  { file: 'HHS_Office_Federated_extracted.db', name: 'HHS',      bms: false, expectedUnchecked: 13 },   // was 21
+  { file: 'HHS_Office_Federated_extracted.db', name: 'HHS',      bms: false, expectedUnchecked: 17 },   // was 21; 13->17 §S64
   { file: 'Clinic_extracted.db',               name: 'Clinic',   bms: true,  expectedUnchecked: 22 },   // count HELD, mix changed (see 3)
   // Coverage extended 2026-08-11 (chase-to-zero pass) — first witness coverage for these two; the
   // 5-building locked set above is UNTOUCHED (its 246 total stands; these rows are additive).
@@ -111,7 +123,7 @@ const BUILDINGS = [
   // member in a mutual pair never converges — measured Clinic 43k pushes/400 sweeps).
   // JKR: bms=false (zero seq-1 elements — its foundation slabs are authored plain IfcSlab at the
   // z≈84m site datum), unchecked=6, floating=81 (same steel co-planar family: CHS members/columns).
-  { file: 'LTU_AHouse_meta.db',                name: 'LTU_AHouse', bms: true,  expectedUnchecked: 611 },
+  { file: 'LTU_AHouse_meta.db',                name: 'LTU_AHouse', bms: true,  expectedUnchecked: 626 },   // 611->626 §S64
   { file: 'JKR_extracted.db',                  name: 'JKR',        bms: false, expectedUnchecked: 6 },
 ];
 

--- a/viewer/tests/witness_tm_geo_order_cycles.js
+++ b/viewer/tests/witness_tm_geo_order_cycles.js
@@ -16,9 +16,10 @@
 //     consumer's LOWER HALF; a wall carries a promoted slab only AT ITS TOP (wallCarries, ±GAP).
 //     Terminal: cycles 37,927→0, §DEQ_REPAIR shifts 251→0, floating 45→8 (37 were cycle-fallback
 //     ordering artifacts; the 8 remain a separate, named, open tail). This witness ASSERTS
-//     cycles=0 plus the floating tail's COUNT AND COMPOSITION so any regression screams. The tail
-//     is 12 since #1345 (§S63, 2026-08-22 — bisected, isolated to one file, cause measured; see the
-//     block at W-TMREPRO-5). It was 8 from 2026-08-10 to #1345.
+//     cycles=0 plus the floating tail's COUNT AND COMPOSITION so any regression screams. History of
+//     the tail: 45 -> 8 (2026-08-10, the cycle fix) -> 12 (#1345, §S63 — bisected and explained) ->
+//     0 (§S64, 2026-08-22 — both causes were audit-side false positives, closed in auditFloating
+//     with no schedule time changed). See the block at W-TMREPRO-5.
 //
 //   ISSUE 2 (refactor invariance): the roof/load-path promotion classifier existed as two copies in
 //     time_machine.js (_buildXrayElements inline + injectGantt inline). Direct verification proved
@@ -165,14 +166,25 @@ const BLD_DIR = process.env.BLD_DIR || path.join(require('os').homedir(), 'bim-o
   // into auditFloating (it surfaced an unrelated _twoTierRemap weakness). Closing the asymmetry is
   // a named open item, NOT this witness's job — see prompts/4D_SCHEDULE_PERFECTION.md §S63.
   //
-  // The lock is therefore 12 AND its composition: count alone would let a swap through.
+  // §S64 (2026-08-22) — the asymmetry named above was STUDIED fleet-wide and CLOSED, audit-side, in
+  // two lines that changed no schedule time: auditFloating's tPool now mirrors hangGate's elPool
+  // (so a stair flight is no longer hung on the landing it sits below), and its wall pool now
+  // carries wallCarries' carry-at-top bound (so a wall cresting metres past a promoted slab's
+  // underside is no longer counted as that slab's support). Terminal's tail went 12 -> 0: the 4
+  // stair flights and the 8 promoted roof slabs were BOTH false positives, from the two different
+  // causes. The lock is therefore ZERO and an EMPTY composition — Terminal's support DAG is acyclic
+  // AND its audit is clean. See prompts/4D_SCHEDULE_PERFECTION.md §S64 for the fleet decomposition
+  // (462 -> 362; the 350 that remain are the §SUPPORT_CYCLE fallback on JKR + LTU_AHouse, 350/350
+  // measured cycle-set membership — not this file's building and not an audit defect).
+  //
+  // The lock is count AND composition: count alone would let a swap through.
   assert(cycles === 0, 'W-TMREPRO-4 Terminal support DAG is acyclic under load-path promotion (cycles=' + cycles + ', fix: lower-half contained + wallCarries)');
   var _byG = new Map(geoEls.map(function (e) { return [e.guid, e]; }));
   var _tail = {};
   collector.forEach(function (g) { var e = _byG.get(g); var c = e ? e.cls : 'NOT-IN-geoEls'; _tail[c] = (_tail[c] || 0) + 1; });
   var tailSig = Object.keys(_tail).sort().map(function (k) { return k + ':' + _tail[k]; }).join(',');
-  assert(floating === 12, 'W-TMREPRO-5 floating tail exactly 12 (8 promoted roof slabs since 2026-08-10 + 4 stair flights since #1345, §S63) — got ' + floating);
-  assert(tailSig === 'IfcSlab:8,IfcStairFlight:4', 'W-TMREPRO-5b floating tail COMPOSITION unchanged (a swap that keeps the count still reddens) — got ' + tailSig);
+  assert(floating === 0, 'W-TMREPRO-5 floating tail exactly 0 (was 45 -> 8 -> 12; §S64 closed both false-positive causes audit-side, no schedule time changed) — got ' + floating);
+  assert(tailSig === '', 'W-TMREPRO-5b floating tail COMPOSITION empty (a returning floater names its own class here) — got ' + (tailSig || '<empty>'));
 
   // THE line. Must be numerically identical pre vs post the _promoteRoofLoadPath refactor
   // (diffed across the two commits' logs — see header ISSUE 2). Numbers only; slice state is on


### PR DESCRIPTION
Implementing bim-compiler `prompts/4D_SCHEDULE_PERFECTION.md` §S64 — the ⛔ open item §S63 left behind.

**Two lines, both inside `auditFloating`.** It is a post-hoc audit that no gate reads, so **no schedule time changes** and the 4D generics cannot regress by construction. The suite proves it rather than asserting it: 44 witnesses, per-file verdicts **byte-identical** to the pre-change run (`green=40 new_red=0 known_red=4 flaky=0`).

## The two disagreements

**C1 — `tPool` never mirrored `hangGate`'s `elPool`.** `hangGate` uses `isPromotedSlab || isStairFlight` (`:611`); the audit still used IfcSlab-only — under a comment that literally claims it *"mirrors the scheduler's hangGate pool rule, so audit and scheduler agree"*. It stopped mirroring at #1345. So the scheduler **refuses** to hang a stair flight on the landing it sits below, and the audit hung it there anyway. **17 false verdicts** (Terminal 4, HHS 4, LTU_AHouse 9), deficits as small as 0.006 d.

**C3 — the audit's wall pool had no carry-at-top bound.** `wallGate` (`:684`) and the DAG's `wallCarries` (`:797`) both require `S.top_z <= T.base_z + GAP`. `auditFloating` offered `wallGrid` to a promoted slab with no upper bound, so a wall cresting metres past the slab's underside counted as support the scheduler never gated on — Terminal wall top 37.06 vs slab base 30.57; LTU 10.80 vs 8.60. **73 false verdicts** (Terminal 8, Clinic 1, LTU_AHouse 64). `structGrid` is deliberately left unbounded: that pool's test is `edgeBearing`'s exact twin and already agrees with the gate.

## Measured, all 7 buildings

New probe `scripts/probe_support_asymmetry.js` attributes **every** floater to a named predicate.

| building | before | after |
|---|---|---|
| Terminal | 12 | **0** |
| Clinic | 1 | **0** |
| HHS_Office_Federated | 9 | 5 |
| LTU_AHouse | 360 | 277 |
| JKR | 80 | 80 |
| Hospital / Duplex | 0 | 0 |
| **fleet** | **462** | **362** |

## What is NOT fixed, and why — the study is the point

**350 of the remaining 362 are not an audit defect at all.** They are *scheduler self-contradictions* (the element starts before its own `geoGate` `below` support ends), and **350 of 350 are members of the `§SUPPORT_CYCLE` fallback set** — JKR 80/80 of 4,564 cycles, LTU_AHouse 270/270 of 25,708. Kahn cannot order a cycle member, so it falls back to seq order and `geoGate` cannot see a support not yet placed. Every `cycles=0` building has **zero** of these. That is upstream modelling geometry, already named and deliberately unresolved (no-invent: a true geometric cycle is a MODELING fact).

A candidate fix was **built and rejected**: extending the `§DEQ_REPAIR` fixpoint to PASS-A gives LTU 360 → **1139**, JKR 80 → **159**, `sweeps=16` (the cap — no fixpoint) with 56,948 / 42,141 shifts. Recorded in §S64 so nobody retries it.

## Re-locked, each with its cause — no baseline moved silently

- `W-TMREPRO-5` Terminal **12 → 0**, `W-TMREPRO-5b` composition → empty. Terminal's audit is now clean.
- `baselines/midair.json` `float_after_cpm`: HHS 889→884, LTU_AHouse 5023→4998, JKR 1222→1212 (down — false positives shed). **`midair` and `orphans` are byte-identical on all 7**, which is the proof this was the audit and not the engine.
- `witness_big_element_support_coverage` `expectedUnchecked`: Terminal 32→36, HHS 13→17, LTU_AHouse 611→626. These move **up**, and that is the intended trade: an element that was being handed a support it never had is now an honest `§SUPPORT_UNCHECKED` finding — named, counted, warn-only, never a gate. The exchange is exact — every added warn is an element whose false carrier was removed.

**Proven red both ways:** revert C1 → `got 4` / `IfcStairFlight:4`; revert C3 → `got 8` / `IfcSlab:8`.

## Gantt editor

`verifyGanttIntegrity` (`time_machine.js:4205`) judges a bar drag with this same `auditFloating`, against a baseline captured on unlock (`§GANTT_LOCK_DELTA`) — so the delta test is unchanged, but both numbers are now free of these false positives and a breach no longer names them as offenders.

`sw.js` `CACHE_VERSION` v1068 → v1069 (`schedule_gate.js` is precached). `_GANTT_CACHE_VERSION` unchanged — the audit is recomputed on load, never cached.

🤖 Generated with [Claude Code](https://claude.com/claude-code)