### PR TITLE
feat(4d): §GANTT_CPM_ANNOTATE — drag → CPM annotate (float + critical path), never a re-solve

### DIFF
--- a/viewer/sw.js
+++ b/viewer/sw.js
@@ -8,7 +8,7 @@
 // Cache-first for heavy assets (.wasm, images). DB files skip SW (IndexedDB handles them).
 //
 // DEPLOY: bump CACHE_VERSION on every OCI upload. Old caches are purged on activate.
-const CACHE_VERSION = 'v1070';   // bump on each deploy; per-change detail is the git commit message.
+const CACHE_VERSION = 'v1071';   // bump on each deploy; per-change detail is the git commit message.
 // v1064 (2026-08-21) 4D_GANTT_TM_REFACTOR.md §S58 — observability hardening, ADDITIVE LOGGING
 // ONLY, no rule or behaviour changed. (a) the three §GANTT_* proof lines now fire on every
 // model REBUILD instead of once per building, so an edit is auditable (rebuild=N ordinal).

--- a/viewer/tests/witness_gantt_cpm_annotate.js
+++ b/viewer/tests/witness_gantt_cpm_annotate.js
@@ -1,0 +1,251 @@
+#!/usr/bin/env node
+// WITNESS — W-CPM — §GANTT_CPM_ANNOTATE (drag → CPM annotate, NOT re-solve)
+// Spec: bim-compiler prompts/4D_GANTT_TM_REFACTOR.md §S68.
+//
+// ISSUE THIS PROVES OR DISPROVES:
+//   The standing question on this lane was "does the in-canvas Gantt drag run CPM?" It does not:
+//   moveTaskCascade runs a push-only forward cascade + predecessor-floor clamp. The product
+//   decision (2026-08-23) was ANNOTATE — run CPM after the cascade, in fixedDates mode, to derive
+//   float and criticality FROM the dates the cascade produced, and paint the critical path. The
+//   decision rests on ONE property: annotate must never move a date. If it can, the drag silently
+//   acquires a second, conflicting date engine — and the derived forward pass is measured to
+//   inflate a real 93d programme to 138d (+48%) on Terminal's 71-zone graph (schedule_author.js
+//   :1385), so a regression here is not cosmetic.
+//
+//   W-CPM-1  wiring   — every re-time path re-annotates (the §S67 failure mode, pre-empted).
+//   W-CPM-2  BEHAVIOUR — computeCpm(fixedDates:true) leaves every schedule_* column byte-identical
+//                        on a REAL materialized schedule, while writing real criticality.
+//   W-CPM-3  counter-proof — fixedDates is load-bearing: with a task deliberately pushed off its
+//                        graph-derived position, the two modes report DIFFERENT early starts. Without
+//                        this, W-CPM-2 could pass simply because both modes agree on this fixture.
+//   W-CPM-4  display  — drawGanttMini actually paints the marks (a computed critical path nothing
+//                        renders is not the feature).
+//
+// ⚠ Source checks are BRACE-MATCHED, never a fixed slice window — witness_gantt_edit_coherence.js's
+//   G-COH-6 has been a false negative since its function outgrew a hardcoded 2200-char window (§S65).
+//
+// Command: node viewer/tests/witness_gantt_cpm_annotate.js
+'use strict';
+const fs = require('fs');
+const path = require('path');
+const os = require('os');
+
+let pass = 0, fail = 0;
+function assert(cond, msg) { if (cond) { pass++; console.log('  PASS ' + msg); } else { fail++; console.log('  FAIL ' + msg); } }
+
+// ─────────────────────────────── W-CPM-1 / W-CPM-4: source gates ───────────────────────────────
+const TM = path.join(__dirname, '..', 'time_machine.js');
+const src = fs.readFileSync(TM, 'utf8');
+
+function namedFns(text) {
+  const out = [];
+  const re = /\bfunction\s+([A-Za-z_$][\w$]*)\s*\(/g;
+  let m;
+  while ((m = re.exec(text))) {
+    const open = text.indexOf('{', m.index);
+    if (open < 0) continue;
+    let depth = 0, end = -1;
+    for (let i = open; i < text.length; i++) {
+      if (text[i] === '{') depth++;
+      else if (text[i] === '}') { depth--; if (depth === 0) { end = i + 1; break; } }
+    }
+    if (end > 0) out.push({ name: m[1], start: m.index, end: end, body: text.slice(m.index, end) });
+  }
+  return out;
+}
+const FNS = namedFns(src);
+function enclosingFn(callIdx) {
+  let best = null;
+  for (const f of FNS) {
+    if (f.start < callIdx && callIdx < f.end && (!best || (f.end - f.start) < (best.end - best.start))) best = f;
+  }
+  return best;
+}
+const lineOf = idx => src.slice(0, idx).split('\n').length;
+
+const CALL = 'retimeTaskElements(';
+const sites = [];
+for (let i = src.indexOf(CALL); i >= 0; i = src.indexOf(CALL, i + 1)) {
+  if (/function\s+$/.test(src.slice(Math.max(0, i - 12), i))) continue;   // the declaration itself
+  sites.push(i);
+}
+assert(sites.length >= 5, 'W-CPM-0 retimeTaskElements call sites found (n=' + sites.length +
+  ') — a 0 here means the function was renamed and this witness went blind, not that the wiring is clean');
+
+const missing = [], seen = {};
+for (const s of sites) {
+  const fn = enclosingFn(s);
+  if (!fn) { missing.push('line ' + lineOf(s) + ' <no enclosing function>'); continue; }
+  const key = fn.name + ':' + fn.start;
+  if (seen[key]) continue;
+  seen[key] = 1;
+  if (fn.body.indexOf('_tmAnnotateCpm(') < 0) missing.push(fn.name + '() at line ' + lineOf(fn.start));
+}
+console.log('§GANTT_CPM_ANNOTATE_WIRING retimeSites=' + sites.length + ' distinctFns=' + Object.keys(seen).length +
+  ' missingAnnotate=' + missing.length + (missing.length ? ' [' + missing.join(' | ') + ']' : ''));
+assert(missing.length === 0, 'W-CPM-1 every function that re-times elements also calls _tmAnnotateCpm() — ' +
+  (missing.length ? 'MISSING in ' + missing.join(', ') : 'all ' + Object.keys(seen).length + ' clean'));
+
+// Undo does NOT call retimeTaskElements (it restores kernel_ops rows directly), so the gate above
+// cannot see it — yet undoing an edit must un-colour the bars that edit coloured. Checked by name.
+const undoFn = FNS.find(f => f.name === 'undoLastGanttEdit');
+assert(!!undoFn && undoFn.body.indexOf('_tmAnnotateCpm(') >= 0,
+  'W-CPM-1b undoLastGanttEdit re-annotates too — an undo that leaves the OLD critical path painted is the §S67 bug in a new costume');
+
+// The graph itself changes float even when no date moves — both edge verbs must re-annotate.
+const linkFn = FNS.find(f => f.name === 'linkGanttBars');
+assert(!!linkFn && linkFn.body.indexOf('_tmAnnotateCpm(') >= 0, 'W-CPM-1c linkGanttBars re-annotates (a new edge changes float with no date move)');
+const propsFn = FNS.find(f => f.name === 'openGanttProps');
+assert(!!propsFn && (propsFn.body.match(/_tmAnnotateCpm\(/g) || []).length >= 2,
+  'W-CPM-1d openGanttProps re-annotates on BOTH its write paths (typed apply AND unlink)');
+
+const annFn = FNS.find(f => f.name === '_tmAnnotateCpm');
+assert(!!annFn, 'W-CPM-1e _tmAnnotateCpm is present and brace-matched');
+assert(!!annFn && /fixedDates:\s*true/.test(annFn.body),
+  'W-CPM-1f it calls computeCpm with fixedDates:true — WITHOUT this flag the forward pass re-derives dates from the graph (measured +48% on Terminal) and annotate becomes a second date engine');
+assert(!!annFn && /_ganttCritical\s*=\s*\{\}/.test(annFn.body),
+  'W-CPM-1g it CLEARS the marks when CPM cannot run (cycle/thin table) instead of leaving a stale critical path on screen');
+
+const drawFn = FNS.find(f => f.name === 'drawGanttMini');
+assert(!!drawFn && drawFn.body.indexOf('_ganttCritical[') >= 0,
+  'W-CPM-4 drawGanttMini reads _ganttCritical — a criticality nothing paints is not the feature');
+assert(!!drawFn && /cpmMark\.critical\s*\?\s*'#e53935'\s*:\s*'#26a69a'/.test(drawFn.body),
+  'W-CPM-4b it paints BOTH rails (red = zero float, green = slack) — see W-CPM-5b: criticality runs ' +
+  '27–82% of tasks across the fleet, so at the top of that range a red-only rail carries almost no signal');
+
+// ─────────────────────── W-CPM-2 / W-CPM-3: behaviour, real fixture ────────────────────────────
+const initSqlJs = require('/home/red1/bim-ootb/node_modules/sql.js');
+const SQLJS_DIST = '/home/red1/bim-ootb/node_modules/sql.js/dist';
+const ScheduleAuthor = require(path.join(__dirname, '..', 'schedule_author.js'));
+const ScheduleGate = require(path.join(__dirname, '..', 'schedule_gate.js'));
+
+// Real LABOR_RATES/RATES, not {}. With empty rate tables materializeZones produces a degenerate
+// ~1-day programme where everything is trivially critical — measured, and it is NOT what the live
+// viewer builds (the live page reports 58% critical on Duplex where the empty-rates path reports
+// 100%). Same rates.js slice loader witness_gantt_native_generate.js uses.
+function loadRules() {
+  const txt = fs.readFileSync(path.join(__dirname, '..', 'rates.js'), 'utf8');
+  const start = txt.indexOf('var RATES = {');
+  const defIdx = txt.indexOf('var SEQUENCE_DEFAULT');
+  const end = txt.indexOf('};', defIdx) + 2;
+  return (new Function(txt.slice(start, end) +
+    '\n return { SEQUENCE_RULES: SEQUENCE_RULES, SEQUENCE_DEFAULT: SEQUENCE_DEFAULT, LABOR_RATES: LABOR_RATES, RATES: RATES };'))();
+}
+const RULES = loadRules();
+
+initSqlJs({ locateFile: f => path.join(SQLJS_DIST, f) }).then(function (SQL) {
+  const dbPath = path.join(os.homedir(), 'bim-ootb', 'buildings', 'Duplex_extracted.db');
+  const db = new SQL.Database(fs.readFileSync(dbPath));
+  const rulesJson = JSON.parse(fs.readFileSync(path.join(__dirname, '..', 'rates', 'sequence_rules.json'), 'utf8'));
+  const SEQUENCE_RULES = rulesJson.SEQUENCE_RULES || rulesJson;
+  const mres = ScheduleAuthor.materializeZones(db, SEQUENCE_RULES,
+    { start: '2026-01-01', laborRates: RULES.LABOR_RATES, rates: RULES.RATES, scheduleGate: ScheduleGate });
+  if (!mres.ok) { console.log('§SKIP materializeZones failed: ' + JSON.stringify(mres)); process.exit(1); }
+  const schedId = mres.scheduleId;
+
+  function readDates() {
+    const r = db.exec('SELECT task_id, schedule_start, schedule_finish, schedule_duration FROM tasks WHERE schedule_id=?', [schedId]);
+    const out = {};
+    (r.length ? r[0].values : []).forEach(row => { out[row[0]] = row[1] + '|' + row[2] + '|' + row[3]; });
+    return out;
+  }
+
+  const before = readDates();
+  assert(Object.keys(before).length >= 4, 'RED-CONTROL: the real materialized schedule has ≥4 tasks (n=' +
+    Object.keys(before).length + ') — a dates-unchanged test needs real rows to be unchanged');
+
+  const fixed = ScheduleAuthor.computeCpm(db, schedId, { fixedDates: true });
+  if (!fixed || fixed.error) {
+    // Never a silent pass: 2 of the 7 fleet buildings carry cycles and computeCpm bails on them by
+    // design. If the FIXTURE is one of those, this witness cannot prove anything and must say so.
+    console.log('§GANTT_CPM_ANNOTATE_WITNESS_ABORT reason=' + (fixed ? fixed.error : 'no_result') +
+      ' — the fixture cannot exercise CPM; W-CPM-2/3 are UNPROVEN, not passing');
+    process.exit(1);
+  }
+
+  const after = readDates();
+  const changed = Object.keys(before).filter(id => before[id] !== after[id]);
+  console.log('§GANTT_CPM_ANNOTATE_DATES tasks=' + Object.keys(before).length + ' changed=' + changed.length +
+    (changed.length ? ' [' + changed.slice(0, 5).join(',') + ']' : ''));
+  assert(changed.length === 0,
+    'W-CPM-2 computeCpm(fixedDates:true) left EVERY schedule_start/schedule_finish/schedule_duration byte-identical — ' +
+    'this is the whole safety property of "annotate, not re-solve"' + (changed.length ? ' — MOVED: ' + changed.join(',') : ''));
+
+  const critRows = db.exec('SELECT COUNT(*) FROM tasks WHERE schedule_id=? AND is_critical=1', [schedId]);
+  const critInDb = critRows.length ? critRows[0].values[0][0] : 0;
+  const critReturned = (fixed.criticalIds || []).length;
+  console.log('§GANTT_CPM_ANNOTATE_CRIT returned=' + critReturned + ' persistedInDb=' + critInDb +
+    ' projectDuration=' + fixed.projectDuration + 'd tasks=' + fixed.tasks.length);
+  assert(critReturned > 0, 'W-CPM-2b it found a real critical path (n=' + critReturned +
+    ') — zero would mean the annotate paints nothing and the feature is invisible');
+  assert(critInDb === critReturned, 'W-CPM-2c is_critical was PERSISTED to the tasks rows the Gantt reads (db=' +
+    critInDb + ' returned=' + critReturned + ')');
+  const floats = fixed.tasks.map(t => t.totalFloat);
+  assert(Math.min.apply(null, floats) <= 0, 'W-CPM-2d at least one task has zero/negative total float (the critical chain)');
+
+  // ── W-CPM-3: the counter-proof. Push ONE task 30 days off its graph-derived position with a real
+  // verb, then the two modes MUST disagree about its early start. If they agree, `fixedDates` is not
+  // doing anything on this fixture and W-CPM-2 proves nothing.
+  const victim = fixed.tasks[fixed.tasks.length - 1].id;
+  const sres = ScheduleAuthor.shiftTasks(db, [victim], 30);
+  assert(sres && sres.ok, 'RED-CONTROL: shiftTasks moved the probe task +30d (setup for the counter-proof)');
+  const fixed2 = ScheduleAuthor.computeCpm(db, schedId, { fixedDates: true });
+  const derived = ScheduleAuthor.computeCpm(db, schedId, {});           // the mode annotate must NOT use
+  const f2 = (fixed2.tasks || []).find(t => t.id === victim);
+  const d2 = (derived.tasks || []).find(t => t.id === victim);
+  console.log('§GANTT_CPM_ANNOTATE_MODEDIFF task=' + victim + ' fixedES=' + (f2 && f2.es) +
+    ' derivedES=' + (d2 && d2.es) + ' fixedPF=' + fixed2.projectDuration + ' derivedPF=' + derived.projectDuration);
+  assert(!!f2 && !!d2 && f2.es !== d2.es,
+    'W-CPM-3 fixedDates is load-bearing: after pushing ' + victim + ' +30d off its derived position the two modes report ' +
+    'DIFFERENT early starts (fixed=' + (f2 && f2.es) + ' derived=' + (d2 && d2.es) + '). Equal values would mean W-CPM-2 passes trivially.');
+
+  // And the derived mode is exactly what §S68 refuses to ship: it re-derives, so it can move the
+  // project end. Reported as a measured number, not an opinion.
+  assert(fixed2.projectDuration !== derived.projectDuration || f2.es !== d2.es,
+    'W-CPM-3b the two modes are distinguishable at project level too (fixedPF=' + fixed2.projectDuration +
+    ' derivedPF=' + derived.projectDuration + ')');
+
+  // ── W-CPM-5: fleet criticality fraction. The display decision (two rails, not one) rests on the
+  // claim that these generated programmes are mostly-critical. That claim is measured here, on every
+  // building present, rather than asserted in a comment.
+  const bDir = path.join(os.homedir(), 'bim-ootb', 'buildings');
+  const fleet = fs.readdirSync(bDir).filter(f => f.endsWith('_extracted.db'));
+  const table = [];
+  for (const f of fleet) {
+    try {
+      const fdb = new SQL.Database(fs.readFileSync(path.join(bDir, f)));
+      const fm = ScheduleAuthor.materializeZones(fdb, SEQUENCE_RULES,
+        { start: '2026-01-01', laborRates: RULES.LABOR_RATES, rates: RULES.RATES, scheduleGate: ScheduleGate });
+      if (!fm.ok) { table.push({ b: f, note: 'materialize_fail' }); fdb.close(); continue; }
+      const fr = ScheduleAuthor.computeCpm(fdb, fm.scheduleId, { fixedDates: true });
+      if (fr.error) { table.push({ b: f, note: 'cpm_' + fr.error }); fdb.close(); continue; }
+      const n = fr.tasks.length, c = fr.criticalIds.length;
+      table.push({ b: f.replace('_extracted.db', ''), n: n, c: c, pct: Math.round(c / n * 100),
+                   pf: fr.projectDuration, maxFloat: Math.max.apply(null, fr.tasks.map(t => t.totalFloat)) });
+      fdb.close();
+    } catch (e) { table.push({ b: f, note: 'threw' }); }
+  }
+  const ok = table.filter(t => t.pct !== undefined);
+  console.log('§GANTT_CPM_ANNOTATE_FLEET ' + table.map(t => t.pct !== undefined
+    ? t.b + '=' + t.c + '/' + t.n + '(' + t.pct + '%) PF=' + t.pf + 'd maxFloat=' + t.maxFloat + 'd'
+    : t.b + '=' + t.note).join(' · '));
+  if (ok.length < 3) {
+    console.log('  SKIP W-CPM-5 — only ' + ok.length + ' building fixture(s) available, not enough to measure a fleet fraction');
+  } else {
+    const pcts = ok.map(t => t.pct);
+    const lo = Math.min.apply(null, pcts), hi = Math.max.apply(null, pcts);
+    assert(ok.length >= 3, 'W-CPM-5 CPM ran end-to-end on ' + ok.length + ' of ' + fleet.length +
+      ' fleet buildings without throwing or bailing — the annotate path is exercised on real programmes, not one fixture');
+    assert(lo < 100 && hi > 0,
+      'W-CPM-5b the criticality fraction spans a real range across the fleet (' + lo + '%..' + hi +
+      '%) — BOTH rails are reachable: at high fractions a red-only rail would mark nearly every bar and ' +
+      'carry no signal, so the complement is what makes the scarce, movable bars findable');
+  }
+
+  console.log('§GANTT_CPM_ANNOTATE_SUMMARY pass=' + pass + ' fail=' + fail);
+  if (fail) { console.error('FAIL — ' + fail + ' check(s) failed'); process.exit(1); }
+  console.log('PASS — annotate wires everywhere, paints, and never moves a date');
+}).catch(function (e) {
+  console.error('FAIL — witness threw: ' + (e && e.stack || e));
+  process.exit(1);
+});

--- a/viewer/tests/witness_gantt_edit_undo.js
+++ b/viewer/tests/witness_gantt_edit_undo.js
@@ -99,7 +99,12 @@ const BUILDING = process.argv[2] || 'Duplex';
     invalidateGanttModel: function () {}, computeDays: function () {}, drawGanttMini: function () {}, renderAtTime: function () {},
     // §GANTT_RETIME_RESYNC (PR #1240) added this call to every retime commit path; a cache/index
     // rebuild is a no-op here (the witness asserts on the DB rows, not the render caches)
-    _tmResyncAfterRetime: function () {}
+    _tmResyncAfterRetime: function () {},
+    // §GANTT_CPM_ANNOTATE (§S68) added a second such call to the same paths. Stubbed for the same
+    // reason — it only writes early_*/late_*/float/is_critical and this witness asserts on
+    // schedule_start/schedule_finish. That annotate cannot touch those columns is proven separately,
+    // on the real verb rather than a stub, by witness_gantt_cpm_annotate.js W-CPM-2.
+    _tmAnnotateCpm: function () {}
   };
   vm.createContext(sandbox);
   vm.runInContext(sliced + '\nglobalThis.__ops = _ops = loadOps(); ' +

--- a/viewer/time_machine.js
+++ b/viewer/time_machine.js
@@ -5552,6 +5552,12 @@
       var _idBars = 0;
       for (var bi = 0; bi < _ganttTasks.length; bi++) if (_ganttTasks[bi].taskId) _idBars++;
       console.log('§GANTT_MINI tasks=' + _ganttTasks.length + ' rebuild=' + _ganttRebuildN);
+      // §GANTT_CPM_ANNOTATE (§S68) — prime float/criticality ONCE per building, so the critical path
+      // is on screen before the first edit. Deliberately not per-rebuild: every rebuild past this one
+      // is edit-driven, and each edit path already re-annotates itself after its own retime, so a
+      // per-rebuild call would run CPM twice for every drag. Reset with the rest of the per-building
+      // state on deactivate.
+      if (!_cpmPrimed) { _cpmPrimed = true; _tmAnnotateCpm(); }
       // K0 proof line: how many bars carry a real tasks.task_id (i.e. are addressable by the edit
       // verbs) vs how many are still the un-authored storey|phase fallback. editable=0 means no
       // authored schedule exists for this building, NOT that the join failed.
@@ -5993,6 +5999,65 @@
     _tmRebuildXrayCache();
   }
 
+  // ── §GANTT_CPM_ANNOTATE — float + critical path, DERIVED from the edit, never driving it ────────
+  // Implementing bim-compiler prompts/4D_GANTT_TM_REFACTOR.md §S68 (product decision, 2026-08-23:
+  // "go with annotate"). Settles the standing question "does the drag run CPM?" — it does not, and
+  // deliberately still does not. moveTaskCascade's push-only cascade + predecessor-floor clamp stays
+  // the date engine. CPM runs AFTER it, in fixedDates mode, purely to derive float/criticality FROM
+  // the dates the cascade just wrote.
+  // Why fixedDates is mandatory here: computeCpm's derived forward pass (max over predecessors'
+  // EF+lag) compounds independently-fitted lags on a multi-parent zone graph — MEASURED at PF=138d
+  // against the real movie's 93d on Terminal's 71-zone graph, +48% (schedule_author.js:1385). A drag
+  // that silently restretches the project by half is worse than the honest cascade. With the flag,
+  // ES/EF come straight from the persisted dates and only the BACKWARD pass runs, over real edges,
+  // so total float and is_critical stay meaningful.
+  // computeCpm's only write is early_*/late_*/free_float/total_float/is_critical — it never touches
+  // schedule_start/schedule_finish/schedule_duration. That is the whole safety property of this
+  // feature, and it is witnessed byte-for-byte (W-CPM-2), not assumed from reading the code.
+  var _ganttCritical = {};   // taskId -> { critical, totalFloat } — DISPLAY state, not a date source
+  var _cpmPrimed = false;    // first-build annotate ran for this building (reset on deactivate)
+  function _tmAnnotateCpm(schedId) {
+    var app = A(), SA = (typeof window !== 'undefined') && window.ScheduleAuthor;
+    if (!app || !app.db || !SA || !SA.computeCpm) {
+      console.log('§GANTT_CPM_ANNOTATE_SKIP reason=ScheduleAuthor_not_loaded');
+      return null;
+    }
+    schedId = schedId || (_taskIndex && _taskIndex.scheduleId) || 'SCH_AUTHORED';
+    // A `tasks` table predating the widened DDL has no is_critical column, so computeCpm's UPDATE
+    // would throw INSIDE a drag commit. Probe first and refuse loudly — annotate must never be able
+    // to break an edit that already succeeded.
+    try { app.db.exec('SELECT is_critical FROM tasks LIMIT 1'); }
+    catch (e) {
+      console.log('§GANTT_CPM_ANNOTATE_SKIP reason=thin_tasks_table schedule=' + schedId);
+      return null;
+    }
+    var r = null;
+    try { r = SA.computeCpm(app.db, schedId, { fixedDates: true }); }
+    catch (e) { console.log('§GANTT_CPM_ANNOTATE_SKIP reason=threw msg=' + (e && e.message)); return null; }
+    if (!r || r.error) {
+      // Cycle/orphan (computeCpm logs §SE_CPM_BAIL) or no tasks. 2 of the 7 fleet buildings still
+      // carry cycles (4D_SCHEDULE_PERFECTION.md §MILESTONE), so this is a real, expected branch.
+      // CLEAR the marks rather than leave stale ones on screen — never paint a critical path that
+      // the current dates do not support.
+      _ganttCritical = {};
+      console.log('§GANTT_CPM_ANNOTATE_SKIP reason=' + (r ? r.error : 'no_result') + ' schedule=' + schedId);
+      return null;
+    }
+    var marks = {}, crit = 0, minF = null, maxF = null;
+    (r.tasks || []).forEach(function (t) {
+      marks[t.id] = { critical: !!t.critical, totalFloat: t.totalFloat };
+      if (t.critical) crit++;
+      if (minF === null || t.totalFloat < minF) minF = t.totalFloat;
+      if (maxF === null || t.totalFloat > maxF) maxF = t.totalFloat;
+    });
+    _ganttCritical = marks;
+    var nT = (r.tasks || []).length;
+    console.log('§GANTT_CPM_ANNOTATE schedule=' + schedId + ' tasks=' + nT +
+      ' critical=' + crit + ' (' + (nT ? Math.round(crit / nT * 100) : 0) + '%) projectDuration=' +
+      r.projectDuration + 'd float=' + minF + '..' + maxF + ' datesWritten=0 (fixedDates)');
+    return r;
+  }
+
   // Commit a finished gesture: engine verb → clamp/cascade result → re-time elements → redraw.
   // ── §TM_BAKE_LOCK — the film plays this timeline; do not edit it mid-record ───────────────────
   // Implementing bim-compiler prompts/SCRIPT_LENGTH_REFACTOR_SEAMS.md §S56.
@@ -6112,6 +6177,7 @@
     console.log('§GANTT_DRAG_COMMIT task=' + bar.taskId + ' mode=' + mode + ' deltaDays=' + deltaDays +
       ' start=' + res.start + ' clamped=' + res.clamped + ' cascaded=' + res.cascaded);
     _tmResyncAfterRetime();   // §GANTT_RETIME_RESYNC — without this the canvas plays the OLD times
+    _tmAnnotateCpm(schedId);   // §GANTT_CPM_ANNOTATE (§S68) — re-derive float/critical FROM the new dates
     invalidateGanttModel();
     computeDays();
     drawGanttMini();
@@ -6190,6 +6256,7 @@
     _lastEdit = { schedId: schedId, taskId: '(whole schedule)', mode: 'shift', tasksBefore: tasksBefore, opsBefore: opsBefore };
     console.log('§TM_RULER_SHIFT_COMMIT schedule=' + schedId + ' deltaDays=' + deltaDays + ' tasks=' + res.moved.length);
     _tmResyncAfterRetime();   // §GANTT_RETIME_RESYNC — without this the canvas plays the OLD times
+    _tmAnnotateCpm(schedId);   // §GANTT_CPM_ANNOTATE (§S68) — re-derive float/critical FROM the new dates
     invalidateGanttModel();
     computeDays();
     drawGanttMini();
@@ -6242,6 +6309,7 @@
     _lastEdit = { schedId: schedId, taskId: '(' + taskIds.length + ' selected)', mode: 'group-shift', tasksBefore: tasksBefore, opsBefore: opsBefore };
     console.log('§GANTT_GROUP_SHIFT_COMMIT tasks=' + res.moved.length + ' deltaDays=' + deltaDays);
     _tmResyncAfterRetime();   // §GANTT_RETIME_RESYNC — without this the canvas plays the OLD times
+    _tmAnnotateCpm(schedId);   // §GANTT_CPM_ANNOTATE (§S68) — re-derive float/critical FROM the new dates
     invalidateGanttModel();
     computeDays();
     drawGanttMini();
@@ -6296,6 +6364,7 @@
       ' tasksRestored=' + tRestored + ' opsRestored=' + oRestored);
     say('Undone: ' + edit.mode + ' ' + edit.taskId);
     _tmResyncAfterRetime();   // §GANTT_RETIME_RESYNC — without this the canvas plays the OLD times
