### PR TITLE
docs(readiness): §CONFORMANCE — consent, recommendation categories, scholarly identity, Limitations

### DIFF
--- a/readiness/assess.html
+++ b/readiness/assess.html
@@ -234,6 +234,22 @@ a.anchor:hover .src{text-decoration:underline}
 .drop.filled{border-style:solid;border-color:var(--accent);text-align:left;padding:18px 20px}
 
 /* ---- PAYLOAD ---- */
+footer{
+  margin:64px 0 0;padding-top:20px;border-top:1px solid var(--rule);
+  font-family:"IBM Plex Mono",monospace;font-size:11.5px;color:var(--faint);line-height:1.8
+}
+footer a{color:var(--muted)}
+.call.warnc{
+  border-left:3px solid var(--warn);background:var(--warn-wash);border-radius:6px;
+  padding:12px 14px;font-size:14.5px;color:var(--ink-2);line-height:1.55
+}
+dl.consent{margin:0;font-size:14.5px}
+dl.consent dt{
+  font-family:"Instrument Sans",sans-serif;font-size:12px;font-weight:600;letter-spacing:.03em;
+  text-transform:uppercase;color:var(--accent-ink);margin-top:13px
+}
+dl.consent dt:first-child{margin-top:0}
+dl.consent dd{margin:4px 0 0;color:var(--ink-2);line-height:1.55}
 pre.payload{
   margin:0;background:var(--surface-2);border:1px solid var(--rule);border-radius:7px;
   padding:14px 16px;overflow-x:auto;font-family:"IBM Plex Mono",monospace;
@@ -300,6 +316,20 @@ pre.payload{
   padding:13px 0;border-bottom:1px solid var(--rule-soft);align-items:start
 }
 .fixes li:last-child{border-bottom:none}
+/* Grant deliverable: recommendations fall in three categories — capability development,
+   standards adoption, implementation planning. Every recommendation carries one. */
+.fixes .cat{
+  display:inline-block;margin-bottom:6px;font-family:"Instrument Sans",sans-serif;font-size:11px;
+  font-weight:600;letter-spacing:.04em;text-transform:uppercase;color:var(--accent-ink);
+  background:var(--accent-wash);border:1px solid var(--accent);border-radius:4px;padding:2px 7px
+}
+.fixes .cat.plan{color:var(--warn);background:var(--warn-wash);border-color:var(--warn)}
+.fixes .cat.cap{color:var(--ink-2);background:var(--surface-2);border-color:var(--rule)}
+/* A value the project does not yet hold. Rendered so it cannot ship unnoticed. */
+.todo{
+  font-family:"IBM Plex Mono",monospace;font-size:12px;color:var(--warn);
+  border:1px dashed var(--warn);border-radius:4px;padding:1px 6px;white-space:nowrap
+}
 .fixes li::before{
   content:counter(f);font-family:"IBM Plex Mono",monospace;font-size:12px;font-weight:600;
   color:var(--accent-ink);background:var(--accent-wash);border-radius:5px;
@@ -356,6 +386,16 @@ details.tvwrap summary{cursor:pointer;font-size:13.5px;color:var(--accent-ink);f
   <div class="railcap" id="railcap" hidden><span id="railnow">About you</span><span id="railpct">Step 1 of 5</span></div>
 
   <div id="screens"></div>
+
+<footer>
+  OpenBIM Readiness Assessment Toolkit for Digital Infrastructure Management &middot; v0.1<br>
+  Mohd Faizal Bin Yusof &middot; research instrument in development &mdash; criteria and thresholds
+  subject to expert validation.<br>
+  <a href="sources.html">Sources and verification</a> &middot;
+  <a href="sources.html#refs">How to cite</a> &middot;
+  <a href="proposal.html">The research proposal</a> &middot;
+  <a href="disclaimer.html">Disclaimer Notice</a>
+</footer>
 
 </div>
 
@@ -435,7 +475,8 @@ SCREENS.intro =
     '<label class="chk" style="margin-top:14px"><input type="checkbox" checked>' +
       '<span>Answer anonymously. No name, firm, email, or project details are collected.</span></label>' +
     '<label class="chk"><input type="checkbox">' +
-      '<span>Include my (anonymous) results in the industry benchmark, so I can see how I compare.</span></label>' +
+      '<span>Include my (anonymous) results in the industry benchmark, so I can see how I compare. ' +
+      'You are asked to consent separately, at the end, once you can see exactly what would be sent.</span></label>' +
   '</div>' +
 
   '<p class="small" style="margin-top:20px">This toolkit is the artifact of a funded research ' +
@@ -762,8 +803,50 @@ SCREENS.model =
       '  "exporter":      "other",\n' +
       '  "toolkit":       "v0.1",\n' +
       '  "kb":            "core-0.1 / ae-v1"\n}</pre>' +
-    '<label class="chk" style="margin-top:14px"><input type="checkbox">' +
-      '<span>Send this. Optional &mdash; your report is complete either way.</span></label>' +
+  '</div>' +
+
+  /* Research participation. This is a funded study and a submission is research data,
+     so consent is asked separately from the disclaimer, at the point of collection. */
+  '<div class="card">' +
+    '<h3>Taking part in the research</h3>' +
+    '<div class="call warnc"><strong>Version 0.1 has no submission endpoint.</strong> Nothing is ' +
+    'transmitted from this page, and no response data is collected or stored by any party. The ' +
+    'checkbox below is part of the mocked flow. This consent statement is published now, ahead of ' +
+    'that capability, so it can be reviewed before it ever governs a real submission.</div>' +
+    '<p class="small" style="margin:12px 0 13px">When submission does exist, sending the payload above ' +
+    'will make you a participant in a funded research study on these terms.</p>' +
+    '<dl class="consent">' +
+      '<dt>Who is running it</dt>' +
+      '<dd>Mohd Faizal Bin Yusof, under a research grant. The full proposal is published at ' +
+        '<a href="proposal.html">The research proposal</a>.</dd>' +
+      '<dt>What is collected</dt>' +
+      '<dd>Exactly the payload shown above &mdash; numbers and fixed categories. No file, no name, no ' +
+        'firm, no email, no project details, no GUIDs, no coordinates, no free text.</dd>' +
+      '<dt>What it is used for</dt>' +
+      '<dd>Two things: the industry benchmark shown in your report, and analysis for a peer-reviewed ' +
+        'journal article. Only aggregates are published &mdash; never a single response.</dd>' +
+      '<dt>Taking part is voluntary</dt>' +
+      '<dd>Declining changes nothing. Your report is complete either way, and no feature is withheld.</dd>' +
+      '<dt>A submission could not be withdrawn</dt>' +
+      '<dd>Because nothing identifying you would be sent, a submission could not afterwards be found ' +
+        'and removed. That is the cost of genuine anonymity, and it is the reason to decide before ' +
+        'sending rather than after.</dd>' +
+      '<dt>How long it is kept</dt>' +
+      '<dd>For the life of the research project and any publication arising from it. Aggregates may be ' +
+        'published as supplementary data; the individual responses behind them are not republished.</dd>' +
+      '<dt>Ethics approval</dt>' +
+      '<dd><span class="todo">ethics approval reference &mdash; to be inserted</span> Any ethics ' +
+        'determination for the study rests with the researcher&rsquo;s institution. The reference will ' +
+        'appear here before the first submission is ever accepted.</dd>' +
+      '<dt>Questions or complaints</dt>' +
+      '<dd><span class="todo">contact address &mdash; to be inserted</span></dd>' +
+    '</dl>' +
+    '<label class="chk" style="margin-top:16px"><input type="checkbox">' +
+      '<span>I have read the above and consent to my anonymous responses being used for research. ' +
+      '<strong>Optional</strong> &mdash; your report is complete either way.</span></label>' +
+    '<p class="small" style="margin-top:11px">Full declarations &mdash; funding, competing interests, ' +
+    'data availability, ethics, use of generative AI, licence &mdash; are at ' +
+    '<a href="disclaimer.html">the Disclaimer Notice</a>.</p>' +
   '</div>' +
 
   '<div class="actions">' +
@@ -859,17 +942,17 @@ SCREENS.results =
 
   '<div class="card">' +
     '<h3>Recommendations</h3>' +
-    '<p class="small" style="margin-top:5px">Capability development &middot; standards adoption &middot; implementation planning &mdash; ordered by how much each unlocks downstream</p>' +
+    '<p class="small" style="margin-top:5px">Each recommendation is placed in one of the three categories &mdash; capability development, standards adoption, implementation planning &mdash; and the set is ordered by how much each unlocks downstream</p>' +
     '<ol class="fixes">' +
-      '<li><div><h4>Add spaces to the model</h4><p>Zero IfcSpace entities. Rooms are required by downstream ' +
+      '<li><div><span class="cat">Standards adoption</span><h4>Add spaces to the model</h4><p>Zero IfcSpace entities. Rooms are required by downstream ' +
       'uses &mdash; FM, area schedules, analysis. A consumer that requires spaces cannot use this file.</p></div></li>' +
-      '<li><div><h4>Classify at type level, not element level</h4><p>234 of 339 types carry no code. Coding types ' +
+      '<li><div><span class="cat plan">Implementation planning</span><h4>Classify at type level, not element level</h4><p>234 of 339 types carry no code. Coding types ' +
       'rather than 12,847 elements is roughly a day of work instead of a month.</p></div></li>' +
-      '<li><div><h4>Resolve 47 duplicate GUIDs before the next issue</h4><p>Duplicates break round-tripping and ' +
+      '<li><div><span class="cat">Standards adoption</span><h4>Resolve 47 duplicate GUIDs before the next issue</h4><p>Duplicates break round-tripping and ' +
       'change tracking silently.</p></div></li>' +
-      '<li><div><h4>Turn on quantity export</h4><p>No IfcElementQuantity present, so nothing downstream can do ' +
+      '<li><div><span class="cat">Standards adoption</span><h4>Turn on quantity export</h4><p>No IfcElementQuantity present, so nothing downstream can do ' +
       'cost or carbon from this model.</p></div></li>' +
-      '<li><div><h4>Write down what the model must contain, before the next project starts</h4>' +
+      '<li><div><span class="cat cap">Capability development</span><h4>Write down what the model must contain, before the next project starts</h4>' +
       '<p>Your lowest-scoring governance item, and the cheapest to fix.</p></div></li>' +
     '</ol>' +
   '</div>' +
@@ -917,6 +1000,23 @@ SCREENS.results =
     'appointment, that obligation is yours and this report substitutes for none of it.</p>' +
     '<p><a href="disclaimer.html">Read the full Disclaimer Notice &rarr;</a> &nbsp;&middot;&nbsp; ' +
     '<span class="mono">Notice v0.1 &middot; 22 Aug 2026</span></p>' +
+  '</div>' +
+
+  /* A report that leaves this page has to say who produced it and how to cite it.
+     Separate card — the Notice above is legally load-bearing and is not edited. */
+  '<div class="card">' +
+    '<h4>Provenance and citation</h4>' +
+    '<p class="small" style="margin-top:9px">Instrument: <strong>OpenBIM Readiness Assessment Toolkit ' +
+    'for Digital Infrastructure Management</strong>, version 0.1. Author of record: ' +
+    '<strong>Mohd Faizal Bin Yusof</strong>. Research instrument in development &mdash; criteria and ' +
+    'thresholds are subject to expert validation and are not final.</p>' +
+    '<p class="small">Every criterion in this assessment names the source it is drawn from, and ' +
+    '<a href="sources.html">Sources and verification</a> gives the clause each was checked against and ' +
+    'how far that source was read. <strong>Sixteen of the twenty criteria are anchored to a published ' +
+    'standard; four are not</strong>, and are marked as such.</p>' +
+    '<p class="small"><strong>No DOI has been minted.</strong> Cite the version number and the access ' +
+    'date. Any DOI attributed to this work before its first version-frozen release is not one the ' +
+    'authors issued. <a href="sources.html#refs">How to cite &rarr;</a></p>' +
   '</div>' +
 
   '<div class="actions">' +

--- a/readiness/disclaimer.html
+++ b/readiness/disclaimer.html
@@ -366,6 +366,13 @@ footer{
   <p>The toolkit collects no participant data in its current version. Any ethics determination for
   the wider study rests with the researcher's institution and is published with the first citable
   release.</p>
+  <p>A participant-facing <strong>consent statement is nevertheless published now</strong>, at the point
+  in the assessment where submission would occur, so that it can be reviewed before it ever governs a
+  real submission. It states who is running the study, exactly what would be collected, that taking
+  part is voluntary and withheld from no feature, that a submission could not be withdrawn once sent
+  because nothing identifying the respondent is included, and how long data would be kept. The ethics
+  approval reference is shown there as an explicit placeholder until the institution issues one; it is
+  not asserted.</p>
 
   <h3>Use of generative AI</h3>
   <p>Generative AI was used in developing this toolkit and in preparing its documentation. All
@@ -379,6 +386,10 @@ footer{
   <p>Source code is available at <span class="mono">github.com/red1oon/bim-ootb</span> under
   <span class="mono">readiness/</span>. Licence terms and a citable DOI are issued with the first
   tagged release; until then this is a pre-release draft and should not be cited.</p>
+  <p>Author of record and corresponding author: <strong>Mohd Faizal Bin Yusof</strong>. Every factual
+  claim the toolkit makes, the source behind it and how far that source was read are set out at
+  <a href="sources.html">Sources and verification</a>, together with the project&rsquo;s stated
+  <a href="sources.html#limitations">limitations</a> and a correspondence address.</p>
 
   <h3>Status</h3>
   <p>Research instrument in development. Criteria, thresholds and weightings are subject to expert

--- a/readiness/sources.html
+++ b/readiness/sources.html
@@ -260,6 +260,10 @@ ol.refs a.back:hover{color:var(--accent-ink)}
 .tier.t4{border-color:var(--warn);color:var(--warn);background:var(--warn-wash)}
 .mx td .cl{font-family:"IBM Plex Mono",monospace;font-size:12px;color:var(--muted);display:block;margin-top:3px}
 .mx tr:target td{background:var(--accent-wash)}
+.todo{
+  font-family:"IBM Plex Mono",monospace;font-size:12px;color:var(--warn);
+  border:1px dashed var(--warn);border-radius:4px;padding:1px 6px;white-space:nowrap
+}
 .mx td.k{font-family:"IBM Plex Mono",monospace;font-weight:600;color:var(--ink);width:52px;vertical-align:top}
 .mx td{vertical-align:top}
 .mx th.c,.mx td.c{width:auto}
@@ -287,6 +291,7 @@ ol.refs a.back:hover{color:var(--accent-ink)}
     <a href="#measured">05 &nbsp;What we measured</a>
     <a href="#unverified">06 &nbsp;Carried without a source</a>
     <a href="#corrections">07 &nbsp;Corrections</a>
+    <a href="#limitations">08 &nbsp;Limitations</a>
     <a href="#refs">References</a>
   </nav>
 </div>
@@ -686,6 +691,55 @@ ol.refs a.back:hover{color:var(--accent-ink)}
   touched.</p>
 </section>
 
+<section id="limitations">
+  <div class="shead"><span class="snum">08</span><h2>Limitations</h2></div>
+  <p class="lede">Stated as a set, in one place, because a reader should not have to assemble them from
+  seven pages. Each is detailed in the section named against it.</p>
+
+  <ol class="refs">
+    <li><strong>Four of the twenty criteria are not anchored to any external source.</strong> A3 data
+      portability, C1 tool concentration, C3 adoption barriers and C4 switching cost rest on the
+      instrument&rsquo;s own design rationale. Construct validity for those four is not demonstrable
+      from the literature and depends on the pilot study. <span class="loc">Section 02.</span></li>
+    <li><strong>The instrument has not been validated.</strong> Expert validation and pilot testing are
+      a planned phase and have not been carried out. No criterion weighting, threshold band or
+      proportionate target in this version has been calibrated against evidence; they are provisional.
+      <span class="loc">Version 0.1 throughout.</span></li>
+    <li><strong>The industry benchmark is empty.</strong> Zero assessments have been submitted, so any
+      comparative statement in a report is a statement about an empty set and is labelled as such. No
+      figure is substituted for it. <span class="loc">Finding F6, section 05.</span></li>
+    <li><strong>Findings F1&ndash;F4 have n&nbsp;=&nbsp;1.</strong> They are measurements of individual
+      named models. They establish that a condition occurs and is detectable; they establish no
+      frequency, prevalence or industry rate, and must not be quoted as industry statistics.
+      <span class="loc">Section 05.</span></li>
+    <li><strong>Responses are self-reported and unaudited.</strong> The organisational half of every
+      assessment is what a respondent says about their own firm. No third party witnesses, checks or
+      attests to it. The model half is measured, but from a file the respondent chooses to supply.
+      <span class="loc">Acknowledgement gate, in the assessment.</span></li>
+    <li><strong>Three standards were read only as far as their publishers&rsquo; previews allow.</strong>
+      For ISO 19650-2, ISO 19650-3 and ISO 12006-2, clause <em>titles</em> are quoted and clause
+      <em>bodies</em> were not read. Anchors resting on those documents are anchored to a clause whose
+      title is verified and whose full text is not. <span class="loc">Section 03.</span></li>
+    <li><strong>One source remains at T2 and six at T3.</strong> ISO 16739-1:2024 is cited from its
+      catalogue record only. The Malaysia, United Kingdom and European Union mandate rows rest on
+      secondary accounts whose primary instrument texts were not obtained.
+      <span class="loc">Sections 03 and 04.</span></li>
+    <li><strong>Regulatory positions are current as at the date each row was read, and mandates
+      change.</strong> This was not hypothetical: the Dubai position published here was two circulars
+      out of date until 23 August 2026, and the error came from a secondary account that was accurate
+      about the instrument it described. <span class="loc">Correction C-3, section 07.</span></li>
+    <li><strong>The toolkit measures losslessness, never lawfulness.</strong> It reports whether
+      information is present and well-formed. It does not certify compliance with any regulation,
+      standard, code or contract &mdash; no software does, in any jurisdiction. Local authority
+      compliance rests with the Appointing Party and the Lead Appointed Party.
+      <span class="loc">Disclaimer Notice.</span></li>
+    <li><strong>No single headline score is issued, by design.</strong> Coverage and well-formedness are
+      independent axes, so a one-word verdict would be arbitrary rather than merely coarse. A reader
+      wanting a single number will not find one here, and that is the finding at F3 rather than an
+      omission. <span class="loc">Section 05.</span></li>
+  </ol>
+</section>
+
 <section id="refs">
   <div class="shead"><span class="snum">&mdash;</span><h2>References</h2></div>
   <p class="lede">Standards are given in the issuing body&rsquo;s own citation form. Each entry states
@@ -726,6 +780,15 @@ ol.refs a.back:hover{color:var(--accent-ink)}
   content of ISO standards or national regulations, which should always be cited to the issuing body.</p>
   <p>Funding, competing interests, data availability, ethics, use of generative AI and licence are
   declared at <a href="disclaimer.html">the Disclaimer Notice</a> and are not duplicated here.</p>
+
+  <h3>Correspondence</h3>
+  <p>Author of record and corresponding author: <strong>Mohd Faizal Bin Yusof</strong>.</p>
+  <p>Queries about a figure, a source, or a request for the underlying data:
+  <span class="todo">contact address &mdash; to be inserted</span></p>
+  <p>Ethics approval reference for the participant-facing study:
+  <span class="todo">ethics approval reference &mdash; to be inserted</span></p>
+  <p class="small">These two values are not yet held by the project. They are shown as placeholders
+  rather than omitted, so that their absence is visible and cannot be mistaken for a value.</p>
 </section>
 
 <footer>


### PR DESCRIPTION
Acts on findings **2–6** of the conformance audit against the grant and against what a reader arriving from a journal expects. **Finding 1** (the LLM interviewer's status on `assess.html`) is a design question and is deliberately not touched here.

## Consent — instituted at the point of collection (finding 4)

"Consent" appeared **zero times across all seven pages**. This is a funded study whose evaluation phase collects practitioner responses for a journal article. New **"Taking part in the research"** card sits with the payload disclosure and states: who runs it · exactly what is collected · what it is used for · that taking part is voluntary and withholds no feature · **that a submission could not be withdrawn once sent**, because nothing identifying the respondent is included · retention · ethics approval · where to complain.

⚠ **A conflict caught by reading first.** `disclaimer.html` already declares that v0.1 has **no submission endpoint** and collects no participant data. A consent statement written as though data were flowing would have contradicted a legally load-bearing declaration. The card therefore opens by saying so — nothing is transmitted, the checkbox is part of the mocked flow, and the statement is published *ahead of* the capability so it can be reviewed before it ever governs a real submission. `disclaimer.html`'s Ethics declaration now points at it.

The non-withdrawal clause is the honest consequence of genuine anonymity, and it is the thing an ethics reviewer checks for.

## Recommendation categories — named *and* structural (finding 2)

The grant commits to three. The results screen carried them as a subtitle, then listed five recommendations with no tag and no grouping. Each now carries its category as a pill:

| Recommendation | Category |
|---|---|
| Add spaces to the model | Standards adoption |
| Classify at type level, not element level | Implementation planning |
| Resolve 47 duplicate GUIDs before the next issue | Standards adoption |
| Turn on quantity export | Standards adoption |
| Write down what the model must contain | Capability development |

## Scholarly identity (finding 3)

`assess.html` was the only page with no author, no version-with-date and no how-to-cite — and it is the URL a paper will deep-link to. Adds a page footer matching the other six, and a **Provenance and citation** card *in the report* carrying instrument name, version, author of record, the 16-of-20 anchoring split, and the no-DOI statement. The printed Notice above it is legally load-bearing and **its wording is untouched** — the provenance card is separate.

## Limitations — a named section (finding 6)

Zero uses of the word across all pages, though the substance was strong and scattered. `sources.html` gains **section 08**: ten numbered limitations in one place, each cross-referenced to where it is detailed — the four unanchored criteria · no expert validation yet · the empty benchmark · n = 1 on F1–F4 · self-reported and unaudited responses · three standards read only to preview depth · one T2 and six T3 sources · regulatory currency, with C-3 as the worked example of that risk actually materialising · losslessness not lawfulness · no single headline score by design.

## Correspondence (finding 5)

`sources.html` names the corresponding author and carries a correspondence block. The **contact address** and the **ethics approval reference** are values the project does not yet hold — both render as dashed-outline placeholders in the warning colour, so their absence is visible and cannot be mistaken for a value. Four such tokens exist and are counted below.

## Verification — programmatic

- Screens built and inspected in node: 5 category tags in the right classes, provenance card, author, no-DOI statement, consent block, no-endpoint notice, non-withdrawal clause, 2 placeholders
- **The 20 questions, tips, option ladders, anchors, clauses and tiers are identical to `origin/main`**
- **The acknowledgement gate and the printed report Notice are byte-identical to `origin/main`**
- `index.html`, `proposal.html`, `why.html`, `faq.html` byte-identical to `origin/main`
- Tag balance clean across 23 tag types on all three edited files; every internal link and fragment resolves, including the 20 runtime criterion deep-links
- `readiness/` is not precached by any `sw.js` — no CACHE_VERSION bump

Audit and remaining findings in `~/Projects/Dubai/PROMPT.md §CONFORMANCE`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EVYqpsZquz3dfP2HaUFuoE