### PR TITLE
test(4d): gate the four canvas gestures — and fix the lock breach that never named what broke

### DIFF
--- a/scripts/probe_gantt_gestures.js
+++ b/scripts/probe_gantt_gestures.js
@@ -1,0 +1,166 @@
+#!/usr/bin/env node
+// PROBE (§S73) — drive the Gantt's CANVAS GESTURES in a real browser and verify each one reaches its
+// engine verb. Same contract as probe_gantt_drag_outliers.js: reports by §-log. Unlike that one it
+// DOES gate — exit 1 on a failed gesture — because these four paths have no node witness and have
+// produced three defects between them (§S67 missing resync, §S69 missing bake-lock, §S72 the 1970
+// dates). Source wiring is gated separately and cheaply by witness_gantt_gesture_wiring.js; this is
+// the half that only a real pointer can prove.
+//
+// Gestures driven: marquee multi-select → en-bloc group move · dblclick → typed properties → Apply ·
+// unlink · link (drag bar→bar). Every one is read back from its own § line, never from a screenshot.
+//
+//   SERVE_ROOT must be the REPO ROOT, not viewer/ — the page loads ../erp/bigdecimal.js and
+//   ../erp/ad_seed.db. Serving viewer/ alone produces 5 spurious "RoundingMode" TypeErrors and two
+//   §*_ERR 404s that look like product defects and are not (§S72).
+'use strict';
+const { spawn } = require('child_process');
+const puppeteer = require(process.env.PUPPETEER || 'puppeteer');
+const PORT = Number(process.env.PORT || 8145);
+const ROOT = process.env.SERVE_ROOT || '/tmp/cpm-serve';
+const BLD = process.env.BLD || 'Duplex_extracted';
+const URL = `http://localhost:${PORT}/viewer/viewer.html?db=/buildings/${BLD}.db`;
+
+let pass = 0, fail = 0;
+const check = (name, cond, detail) => {
+  if (cond) { pass++; console.log('  PASS ' + name + (detail ? '  ' + detail : '')); }
+  else { fail++; console.log('  FAIL ' + name + (detail ? '  ' + detail : '')); }
+};
+
+(async () => {
+  const server = spawn('python3', ['-m', 'http.server', String(PORT), '--directory', ROOT], { stdio: 'ignore' });
+  await new Promise(r => setTimeout(r, 1500));
+  const browser = await puppeteer.launch({ headless: 'new',
+    args: ['--no-sandbox', '--disable-dev-shm-usage', '--use-angle=swiftshader', '--enable-unsafe-swiftshader'] });
+  const page = await browser.newPage();
+  const lines = [], errs = [];
+  page.on('console', m => { const t = m.text(); if (t.indexOf('§') >= 0) lines.push(t); });
+  page.on('pageerror', e => errs.push(String(e).slice(0, 160)));
+  const since = n => lines.slice(n);
+  const has = (n, re) => since(n).some(l => re.test(l));
+  const grab = (n, re) => (since(n).filter(l => re.test(l)).pop() || '');
+
+  await page.goto(URL, { waitUntil: 'domcontentloaded', timeout: 60000 });
+  await page.waitForFunction(() => typeof window.toggleTimeMachine === 'function', { timeout: 180000 });
+  await page.waitForFunction(() => window.APP && window.APP.db, { timeout: 240000 }).catch(() => {});
+  await new Promise(r => setTimeout(r, 12000));
+  check('G0 page loads with no JS error', errs.length === 0, errs.length ? errs[0] : '(0 page errors)');
+
+  await page.evaluate(() => window.toggleTimeMachine());
+  await new Promise(r => setTimeout(r, 15000));
+  await page.evaluate(() => { const g = document.getElementById('tm-gantt'); g && g.dispatchEvent(new PointerEvent('pointerup', { bubbles: true })); });
+  await new Promise(r => setTimeout(r, 6000));
+  await page.evaluate(() => { const l = document.getElementById('tm-gantt-editlock'); l && l.dispatchEvent(new PointerEvent('pointerup', { bubbles: true })); });
+  await new Promise(r => setTimeout(r, 4000));
+  check('G1 gantt drawer open and editing enabled',
+    lines.some(l => /§GANTT_EDIT_LOCK editable=true/.test(l)) && (await page.evaluate(() => Array.isArray(window.__tmGanttBars) && window.__tmGanttBars.filter(b => b.taskId).length)) > 1,
+    'bars=' + (await page.evaluate(() => (window.__tmGanttBars || []).filter(b => b.taskId).length)));
+
+  // ── E5 marquee multi-select: drag over empty canvas spanning several rows ───────────────────────
+  let mark = lines.length;
+  const marq = await page.evaluate(() => {
+    const rects = (window.__tmGanttBars || []).filter(b => b.taskId);
+    const c = document.getElementById('tm-gantt-canvas'), r = c.getBoundingClientRect();
+    const rows = rects.slice(0, 4);
+    // Start in EMPTY canvas (left of the leftmost bar in the band), sweep right/down across the rows.
+    const x0 = Math.max(2, Math.min.apply(null, rows.map(b => b.x)) - 6);
+    const y0 = rows[0].y - 2, x1 = Math.max.apply(null, rows.map(b => b.x + b.w)) + 4;
+    const y1 = rows[rows.length - 1].y + rows[rows.length - 1].h + 2;
+    const ev = (ty, x, y) => c.dispatchEvent(new PointerEvent(ty, { bubbles: true, clientX: r.left + x, clientY: r.top + y, pointerId: 1, isPrimary: true, button: 0, buttons: 1 }));
+    ev('pointerdown', x0, y0); ev('pointermove', (x0 + x1) / 2, (y0 + y1) / 2); ev('pointermove', x1, y1); ev('pointerup', x1, y1);
+    return { rows: rows.length, box: [Math.round(x0), Math.round(y0), Math.round(x1), Math.round(y1)] };
+  });
+  await new Promise(r => setTimeout(r, 2500));
+  const selLine = grab(mark, /§GANTT_GROUP_SELECT/);
+  const selCount = Number((selLine.match(/count=(\d+)/) || [0, 0])[1]);
+  check('G2 marquee selects multiple bars', selCount >= 2,
+    'swept ' + JSON.stringify(marq.box) + ' over ' + marq.rows + ' rows → ' + (selLine || '(no §GANTT_GROUP_SELECT)'));
+
+  // ── E5b en-bloc move: drag one SELECTED bar; the whole selection travels ────────────────────────
+  mark = lines.length;
+  const gdrag = await page.evaluate(sel => {
+    const rects = (window.__tmGanttBars || []).filter(b => b.taskId).slice(0, sel);
+    const c = document.getElementById('tm-gantt-canvas'), r = c.getBoundingClientRect();
+    const t = rects[0];
+    const ev = (ty, x, y) => c.dispatchEvent(new PointerEvent(ty, { bubbles: true, clientX: r.left + x, clientY: r.top + y, pointerId: 1, isPrimary: true, button: 0, buttons: 1 }));
+    ev('pointerdown', t.midX, t.midY);
+    for (let dx = 10; dx <= 90; dx += 20) ev('pointermove', t.midX + dx, t.midY);
+    ev('pointerup', t.midX + 90, t.midY);
+    return 'dragged ' + t.taskId + ' +90px';
+  }, selCount);
+  await new Promise(r => setTimeout(r, 5000));
+  const gsLine = grab(mark, /§GANTT_GROUP_SHIFT|§SE_SHIFT_TASKS|§GANTT_EDIT_MOVE/);
+  check('G3 en-bloc move commits through the group verb',
+    has(mark, /§GANTT_GROUP_SHIFT/), gdrag + ' → ' + (gsLine || '(no group-shift § line)'));
+  check('G3b the en-bloc move persists', has(mark, /§GANTT_EDIT_PERSIST what=groupShift/),
+    grab(mark, /§GANTT_EDIT_PERSIST/) || '(no persist line)');
+
+  // ── E7 typed properties: dblclick → panel → Apply ───────────────────────────────────────────────
+  mark = lines.length;
+  const panel = await page.evaluate(() => {
+    const rects = (window.__tmGanttBars || []).filter(b => b.taskId);
+    const c = document.getElementById('tm-gantt-canvas'), r = c.getBoundingClientRect(), t = rects[0];
+    c.dispatchEvent(new MouseEvent('dblclick', { bubbles: true, clientX: r.left + t.midX, clientY: r.top + t.midY, detail: 2 }));
+    return t.taskId;
+  });
+  await new Promise(r => setTimeout(r, 3000));
+  const shown = await page.evaluate(() => { const s = document.getElementById('tmp-s'); return s ? s.value : null; });
+  check('G4 dblclick opens the typed panel', has(mark, /§GANTT_PROPS_OPEN/), panel + ' start=' + shown);
+  // §S72: the panel must show the task's REAL calendar date, not the TM's near-1970 playback clock.
+  const real = await page.evaluate(t => {
+    const q = window.APP.db.exec('SELECT schedule_start FROM tasks WHERE task_id=?', [t]);
+    return q.length && q[0].values.length ? q[0].values[0][0] : null;
+  }, panel);
+  check('G4b the panel shows the REAL date (§S72 regression)', shown === real,
+    'panel=' + shown + ' tasks.schedule_start=' + real);
+
+  mark = lines.length;
+  const applied = await page.evaluate(() => {
+    const s = document.getElementById('tmp-s'); if (!s) return 'NO_INPUT';
+    const d = new Date(Date.parse(s.value + 'T00:00:00Z') + 4 * 86400000).toISOString().slice(0, 10);
+    s.value = d; document.getElementById('tmp-apply').click(); return d;
+  });
+  await new Promise(r => setTimeout(r, 5000));
+  check('G5 Apply commits the typed date', has(mark, /§GANTT_PROPS_APPLY/), 'typed ' + applied + ' → ' + grab(mark, /§GANTT_PROPS_APPLY/));
+  check('G5b the typed date is written verbatim, no epoch drift',
+    new RegExp('§GANTT_PROPS_APPLY[^\\n]*start=' + applied).test(grab(mark, /§GANTT_PROPS_APPLY/)),
+    grab(mark, /§GANTT_EDIT_MOVE|§GANTT_EDIT_RESIZE/));
+
+  // ── E4 unlink ───────────────────────────────────────────────────────────────────────────────────
+  mark = lines.length;
+  const unl = await page.evaluate(() => { const b = document.querySelector('#tm-gantt-props [data-unlink]'); if (!b) return 'NO_BUTTON'; b.click(); return 'clicked'; });
+  await new Promise(r => setTimeout(r, 4000));
+  check('G6 unlink removes a dependency', has(mark, /§GANTT_EDIT_UNLINK/), unl + ' → ' + grab(mark, /§GANTT_EDIT_UNLINK/));
+
+  // ── E3 link: drag bar → bar with ≥14px vertical travel ──────────────────────────────────────────
+  // Clear the marquee selection FIRST. This is documented precedence, not a workaround: a pointerdown
+  // on a bar that is part of a multi-selection starts a GROUP DRAG (time_machine.js ~:6581), so the
+  // link gesture is deliberately shadowed while a selection is live. A near-zero marquee on empty
+  // canvas is the "click away" that dissolves it (§GANTT_GROUP_SELECT count=0).
+  mark = lines.length;
+  await page.evaluate(() => {
+    const c = document.getElementById('tm-gantt-canvas'), r = c.getBoundingClientRect();
+    const ev = (ty, x, y) => c.dispatchEvent(new PointerEvent(ty, { bubbles: true, clientX: r.left + x, clientY: r.top + y, pointerId: 1, isPrimary: true, button: 0, buttons: 1 }));
+    ev('pointerdown', 2, 2); ev('pointerup', 2, 2);
+  });
+  await new Promise(r => setTimeout(r, 2000));
+  check('G6b clicking empty canvas clears the selection (so link is reachable again)',
+    has(mark, /§GANTT_GROUP_SELECT count=0/), grab(mark, /§GANTT_GROUP_SELECT/) || '(no clear line)');
+
+  mark = lines.length;
+  const lnk = await page.evaluate(() => {
+    const rects = (window.__tmGanttBars || []).filter(b => b.taskId);
+    const c = document.getElementById('tm-gantt-canvas'), r = c.getBoundingClientRect();
+    const a = rects[0], z = rects.find(x => Math.abs(x.midY - a.midY) >= 20) || rects[1];
+    const ev = (ty, x, y) => c.dispatchEvent(new PointerEvent(ty, { bubbles: true, clientX: r.left + x, clientY: r.top + y, pointerId: 1, isPrimary: true, button: 0, buttons: 1 }));
+    ev('pointerdown', a.midX, a.midY); ev('pointermove', a.midX + 2, a.midY + 8); ev('pointermove', z.midX, z.midY); ev('pointerup', z.midX, z.midY);
+    return a.taskId + ' → ' + z.taskId;
+  });
+  await new Promise(r => setTimeout(r, 4000));
+  check('G7 link creates a dependency (or refuses on a cycle, loudly)',
+    has(mark, /§GANTT_EDIT_LINK|§GANTT_EDIT_CYCLE_BLOCKED/), lnk + ' → ' + grab(mark, /§GANTT_EDIT_LINK|§GANTT_EDIT_CYCLE_BLOCKED/));
+
+  check('G8 no JS error across every gesture', errs.length === 0, errs.length ? errs[0] : '(0 page errors)');
+  console.log('§GANTT_GESTURES_SUMMARY pass=' + pass + ' fail=' + fail);
+  await browser.close(); server.kill();
+  process.exit(fail ? 1 : 0);
+})().catch(e => { console.error('ERR ' + (e && e.stack || e)); process.exit(2); });