+    _tmAnnotateCpm(edit.schedId);   // §GANTT_CPM_ANNOTATE (§S68) — re-derive float/critical FROM the new dates
     invalidateGanttModel();
     computeDays();
     drawGanttMini();
@@ -6615,6 +6684,9 @@
         _tmResyncAfterRetime();   // §GANTT_RETIME_RESYNC — without this the canvas plays the OLD times
       }
     }
+    // §GANTT_CPM_ANNOTATE (§S68) — OUTSIDE the moved-check on purpose: a new EDGE changes the graph,
+    // so it changes float and criticality even when the clamp left every date exactly where it was.
+    _tmAnnotateCpm(schedId);
     invalidateGanttModel(); computeDays(); drawGanttMini(); renderAtTime(_cursor);
   }
 
@@ -6636,6 +6708,7 @@
     })();
     var deps = (SA.listDependencies ? SA.listDependencies(app.db, schedId) : [])
       .filter(function (x) { return x.succId === bar.taskId || x.predId === bar.taskId; });
+    var cpmInfo = bar.taskId ? _ganttCritical[bar.taskId] : null;   // §S68 — display only, never a date source
     var depHtml = deps.length ? deps.map(function (x, i) {
       var dir = x.succId === bar.taskId ? '← after' : '→ before';
       var other = x.succId === bar.taskId ? x.predName : x.succName;
@@ -6647,6 +6720,12 @@
     box.innerHTML =
       '<div style="font-weight:bold;margin-bottom:4px">' + (bar.taskName || (bar.phase + ' — ' + bar.storey)) + '</div>' +
       '<div style="color:#8a97a5;margin-bottom:6px">' + bar.count + ' elements · ' + bar.taskId + '</div>' +
+      // §GANTT_CPM_ANNOTATE (§S68) — read-only. Total float is the ONE number that tells you whether
+      // a slip on this task moves the project end; the bar's red rail only says "zero float". Blank
+      // when CPM could not run (cycle/thin table) rather than showing a made-up 0.
+      (cpmInfo ? '<div style="margin-bottom:6px;color:' + (cpmInfo.critical ? '#e53935' : '#8a97a5') + '">' +
+        (cpmInfo.critical ? 'CRITICAL PATH · zero float' : 'Total float ' + cpmInfo.totalFloat + 'd') +
+        ' <span style="font-size:9px;color:#8a97a5">(CPM, dates unchanged)</span></div>' : '') +
       '<div style="display:flex;gap:4px;align-items:center;margin-bottom:4px">Start' +
         '<input id="tmp-s" type="date" value="' + d(bar.startTs) + '" style="flex:1;font-size:11px"></div>' +
       '<div style="display:flex;gap:4px;align-items:center;margin-bottom:6px">Finish' +
@@ -6665,6 +6744,7 @@
         if (!x || !SA.removeDependency) return;
         SA.removeDependency(app.db, x.predId, x.succId);
         console.log('§GANTT_EDIT_UNLINK pred=' + x.predId + ' succ=' + x.succId);
+        _tmAnnotateCpm(schedId);   // §GANTT_CPM_ANNOTATE (§S68) — removing an edge changes float too
         invalidateGanttModel(); computeDays(); drawGanttMini(); openGanttProps(bar);
       };
     });
