### PR TITLE
fix(4d): the CPM float rail was painted over — draw it after the frames

### DIFF
--- a/viewer/sw.js
+++ b/viewer/sw.js
@@ -8,7 +8,7 @@
 // Cache-first for heavy assets (.wasm, images). DB files skip SW (IndexedDB handles them).
 //
 // DEPLOY: bump CACHE_VERSION on every OCI upload. Old caches are purged on activate.
-const CACHE_VERSION = 'v1075';   // bump on each deploy; per-change detail is the git commit message.
+const CACHE_VERSION = 'v1076';   // bump on each deploy; per-change detail is the git commit message.
 // v1064 (2026-08-21) 4D_GANTT_TM_REFACTOR.md §S58 — observability hardening, ADDITIVE LOGGING
 // ONLY, no rule or behaviour changed. (a) the three §GANTT_* proof lines now fire on every
 // model REBUILD instead of once per building, so an edit is auditable (rebuild=N ordinal).

--- a/viewer/tests/witness_gantt_cpm_annotate.js
+++ b/viewer/tests/witness_gantt_cpm_annotate.js
@@ -109,6 +109,21 @@ assert(!!annFn && /_ganttCritical\s*=\s*\{\}/.test(annFn.body),
 const drawFn = FNS.find(f => f.name === 'drawGanttMini');
 assert(!!drawFn && drawFn.body.indexOf('_ganttCritical[') >= 0,
   'W-CPM-4 drawGanttMini reads _ganttCritical — a criticality nothing paints is not the feature');
+// §S74 — ORDER, not just presence. The rail is painted over unless it is drawn AFTER every frame.
+// Measured on the live site before the fix, by reading canvas pixels back: of 19 bars the rail
+// showed on one of its two rows (h-2: 15 bars, h-1: 0) because the yellow captured-schedule frame —
+// a 1px strokeRect around the whole bar — owned row h-1 on 17 of them. A 2px cue rendering as 1px is
+// why the feature read as "no visual cue at all".
+(function () {
+  const b = drawFn ? drawFn.body : '';
+  const iRail = b.indexOf("cpmMark.critical ? '#e53935'");
+  const iYellow = b.indexOf("strokeStyle = '#ffeb3b'");
+  const iOrange = b.indexOf("strokeStyle = '#ff8c00'");
+  const iCyan = b.indexOf("strokeStyle = '#4fc3f7'");
+  console.log('§GANTT_RAIL_ORDER rail=' + iRail + ' yellowFrame=' + iYellow + ' orangeFrame=' + iOrange + ' cyanFrame=' + iCyan);
+  assert(iRail > 0 && iYellow > 0 && iOrange > 0 && iCyan > 0 && iRail > iYellow && iRail > iOrange && iRail > iCyan,
+    'W-CPM-6 the float rail is drawn AFTER all three stroke frames — drawn before them, the frames paint over its bottom row and the cue reads as 1px of blended colour');
+})();
 assert(!!drawFn && /cpmMark\.critical\s*\?\s*'#e53935'\s*:\s*'#26a69a'/.test(drawFn.body),
   'W-CPM-4b it paints BOTH rails (red = zero float, green = slack) — see W-CPM-5b: criticality runs ' +
   '27–82% of tasks across the fleet, so at the top of that range a red-only rail carries almost no signal');

--- a/viewer/time_machine.js
+++ b/viewer/time_machine.js
@@ -7054,24 +7054,6 @@
       ctx.fillStyle = color;
       ctx.fillRect(x, y, w, barH);
 
-      // §GANTT_CPM_ANNOTATE (§S68): float rail on the BOTTOM edge — red = on the critical path
-      // (zero float), green = has slack. NOT a fourth stroke frame: yellow (captured), orange
-      // (cursor-active) and cyan (marquee-selected) already take all three, and a fourth at 9px row
-      // height is unreadable. Same solid-edge-marker idiom the variance panel uses for its cost cap.
-      // Why BOTH colours rather than red-only: MEASURED over the 8-building fleet with the real rate
-      // tables, criticality runs 27–82% of tasks (Terminal/TermRooms 27%, Hospital 33%, LTU 55%,
-      // JKR 64%, Clinic 78%, Duplex 79%, HHS 82% — witness_gantt_cpm_annotate.js W-CPM-5). At the
-      // top of that range a red-only rail marks four bars in five and carries almost no signal;
-      // painting the complement makes the SCARCE thing — the bars that can actually move without
-      // pushing the end date — the thing that stands out, at every fraction.
-      // The marks are derived FROM the dates the cascade wrote — annotate never moved one.
-      var cpmMark = task.taskId ? _ganttCritical[task.taskId] : null;
-      if (cpmMark) {
-        ctx.globalAlpha = 1;
-        ctx.fillStyle = cpmMark.critical ? '#e53935' : '#26a69a';
-        ctx.fillRect(x, y + barH - 2, w, 2);
-      }
-
       // §gate: captured (preset IFC 4D) bars get a bright-yellow frame so you can tell the real
       // programme from the generated fallback. cap = #captured ops in this storey|phase group.
       if (task.cap > 0) {
@@ -7097,6 +7079,29 @@
         ctx.strokeStyle = '#4fc3f7';
         ctx.lineWidth = 2;
         ctx.strokeRect(x - 1, y - 1, w + 2, barH + 2);
+      }
+
+      // §GANTT_CPM_ANNOTATE (§S68/§S74): float rail on the BOTTOM edge — red = on the critical path
+      // (zero float), green = has slack. DRAWN LAST, and that placement is the fix, not a preference:
+      // §S68 drew it right after the bar fill, so the yellow captured-schedule frame (a 1px
+      // strokeRect around the whole bar) painted straight over its bottom row. MEASURED on the live
+      // site before this change — canvas pixels read back, not eyeballed — 19 bars: the rail showed
+      // on only ONE of its two rows (railVisibleAt row h-2 = 15, at h-1 = 0) and the yellow frame
+      // owned h-1 on 17 of 19. A 2px cue that renders as 1px, half of it blended against the phase
+      // fill, is why it read as "no visual cue at all".
+      // NOT a fourth stroke frame: yellow (captured), orange (cursor-active) and cyan
+      // (marquee-selected) already take all three, and a fourth at this row height is unreadable.
+      // Why BOTH colours rather than red-only: MEASURED over the 8-building fleet with the real rate
+      // tables, criticality runs 27–82% of tasks (witness_gantt_cpm_annotate.js W-CPM-5). At the top
+      // of that range a red-only rail marks four bars in five and carries almost no signal; painting
+      // the complement makes the SCARCE thing — the bars that can actually move without pushing the
+      // end date — the thing that stands out, at every fraction.
+      // The marks are derived FROM the dates the cascade wrote — annotate never moved one.
+      var cpmMark = task.taskId ? _ganttCritical[task.taskId] : null;
+      if (cpmMark) {
+        ctx.globalAlpha = 1;
+        ctx.fillStyle = cpmMark.critical ? '#e53935' : '#26a69a';
+        ctx.fillRect(x, y + barH - 2, w, 2);
       }
 
       // Label: explicit phase short-code (§GANTT_PALETTE). substring(0,3) used to yield "Sub" vs


### PR DESCRIPTION
> *"I am not aware of any visual cue showing CPM."*

Correct — and it was not a discoverability problem. The cue was rendering at **half its size**, with the visible half blended.

## What was wrong
§S68 drew the float rail immediately after the bar fill, **before** the three stroke frames. The yellow captured-schedule frame is a 1px `strokeRect` around the whole bar, so it painted straight over the rail's bottom row.

**Measured on the LIVE deployed site** by reading the Gantt canvas back pixel by pixel — not by looking at it — 19 bars on Duplex:
```
railVisibleAt row h-2 = 15    railVisibleAt row h-1 = 0    yellowFrame at h-1 = 17 / 19
```
A 2px cue rendered as **1px**, and that 1px was often an anti-aliased blend of rail colour and phase fill (`#ea5a36` where `#e53935` was intended).

CPM itself was running the whole time:
```
§GANTT_CPM_ANNOTATE schedule=SCH_AUTHORED tasks=19 critical=11 (58%) projectDuration=13d float=0..3
```

## The fix is placement only
The rail moves after the yellow / orange / cyan frames. Nothing else changes. Same measurement after:
```
railVisibleAt h-2 = 18    railVisibleAt h-1 = 18    yellowFrame at h-1 = 0    colour = exact #e53935
```
A critical bar keeps three sides of its frame, which is the right trade: the frame says *"captured"*, the rail says *"this task cannot slip without moving the end date"* — and only the rail was invisible.

**W-CPM-6** gates the order by source index, so an edit that moves the rail back above the frames fails instead of silently going quiet. W-CPM **20 → 21** checks.

`sw.js` CACHE_VERSION **v1075 → v1076**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GarL4iUhgD1Qvqntod2Gnc