--- a/viewer/support_sweep.js
+++ b/viewer/support_sweep.js
@@ -506,7 +506,14 @@
     var des = _designatedSupport(items, G);
     for (var i = 0; i < items.length; i++) {
       var sIdx = des[i]; if (sIdx < 0) continue;
-      if (items[sIdx].s > items[i].s + 1) { out.midair++; if (out.guids.length < 20) out.guids.push(items[i].guid); }
+      // §S73 — collect EVERY midair guid, do not cap here. The old `if (out.guids.length < 20)` kept
+      // the first twenty IN SCAN ORDER, which on a building with a known midair tail (173 on this
+      // lane's Duplex fixture) meant the element a planner just broke was essentially never in the
+      // list — verifyGanttIntegrity's lock breach then named twenty elements the planner had not
+      // touched. Sampling is the CALLER's decision (it ranks newly-broken elements first, then caps
+      // at 20); an audit that silently truncates its own findings cannot be ranked at all.
+      // Cost is one guid string per offender on a count that is already being computed.
+      if (items[sIdx].s > items[i].s + 1) { out.midair++; out.guids.push(items[i].guid); }
     }
     out.ok = out.midair === 0;
     return out;

--- a/viewer/sw.js
+++ b/viewer/sw.js
@@ -8,7 +8,7 @@
 // Cache-first for heavy assets (.wasm, images). DB files skip SW (IndexedDB handles them).
 //
 // DEPLOY: bump CACHE_VERSION on every OCI upload. Old caches are purged on activate.