@@ -6691,6 +6771,7 @@
       for (var i = 0; i < _ganttTasks.length; i++) if (_ganttTasks[i].taskId) byTask[_ganttTasks[i].taskId] = _ganttTasks[i];
       retimeTaskElements(app.db, byTask, res.moved || [], tasksBeforeApply);
       _tmResyncAfterRetime();   // §GANTT_RETIME_RESYNC — without this the canvas plays the OLD times
+      _tmAnnotateCpm(schedId);   // §GANTT_CPM_ANNOTATE (§S68) — re-derive float/critical FROM the new dates
       console.log('§GANTT_PROPS_APPLY task=' + bar.taskId + ' start=' + res.start +
         ' clamped=' + res.clamped + ' cascaded=' + res.cascaded);
       invalidateGanttModel(); computeDays(); drawGanttMini(); renderAtTime(_cursor);
@@ -6855,6 +6936,24 @@
       ctx.globalAlpha = 1;
       ctx.fillStyle = color;
       ctx.fillRect(x, y, w, barH);
+
+      // §GANTT_CPM_ANNOTATE (§S68): float rail on the BOTTOM edge — red = on the critical path
+      // (zero float), green = has slack. NOT a fourth stroke frame: yellow (captured), orange
+      // (cursor-active) and cyan (marquee-selected) already take all three, and a fourth at 9px row
+      // height is unreadable. Same solid-edge-marker idiom the variance panel uses for its cost cap.
+      // Why BOTH colours rather than red-only: MEASURED over the 8-building fleet with the real rate
+      // tables, criticality runs 27–82% of tasks (Terminal/TermRooms 27%, Hospital 33%, LTU 55%,
+      // JKR 64%, Clinic 78%, Duplex 79%, HHS 82% — witness_gantt_cpm_annotate.js W-CPM-5). At the
+      // top of that range a red-only rail marks four bars in five and carries almost no signal;
+      // painting the complement makes the SCARCE thing — the bars that can actually move without
+      // pushing the end date — the thing that stands out, at every fraction.
+      // The marks are derived FROM the dates the cascade wrote — annotate never moved one.
+      var cpmMark = task.taskId ? _ganttCritical[task.taskId] : null;
+      if (cpmMark) {
+        ctx.globalAlpha = 1;
+        ctx.fillStyle = cpmMark.critical ? '#e53935' : '#26a69a';
+        ctx.fillRect(x, y + barH - 2, w, 2);
+      }
 
       // §gate: captured (preset IFC 4D) bars get a bright-yellow frame so you can tell the real
       // programme from the generated fallback. cap = #captured ops in this storey|phase group.
