### PR TITLE
housekeeping(viewer): §SQLJS_CLOSE — sql.js close-on-reassign guards + §STAFFAGE_TEX_CAP

### DIFF
--- a/viewer/city.js
+++ b/viewer/city.js
@@ -315,6 +315,11 @@ function setupCity(A) {
     A.citySQL = SQL;
     A.status.textContent = (typeof _TRL!=='undefined'&&_TRL.ui_fetching_city||'Fetching city index ({url})...').replace('{url}', A.CITY_URL);
     const buf = await A.cachedFetch(A.CITY_URL);
+    // §SQLJS_CLOSE (housekeeping/sqljs-close-leaks): free a prior instance before reassigning —
+    // defensive-only today: initCity is reached once per page life (streaming.js A.init, called once
+    // from main.js:942, or A.loadCityManual which early-returns `if (A.cityDb)`). Nothing else
+    // aliases A.cityDb (A.cityBuildingDbs holds per-archetype building DBs, not the index).
+    if (A.cityDb && typeof A.cityDb.close === 'function') { try { A.cityDb.close(); } catch (e) {} }
     A.cityDb = new SQL.Database(new Uint8Array(buf));
     console.log(`[S203] §CITY_INDEX size=${(buf.byteLength/1024).toFixed(0)}KB`);
 

--- a/viewer/effects.js
+++ b/viewer/effects.js
@@ -192,6 +192,18 @@ async function setupEffects(A, renderer, scene, camera) {
     return false;
   }
   var _staffageTexCache = {};
+  // §STAFFAGE_TEX_CAP (housekeeping/sqljs-close-leaks): the cache's key space is strictly bounded
+  // by the static roster (12 files — _STAFFAGE_PEOPLE 6 + _STAFFAGE_TREES 6; a DB-saved file name
+  // outside the roster never reaches _staffageTex, _restoreStaffageInstances drops it via its
+  // `if (!entry) return`), and session-lifetime caching is the documented design
+  // (§PHOTO_STAFFAGE_PRELOAD below: cutouts are building-independent, "loaded once per session" so
+  // the second Alt+P is instant). There is deliberately NO clear-on-teardown: _disposeStaffage()
+  // keeps textures cached across building switches by design, and clearRouteCache()'s trigger
+  // (Find-panel open, navigate_find.js) is semantically unrelated to staffage. So: a dormant size
+  // cap at 2x roster instead — it can only ever fire if a future change makes the key space dynamic,
+  // at which point oldest-in is disposed+evicted (three.js re-uploads from tex.image if a live
+  // sprite still references an evicted texture, so eviction can never break a rendered sprite).
+  var _STAFFAGE_TEX_CAP = 24;
   var _STAFFAGE_BASE = 'textures/staffage/';
   // §STAFFAGE_OFFLINE (2026-07-18): adding/removing a `file:` entry below or in _STAFFAGE_TREES?
   // Mirror it in viewer/sw.js's STAFFAGE_ASSETS list too. These pngs load via _STAFFAGE_BASE, not
@@ -915,6 +927,15 @@ async function setupEffects(A, renderer, scene, camera) {
   // aspect once the pixels are known (no hardcoded widths), anchor its bottom to the ground.
   function _staffageTex(path) {
     if (_staffageTexCache[path]) return _staffageTexCache[path];
+    // §STAFFAGE_TEX_CAP — see the cap's comment at its declaration. Dormant at roster scale
+    // (12 keys < 24): fires only if the key space ever becomes dynamic.
+    var _tcKeys = Object.keys(_staffageTexCache);
+    if (_tcKeys.length >= _STAFFAGE_TEX_CAP) {
+      var _evict = _staffageTexCache[_tcKeys[0]];
+      if (_evict && typeof _evict.dispose === 'function') { try { _evict.dispose(); } catch (e) {} }
+      delete _staffageTexCache[_tcKeys[0]];
+      console.log('§STAFFAGE_TEX_EVICT ' + _tcKeys[0] + ' cap=' + _STAFFAGE_TEX_CAP);
+    }
     var tex = new THREE.TextureLoader().load(_STAFFAGE_BASE + path,
       function() { console.log('§STAFFAGE_TEX_READY ' + path); },
       undefined,

--- a/viewer/streaming.js
+++ b/viewer/streaming.js
@@ -2289,8 +2289,23 @@ function setupStreaming(A) {
       // lens/graph actually read in split mode, so a shipped-stale room set (e.g. Terminal's
       // pre-STAIRWELL-STACK 43 rooms) is patched here or nowhere. Raw bytes stay in IDB.
       if (A._applyPendingPatch) metaBuf = await A._applyPendingPatch(metaBuf, metaUrl);
+      // §SQLJS_CLOSE (housekeeping/sqljs-close-leaks): free the prior sql.js WASM instance before
+      // reassigning — an orphaned Database keeps its whole DB copy alive on the WASM heap forever
+      // (no GC reaches it). Defensive-only today: A.init() runs exactly once per page life
+      // (main.js:942; Ctrl+O "replace" navigates to a fresh page, scene.js:1073, and the merge path
+      // folds into the LIVE A.db without reassigning), so no current user path re-enters here.
+      // A.libDb may alias A.db (set just below, and at §SPLIT_GEO_FALLBACK_META / §BBOX_PAINT_YIELD)
+      // — clear the alias so no closed handle survives. City-mode swaps (city.js:707/744/796/950)
+      // never run this code (A.init returns before the split/single load in city mode).
+      if (A.db && typeof A.db.close === 'function') {
+        try { A.db.close(); } catch (e) {}
+        if (A.libDb === A.db) A.libDb = null;
+      }
       A.db = new SQL.Database(new Uint8Array(metaBuf));
       if (A.composeGhostsFromAggregates) A.composeGhostsFromAggregates(A.db);
+      // §SQLJS_CLOSE: on a (hypothetical) re-entry a previous split-load's separate geo instance
+      // would be orphaned by this alias — close it first. Never closes the live meta (!== A.db).
+      if (A.libDb && A.libDb !== A.db && typeof A.libDb.close === 'function') { try { A.libDb.close(); } catch (e) {} }
       A.libDb = A.db;
       A._splitHasMeta = true;
       console.log(`[S192] §DB_META_LOADED size=${(metaBuf.byteLength/1024/1024).toFixed(1)}MB`);
@@ -2358,6 +2373,10 @@ function setupStreaming(A) {
           ? `Loading geometry from cache...`
           : `First visit — downloading geometry (${_posLoaded ? 'bboxes visible' : 'please wait'})...`;
         var geoBuf = _geoCached || await A.cachedFetch(geoUrl);
+        // §SQLJS_CLOSE: A.libDb aliases the live meta A.db here (set above) — the guard's !== A.db
+        // check makes it a no-op in the normal flow; it only fires if a future reorder leaves a
+        // separate prior geo instance in A.libDb. Never closes the meta DB through its alias.
+        if (A.libDb && A.libDb !== A.db && typeof A.libDb.close === 'function') { try { A.libDb.close(); } catch (e) {} }
         A.libDb = new SQL.Database(new Uint8Array(geoBuf));
         A._splitHasMeta = false;  // use sync streaming path (libDb has geometry)
         var _geoMs = (performance.now() - _geoT0).toFixed(0);
@@ -2372,6 +2391,8 @@ function setupStreaming(A) {
         try {
           A.status.textContent = 'geo.db not found — loading extracted DB as geometry source...';
           var _extBuf = await A.cachedFetch(A.DB_URL);
+          // §SQLJS_CLOSE: same alias-aware guard as the geo.db site above.
+          if (A.libDb && A.libDb !== A.db && typeof A.libDb.close === 'function') { try { A.libDb.close(); } catch (e) {} }
           A.libDb = new SQL.Database(new Uint8Array(_extBuf));
           A._splitHasMeta = false;
           console.log(`§SPLIT_GEO_FALLBACK_EXTRACTED url=${A.DB_URL} size=${(_extBuf.byteLength/1024/1024).toFixed(1)}MB`);
@@ -2379,6 +2400,8 @@ function setupStreaming(A) {
           _geoOk = true;
         } catch(_extErr) {
           console.log(`§SPLIT_GEO_FALLBACK_META err=${_extErr.message} — using meta.db (bboxes only)`);
+          // §SQLJS_CLOSE: same alias-aware guard (a prior separate geo instance would be orphaned here).
+          if (A.libDb && A.libDb !== A.db && typeof A.libDb.close === 'function') { try { A.libDb.close(); } catch (e) {} }
           A.libDb = A.db;
           A._splitHasMeta = true;
           A.status.textContent = 'Geometry unavailable — showing bounding boxes only.';
@@ -2444,6 +2467,11 @@ function setupStreaming(A) {
       A.status.textContent = (typeof _TRL!=='undefined'&&_TRL.ui_status_fetching||'Fetching {url}...').replace('{url}',A.DB_URL);
       var dbBuf = await A.cachedFetch(A.DB_URL);
       if (A._applyPendingPatch) dbBuf = await A._applyPendingPatch(dbBuf, A.DB_URL);
+      // §SQLJS_CLOSE: same defensive close-before-reassign as the split path (see comment there).
+      if (A.db && typeof A.db.close === 'function') {
+        try { A.db.close(); } catch (e) {}
+        if (A.libDb === A.db) A.libDb = null;
+      }
       A.db = new SQL.Database(new Uint8Array(dbBuf));
       if (A.composeGhostsFromAggregates) A.composeGhostsFromAggregates(A.db);
       console.log(`[S192] §DB_LOADED size=${(dbBuf.byteLength/1024/1024).toFixed(0)}MB`);
@@ -2621,6 +2649,9 @@ function setupStreaming(A) {
     // libDb is enabled (streamTick gates on libDb), i.e. before mesh streaming grabs the thread.
     if (!_splitMode && !A._useRangeStream) {
       await new Promise(function (r) { requestAnimationFrame(function () { requestAnimationFrame(r); }); });
+      // §SQLJS_CLOSE: same alias-aware guard — a re-entry after a previous SPLIT load would
+      // otherwise orphan that load's separate geo instance here.
+      if (A.libDb && A.libDb !== A.db && typeof A.libDb.close === 'function') { try { A.libDb.close(); } catch (e) {} }
       A.libDb = A.db;
       console.log('[S241] §BBOX_PAINT_YIELD bboxes painted; enabling mesh stream');
     }

--- a/viewer/sw.js
+++ b/viewer/sw.js
@@ -8,7 +8,7 @@
 // Cache-first for heavy assets (.wasm, images). DB files skip SW (IndexedDB handles them).
 //
 // DEPLOY: bump CACHE_VERSION on every OCI upload. Old caches are purged on activate.
-const CACHE_VERSION = 'v1076';   // bump on each deploy; per-change detail is the git commit message.
+const CACHE_VERSION = 'v1077';   // bump on each deploy; per-change detail is the git commit message.
 // v1064 (2026-08-21) 4D_GANTT_TM_REFACTOR.md §S58 — observability hardening, ADDITIVE LOGGING
 // ONLY, no rule or behaviour changed. (a) the three §GANTT_* proof lines now fire on every
 // model REBUILD instead of once per building, so an edit is auditable (rebuild=N ordinal).

--- a/viewer/viewer.html
+++ b/viewer/viewer.html
@@ -822,7 +822,7 @@ html.bim-embedded, html.bim-embedded body { background: #0b0b0b; }
 <script src="qrcode.min.js?v=1" onerror="console.warn('§LOAD_FAIL qrcode.min.js — QR sharing disabled')"></script>
 <script src="config.js?v=4" onerror="console.warn('§LOAD_FAIL config.js')"></script>
 <script src="db_resolve.js?v=2" onerror="console.warn('§LOAD_FAIL db_resolve.js')"></script>
-<script src="effects.js?v=25" onerror="console.warn('§LOAD_FAIL effects.js')"></script>
+<script src="effects.js?v=26" onerror="console.warn('§LOAD_FAIL effects.js')"></script>
 <script src="effects_gi_poc.js?v=3" onerror="console.warn('§LOAD_FAIL effects_gi_poc.js')"></script>
 <script src="lib/mp4_mux.js?v=1" onerror="console.warn('§LOAD_FAIL mp4_mux.js — MaxQ falls back to webm')"></script>
 <script src="cinema_path_editor.js?v=15" onerror="console.warn('§LOAD_FAIL cinema_path_editor.js — Alt+C path editing disabled')"></script>
@@ -837,7 +837,7 @@ html.bim-embedded, html.bim-embedded body { background: #0b0b0b; }
 <script src="scene.js?v=57" onerror="console.warn('§LOAD_FAIL scene.js')"></script>
 <script src="panel_nav.js?v=1" onerror="console.warn('§LOAD_FAIL panel_nav.js')"></script>
 <script src="helpers.js?v=6" onerror="console.warn('§LOAD_FAIL helpers.js')"></script>
-<script src="streaming.js?v=63" onerror="console.warn('§LOAD_FAIL streaming.js')"></script>
+<script src="streaming.js?v=64" onerror="console.warn('§LOAD_FAIL streaming.js')"></script>
 <script src="dlod.js?v=8" onerror="console.warn('§LOAD_FAIL dlod.js')"></script>
 <script src="panels.js?v=44" onerror="console.warn('§LOAD_FAIL panels.js')"></script>
 <script src="tools.js?v=42" onerror="console.warn('§LOAD_FAIL tools.js')"></script>
@@ -861,7 +861,7 @@ html.bim-embedded, html.bim-embedded body { background: #0b0b0b; }
 <script src="wh_route.js?v=2" onerror="console.warn('§LOAD_FAIL wh_route.js — pick walk disabled')"></script>
 <script src="wh_walk.js?v=8" onerror="console.warn('§LOAD_FAIL wh_walk.js — pick walk disabled')"></script>
 <!-- navigate.js lazy-loaded on demand by main.js A.loadNavigate() -->
-<script src="city.js?v=7"></script>
+<script src="city.js?v=8"></script>
 <script src="rates.js?v=7"></script>
 <!-- BIM→Project Order (TASK C): BigDecimal must precede proj_fold (it reads global.BigDecimal at load) -->
 <script src="../erp/bigdecimal.js"></script>


### PR DESCRIPTION
## Verdict up front: dormant defensive hardening, not an active leak

**Step-1 reachability investigation (traced, not assumed):** every `A.db` / `A.libDb` `new SQL.Database(...)` site lives inside `A.init()` (streaming.js:2157), which is called exactly once per page life (`main.js:942`). Every "load another building" path was traced:
- Ctrl+O / Open-pill **replace** → `location.assign(...)` full navigation (`scene.js:1073`) — fresh page, fresh init.
- Open **merge** → `A._mergeDbIntoScene` folds tables into the LIVE `A.db`/`A.libDb` without reassigning; its temp `src` DB already closes correctly (scene.js:980/987).
- City-mode building switches (`city.js:707/744/796/950`) swap between instances cached in `A.cityBuildingDbs` — references, not constructions, and NOT discards (must never be closed).
- `A.cityDb` (city.js `initCity`) is reached once: from `A.init` (once) or `A.loadCityManual`, which early-returns `if (A.cityDb)`.

So **no user can currently trigger a second fire** of any guarded site — the bug class is real (a re-entry would orphan a 100-250MB WASM-heap DB copy per fire, invisible to GC forever) but the trigger does not exist today. Claim is therefore **"leak hardened, trigger not currently reachable"** — not "leak fixed".

## Changes
- **streaming.js** — alias-aware close guards at all 7 `A.db`/`A.libDb` reassignments in `A.init()`: the 4 `new SQL.Database` sites (meta :2292-region, geo, geo-fallback-extracted, single-DB) **plus the 3 `A.libDb = A.db` alias sites** (split meta phase, `§SPLIT_GEO_FALLBACK_META`, `§BBOX_PAINT_YIELD`) — on a re-entry the alias sites are exactly where a previous split-load's separate geo instance (116MB on Clinic) would be orphaned. The `!== A.db` check guarantees the live meta DB is never closed through its alias; the `A.db` guard nulls a stale alias so no closed handle survives. Pattern copied from the file's own proven sites (`city.js` archDb :477, scene.js import temps :987/:1410).
- **city.js** — same guard before `A.cityDb` assignment.
- **effects.js** — `_staffageTexCache`: chose the **size cap** option, not a clear-trigger. Why: the key space is strictly bounded by the 12-file static roster (`_restoreStaffageInstances` drops non-roster file names via `if (!entry) return`), and session-lifetime caching is the *documented design* (`§PHOTO_STAFFAGE_PRELOAD`: cutouts are building-independent, warmed once so the second Alt+P is instant). `clearRouteCache()`'s trigger is Find-panel open (`navigate_find.js:4436`) — semantically unrelated to staffage; clearing in `_disposeStaffage()` would defeat the preload design on every building switch. The cap (24 = 2x roster, dispose+evict oldest, `§STAFFAGE_TEX_EVICT` log) is dormant today and only fires if a future change makes the key space dynamic.
- **sw.js** `CACHE_VERSION` v1076→**v1077** (v1076 was a sibling session's bump — took the higher number per the conflict-magnet rule) + **viewer.html** `?v=` bumps for the three changed files (effects 25→26, streaming 63→64, city 7→8).

## Numeric proof (headless Playwright + CDP, per prompts/VIEWER_MEMORY_LEAK.md §Method — no screenshots)
Re-entered `A.init()` programmatically (the exact hypothetical multi-fire the guards protect), 3 cycles per building, real local DBs:

**Duplex 9.3MB single-DB path** (guards: A.db close + §BBOX_PAINT_YIELD alias):
```
§WITNESS_CYCLE1 {"count":1193,"libSameAsDb":true,"textures":122,"geometries":90}
§WITNESS_REINIT cycle=2 {"initErr":null,"newDbIsNew":true,"oldDbClosed":true,"oldLibClosed":"n/a (was alias of oldDb)","newCount":1193,"newLibOk":true}
§WITNESS_VERDICT cycle=2 PASS   §WITNESS_VERDICT cycle=3 PASS
§WITNESS_PAGE_ERRORS n=0
```
**Clinic 6.1MB meta + 116MB geo split path** (guards: meta close + alias-site close of the separate geo instance):
```
§WITNESS_CYCLE1 {"count":16114,"libSameAsDb":false,"textures":191,"geometries":288,"meshes":300}
§WITNESS_REINIT cycle=2 {"initErr":null,"newDbIsNew":true,"oldDbClosed":true,"oldLibClosed":true,"newCount":16114,"newLibOk":true}
§WITNESS_CYCLE2 {"textures":383,"geometries":528,"meshes":712}
§WITNESS_REINIT cycle=3 {...identical, oldDbClosed:true, oldLibClosed:true...}
§WITNESS_CYCLE3 {"textures":383,"geometries":528,"meshes":712}   ← cycle2→3 delta 0 on every counter
§WITNESS_VERDICT cycle=2 PASS   §WITNESS_VERDICT cycle=3 PASS
§WITNESS_PAGE_ERRORS n=0
```
`oldDbClosed`/`oldLibClosed` = the prior instance's `exec('SELECT 1')` **throws "Database closed"** — instance-identity proof the guard fired; `newCount` stable = loading unbroken. Clinic's `oldLibClosed:true` is the alias-site guard closing the real 116MB geo instance a naive per-site fix would have missed (and a naive non-alias-aware fix would instead have closed the live meta DB — the trap the guards' `!== A.db` check exists for).

**Staffage cap regression** (Duplex, preload + 2x `togglePopulate()`):
```
§WITNESS_STAFFAGE preload="§PHOTO_STAFFAGE_PRELOAD warming 12 cutouts + car mesh" texReadyAfterPreload=12 texReadyTotalAfter2Presses=12 evictLines=0 texFail=0
§WITNESS_STAFFAGE_GPU textures pre=123 afterPress1=130 afterPress2=133
§WITNESS_STAFFAGE_VERDICT PASS pageErrors=0
```
Exactly 12 texture loads ever (dedup intact through the new cap code), 0 evictions (cap dormant at roster scale), press-2 GPU-texture growth is the documented additive-placement design, bounded by the roster. All 4 changed JS files `node --check` clean. Note: the single-cycle load (cycle 1) is the real user path and is byte-identical in behavior — every guard is a no-op there (prior value null or alias-skipped).

Findings doc: appended to bim-compiler `prompts/VIEWER_MEMORY_LEAK.md` (separate PR, cross-repo convention).

🤖 Generated with [Claude Code](https://claude.com/claude-code)