-const CACHE_VERSION = 'v1074';   // bump on each deploy; per-change detail is the git commit message.
+const CACHE_VERSION = 'v1075';   // bump on each deploy; per-change detail is the git commit message.
 // v1064 (2026-08-21) 4D_GANTT_TM_REFACTOR.md §S58 — observability hardening, ADDITIVE LOGGING
 // ONLY, no rule or behaviour changed. (a) the three §GANTT_* proof lines now fire on every
 // model REBUILD instead of once per building, so an edit is auditable (rebuild=N ordinal).

--- a/viewer/tests/witness_gantt_gesture_wiring.js
+++ b/viewer/tests/witness_gantt_gesture_wiring.js
@@ -1,0 +1,98 @@
+#!/usr/bin/env node
+// WITNESS — W-GEST — the Gantt's four CANVAS GESTURES are wired, and their precedence is explicit
+// Spec: bim-compiler prompts/4D_GANTT_TM_REFACTOR.md §S73.
+//
+// ISSUE THIS PROVES OR DISPROVES:
+//   Four edit paths are reachable only through a pointer on the canvas — marquee multi-select +
+//   en-bloc move (E5), link by dragging bar→bar (E3), unlink (E4), and the typed properties panel
+//   opened by double-click (E7). Having no node witness, they accumulated three separate defects
+//   that shipped: §S67 (two paths re-timed the model and never resynced the canvas), §S69 (five
+//   paths could mutate the timeline mid-bake), §S72 (the typed panel wrote 1970 dates and cached
+//   them). Every one was a MISSING CALL that a source gate would have caught the day it landed.
+//
+//   This is the cheap half — it runs in milliseconds and gates the wiring. The other half, that a
+//   real pointer actually reaches these verbs, needs a browser and lives in
+//   scripts/probe_gantt_gestures.js (which drives all four and reads back their § lines).
+//
+//   W-GEST-1  each gesture is bound, and calls its own verb.
+//   W-GEST-2  PRECEDENCE: a pointerdown on a bar inside a multi-selection starts a GROUP drag, and
+//             that branch is tested BEFORE the single-bar/link branches. This is the behaviour a
+//             user sees as "marquee then drag moves the whole block" — and it is why the link
+//             gesture is deliberately shadowed while a selection is live.
+//   W-GEST-3  every gesture's verb carries the four things this lane had to add by hand: the bake
+//             lock, the canvas resync, the CPM re-annotate and the persist.
+//
+// ⚠ Brace-matched, never a fixed slice window (the G-COH-6 false-negative class, §S65/§S71).
+//
+// Command: node viewer/tests/witness_gantt_gesture_wiring.js     (no fixtures, no DB, no browser)
+'use strict';
+const fs = require('fs');
+const path = require('path');
+
+let pass = 0, fail = 0;
+function assert(cond, msg) { if (cond) { pass++; console.log('  PASS ' + msg); } else { fail++; console.log('  FAIL ' + msg); } }
+
+const src = fs.readFileSync(path.join(__dirname, '..', 'time_machine.js'), 'utf8');
+function fnBody(name) {
+  const idx = src.indexOf('function ' + name + '(');
+  if (idx < 0) return '';
+  let d = 0, open = false;
+  for (let i = idx; i < src.length; i++) {
+    if (src[i] === '{') { d++; open = true; }
+    else if (src[i] === '}') { d--; if (open && d === 0) return src.slice(idx, i + 1); }
+  }
+  return '';
+}
+console.log('── witness_gantt_gesture_wiring (§S73) ──');
+
+// ── W-GEST-1: the bindings exist and reach their verbs.
+const wire = fnBody('wireGanttResize') || src;   // the canvas handlers live in the drawer wiring
+assert(/addEventListener\('dblclick'/.test(src), 'W-GEST-1a the canvas binds dblclick (the typed-panel gesture)');
+assert(/openGanttProps\(hit\.bar\)/.test(src), 'W-GEST-1b dblclick opens the typed properties panel');
+assert(/linkGanttBars\(d\.bar, drop\.bar\)/.test(src), 'W-GEST-1c a bar→bar drop calls linkGanttBars');
+assert(/commitGanttGroupShift\(/.test(src), 'W-GEST-1d the group drag calls commitGanttGroupShift');
+assert(/§GANTT_GROUP_SELECT count=/.test(src), 'W-GEST-1e the marquee reports its selection count (the only way a probe can see it)');
+assert(/barsInRect\(/.test(src), 'W-GEST-1f the marquee resolves its rectangle through barsInRect (gated separately by witness_gantt_bars_in_rect.js)');
+
+// The link gesture's own guard: a horizontal wobble during a move must not silently create an edge.
+assert(/Math\.abs\(e\.clientY - d\.y0\) >= 14/.test(src),
+  'W-GEST-1g link requires real vertical travel (>=14px) — "put these two in sequence", not drift during a move');
+
+// The typed panel is gated by the same edit lock as the drag, and refuses loudly.
+assert(/§GANTT_PROPS_REJECT reason=locked/.test(src),
+  'W-GEST-1h dblclick on a LOCKED gantt refuses loudly instead of opening an editor that cannot commit');
+
+// ── W-GEST-2: precedence. Group drag must be considered before the single-bar/link path.
+const iGroup = src.indexOf('_groupDrag = {');
+const iLink = src.indexOf('linkGanttBars(d.bar, drop.bar)');
+const iSelCheck = src.indexOf('_ganttSelected[hit.bar.taskId] && Object.keys(_ganttSelected).length > 1');
+console.log('§GANTT_GESTURE_PRECEDENCE selCheck=' + iSelCheck + ' groupDragStart=' + iGroup + ' linkDrop=' + iLink);
+assert(iSelCheck > 0 && iGroup > 0 && iSelCheck < iGroup + 200 && iSelCheck < iLink,
+  'W-GEST-2 a pointerdown on a bar that is part of a multi-selection starts the GROUP drag, checked BEFORE the ' +
+  'single-bar/link path — this is why "marquee then drag" moves the block, and why link is shadowed while a selection is live');
+assert(/§GANTT_GROUP_SELECT count=0 \(cleared\)/.test(src),
+  'W-GEST-2b a near-zero marquee on empty canvas CLEARS the selection — the documented way back to the single-bar gestures');
+
+// ── W-GEST-3: every canvas-gesture verb carries the four calls this lane had to add by hand.
+const NEED = [
+  ['commitGanttGroupShift', ['_tmEditLocked(', '_tmResyncAfterRetime(', '_tmAnnotateCpm(', '_tmPersistEdit(']],
+  ['linkGanttBars',         ['_tmEditLocked(', '_tmResyncAfterRetime(', '_tmAnnotateCpm(', '_tmPersistEdit(']],
+  ['openGanttProps',        ['_tmEditLocked(', '_tmResyncAfterRetime(', '_tmAnnotateCpm(', '_tmPersistEdit(']],
+  ['commitGanttDrag',       ['_tmEditLocked(', '_tmResyncAfterRetime(', '_tmAnnotateCpm(', '_tmPersistEdit(']]
+];
+NEED.forEach(function (spec) {
+  const body = fnBody(spec[0]);
+  const missing = spec[1].filter(c => body.indexOf(c) < 0);
+  assert(body.length > 0 && missing.length === 0,
+    'W-GEST-3 ' + spec[0] + ' carries bake-lock + resync + CPM re-annotate + persist' +
+    (missing.length ? ' — MISSING ' + missing.join(', ') : ' (all 4)'));
+});
+
+// §S72 regression, cheap to keep here too: the typed panel must not read the TM playback clock.
+const props = fnBody('openGanttProps');
+assert(!/value="' \+ d\(bar\.startTs\)/.test(props),
+  'W-GEST-3b the typed panel still reads real calendar dates, not bar.startTs (§S72 — it wrote 1970 dates)');
+
+console.log('§GANTT_GESTURE_WIRING_SUMMARY pass=' + pass + ' fail=' + fail);
+if (fail) { console.error('FAIL — ' + fail + ' check(s) failed'); process.exit(1); }
+console.log('PASS — all four canvas gestures wired, precedence explicit');

--- a/viewer/tests/witness_gantt_lock_integrity.js
+++ b/viewer/tests/witness_gantt_lock_integrity.js
@@ -37,9 +37,17 @@ function assert(cond, msg) { if (cond) { pass++; console.log('  PASS ' + msg); }
 const ScheduleGate = require(path.join(__dirname, '..', 'schedule_gate.js'));
 const tmSrc = fs.readFileSync(path.join(__dirname, '..', 'time_machine.js'), 'utf8');
 
+// §S73: LINE-ANCHORED. A plain indexOf finds the first mention of `function NAME(` ANYWHERE —
+// including inside a comment that talks about the function — and then slices prose as if it were
+// code. That is exactly why this witness was RED on main: time_machine.js:4154 carries a comment
+// containing the words `function _midairAudit(` (it describes this very check) and the real
+// definition sits eight lines below it, so the slice began mid-sentence and vm threw
+// `SyntaxError: Unexpected template string`. Same family as G-COH-6. Anchor to the start of a line
+// so only a real definition can match.
 function sliceFn(src, name) {
-  const idx = src.indexOf('function ' + name + '(');
-  if (idx < 0) throw new Error(name + ' not found');
+  const m = new RegExp('^[ \\t]*function ' + name + '\\(', 'm').exec(src);
+  const idx = m ? m.index + m[0].indexOf('function') : -1;
+  if (idx < 0) throw new Error(name + ' not found (no line-anchored definition)');
   let depth = 0, i = idx, seenOpen = false;
   for (; i < src.length; i++) {
     if (src[i] === '{') { depth++; seenOpen = true; }
@@ -125,7 +133,8 @@ const BLD_DIR = process.env.BLD_DIR || path.join(require('os').homedir(), 'bim-o
     // §MIDAIR_REPAIR (2026-08-12): the lock gate now ALSO judges "nothing appears before the first
     // thing it touches" (_midairAudit → _contactGraph) — auditFloating's pools cannot see that
     // population. Slice them when present, same both-commits pattern as _promoteRoofLoadPath above.
-    const _hasMidairAudit = tmSrc.indexOf('function _midairAudit(') >= 0;
+    // §S73: line-anchored for the same reason sliceFn is — the comment above mentions the name.
+    const _hasMidairAudit = new RegExp('^[ \\t]*function _midairAudit\\(', 'm').test(tmSrc);
     if (_hasMidairAudit) _names.unshift('_contactGraph', '_designatedSupport', '_midairAudit');
     // §S20 Part B (2026-08-17, 4D_GANTT_TM_REFACTOR.md) — FIXES THE LANDMINE §S19_RESULTS named:
     // this used to conditionally slice `_midairRepair` (the dead legacy display-repair chain)
@@ -165,6 +174,11 @@ const BLD_DIR = process.env.BLD_DIR || path.join(require('os').homedir(), 'bim-o
     ScheduleGate: ScheduleGate,
     window: { SEQUENCE_RULES: rulesJson.SEQUENCE_RULES, SEQUENCE_DEFAULT: rulesJson.SEQUENCE_DEFAULT, SEQUENCE_NAME_OVERRIDES: rulesJson.SEQUENCE_NAME_OVERRIDES || rulesJson.NAME_OVERRIDES || [] },
     ZoneIndex: ZoneIndex,
+    // §S73: §S58 moved _contactGraph/_designatedSupport/_midairAudit into support_sweep.js and left
+    // one-line delegating wrappers behind, so the sliced wrappers need the real module — the same
+    // "give the sandbox the collaborator, never a second copy of the logic" rule this file's header
+    // already states for the restore SQL.
+    SupportSweep: require(path.join(__dirname, '..', 'support_sweep.js')),
     A: function () { return { db: db }; },
     _ops: [],
     URLSearchParams: URLSearchParams,
@@ -235,20 +249,16 @@ const BLD_DIR = process.env.BLD_DIR || path.join(require('os').homedir(), 'bim-o
   assert(breach && breach.ok === false && (breach.dFloating > 0 || breach.dMidair > 0),
     'G-LI-2d breach detected on lock-back verify (floating=' + (breach && breach.floating) + ' +' +
     (breach && breach.dFloating) + ', midair=' + (breach && breach.midair) + ' +' + (breach && breach.dMidair) + ')');
-  // §S20 Part B (2026-08-17) — found while fixing this file's landmines, NOT caused by the
-  // dead-chain deletion or this witness's own redesign: `verifyGanttIntegrity()` (time_machine.js)
-  // builds `guids` from `ScheduleGate.auditFloating`'s own UNBOUNDED collector first, then only
-  // appends `_midairAudit`'s offender list `if (ma.midair && guids.length < 20)` — so whenever the
-  // auditFloating tail alone already reaches 20 (documented as real and expected on 4 of 7 shipped
-  // buildings: "Terminal 8, Clinic 1, JKR 81, LTU_AHouse 334"), the midair-specific offender is
-  // SILENTLY never appended, regardless of which element actually broke. This fixture's own
-  // auditFloating baseline moved from near-zero (under the retired legacy chain's authored times)
-  // to 362 (under CPM's) — a genuine, measured difference between the two display-authoring paths
-  // on this witness's synthetic flat-120s-installSecs fixture — which is what exposes the bug here
-  // for the first time. This is a real, pre-existing PRODUCTION bug in `verifyGanttIntegrity()`
-  // itself, unrelated to the dead pipeline and out of THIS stage's scope to fix (touching it is new,
-  // unscoped engine work, not a deletion follow-up) — reported, not silently worked around. G-LI-2e
-  // is LEFT RED, honestly, rather than papered over.
+  // §S20 Part B (2026-08-17) named this as a real, pre-existing PRODUCTION bug in
+  // verifyGanttIntegrity() and deliberately LEFT G-LI-2e RED rather than paper over it:
+  // `guids` was auditFloating's own unbounded collector, with _midairAudit's offenders appended only
+  // `if (ma.midair && guids.length < 20)`, so on a building with a known floating tail the midair
+  // offender was silently dropped. FIXED 2026-08-23 (§S73), and the cause ran one layer deeper than
+  // the append: SupportSweep's _midairAudit was itself capped at `out.guids.length < 20` IN SCAN
+  // ORDER, so with 173 midair elements on this fixture the element the drag actually broke was never
+  // in its list at all (measured: brokeGuid inAll=false, allGuids=84). The audit now reports every
+  // offender (allGuids=237) and verifyGanttIntegrity ranks the ones ABSENT from the lock baseline
+  // first, so what the planner just broke leads the sample instead of being buried under the tail.
   assert(breach && breach.guids && breach.guids.indexOf(brokeGuid) >= 0,
     'G-LI-2e breach NAMES the dragged element (guids sample=[' + (breach ? breach.guids.slice(0, 3).join(',') : '') +
     ']) — KNOWN PRE-EXISTING BUG if this fails: verifyGanttIntegrity()\'s guids=auditFloating-collector-then-' +

--- a/viewer/time_machine.js
+++ b/viewer/time_machine.js
@@ -4215,7 +4215,28 @@
         x0: e.x0, x1: e.x1, y0: e.y0, y1: e.y1 };
     });
     var ma = _midairAudit(mrItems);
-    if (ma.midair && guids.length < 20) guids = guids.concat(ma.guids.slice(0, 20 - guids.length));
+    // §S73 — the breach must name WHAT THE EDIT BROKE, not the first 20 offenders it happens to scan.
+    // Two defects lived in the one line this replaces (`if (ma.midair && guids.length < 20) guids =
+    // guids.concat(...)`):
+    //   1. whenever auditFloating's own collector alone reached 20 — documented as normal on 4 of 7
+    //      shipped buildings (Terminal 8, Clinic 1, JKR 81, LTU_AHouse 334) — the midair offenders
+    //      were SILENTLY dropped, so a midair-caused breach listed only floating elements;
+    //   2. even with room, the sample was scan-ordered, so it was dominated by the PRE-EXISTING tail
+    //      the baseline already knew about, and the element the planner just dragged was usually
+    //      absent. That is the operator-facing failure: "your edit broke physics — here are twenty
+    //      guids you did not touch."
+    // Fix: rank NEW offenders (absent from the lock baseline's own offender set) ahead of known ones,
+    // keep floating-then-midair order inside each rank, then cap at the same 20. The full list is
+    // returned as allGuids so captureLockBaseline can remember the set instead of just the counts.
+    var allGuids = guids.concat(ma.guids || []);
+    var baseSet = (_lockBaseline && _lockBaseline.guidSet) || null;
+    var ranked = allGuids;
+    if (baseSet) {
+      var fresh = [], known = [];
+      for (var ai = 0; ai < allGuids.length; ai++) (baseSet[allGuids[ai]] ? known : fresh).push(allGuids[ai]);
+      ranked = fresh.concat(known);
+    }
+    guids = ranked.slice(0, 20);
     // §GANTT_LOCK_DELTA (2026-08-12) — the gate asks "did YOUR EDIT break physics", not "is the
     // generator perfect". Absolute zero was the wrong test and was already wrong before
     // §MIDAIR_REPAIR: measured pre-repair auditFloating on the shipped buildings was Terminal 8,
@@ -4229,7 +4250,7 @@
     return { ok: n <= base.floating && ma.midair <= base.midair,
       floating: n, midair: ma.midair, baseFloating: base.floating, baseMidair: base.midair,
       dFloating: n - base.floating, dMidair: ma.midair - base.midair,
-      total: audited.length, guids: guids, ms: ms() };
+      total: audited.length, guids: guids, allGuids: allGuids, ms: ms() };
   }
 
   // §GANTT_LOCK_DELTA — the physics state at the moment editing STARTED. Captured on 🔒→🔓 so the
@@ -4239,7 +4260,12 @@
   var _lockBaseline = null;
   function captureLockBaseline() {
     var v = verifyGanttIntegrity();
-    _lockBaseline = { floating: v.floating, midair: v.midair };
+    // §S73: remember WHICH elements were already offending, not just how many. That set is what lets
+    // a later breach rank the newly-broken elements first — the ones the planner's edit is
+    // responsible for — instead of burying them under the tail that was there all along.
+    var gset = {};
+    (v.allGuids || v.guids || []).forEach(function (g) { gset[g] = 1; });
+    _lockBaseline = { floating: v.floating, midair: v.midair, guidSet: gset };
     console.log('§GANTT_LOCK_BASELINE floating=' + v.floating + ' midair=' + v.midair +
       ' total=' + v.total + ' ms=' + v.ms + ' (edit start — a lock is refused only on an INCREASE)');
     return _lockBaseline;
@@ -6227,14 +6253,22 @@
     computeDays();
     drawGanttMini();
     renderAtTime(_cursor);
+    // §S73 — the ONLY `return true` in this function. Every refusal above returns undefined, so the
+    // __tmGanttDrag test hook can report what actually happened instead of "I found the bar."
+    return true;
   }
   // Test hooks (diagnostic only, same contract as __tmZoneProbe) — §S7's live drag reproduction:
   // a headless probe needs the real commit path and the real computed bars, not a DOM gesture.
+  // §S73: returns whether the edit COMMITTED, not whether the bar was found. It used to return true
+  // for a refused edit too — including a §TM_BAKE_LOCK refusal — so a probe watching this hook would
+  // report a mid-bake edit as successful, which is precisely the regression the lock exists to catch.
+  // `notFound` is distinguishable from `false` for the same reason: a renamed task should not read as
+  // "the software refused."
   window.__tmGanttDrag = function (taskId, mode, deltaDays) {
     for (var i = 0; i < _ganttTasks.length; i++) {
-      if (_ganttTasks[i].taskId === taskId) { commitGanttDrag(_ganttTasks[i], mode, deltaDays); return true; }
+      if (_ganttTasks[i].taskId === taskId) return commitGanttDrag(_ganttTasks[i], mode, deltaDays) === true;
     }
-    return false;
+    return 'notFound';
   };
   window.__tmGanttWindows = function () {   // NOT __tmGanttBars — drawGanttMini owns that name (rects)
     return _ganttTasks.map(function (g) {


### PR DESCRIPTION
Implements bim-compiler `prompts/4D_GANTT_TM_REFACTOR.md` **§S73**, closing gaps **1, 2 and 5** of the §S72 audit.

## Marquee multi-select + en-bloc move: confirmed, and it does not conflict
Driven live with real pointer events:
```
§GANTT_GROUP_SELECT count=5
§GANTT_GROUP_SHIFT_COMMIT tasks=5 deltaDays=2
§GANTT_EDIT_PERSIST what=groupShift ok=true
```
The precedence question has a real answer in the code: a `pointerdown` on a bar that belongs to a multi-selection starts a **group drag**, checked *before* the single-bar/link branch (`time_machine.js` ~:6581). So while a selection is live the bar→bar **link** gesture is deliberately shadowed, and a near-zero marquee on empty canvas is the documented way back (`§GANTT_GROUP_SELECT count=0`). **W-GEST-2 asserts that ordering by index** so a refactor cannot silently invert it.

## Two new gates for the four gestures that had none
These are the paths that produced §S67's missing resync, §S69's missing bake-lock and §S72's 1970 dates.

- **`viewer/tests/witness_gantt_gesture_wiring.js`** — 15 checks, milliseconds. Each gesture is bound and reaches its verb; the precedence ordering; and every gesture verb carries all four calls this lane had to add by hand: bake lock, canvas resync, CPM re-annotate, persist.
- **`scripts/probe_gantt_gestures.js`** — 13 checks, real browser. Drives marquee → en-bloc → dblclick → Apply → unlink → clear → link and reads each verb's own `§` line back. **13/13, zero page errors.** Its header records that `SERVE_ROOT` must be the repo root: serving `viewer/` alone 404s `../erp/bigdecimal.js` and manufactures five "RoundingMode" TypeErrors that look like product defects (§S72).

## `witness_gantt_lock_integrity` was RED on main — three layers, all real
1. `sliceFn` used a plain `indexOf`, so `` `function _midairAudit(` `` matched a **comment** at :4154 describing this very check, and the slice returned prose → `SyntaxError`. Line-anchored now, and the sandbox gets the real `SupportSweep` module the surviving wrappers delegate to.
2. Underneath: the bug §S20 Part B named and deliberately left red — `verifyGanttIntegrity` appended midair offenders only `if (guids.length < 20)`.
3. Underneath **that**, the actual cause: `SupportSweep._midairAudit` capped its own list at 20 **in scan order**, so with 173 midair elements the element the drag broke was never in it. Measured: `brokeGuid inAll=false, allGuids=84`.

The audit now reports every offender (`allGuids=237`) and `verifyGanttIntegrity` ranks offenders **absent from the lock baseline** first — so what the planner just broke leads the sample instead of being buried under a tail they never touched. `captureLockBaseline` remembers the offender *set*, not just the counts. **G-LI-2e passes on its original assertion — 20/20, weakened nowhere.**

## The drag test hook was lying
`window.__tmGanttDrag` returned `true` for a **refused** edit, including a `§TM_BAKE_LOCK` refusal — so a probe watching it would report a mid-bake edit as successful, exactly the regression the lock exists to catch. `commitGanttDrag` now returns `true` only when it commits; the hook reports that, and `'notFound'` stays distinguishable from a refusal.

Regression sweep **15/15**. `sw.js` CACHE_VERSION **v1074 → v1075**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GarL4iUhgD1Qvqntod2Gnc