### PR TITLE
fix(4d): §TM_BAKE_LOCK — one shared refusal, and all 8 edit paths call it (was 2)

### DIFF
--- a/viewer/sw.js
+++ b/viewer/sw.js
@@ -8,7 +8,7 @@
 // Cache-first for heavy assets (.wasm, images). DB files skip SW (IndexedDB handles them).
 //
 // DEPLOY: bump CACHE_VERSION on every OCI upload. Old caches are purged on activate.
-const CACHE_VERSION = 'v1071';   // bump on each deploy; per-change detail is the git commit message.
+const CACHE_VERSION = 'v1072';   // bump on each deploy; per-change detail is the git commit message.
 // v1064 (2026-08-21) 4D_GANTT_TM_REFACTOR.md §S58 — observability hardening, ADDITIVE LOGGING
 // ONLY, no rule or behaviour changed. (a) the three §GANTT_* proof lines now fire on every
 // model REBUILD instead of once per building, so an edit is auditable (rebuild=N ordinal).

--- a/viewer/tests/witness_gantt_edit_undo.js
+++ b/viewer/tests/witness_gantt_edit_undo.js
@@ -40,6 +40,10 @@ const tmSrc = fs.readFileSync(path.join(__dirname, '..', 'time_machine.js'), 'ut
   // the suite runner caught the omission the moment the guard landed.
 const sliced = [
   '_tmBusyRecording',
+  // §S69: the per-site refusal moved into one helper, so the sliced verbs call THIS now. Sliced
+  // rather than stubbed — it is five lines and slicing the real one keeps the sandbox honest about
+  // what the guard actually does (with no recording flag set on the fake app, it returns false).
+  '_tmEditLocked',
   'loadOps', '_retimeSpan', 'retimeTaskElements', 'commitGanttDrag', 'undoLastGanttEdit'
 ].map(function (n) { return sliceFn(tmSrc, n); }).join('\n');
 

--- a/viewer/tests/witness_gantt_native_generate.js
+++ b/viewer/tests/witness_gantt_native_generate.js
@@ -42,6 +42,7 @@ if (!_verMatch) throw new Error('_GANTT_CACHE_VERSION not found in time_machine.
 const sliced = 'var _GANTT_CACHE_VERSION = ' + _verMatch[1] + ';\n' +
   'var _tmDisplayRemap = function () { return null; };\n' +
   sliceFn(tmSrc, '_tmBusyRecording') + '\n' +   // §S56: the §TM_BAKE_LOCK guard the verb now calls
+  sliceFn(tmSrc, '_tmEditLocked') + '\n' +      // §S69: ...through the one shared refusal helper
   sliceFn(tmSrc, 'generateGanttSchedule');
 
 function loadRules() {

--- a/viewer/tests/witness_tm_bake_lock.js
+++ b/viewer/tests/witness_tm_bake_lock.js
@@ -38,7 +38,7 @@ function sliceFn(src, name) {
 // One sandbox per case: the verbs are sliced with the guard helper they call. ScheduleAuthor is a
 // COUNTING STUB — reaching it is exactly what "the edit happened" means, so the count is the assert.
 function run(flags) {
-  const calls = { move: 0, materialize: 0 };
+  const calls = { move: 0, materialize: 0, shiftSchedule: 0, shiftTasks: 0 };
   const logs = [];
   const sandbox = {
     console: { log: (...a) => logs.push(a.join(' ')), warn: () => {} },
@@ -47,7 +47,11 @@ function run(flags) {
     window: {
       ScheduleAuthor: {
         moveTaskCascade: () => { calls.move++; return { moved: [] }; },
-        materializeZones: () => { calls.materialize++; return { tasks: 0 }; }
+        materializeZones: () => { calls.materialize++; return { tasks: 0 }; },
+        // §S69: the ruler shift and the group shift are edit paths too — same counting-stub
+        // contract, reaching them is what "the edit happened" means.
+        shiftSchedule: () => { calls.shiftSchedule++; return { ok: true, moved: [] }; },
+        shiftTasks: () => { calls.shiftTasks++; return { ok: true, moved: [] }; }
       }
     },
     A: () => Object.assign({ db: { exec: () => [], run: () => {}, prepare: () => ({ step: () => false, free: () => {} }) },
@@ -58,20 +62,42 @@ function run(flags) {
   // being wrong. They are inputs to the code under test, not part of what is being asserted.
   sandbox._taskIndex = { scheduleId: 'SCH_AUTHORED', tasks: {}, byGuid: {} };
   sandbox._GANTT_CACHE_VERSION = 1;
+  sandbox._ganttTasks = [];
+  sandbox._ops = [];
   sandbox.window.window = sandbox.window;
   vm.createContext(sandbox);
   vm.runInContext(
     sliceFn(tmSrc, '_tmBusyRecording') + '\n' +
+    sliceFn(tmSrc, '_tmEditLocked') + '\n' +      // §S69: the refusal now lives in one helper
     sliceFn(tmSrc, 'commitGanttDrag') + '\n' +
     sliceFn(tmSrc, 'generateGanttSchedule') + '\n' +
-    'this.__drag = commitGanttDrag; this.__gen = generateGanttSchedule;', sandbox);
+    sliceFn(tmSrc, 'shiftGanttSchedule') + '\n' +
+    sliceFn(tmSrc, 'commitGanttGroupShift') + '\n' +
+    'this.__drag = commitGanttDrag; this.__gen = generateGanttSchedule; ' +
+    'this.__shift = shiftGanttSchedule; this.__group = commitGanttGroupShift;', sandbox);
 
+  // Each verb is driven independently and its throw caught: past the guard these paths run into
+  // render/retime helpers this sandbox deliberately does not provide. That is fine and is not what
+  // is being asserted — the counting stub has already recorded whether the ENGINE was reached,
+  // which is the whole claim. A verb that never gets past the guard increments nothing.
   try { sandbox.__drag({ taskId: 'T1', storey: 'L1', phase: 'Architecture' }, 'move', 1); } catch (e) { logs.push('THREW ' + e.message); }
   try { sandbox.__gen(); } catch (e) { logs.push('THREW ' + e.message); }
+  try { sandbox.__shift(3); } catch (e) { logs.push('THREW ' + e.message); }
+  try { sandbox.__group(['T1'], 3); } catch (e) { logs.push('THREW ' + e.message); }
   return { calls, logs, locked: logs.filter(l => l.indexOf('§TM_BAKE_LOCK') === 0 || l.indexOf('§TM_BAKE_LOCK') > 0) };
 }
 
-console.log('── witness_tm_bake_lock (§S56) ──');
+console.log('── witness_tm_bake_lock (§S56 + §S69) ──');
+
+// If the shared refusal helper is missing, every sandbox slice below throws an opaque ReferenceError
+// and the run reads as infrastructure breakage rather than as the finding it is. Say it plainly and
+// stop — this is what the witness reports when run against a tree predating §S69.
+if (tmSrc.indexOf('function _tmEditLocked(') < 0) {
+  assert(false, 'W-TBL-0c _tmEditLocked (the ONE refusal every edit path calls, §S69) is not defined in time_machine.js — ' +
+    'the guard is still duplicated per-site, so any path that never got a copy can mutate the timeline mid-bake');
+  console.log('§TM_BAKE_LOCK_SUMMARY pass=' + pass + ' fail=' + fail);
+  process.exit(1);
+}
 
 // W-TBL-0 — the guard reads the flags that already exist, not a new one it invented.
 assert(tmSrc.indexOf('function _tmBusyRecording(') >= 0, 'W-TBL-0a _tmBusyRecording is defined in time_machine.js');
@@ -83,10 +109,12 @@ assert(!/app\._bakeActive|_bakeActive\s*=/.test(tmSrc),
 // W-TBL-1..3 — each recording flag independently refuses BOTH edit verbs.
 for (const [flag, label] of [['_maxqActive', 'maxq_bake'], ['_cinemaOrbitActive', 'cinema_orbit'], ['_stillRefineActive', 'still_refine']]) {
   const r = run({ [flag]: true });
-  assert(r.calls.move === 0 && r.calls.materialize === 0,
-    'W-TBL-1 ' + flag + ': neither edit verb reached ScheduleAuthor (move=' + r.calls.move + ' materialize=' + r.calls.materialize + ')');
-  assert(r.locked.length >= 2 && r.locked.some(l => l.indexOf(label) > 0),
-    'W-TBL-2 ' + flag + ': both refusals are LOUD and name the reason (' + label + ', ' + r.locked.length + ' §TM_BAKE_LOCK lines)');
+  const reached = r.calls.move + r.calls.materialize + r.calls.shiftSchedule + r.calls.shiftTasks;
+  assert(reached === 0,
+    'W-TBL-1 ' + flag + ': NO edit verb reached ScheduleAuthor (move=' + r.calls.move + ' materialize=' + r.calls.materialize +
+    ' shiftSchedule=' + r.calls.shiftSchedule + ' shiftTasks=' + r.calls.shiftTasks + ')');
+  assert(r.locked.length >= 4 && r.locked.some(l => l.indexOf(label) > 0),
+    'W-TBL-2 ' + flag + ': every refusal is LOUD and names the reason (' + label + ', ' + r.locked.length + ' §TM_BAKE_LOCK lines)');
 }
 
 // W-TBL-4 — THE PAIRED CHECK. With nothing recording, the verbs must still work: a guard that
@@ -104,6 +132,80 @@ assert(idleReachedBody,
   'W-TBL-4b idle: commitGanttDrag runs PAST the guard into its own logic (' +
   (idle.calls.move > 0 ? 'reached moveTaskCascade' : 'reached its own §GANTT_DRAG_REJECT') +
   ') — the guard did not disable editing');
+
+// ── W-TBL-6 (§S69) — the RELATIVE pairing extended to the two newly-guarded verbs. Locked above
+// proved they refuse; this proves they still work when nothing is recording. Without this half, a
+// guard that refused unconditionally would pass everything above.
+const shiftRan = idle.calls.shiftSchedule > 0 || idle.logs.some(l => l.indexOf('§TM_RULER_SHIFT_REJECT') >= 0);
+const groupRan = idle.calls.shiftTasks > 0 || idle.logs.some(l => l.indexOf('§GANTT_GROUP_SHIFT_REJECT') >= 0);
+assert(shiftRan, 'W-TBL-6a idle: shiftGanttSchedule runs PAST the guard into its own logic (' +
+  (idle.calls.shiftSchedule > 0 ? 'reached SA.shiftSchedule' : 'reached its own reject') + ')');
+assert(groupRan, 'W-TBL-6b idle: commitGanttGroupShift runs PAST the guard into its own logic (' +
+  (idle.calls.shiftTasks > 0 ? 'reached SA.shiftTasks' : 'reached its own reject') + ')');
+
+// ── W-TBL-5 (§S69) — THE GATE THAT KEEPS THE COUNT HONEST. Item 2 existed because two edit paths
+// (linkGanttBars, openGanttProps) were added after §S56 and nobody re-typed the guard into them, and
+// the note describing the gap said "2 of 5" when it was really 2 of 7. So do NOT hardcode a list:
+// derive "this function mutates the timeline" from the code — it calls retimeTaskElements or one of
+// the mutating engine verbs — and require every such function to be guarded. A path added next month
+// is caught by construction.
+function namedFns(text) {
+  const out = [];
+  const re = /\bfunction\s+([A-Za-z_$][\w$]*)\s*\(/g;
+  let m;
+  while ((m = re.exec(text))) {
+    const open = text.indexOf('{', m.index);
+    if (open < 0) continue;
+    let depth = 0, end = -1;
+    for (let i = open; i < text.length; i++) {
+      if (text[i] === '{') depth++;
+      else if (text[i] === '}') { depth--; if (depth === 0) { end = i + 1; break; } }
+    }
+    if (end > 0) out.push({ name: m[1], start: m.index, end: end, body: text.slice(m.index, end) });
+  }
+  return out;
+}
+const FNS = namedFns(tmSrc);
+const MUTATORS = ['retimeTaskElements(', '.moveTaskCascade(', '.shiftSchedule(', '.shiftTasks(',
+                  '.materializeZones(', '.addDependency(', '.removeDependency('];
+// Skip the wrappers that are not user-facing edit ENTRY points: the pre-materialize bootstrap runs
+// before any film exists, and the helper/model builders below are called BY the guarded verbs.
+// _materializeNativeSchedule is the ONLY name-based exemption, and W-TBL-5d below asserts the
+// property that earns it rather than taking the name on trust.
+const NOT_ENTRY = ['retimeTaskElements', '_tmEditLocked', 'buildGanttTasks', '_materializeNativeSchedule'];
+const mutating = FNS.filter(f => !NOT_ENTRY.includes(f.name) &&
+  MUTATORS.some(v => f.body.indexOf(v) >= 0) &&
+  // the innermost named function only — an outer function containing a guarded inner one would
+  // otherwise be reported as unguarded for its inner's verb call
+  !FNS.some(g => g !== f && g.start > f.start && g.end < f.end && MUTATORS.some(v => g.body.indexOf(v) >= 0)));
+const unguarded = mutating.filter(f => f.body.indexOf('_tmEditLocked(') < 0).map(f => f.name);
+console.log('§TM_BAKE_LOCK_WIRING mutatingEntryPoints=' + mutating.length +
+  ' [' + mutating.map(f => f.name).join(',') + '] unguarded=' + unguarded.length +
+  (unguarded.length ? ' [' + unguarded.join(',') + ']' : ''));
+assert(mutating.length >= 5, 'W-TBL-5a the derivation found the real edit paths (n=' + mutating.length +
+  ') — a 0 here means the verb names changed and this gate went blind, not that everything is guarded');
+assert(unguarded.length === 0, 'W-TBL-5 every timeline-mutating entry point calls _tmEditLocked() — ' +
+  (unguarded.length ? 'UNGUARDED: ' + unguarded.join(', ') : 'all ' + mutating.length + ' guarded'));
+
+// undoLastGanttEdit mutates by restoring `tasks` and `kernel_ops` rows DIRECTLY — it calls none of
+// the engine verbs above, so the derivation cannot see it. Checked by name, same as W-CPM-1b.
+const undoFn = FNS.find(f => f.name === 'undoLastGanttEdit');
+assert(!!undoFn && undoFn.body.indexOf('_tmEditLocked(') >= 0,
+  'W-TBL-5b undoLastGanttEdit is guarded too — an undo mutates the timeline exactly as much as the edit it reverses');
+
+// _materializeNativeSchedule is exempt because it can only write a building's FIRST schedule — it
+// returns early when one already exists, and a bake plays an existing schedule by definition. That
+// early return IS the exemption, so it is asserted, not assumed.
+const matFn = FNS.find(f => f.name === '_materializeNativeSchedule');
+assert(!!matFn && /activeSchedule\s*\(/.test(matFn.body) && /if\s*\(act\)\s*return false/.test(matFn.body),
+  'W-TBL-5d _materializeNativeSchedule still bails when a schedule already exists — the property that exempts it from the lock');
+
+// setGanttBaseline is deliberately NOT guarded: it writes only the task_baseline snapshot table and
+// touches no date and no kernel_ops row, so it cannot desync a recording. Asserted so the exemption
+// is a decision on record rather than an oversight someone "fixes" later.
+const blFn = FNS.find(f => f.name === 'setGanttBaseline');
+assert(!!blFn && !MUTATORS.some(v => blFn.body.indexOf(v) >= 0),
+  'W-TBL-5c setGanttBaseline still mutates nothing on the timeline — the reason it is exempt from the lock');
 
 console.log('§TM_BAKE_LOCK_SUMMARY pass=' + pass + ' fail=' + fail);
 process.exit(fail === 0 ? 0 : 1);

--- a/viewer/time_machine.js
+++ b/viewer/time_machine.js
@@ -5151,7 +5151,13 @@
     // task index is built from it. sched.safeToRegen already excludes captured (imported) schedules
     // and anything with a baseline set (the user's committed, edited product) — see activeSchedule's
     // own header for the exact contract.
-    if (sched.safeToRegen && SA.materializeZones) {
+    // §TM_BAKE_LOCK (§S69) — the guard is on the REGEN, not on buildTaskIndex itself. This block
+    // rewrites the whole schedule in place, so firing it mid-bake would swap the timeline out from
+    // under the recorder; but refusing the whole function would leave the Gantt with no task index
+    // and break the very display the film is recording. Skipping only the regen keeps the film on
+    // the exact schedule it started with, and genVersion stays stale so the self-heal simply runs on
+    // the next rebuild after the bake finishes. Found by W-TBL-5's derivation, not by hand.
+    if (sched.safeToRegen && SA.materializeZones && !_tmEditLocked('buildTaskIndex:staleRegen')) {
       console.log('§GANTT_SCHEDULE_STALE_REGEN id=' + sched.id + ' genVersion=' + sched.genVersion +
         ' current=' + _GANTT_CACHE_VERSION + ' — re-materializing in place');
       try {
@@ -6077,14 +6083,26 @@
     return null;
   }
 
+  // _tmEditLocked(verb) — the ONE refusal, called by every timeline-mutating entry point.
+  // Implementing bim-compiler prompts/4D_GANTT_TM_REFACTOR.md §S69. §S56 shipped this guard as five
+  // duplicated lines inside commitGanttDrag and generateGanttSchedule; the five paths added since
+  // (ruler shift, group shift, undo, link, typed apply/unlink) never got a copy, so a bake could be
+  // desynced by any of them. Duplication was the mechanism — a rule that has to be re-typed at each
+  // new call site is a rule that eventually is not. One helper, one log format, and W-TBL-5 derives
+  // the list of callers from the code instead of trusting a hand-kept list.
+  // Refusal stays LOUD and returns — never a silent no-op, never an edit queued and applied after
+  // the bake finishes.
+  function _tmEditLocked(verb) {
+    var busy = _tmBusyRecording(A());
+    if (!busy) return false;
+    console.log('§TM_BAKE_LOCK refused=' + verb + ' reason=' + busy +
+      ' — the film is playing this timeline; editing it mid-record would desync the recording');
+    return true;
+  }
+
   function commitGanttDrag(bar, mode, deltaDays) {
+    if (_tmEditLocked('commitGanttDrag')) return;
     var app = A();
-    var _tmBusy = _tmBusyRecording(app);
-    if (_tmBusy) {
-      console.log('§TM_BAKE_LOCK refused=commitGanttDrag reason=' + _tmBusy +
-        ' — the film is playing this timeline; editing it mid-record would desync the recording');
-      return;
-    }
     var SA = (typeof window !== 'undefined') && window.ScheduleAuthor;
     if (!app || !app.db || !SA || !SA.moveTaskCascade) {
       console.log('§GANTT_DRAG_REJECT reason=ScheduleAuthor_not_loaded');
@@ -6216,6 +6234,7 @@
   // only) — undoLastGanttEdit's restore loop doesn't branch on it, so no other change was needed
   // there at all.
   function shiftGanttSchedule(deltaDays) {
+    if (_tmEditLocked('shiftGanttSchedule')) return;   // §TM_BAKE_LOCK (§S69)
     var app = A();
     var SA = (typeof window !== 'undefined') && window.ScheduleAuthor;
     if (!app || !app.db || !SA || !SA.shiftSchedule) {
@@ -6268,6 +6287,7 @@
   // restore loop doesn't care whether tasksBefore/opsBefore covers a cascade, the whole schedule,
   // or a selection, it just restores whatever's in there.
   function commitGanttGroupShift(taskIds, deltaDays) {
+    if (_tmEditLocked('commitGanttGroupShift')) return;   // §TM_BAKE_LOCK (§S69)
     var app = A();
     var SA = (typeof window !== 'undefined') && window.ScheduleAuthor;
     if (!app || !app.db || !SA || !SA.shiftTasks) {
@@ -6321,6 +6341,8 @@
   // element ops (retimeTaskElements's write to `kernel_ops`) — same two tables, same shape, run
   // backward. Single-level: clears _lastEdit so a second click is a no-op, not a second undo step.
   function undoLastGanttEdit() {
+    // §TM_BAKE_LOCK (§S69) — an undo mutates the timeline exactly as much as the edit it reverses.
+    if (_tmEditLocked('undoLastGanttEdit')) return;
     var app = A();
     var tip = document.getElementById('tm-gantt-tip');
     function say(msg) {
@@ -6409,6 +6431,10 @@
   function _materializeNativeSchedule(app) {
     var SA = (typeof window !== 'undefined') && window.ScheduleAuthor;
     if (!app || !app.db || !SA || !SA.materializeZones) return false;
+    // §TM_BAKE_LOCK (§S69) — deliberately NOT guarded, and the line below is why: this bootstrap
+    // returns early whenever a schedule already exists, and a bake by definition plays an existing
+    // one. It can only ever write the FIRST schedule for a building, which is not a timeline any
+    // film is mid-way through recording. W-TBL-5d asserts that early-return still stands.
     var act = SA.activeSchedule ? SA.activeSchedule(app.db) : null;
     if (act) return false;                       // schedule exists — injectGantt absorbs it, one pass
     var todayStart = new Date().toISOString().slice(0, 10);
@@ -6423,13 +6449,8 @@
   }
 
   function generateGanttSchedule() {
+    if (_tmEditLocked('generateGanttSchedule')) return;
     var app = A();
-    var _tmBusy = _tmBusyRecording(app);
-    if (_tmBusy) {
-      console.log('§TM_BAKE_LOCK refused=generateGanttSchedule reason=' + _tmBusy +
-        ' — the film is playing this timeline; editing it mid-record would desync the recording');
-      return;
-    }
     var SA = (typeof window !== 'undefined') && window.ScheduleAuthor;
     var tip = document.getElementById('tm-gantt-tip');
     function say(msg) {
@@ -6645,6 +6666,7 @@
   // §GANTT_LINK (E3) — create a real FS dependency, guarded by the EXISTING wouldCycle. A cyclic
   // schedule is invalid, so the guard refuses rather than "fixing" it silently.
   function linkGanttBars(predBar, succBar) {
+    if (_tmEditLocked('linkGanttBars')) return;   // §TM_BAKE_LOCK (§S69)
     var app = A(), SA = (typeof window !== 'undefined') && window.ScheduleAuthor;
     if (!app || !app.db || !SA || !SA.addDependency) { console.log('§GANTT_LINK_REJECT reason=ScheduleAuthor_not_loaded'); return; }
     var tip = document.getElementById('tm-gantt-tip');
@@ -6740,6 +6762,9 @@
     document.getElementById('tmp-close').onclick = function () { box.style.display = 'none'; };
     box.querySelectorAll('[data-unlink]').forEach(function (btn) {
       btn.onclick = function () {
+        // §TM_BAKE_LOCK (§S69) — on the WRITE, not on opening the panel: reading a task's dates
+        // mid-bake is harmless, and refusing that would be a worse product than the bug.
+        if (_tmEditLocked('openGanttProps:unlink')) return;
         var x = deps[parseInt(btn.getAttribute('data-unlink'), 10)];
         if (!x || !SA.removeDependency) return;
         SA.removeDependency(app.db, x.predId, x.succId);
@@ -6749,6 +6774,7 @@
       };
     });
     document.getElementById('tmp-apply').onclick = function () {
+      if (_tmEditLocked('openGanttProps:apply')) return;   // §TM_BAKE_LOCK (§S69) — same, on the write
       var s = document.getElementById('tmp-s').value, f = document.getElementById('tmp-f').value;
       var msg = document.getElementById('tmp-msg');
       // Typed dates go through the SAME constraint-aware verbs as a drag — keyin is a second input


### PR DESCRIPTION
Implements bim-compiler `prompts/4D_GANTT_TM_REFACTOR.md` **§S69** (RESUME item 2).

## The count was wrong, in the unsafe direction
RESUME said "2 of 5". Measured on unmodified `origin/main`, with the same derivation the new gate uses:

```
mutating entry points (incl. undo) = 8
  GUARDED   (2): commitGanttDrag, generateGanttSchedule
  UNGUARDED (6): buildTaskIndex, shiftGanttSchedule, commitGanttGroupShift,
                 linkGanttBars, openGanttProps, undoLastGanttEdit
```

Any of those six could mutate the timeline while the film was mid-record — the exact thing §S56 built this lock to stop.

## The mechanism was duplication
§S56 shipped the guard as five lines re-typed inside two verbs, so every path added since simply did not get a copy. `_tmEditLocked(verb)` is now the one refusal (same `§TM_BAKE_LOCK` line, byte-identical by construction) and all eight call it. `openGanttProps` is guarded on its two **write** handlers, not on opening the panel — reading a task's dates mid-bake is harmless, and refusing that would be a worse product than the bug.

## The eighth path was found by the gate, not by reading
`buildTaskIndex`'s `§GANTT_SCHEDULE_STALE` self-heal calls `materializeZones` and rewrites the whole schedule in place; mid-bake that swaps the timeline out from under the recorder. It was on nobody's list. Its guard goes on the **regen block only** — refusing the whole function would leave the Gantt with no task index and break the display being recorded. `genVersion` stays stale, so the self-heal simply runs on the next rebuild after the bake.

## Witness: W-TBL 10 → 17 checks
- **W-TBL-5** derives the mutating set from the code (calls `retimeTaskElements` or a mutating engine verb) and requires each to be guarded → `§TM_BAKE_LOCK_WIRING mutatingEntryPoints=7 [...] unguarded=0`. A path added next month is caught by construction rather than by someone remembering.
- **W-TBL-5b/5c/5d** cover what the derivation cannot: `undoLastGanttEdit` (restores rows directly, calls no engine verb) and the two deliberate exemptions, `setGanttBaseline` and `_materializeNativeSchedule` — each asserting the **property** that earns the exemption, not the name.
- **W-TBL-6a/6b** extend the existing relative pairing to the two shift verbs: locked, they reach no engine verb (`move=0 materialize=0 shiftSchedule=0 shiftTasks=0`, 4 loud refusals); idle, both run past the guard into `SA.shiftSchedule` / `SA.shiftTasks`.

**Red-proved** on unmodified `origin/main`: exit 1 with an explicit `W-TBL-0c` naming the missing helper, rather than an opaque `ReferenceError` from a slice.

**Live headless check** (Duplex — the guard sits in `buildTaskIndex`, which runs on every rebuild, so "does the viewer still work idle" is a real question): unchanged behaviour, no spurious refusal, drag still commits and re-annotates 58% → 16% / 13d → 20d.

`witness_gantt_edit_undo` and `witness_gantt_native_generate` slice verbs into a `vm` sandbox and went red here; both now slice the real `_tmEditLocked` alongside `_tmBusyRecording` — the real helper, not a stub. Full related sweep: **13/13 PASS**.

`sw.js` CACHE_VERSION **v1071 → v1072**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GarL4iUhgD1Qvqntod2Gnc