@@ -7752,6 +7851,7 @@
     _shopfloor = null; _shopfloorLoading = false;    // §E2b: invalidate shopfloor cache on building change
     _ganttTasks = [];
     _ganttTasksComputed = false; _ganttRebuildN = 0;   // §S58: ordinal is per building
+    _ganttCritical = {}; _cpmPrimed = false;          // §S68: CPM marks are per building too
     invalidateGanttModel();   // K0: building changed → drop the cached task index + bar rollup
     var ganttBtn = document.getElementById('tm-gantt');
     if (ganttBtn) ganttBtn.classList.remove('tm-active');


### PR DESCRIPTION
Implements bim-compiler `prompts/4D_GANTT_TM_REFACTOR.md` **§S68**. Settles the standing lane question *"does the in-canvas Gantt drag run CPM?"* — it does not, and deliberately still does not. `moveTaskCascade`'s push-only cascade + predecessor-floor clamp stays the date engine; `computeCpm` now runs **after** it with `fixedDates:true`, purely to derive float and criticality **from** the dates the cascade wrote — and to paint them.

## The safety property, measured not assumed
`computeCpm`'s only write is `early_*` / `late_*` / `free_float` / `total_float` / `is_critical`. **W-CPM-2** proves it byte-for-byte on a real materialized Duplex schedule rather than by reading the code:

```
§GANTT_CPM_ANNOTATE_DATES tasks=20 changed=0
§GANTT_CPM_ANNOTATE_CRIT returned=15 persistedInDb=15 projectDuration=29d
```

## `fixedDates` is load-bearing on the EDIT case
On an unedited schedule both modes now agree — identical PF on all 8 fleet buildings, so the historical +48% at `schedule_author.js:1385` does **not** reproduce on current main. But push a task 30d off its derived position (exactly what a drag does) and they split (**W-CPM-3**): `fixedES=54` vs `derivedES=24`, PF `59d` vs `29d`. Without the flag, CPM would compute float against dates the user's drag deliberately overrode, and write an `early_start` contradicting the `schedule_start` on the same row.

## Live, real page, real drag (`__tmGanttDrag`, Duplex)
```
first build    §GANTT_CPM_ANNOTATE tasks=19 critical=11 (58%) projectDuration=13d float=0..3
after move+7d  §GANTT_EDIT_MOVE ... cascaded=5
               §GANTT_CPM_ANNOTATE tasks=19 critical=3 (16%) projectDuration=20d float=0..10
```
The drag pushed the end date 13d → 20d and the critical set re-derived off the new dates. §-log values, no screenshot involved.

## Wiring
`_tmAnnotateCpm()` in all five re-time paths, `undoLastGanttEdit` (an undo must un-colour what its edit coloured), **both** edge verbs (link/unlink changes float with no date move at all), and a once-per-building prime so the critical path is on screen before the first edit.

