### PR TITLE
fix(4d): §S22_EPOCH_FIX for E7 — the typed properties panel was writing 1970 dates

### DIFF
--- a/viewer/sw.js
+++ b/viewer/sw.js
@@ -8,7 +8,7 @@
 // Cache-first for heavy assets (.wasm, images). DB files skip SW (IndexedDB handles them).
 //
 // DEPLOY: bump CACHE_VERSION on every OCI upload. Old caches are purged on activate.
-const CACHE_VERSION = 'v1073';   // bump on each deploy; per-change detail is the git commit message.
+const CACHE_VERSION = 'v1074';   // bump on each deploy; per-change detail is the git commit message.
 // v1064 (2026-08-21) 4D_GANTT_TM_REFACTOR.md §S58 — observability hardening, ADDITIVE LOGGING
 // ONLY, no rule or behaviour changed. (a) the three §GANTT_* proof lines now fire on every
 // model REBUILD instead of once per building, so an edit is auditable (rebuild=N ordinal).

--- a/viewer/tests/witness_gantt_props_epoch.js
+++ b/viewer/tests/witness_gantt_props_epoch.js
@@ -1,0 +1,83 @@
+#!/usr/bin/env node
+// WITNESS — W-PROPS-EPOCH — §GANTT_PROPS (E7) must speak REAL calendar dates
+// Spec: bim-compiler prompts/4D_GANTT_TM_REFACTOR.md §S72.
+//
+// ISSUE THIS PROVES OR DISPROVES:
+//   bar.startTs / bar.endTs are the Time Machine's OWN internal playback clock — a kernel_ops-derived
+//   day-offset solve that sits near 1970 by construction. tasks.schedule_start is a real calendar
+//   date. §S22 established that confusing the two silently corrupts the schedule, and fixed
+//   commitGanttDrag by reading the task's real dates out of `tasks` first.
+//
+//   The typed properties panel (E7) was never brought along. MEASURED live on Duplex before the fix,
+//   through a real dblclick and a real Apply click:
+//     §GANTT_PROPS_OPEN task=TASK_Substructure_T_FDN     → the Start input read 1970-01-01
+//     §GANTT_EDIT_MOVE  task=TASK_Substructure_T_FDN start=1970-01-05 clamped=false cascaded=0
+//     §GANTT_EDIT_PERSIST what=propsApply ok=true        → and §S70 cached the corrupted date
+//   The task's real start was 2026-09-07. Typing into that panel moved the task 56 years.
+//
+//   W-PE-1  the panel's date inputs come from `tasks`, never from bar.startTs/bar.endTs.
+//   W-PE-2  the apply path COMPARES against those same real dates (comparing against the TM clock
+//           made "start changed, finish didn't" always true, routing a pure finish edit through
+//           moveTaskCascade as if it were a move).
+//   W-PE-3  no real dates → loud refusal, never an edit offered on invented values.
+//   W-PE-4  the sibling paths that already got §S22 right are still right (regression guard).
+//
+// ⚠ Brace-matched, never a fixed slice window (the G-COH-6 false-negative class, §S65/§S71).
+//
+// Command: node viewer/tests/witness_gantt_props_epoch.js     (no fixtures, no DB, no browser)
+'use strict';
+const fs = require('fs');
+const path = require('path');
+
+let pass = 0, fail = 0;
+function assert(cond, msg) { if (cond) { pass++; console.log('  PASS ' + msg); } else { fail++; console.log('  FAIL ' + msg); } }
+
+const src = fs.readFileSync(path.join(__dirname, '..', 'time_machine.js'), 'utf8');
+function fnBody(name) {
+  const idx = src.indexOf('function ' + name + '(');
+  if (idx < 0) return '';
+  let d = 0, open = false;
+  for (let i = idx; i < src.length; i++) {
+    if (src[i] === '{') { d++; open = true; }
+    else if (src[i] === '}') { d--; if (open && d === 0) return src.slice(idx, i + 1); }
+  }
+  return '';
+}
+console.log('── witness_gantt_props_epoch (§S72) ──');
+
+const props = fnBody('openGanttProps');
+assert(props.length > 0, 'W-PE-0 openGanttProps found and brace-matched (' + props.length + ' chars)');
+
+// The two inputs the user types into.
+const startInput = /id="tmp-s"[^+]*\+\s*([A-Za-z_$][\w$.()]*)/.exec(props);
+const finishInput = /id="tmp-f"[^+]*\+\s*([A-Za-z_$][\w$.()]*)/.exec(props);
+console.log('§PROPS_EPOCH_SOURCE start=' + (startInput ? startInput[1] : '?') + ' finish=' + (finishInput ? finishInput[1] : '?'));
+assert(!!startInput && !/bar\.startTs/.test(startInput[1]),
+  'W-PE-1a the Start input is NOT populated from bar.startTs (the TM playback clock) — it reads ' + (startInput ? startInput[1] : '?'));
+assert(!!finishInput && !/bar\.endTs/.test(finishInput[1]),
+  'W-PE-1b the Finish input is NOT populated from bar.endTs — it reads ' + (finishInput ? finishInput[1] : '?'));
+assert(/SELECT schedule_start, schedule_finish FROM tasks WHERE task_id=\?/.test(props),
+  'W-PE-1c it reads the task\'s REAL dates from `tasks` — the same source ScheduleAuthor itself edits');
+
+// The apply comparison. `d(bar.startTs)` anywhere in the compare re-introduces the clock mismatch.
+assert(!/s\s*!==\s*d\(bar\.startTs\)/.test(props),
+  'W-PE-2a the apply path does not compare the typed start against the TM clock');
+assert(!/f\s*===\s*d\(bar\.endTs\)/.test(props),
+  'W-PE-2b nor the typed finish against it — that comparison decided move-vs-resize, so it silently mis-routed pure finish edits');
+assert(/s\s*!==\s*realS/.test(props) && /f\s*===\s*realF/.test(props),
+  'W-PE-2c it compares against the same real dates the inputs were populated with');
+
+assert(/§GANTT_PROPS_REJECT reason=no_real_task_dates/.test(props),
+  'W-PE-3 no real dates → LOUD refusal, never an edit offered on invented values (same shape as commitGanttDrag\'s no_real_task_snapshot)');
+
+// Regression guard: the paths §S22 already fixed must still convert through tasksBefore.
+const drag = fnBody('commitGanttDrag');
+assert(/tasksBefore\[bar\.taskId\]/.test(drag) && /no_real_task_snapshot/.test(drag),
+  'W-PE-4a commitGanttDrag still targets the task\'s real calendar position (§S22 intact)');
+const retime = fnBody('retimeTaskElements');
+assert(/§S22_EPOCH_FIX/.test(retime),
+  'W-PE-4b retimeTaskElements still carries its §S22 clock translation');
+
+console.log('§PROPS_EPOCH_SUMMARY pass=' + pass + ' fail=' + fail);
+if (fail) { console.error('FAIL — ' + fail + ' check(s) failed'); process.exit(1); }
+console.log('PASS — the typed panel reads and writes real calendar dates');

