### PR TITLE
fix(4d): §GANTT_EDIT_PERSIST — Gantt edits survive a reload, and persistDb writes the slot the loader reads

### DIFF
--- a/viewer/kernel_ops.js
+++ b/viewer/kernel_ops.js
@@ -129,6 +129,11 @@
           var dbUrl = window.APP && APP.DB_URL;
           if (!dbUrl) return;
           if (window.APP && APP._cacheDisabled) return;   // incognito / low quota → no IDB
+          // §SCHED_PERSIST_KEY (§S70): cachedFetch reads under DbResolve.cacheKey(url), not the raw
+          // url — writing the raw url put "survive refresh" in a slot nothing reads on any profile
+          // that had loaded the building normally. Same derivation as ScheduleAuthor.persistDb.
+          var dbKey = (window.DbResolve && window.DbResolve.cacheKey)
+            ? window.DbResolve.cacheKey(dbUrl, window.APP && APP.PROD_BASE) : dbUrl;
           var buf = db.export().buffer;
           // §KRN_PERSIST_FIX: open the cache DB through the app's SINGLE opener (scene.js
           // openCacheDB → version 2, ensures the 'dbs' store). The old hardcoded
@@ -146,8 +151,8 @@
             if (!idb) { console.warn('§KRN_PERSIST_ERR no cacheDB'); return; }
             if (!idb.objectStoreNames.contains('dbs')) { console.warn('§KRN_PERSIST_ERR no dbs store'); return; }
             var tx = idb.transaction('dbs', 'readwrite');
-            tx.objectStore('dbs').put(buf, dbUrl);
-            tx.oncomplete = function() { console.log('§KRN_PERSIST url=' + dbUrl + ' size=' + (buf.byteLength/1024).toFixed(0) + 'KB'); };
+            tx.objectStore('dbs').put(buf, dbKey);
+            tx.oncomplete = function() { console.log('§KRN_PERSIST url=' + dbUrl + ' key=' + dbKey + ' size=' + (buf.byteLength/1024).toFixed(0) + 'KB'); };
             tx.onerror = function() { console.warn('§KRN_PERSIST_ERR tx ' + (tx.error && tx.error.message)); };
           }).catch(function(e) { console.warn('§KRN_PERSIST_ERR open ' + (e && e.message)); });
         } catch(e) { console.warn('§KRN_PERSIST_ERR', e); }

--- a/viewer/schedule_author.js
+++ b/viewer/schedule_author.js
@@ -1654,9 +1654,25 @@
   }
 
   var _persistTimers = {};   // url -> timer, so rapid edits on the SAME db coalesce into one write