## Display
A 2px rail on the bar's bottom edge — red `#e53935` = zero float, green `#26a69a` = has slack. Both colours because fleet criticality measures **27–82%** of tasks (**W-CPM-5**: Terminal 27%, TermRooms 27%, Hospital 33%, LTU 55%, JKR 64%, Clinic 78%, Duplex 79%, HHS 82%), and at the top of that range a red-only rail marks four bars in five and carries no signal. Not a fourth stroke frame — yellow (captured), orange (cursor-active), cyan (marquee-selected) already take all three, and a fourth is unreadable at a 9px row.

## Witness
`viewer/tests/witness_gantt_cpm_annotate.js` (new): brace-matched source gates — never a fixed slice, that is the G-COH-6 false-negative class — plus real-engine behaviour, a counter-proof that `fixedDates` changes the answer, and the fleet sweep. **20/20 green**, and **proven RED against unmodified `origin/main`** (exit 1, naming exactly the five unwired functions and both display gates, while W-CPM-2 correctly stays green there).

Regression sweep over 14 related witnesses: 13 PASS. The one red, `witness_gantt_lock_integrity`, is **red on unmodified `origin/main` too** (verified) — it slices by name and picks up a *comment* containing `` `function _midairAudit(` ``, same class as G-COH-6. Named, not fixed here. `witness_gantt_edit_undo` did go red on this branch and is fixed properly: it needed a `_tmAnnotateCpm` stub beside the `_tmResyncAfterRetime` one §GANTT_RETIME_RESYNC added for the same reason.

`sw.js` CACHE_VERSION **v1070 → v1071**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GarL4iUhgD1Qvqntod2Gnc