--- a/viewer/time_machine.js
+++ b/viewer/time_machine.js
@@ -6750,6 +6750,27 @@
     if (!app || !app.db || !SA) return;
     var schedId = (_taskIndex && _taskIndex.scheduleId) || 'SCH_AUTHORED';
     var d = function (ms) { return new Date(ms).toISOString().slice(0, 10); };
+    // §S22_EPOCH_FIX, E7 (bim-compiler prompts/4D_GANTT_TM_REFACTOR.md §S72) — the REAL calendar
+    // dates, read from `tasks`, never bar.startTs/bar.endTs.
+    // bar.startTs is the TM's OWN internal playback clock (a kernel_ops-derived day-offset solve,
+    // near-1970 by construction). §S22 fixed commitGanttDrag for exactly this and E7 was never
+    // brought along: the panel showed "1970-01-01" for a task really starting 2026-09-07, and
+    // Apply then wrote that 1970 date straight into tasks.schedule_start through moveTaskCascade.
+    // MEASURED live before the fix (Duplex, real dblclick → real Apply):
+    //   §GANTT_PROPS_OPEN task=TASK_Substructure_T_FDN → input value 1970-01-01
+    //   §GANTT_EDIT_MOVE  task=TASK_Substructure_T_FDN start=1970-01-05 cascaded=0
+    //   §GANTT_EDIT_PERSIST what=propsApply ok=true      ← and §S70 then cached the corruption
+    var realS = null, realF = null;
+    try {
+      var rr = app.db.exec('SELECT schedule_start, schedule_finish FROM tasks WHERE task_id=?', [bar.taskId]);
+      if (rr.length && rr[0].values.length) { realS = rr[0].values[0][0]; realF = rr[0].values[0][1]; }
+    } catch (e) {}
+    if (!realS || !realF) {
+      // Honest refusal, same shape as commitGanttDrag's no_real_task_snapshot: a panel that cannot
+      // read the task's real dates must not offer to edit them with made-up ones.
+      console.log('§GANTT_PROPS_REJECT reason=no_real_task_dates task=' + bar.taskId);
+      return;
+    }
     var box = document.getElementById('tm-gantt-props') || (function () {
       var el = document.createElement('div');
       el.id = 'tm-gantt-props';
@@ -6780,9 +6801,9 @@
         (cpmInfo.critical ? 'CRITICAL PATH · zero float' : 'Total float ' + cpmInfo.totalFloat + 'd') +
         ' <span style="font-size:9px;color:#8a97a5">(CPM, dates unchanged)</span></div>' : '') +
       '<div style="display:flex;gap:4px;align-items:center;margin-bottom:4px">Start' +
-        '<input id="tmp-s" type="date" value="' + d(bar.startTs) + '" style="flex:1;font-size:11px"></div>' +
+        '<input id="tmp-s" type="date" value="' + realS + '" style="flex:1;font-size:11px"></div>' +
       '<div style="display:flex;gap:4px;align-items:center;margin-bottom:6px">Finish' +
-        '<input id="tmp-f" type="date" value="' + d(bar.endTs) + '" style="flex:1;font-size:11px"></div>' +
+        '<input id="tmp-f" type="date" value="' + realF + '" style="flex:1;font-size:11px"></div>' +
       '<div style="margin-bottom:4px;color:#8a97a5">Dependencies</div>' + depHtml +
       '<div style="display:flex;gap:6px;margin-top:8px">' +
         '<button id="tmp-apply" style="flex:1;font-size:11px">Apply</button>' +
@@ -6819,7 +6840,10 @@
         var tbA = app.db.exec('SELECT task_id, schedule_start, schedule_finish, schedule_duration FROM tasks WHERE schedule_id=?', [schedId]);
         if (tbA.length) tbA[0].values.forEach(function (row) { tasksBeforeApply[row[0]] = { start: row[1], finish: row[2], duration: row[3] }; });
       } catch (e) {}