+  // §SCHED_PERSIST_KEY (4D_GANTT_TM_REFACTOR.md §S70) — key the write the way the READER keys it.
+  // MEASURED live before this fix: a Gantt drag persisted fine (§SCHED_PERSIST ok=true, 15264KB),
+  // the reload hit the cache (§CACHE_HIT Duplex_extracted.db 14.3MB), and the edit was GONE — two
+  // different slots. scene.js's cachedFetch looks blobs up under DbResolve.cacheKey(url) (W-DB-CACHE-KEY:
+  // '/buildings/X.db' and 'buildings/X.db?v=2' both fold to 'buildings/X.db'), while every persist path
+  // wrote under the RAW url. cachedFetch treats the raw url as the LEGACY slot and only reads it when
+  // the canonical key MISSES — so on any profile that has ever loaded the building normally, every
+  // persisted edit was written somewhere nothing reads. That silently broke schedule_editor_ui.js's
+  // §SE-6 ("edits vanish on tab close") and kernel_ops.js's "survive refresh" too, not just this path.
+  function _cacheKeyFor(url) {
+    var DR = (typeof window !== 'undefined') && window.DbResolve;
+    var A = (typeof window !== 'undefined') && (window.APP || window.A);
+    return (DR && DR.cacheKey) ? DR.cacheKey(url, A && A.PROD_BASE) : url;
+  }
+
   function persistDb(db, url, opts) {
     opts = opts || {};
     if (!db || !url) return Promise.resolve(false);
+    var key = _cacheKeyFor(url);
     var delay = opts.immediate ? 0 : (opts.delay != null ? opts.delay : 1200);
     if (_persistTimers[url]) { clearTimeout(_persistTimers[url]); }
     return new Promise(function (resolve) {
@@ -1669,9 +1685,9 @@
               console.warn('§SCHED_PERSIST_ERR no cache store url=' + url); resolve(false); return;
             }
             var tx = idb.transaction('dbs', 'readwrite');
-            tx.objectStore('dbs').put(buf, url);
+            tx.objectStore('dbs').put(buf, key);
             tx.oncomplete = function () {
-              console.log('§SCHED_PERSIST url=' + url + ' size=' + (buf.byteLength / 1024).toFixed(0) + 'KB');
+              console.log('§SCHED_PERSIST url=' + url + ' key=' + key + ' size=' + (buf.byteLength / 1024).toFixed(0) + 'KB');
               resolve(true);
             };
             tx.onerror = function () { console.warn('§SCHED_PERSIST_ERR tx ' + (tx.error && tx.error.message)); resolve(false); };
@@ -1682,6 +1698,7 @@
   }
 
   var API = {
+    _cacheKeyFor: _cacheKeyFor,   // §S70: read and write MUST derive the slot the same way
     matchRule: matchRule,
     matchNameOverride: matchNameOverride,
     // §TM_DURATION_SYNC — exported so time_machine.js's playback-clock duration engine

--- a/viewer/schedule_editor_ui.js
+++ b/viewer/schedule_editor_ui.js
@@ -514,11 +514,14 @@
   // profile (caught live by W-SCHED-PERSIST); the shared opener self-heals that via a versioned
   // onupgradeneeded, so read and write now use the exact same, robust opener.
   function _idbGetDb(url) {
+    // §SCHED_PERSIST_KEY (§S70): derive the slot exactly as persistDb writes it and as cachedFetch
+    // reads it — a read keyed by the raw url misses every canonically-keyed blob.
+    var key = (SA()._cacheKeyFor ? SA()._cacheKeyFor(url) : url);
     return SA().openBuildingCache().then(function (idb) {
       return new Promise(function (resolve) {
         if (!idb || !idb.objectStoreNames.contains('dbs')) { resolve(null); return; }
         try {
-          var g = idb.transaction('dbs', 'readonly').objectStore('dbs').get(url);
+          var g = idb.transaction('dbs', 'readonly').objectStore('dbs').get(key);
           g.onsuccess = function () { resolve(g.result || null); };
           g.onerror = function () { resolve(null); };
         } catch (e) { resolve(null); }

--- a/viewer/sw.js
+++ b/viewer/sw.js
@@ -8,7 +8,7 @@
 // Cache-first for heavy assets (.wasm, images). DB files skip SW (IndexedDB handles them).
 //
 // DEPLOY: bump CACHE_VERSION on every OCI upload. Old caches are purged on activate.
-const CACHE_VERSION = 'v1072';   // bump on each deploy; per-change detail is the git commit message.
+const CACHE_VERSION = 'v1073';   // bump on each deploy; per-change detail is the git commit message.
 // v1064 (2026-08-21) 4D_GANTT_TM_REFACTOR.md §S58 — observability hardening, ADDITIVE LOGGING
 // ONLY, no rule or behaviour changed. (a) the three §GANTT_* proof lines now fire on every
 // model REBUILD instead of once per building, so an edit is auditable (rebuild=N ordinal).

--- a/viewer/tests/witness_gantt_edit_persist.js
+++ b/viewer/tests/witness_gantt_edit_persist.js
@@ -1,0 +1,171 @@
+#!/usr/bin/env node
+// WITNESS — W-PERS — §GANTT_EDIT_PERSIST: an in-canvas Gantt edit survives a reload
+// Spec: bim-compiler prompts/4D_GANTT_TM_REFACTOR.md §S70.
+//
+// ISSUE THIS PROVES OR DISPROVES:
+//   Every edit made in the Time Machine's Gantt drawer — drag, ruler shift, group move, undo, link,
+//   unlink, typed apply — lived ONLY in the in-memory sql.js db and died on reload. Verified on
+//   origin/main before the fix: ScheduleAuthor.persistDb had exactly two callers
+//   (schedule_editor_ui.js, schedule_author_ui.js), neither in time_machine.js; and
+//   retimeTaskElements writes kernel_ops with raw SQL rather than through KernelOps' commit API, so
+//   kernel_ops.js's own debounced persist never fired for a Gantt edit either.
+//
+//   This is the SAME gap schedule_editor_ui.js closed for the Editor tab — its own comment calls it
+//   "the gap that made every schedule edit vanish on tab close" (§SE-6) — on the same db, the same
+//   IDB slot, through the same verb. So: a gap, not a design choice.
+//
+//   W-PERS-1  wiring    — every edit commit path calls _tmPersistEdit().
+//   W-PERS-2  exemption — buildTaskIndex's stale-schedule REGEN does NOT, on purpose: it runs on a
+//                         plain page load, and persisting there would turn every ordinary visit to a
+//                         252MB building into a 252MB IDB write. A regen is reproducible; an edit is not.
+//   W-PERS-3  behaviour — _tmPersistEdit hands persistDb APP.db under APP.DB_URL and nothing else,
+//                         and refuses when the url is missing or the cache is disabled. Passing the
+//                         WRONG db under that key is not hypothetical: it cost a P0 in kernel_ops.js
+//                         (§KRN_PERSIST_GUARD, 2026-06-12).
+//
+//   The round trip itself (drag → reload → new date still there) is proven live by the headless
+//   probe recorded in §S70, not here: it needs a browser, an IndexedDB and a real building load.
+//
+// ⚠ Brace-matched, never a fixed slice window (the G-COH-6 false-negative class, §S65).
+//
+// Command: node viewer/tests/witness_gantt_edit_persist.js     (no fixtures, no DB, no browser)
+'use strict';
+const fs = require('fs');
+const path = require('path');
+const vm = require('vm');
+
+let pass = 0, fail = 0;
+function assert(cond, msg) { if (cond) { pass++; console.log('  PASS ' + msg); } else { fail++; console.log('  FAIL ' + msg); } }
+
+const TM = path.join(__dirname, '..', 'time_machine.js');
+const src = fs.readFileSync(TM, 'utf8');
+
+function namedFns(text) {
+  const out = [];
+  const re = /\bfunction\s+([A-Za-z_$][\w$]*)\s*\(/g;
+  let m;
+  while ((m = re.exec(text))) {
+    const open = text.indexOf('{', m.index);
+    if (open < 0) continue;
+    let depth = 0, end = -1;
+    for (let i = open; i < text.length; i++) {
+      if (text[i] === '{') depth++;
+      else if (text[i] === '}') { depth--; if (depth === 0) { end = i + 1; break; } }
+    }
+    if (end > 0) out.push({ name: m[1], start: m.index, end: end, body: text.slice(m.index, end) });
+  }
+  return out;
+}
+const FNS = namedFns(src);
+function enclosingFn(idx) {
+  let best = null;
+  for (const f of FNS) if (f.start < idx && idx < f.end && (!best || (f.end - f.start) < (best.end - best.start))) best = f;
+  return best;
+}
+const lineOf = idx => src.slice(0, idx).split('\n').length;
+
+console.log('── witness_gantt_edit_persist (§S70) ──');
+
+const persistFn = FNS.find(f => f.name === '_tmPersistEdit');
+assert(!!persistFn, 'W-PERS-0 _tmPersistEdit is defined in time_machine.js — without it every Gantt edit still dies on reload');
+if (!persistFn) { console.log('§GANTT_EDIT_PERSIST_SUMMARY pass=' + pass + ' fail=' + fail); process.exit(1); }
+
+// ── W-PERS-1: every re-time path persists.
+const CALL = 'retimeTaskElements(';
+const sites = [];
+for (let i = src.indexOf(CALL); i >= 0; i = src.indexOf(CALL, i + 1)) {
+  if (/function\s+$/.test(src.slice(Math.max(0, i - 12), i))) continue;
+  sites.push(i);
+}
+assert(sites.length >= 5, 'W-PERS-1a retimeTaskElements call sites found (n=' + sites.length +
+  ') — a 0 means the function was renamed and this gate went blind, not that the wiring is clean');
+const missing = [], seen = {};
+for (const s of sites) {
+  const fn = enclosingFn(s);
+  if (!fn) { missing.push('line ' + lineOf(s)); continue; }
+  if (seen[fn.name]) continue;
+  seen[fn.name] = 1;
+  if (fn.body.indexOf('_tmPersistEdit(') < 0) missing.push(fn.name + '() at line ' + lineOf(fn.start));
+}
+console.log('§GANTT_EDIT_PERSIST_WIRING retimeSites=' + sites.length + ' distinctFns=' + Object.keys(seen).length +
+  ' missingPersist=' + missing.length + (missing.length ? ' [' + missing.join(' | ') + ']' : ''));
+assert(missing.length === 0, 'W-PERS-1 every function that re-times elements also persists — ' +
+  (missing.length ? 'MISSING in ' + missing.join(', ') : 'all ' + Object.keys(seen).length + ' clean'));
+
+const undoFn = FNS.find(f => f.name === 'undoLastGanttEdit');
+assert(!!undoFn && undoFn.body.indexOf('_tmPersistEdit(') >= 0,
+  'W-PERS-1b undoLastGanttEdit persists too — it mutates by restoring rows directly, so the wiring gate above cannot see it, and an un-persisted undo would silently come back on reload');
+
+// ── W-PERS-2: the deliberate exemption stays exempt.
+const btiFn = FNS.find(f => f.name === 'buildTaskIndex');
+assert(!!btiFn && btiFn.body.indexOf('_tmPersistEdit(') < 0,
+  'W-PERS-2 buildTaskIndex (the §GANTT_SCHEDULE_STALE regen) does NOT persist — it runs on a plain page load, and wiring it would put a whole-db IDB write (252MB on Hospital) on every ordinary visit');
+
+// ── W-PERS-3: behaviour, in a sandbox. What persistDb actually receives.
+function drive(app) {
+  const got = [];
+  const logs = [];
+  const sandbox = {
+    console: { log: (...a) => logs.push(a.join(' ')), warn: () => {} },
+    window: { ScheduleAuthor: { persistDb: (db, url, opts) => { got.push({ db, url, opts }); return Promise.resolve(true); } } },
+    A: () => app
+  };
+  sandbox.window.window = sandbox.window;
+  vm.createContext(sandbox);
+  vm.runInContext(persistFn.body + '\nthis.__p = _tmPersistEdit;', sandbox);
+  sandbox.__p('probe');
+  return { got, logs };
+}
+const realDb = { marker: 'APP.db' };
+const ok = drive({ db: realDb, DB_URL: 'buildings/Hospital_extracted.db' });
+assert(ok.got.length === 1, 'W-PERS-3a a normal edit reaches persistDb exactly once (n=' + ok.got.length + ')');
+assert(ok.got.length === 1 && ok.got[0].db === realDb,
+  'W-PERS-3b it passes APP.db ITSELF, not another db — writing a foreign db under the building key is the §KRN_PERSIST_GUARD P0');
+assert(ok.got.length === 1 && ok.got[0].url === 'buildings/Hospital_extracted.db',
+  'W-PERS-3c it hands persistDb APP.DB_URL — the url persistDb canonicalises into the slot cachedFetch reads (W-PERS-5)');
+
+const noUrl = drive({ db: realDb });
+assert(noUrl.got.length === 0 && noUrl.logs.some(l => l.indexOf('reason=no_db_url') >= 0),
+  'W-PERS-3d no DB_URL: refuses LOUDLY and writes nothing (' + (noUrl.logs[0] || 'no log') + ')');
+
+const disabled = drive({ db: realDb, DB_URL: 'x.db', _cacheDisabled: true });
+assert(disabled.got.length === 0 && disabled.logs.some(l => l.indexOf('reason=cache_disabled') >= 0),
+  'W-PERS-3e _cacheDisabled (incognito / low quota): refuses LOUDLY and writes nothing — same guard kernel_ops.js uses');
+
+// ── W-PERS-5: the write must land in the slot the READER reads. This is not theoretical — it is
+// what the live round-trip caught. The drag persisted (§SCHED_PERSIST ok=true, 15264KB), the reload
+// hit the cache (§CACHE_HIT 14.3MB) and the edit was GONE: scene.js's cachedFetch looks up
+// DbResolve.cacheKey(url), every persist path wrote the RAW url, and cachedFetch reads the raw url
+// only as a LEGACY fallback when the canonical key misses. On any profile that had loaded the
+// building normally, every persisted edit went somewhere nothing reads.
+const SA_SRC = fs.readFileSync(path.join(__dirname, '..', 'schedule_author.js'), 'utf8');
+const KO_SRC = fs.readFileSync(path.join(__dirname, '..', 'kernel_ops.js'), 'utf8');
+const SEU_SRC = fs.readFileSync(path.join(__dirname, '..', 'schedule_editor_ui.js'), 'utf8');
+const SA_FNS = namedFns(SA_SRC);
+const persistDbFn = SA_FNS.find(f => f.name === 'persistDb');
+assert(!!persistDbFn && /put\(buf,\s*key\)/.test(persistDbFn.body) && /_cacheKeyFor\(url\)/.test(persistDbFn.body),
+  'W-PERS-5a ScheduleAuthor.persistDb writes under the canonical cacheKey, not the raw url');
+const koFn = namedFns(KO_SRC).find(f => f.name === '_persistToIdb');
+assert(!!koFn && /put\(buf,\s*dbKey\)/.test(koFn.body) && /DbResolve\.cacheKey/.test(koFn.body),
+  'W-PERS-5b kernel_ops.js persists under the same canonical key — its "survive refresh" had the identical defect');
+const seuFn = namedFns(SEU_SRC).find(f => f.name === '_idbGetDb');
+assert(!!seuFn && /_cacheKeyFor\(url\)/.test(seuFn.body) && /objectStore\('dbs'\)\.readonly|get\(key\)/.test(seuFn.body),
+  'W-PERS-5c the Editor READS by the same derivation it now writes by — a raw-url read misses every canonical blob');
+
+// Behavioural: the helper and the reader's own function must agree, on real url shapes.
+const DbResolve = require(path.join(__dirname, '..', 'db_resolve.js'));
+global.window = { DbResolve: DbResolve };
+const SAmod = require(path.join(__dirname, '..', 'schedule_author.js'));
+const SHAPES = ['/buildings/Duplex_extracted.db', 'buildings/Hospital_extracted.db',
+  'buildings/Terminal_extracted.db?v=3', 'https://objectstorage.example/x/buildings/JKR_extracted.db',
+  '/deploy/dev/buildings/Terminal_extracted.db', 'import://scratch'];
+const disagree = SHAPES.filter(u => SAmod._cacheKeyFor(u) !== DbResolve.cacheKey(u));
+console.log('§SCHED_PERSIST_KEY ' + SHAPES.map(u => u.split('/').pop() + '→' + SAmod._cacheKeyFor(u)).join(' · '));
+assert(disagree.length === 0, 'W-PERS-5d persistDb\'s key derivation agrees with DbResolve.cacheKey on every url shape' +
+  (disagree.length ? ' — DISAGREES on ' + disagree.join(', ') : ' (' + SHAPES.length + ' shapes)'));
+assert(SAmod._cacheKeyFor('/buildings/Duplex_extracted.db') !== '/buildings/Duplex_extracted.db',
+  'W-PERS-5e RED CONTROL: the canonical key really does differ from the raw url for a normal viewer url — otherwise this whole fix would be a no-op and W-PERS-5d would pass trivially');
+
+console.log('§GANTT_EDIT_PERSIST_SUMMARY pass=' + pass + ' fail=' + fail);
+if (fail) { console.error('FAIL — ' + fail + ' check(s) failed'); process.exit(1); }
+console.log('PASS — every Gantt edit path persists, the cold path does not');

--- a/viewer/tests/witness_gantt_edit_undo.js
+++ b/viewer/tests/witness_gantt_edit_undo.js
@@ -108,7 +108,13 @@ const BUILDING = process.argv[2] || 'Duplex';
     // reason — it only writes early_*/late_*/float/is_critical and this witness asserts on
     // schedule_start/schedule_finish. That annotate cannot touch those columns is proven separately,
     // on the real verb rather than a stub, by witness_gantt_cpm_annotate.js W-CPM-2.
-    _tmAnnotateCpm: function () {}
+    _tmAnnotateCpm: function () {},
+    // §S70 added a debounced IndexedDB write-back to the same commit paths. STUBBED, unlike
+    // _tmEditLocked which is sliced: the lock can PREVENT the edit, so slicing it is required for
+    // this sandbox to be honest; the persist is a pure side effect that cannot change a single row
+    // this witness asserts on, and there is no IndexedDB in node. That the edit actually survives a
+    // reload is proven where it can be — live, by §S70's round-trip probe.
+    _tmPersistEdit: function () {}
   };
   vm.createContext(sandbox);
   vm.runInContext(sliced + '\nglobalThis.__ops = _ops = loadOps(); ' +

--- a/viewer/time_machine.js
+++ b/viewer/time_machine.js
@@ -6100,6 +6100,32 @@
     return true;
   }
 
+  // _tmPersistEdit(what) — write the edited building back to the IndexedDB slot it was loaded from.
+  // Implementing bim-compiler prompts/4D_GANTT_TM_REFACTOR.md §S70.
+  // Until now an in-canvas Gantt edit lived ONLY in the in-memory sql.js db and died on reload.
+  // retimeTaskElements writes kernel_ops with raw SQL rather than through KernelOps' commit API, so
+  // kernel_ops.js's own debounce never fired for it, and nothing else persisted it either. This is
+  // the same gap schedule_editor_ui.js closed for the Editor tab (§SE-6, "the gap that made every
+  // schedule edit vanish on tab close") — same DB, same slot, same verb, just never wired here.
+  // MEASURED cost of persistDb's whole-db export on the real fleet: Duplex 3ms, Terminal 10ms,
+  // LTU 26ms, Clinic 47ms, JKR 70ms, Hospital (252MB) 86ms — one dropped frame at the worst, and
+  // persistDb debounces 1200ms on top, so a burst of drags collapses to a single write.
+  // Guards mirror §KRN_PERSIST_GUARD: only APP.db under APP.DB_URL, never a foreign db (a lens
+  // committing its own op-db under the building's key cost a P0 in kernel_ops.js), and never when
+  // _cacheDisabled (incognito / low quota).
+  function _tmPersistEdit(what) {
+    var app = A(), SA = (typeof window !== 'undefined') && window.ScheduleAuthor;
+    if (!app || !app.db || !SA || !SA.persistDb) {
+      console.log('§GANTT_EDIT_PERSIST_SKIP what=' + what + ' reason=ScheduleAuthor_not_loaded');
+      return;
+    }
+    if (!app.DB_URL) { console.log('§GANTT_EDIT_PERSIST_SKIP what=' + what + ' reason=no_db_url'); return; }
+    if (app._cacheDisabled) { console.log('§GANTT_EDIT_PERSIST_SKIP what=' + what + ' reason=cache_disabled'); return; }
+    SA.persistDb(app.db, app.DB_URL, {}).then(function (ok) {
+      console.log('§GANTT_EDIT_PERSIST what=' + what + ' url=' + app.DB_URL + ' ok=' + ok);
+    });
+  }
+
   function commitGanttDrag(bar, mode, deltaDays) {
     if (_tmEditLocked('commitGanttDrag')) return;
     var app = A();
@@ -6196,6 +6222,7 @@
       ' start=' + res.start + ' clamped=' + res.clamped + ' cascaded=' + res.cascaded);
     _tmResyncAfterRetime();   // §GANTT_RETIME_RESYNC — without this the canvas plays the OLD times
     _tmAnnotateCpm(schedId);   // §GANTT_CPM_ANNOTATE (§S68) — re-derive float/critical FROM the new dates
+    _tmPersistEdit('drag');   // §S70 — the edit must survive a reload
     invalidateGanttModel();
     computeDays();
     drawGanttMini();
@@ -6276,6 +6303,7 @@
     console.log('§TM_RULER_SHIFT_COMMIT schedule=' + schedId + ' deltaDays=' + deltaDays + ' tasks=' + res.moved.length);
     _tmResyncAfterRetime();   // §GANTT_RETIME_RESYNC — without this the canvas plays the OLD times
     _tmAnnotateCpm(schedId);   // §GANTT_CPM_ANNOTATE (§S68) — re-derive float/critical FROM the new dates
+    _tmPersistEdit('rulerShift');   // §S70 — the edit must survive a reload
     invalidateGanttModel();
     computeDays();
     drawGanttMini();
@@ -6330,6 +6358,7 @@
     console.log('§GANTT_GROUP_SHIFT_COMMIT tasks=' + res.moved.length + ' deltaDays=' + deltaDays);
     _tmResyncAfterRetime();   // §GANTT_RETIME_RESYNC — without this the canvas plays the OLD times
     _tmAnnotateCpm(schedId);   // §GANTT_CPM_ANNOTATE (§S68) — re-derive float/critical FROM the new dates
+    _tmPersistEdit('groupShift');   // §S70 — the edit must survive a reload
     invalidateGanttModel();
     computeDays();
     drawGanttMini();
@@ -6387,6 +6416,7 @@
     say('Undone: ' + edit.mode + ' ' + edit.taskId);
     _tmResyncAfterRetime();   // §GANTT_RETIME_RESYNC — without this the canvas plays the OLD times
     _tmAnnotateCpm(edit.schedId);   // §GANTT_CPM_ANNOTATE (§S68) — re-derive float/critical FROM the new dates
+    _tmPersistEdit('undo');   // §S70 — the edit must survive a reload
     invalidateGanttModel();
     computeDays();
     drawGanttMini();
@@ -6709,6 +6739,7 @@
     // §GANTT_CPM_ANNOTATE (§S68) — OUTSIDE the moved-check on purpose: a new EDGE changes the graph,
     // so it changes float and criticality even when the clamp left every date exactly where it was.
     _tmAnnotateCpm(schedId);
+    _tmPersistEdit('link');   // §S70 — the edit must survive a reload
     invalidateGanttModel(); computeDays(); drawGanttMini(); renderAtTime(_cursor);
   }
 
@@ -6770,6 +6801,7 @@
         SA.removeDependency(app.db, x.predId, x.succId);
         console.log('§GANTT_EDIT_UNLINK pred=' + x.predId + ' succ=' + x.succId);
         _tmAnnotateCpm(schedId);   // §GANTT_CPM_ANNOTATE (§S68) — removing an edge changes float too
+        _tmPersistEdit('unlink');   // §S70 — the edit must survive a reload
         invalidateGanttModel(); computeDays(); drawGanttMini(); openGanttProps(bar);
       };
     });
@@ -6798,6 +6830,7 @@
       retimeTaskElements(app.db, byTask, res.moved || [], tasksBeforeApply);
       _tmResyncAfterRetime();   // §GANTT_RETIME_RESYNC — without this the canvas plays the OLD times
       _tmAnnotateCpm(schedId);   // §GANTT_CPM_ANNOTATE (§S68) — re-derive float/critical FROM the new dates
+      _tmPersistEdit('propsApply');   // §S70 — the edit must survive a reload
       console.log('§GANTT_PROPS_APPLY task=' + bar.taskId + ' start=' + res.start +
         ' clamped=' + res.clamped + ' cascaded=' + res.cascaded);
       invalidateGanttModel(); computeDays(); drawGanttMini(); renderAtTime(_cursor);


### PR DESCRIPTION
Implements bim-compiler `prompts/4D_GANTT_TM_REFACTOR.md` **§S70** (RESUME item 3). Two defects, one PR: the missing wiring, and the reason the wiring alone would not have worked.

## 1. The TM edit path never persisted — a gap, not a design choice
Verified on main: `persistDb` had two callers, neither in `time_machine.js`; and `retimeTaskElements` writes `kernel_ops` with raw SQL rather than through `KernelOps`' commit API, so `kernel_ops.js`'s own debounce never fired for a Gantt edit either. A drag lived only in the in-memory sql.js db and died on reload.

This project already ruled on the identical question for the Editor tab — `§SE-6`, *"the gap that made every schedule edit vanish on tab close"* — same db, same slot, same verb. `_tmPersistEdit()` now runs on all seven edit commit points, and deliberately **not** on `buildTaskIndex`'s stale-schedule regen: that runs on a plain page load, where it would put a 252MB IDB write on every ordinary visit.

Cost measured before wiring anything (whole-db `export()`, real sql.js, real fleet): Duplex 3ms · Terminal 10ms · LTU 26ms · HHS 28ms · Clinic 47ms · JKR 70ms · **Hospital (252MB) 86ms**. One dropped frame at the worst, behind `persistDb`'s existing 1200ms debounce.

## 2. Then the live round trip failed — and that is the bigger finding
```
[drag]   §SCHED_PERSIST url=/buildings/Duplex_extracted.db size=15264KB
[drag]   §GANTT_EDIT_PERSIST what=drag ok=true
         afterDrag   = 2026-08-30
[reload] §CACHE_HIT Duplex_extracted.db size=14.3MB      ← a DIFFERENT blob
         afterReload = 2026-08-23                        ← the edit is gone
```
The write succeeded, the read hit the cache, and they were **two different slots**. `scene.js`'s `cachedFetch` looks blobs up under `DbResolve.cacheKey(url)` (W-DB-CACHE-KEY) and reads the raw url only as a **legacy fallback when the canonical key misses**. Every persist path wrote the raw url.

**So on any profile that had ever loaded the building normally, every persisted edit was written somewhere nothing reads — already true before this lane touched anything.** It silently broke the Editor's `§SE-6` and `kernel_ops.js`'s "survive refresh" (`§KRN_PERSIST_FIX`, previously debugged once for a *different* cause and still not working). Three write paths, one shared defect.

Fixed in the writer rather than per-caller: `persistDb` derives the slot through `_cacheKeyFor()` (exported, so read and write cannot drift), `kernel_ops.js` derives the same, and `schedule_editor_ui.js`'s `_idbGetDb` now **reads** by that derivation.

```
[drag]   §SCHED_PERSIST url=/buildings/Duplex_extracted.db key=buildings/Duplex_extracted.db
         afterDrag   = 2026-08-30
[reload] §CACHE_HIT Duplex_extracted.db size=14.9MB   ← the edited blob
         §GANTT_CACHE_HIT ops=1119                    ← no §GANTT_PREMATERIALIZE: a schedule now exists
         afterReload = 2026-08-30                     ✅ PASS
```

## Witness — W-PERS 15/15
Wiring gates brace-matched (never a fixed slice). **W-PERS-2** asserts the cold path stays exempt. **W-PERS-3** drives `_tmPersistEdit` in a sandbox: it hands `persistDb` `APP.db` *itself* (a foreign db under that key was a P0 — `§KRN_PERSIST_GUARD`) and refuses loudly with no `DB_URL` or with `_cacheDisabled`. **W-PERS-5d** runs the derivation against `DbResolve.cacheKey` on six real url shapes (prod, `?v=` busted, absolute OCI, `/deploy/` dev tree, `import://`); **W-PERS-5e** is the red control that the canonical key really does differ from the raw url, or 5d would pass trivially.

**Red-proved twice:** with main's `time_machine.js` (W-PERS-0 fails), and with the branch's `time_machine.js` over main's other three files, where exactly 5a/5b/5c fail and nothing else does.

Regression sweep **15/15**. `witness_gantt_edit_undo` needed a `_tmPersistEdit` stub — stubbed rather than sliced, because the persist cannot change a row that witness asserts on, unlike `_tmEditLocked`, which can prevent the edit and is therefore sliced.

`sw.js` CACHE_VERSION **v1072 → v1073**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GarL4iUhgD1Qvqntod2Gnc