-      var res = (s !== d(bar.startTs) && f === d(bar.endTs) && SA.moveTaskCascade)
+      // Compare against the REAL dates the panel was populated with (§S72) — comparing the typed
+      // value against the TM-clock d(bar.startTs) made "start changed, finish didn't" always true,
+      // so a pure finish edit was routed through moveTaskCascade as if it were a move.
+      var res = (s !== realS && f === realF && SA.moveTaskCascade)
         ? SA.moveTaskCascade(app.db, schedId, bar.taskId, s, {})
         : SA.resizeTask(app.db, schedId, bar.taskId, s, f, {});
       if (!res || !res.ok) { if (msg) msg.textContent = 'Rejected: ' + ((res && res.reason) || 'unknown'); return; }


### PR DESCRIPTION
**Found by the end-to-end Time Machine audit, not by a report.**

`bar.startTs` / `bar.endTs` are the Time Machine's own internal playback clock — a kernel_ops-derived day-offset solve, near 1970 by construction. `tasks.schedule_start` is a real calendar date. §S22 established that confusing the two silently corrupts the schedule, and fixed `commitGanttDrag`. **`openGanttProps` was never brought along.**

## Measured live on Duplex, before the fix (real dblclick → real Apply click)
```
§GANTT_PROPS_OPEN task=TASK_Substructure_T_FDN     → Start input showed 1970-01-01
§GANTT_EDIT_MOVE  task=TASK_Substructure_T_FDN start=1970-01-05 clamped=false cascaded=0
§GANTT_EDIT_PERSIST what=propsApply ok=true
```
The task's real start was **2026**. Typing into that panel moved it 56 years — and §S70's persistence then wrote the corrupted date to the IDB cache, so it survived a reload.

## After the fix, same building, same gesture
```
panel Start = 2026-08-23            ← the task's real date
§GANTT_EDIT_MOVE start=2026-08-27 clamped=false cascaded=18
```
`cascaded` went **0 → 18**: the 1970 target was also collapsing the cascade, so successors never moved.

## The apply comparison had the same defect
`s !== d(bar.startTs) && f === d(bar.endTs)` compared typed real dates against TM-clock values, so *"start changed, finish didn't"* was **always true** — a pure **finish** edit was routed through `moveTaskCascade` as if it were a move. It now compares against the same real dates the inputs were populated with. A task whose real dates cannot be read is refused loudly (`§GANTT_PROPS_REJECT reason=no_real_task_dates`), never edited on invented values — the same shape as `commitGanttDrag`'s `no_real_task_snapshot`.

## Witness
`witness_gantt_props_epoch.js`, brace-matched: where the inputs come from, what the apply compares against, the refusal, plus a regression guard that `commitGanttDrag` and `retimeTaskElements` still carry their §S22 conversions. **10/10 green**; **red-proved on `origin/main` at 7 fails**, printing the smoking gun:
```
§PROPS_EPOCH_SOURCE start=d(bar.startTs) finish=d(bar.endTs)
```

Regression sweep **10/10**. `sw.js` CACHE_VERSION **v1073 → v1074**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GarL4iUhgD1Qvqntod2Gnc