### PR TITLE
refactor(viewer): §S59 — extract navigate_find.js's ERP-push block into find_erp_push.js

### DIFF
--- a/viewer/find_erp_push.js
+++ b/viewer/find_erp_push.js
@@ -1,0 +1,280 @@
+// Copyright (c) 2025-2026 Redhuan D. Oon <red1org@gmail.com>
+// SPDX-License-Identifier: MIT
+/* find_erp_push.js — the Find panel's 5D-cost/ERP-PUSH block, extracted verbatim from
+ * navigate_find.js (bim-compiler prompts/SCRIPT_LENGTH_REFACTOR_SEAMS.md §S59 candidate 2).
+ *
+ * WHY THIS FILE EXISTS. navigate_find.js is 5,452 lines — one giant init() closure holding a
+ * dozen domains. This block (ERP db load/persist, class-twin cost fold, existing-order +
+ * construction deep-links, class-cost panel, the › ERP Project-Order push) is a self-contained
+ * ERP-side domain locked end-to-end by two live-browser witnesses (poc_find_erp_link_live.js,
+ * poc_construction_link_live.js) — the survey's "provably safe to move" bar.
+ *
+ * WHAT DID NOT MOVE — deliberate scope narrowing vs the survey's first draft:
+ * _selectionPriced/_selectionCost/_updateSelCost (the pure-math pricing half) STAY in
+ * navigate_find.js: no witness locks them, and per the survey's own rule low witness coverage
+ * DISQUALIFIES a candidate. _pushToErp consumes _selectionPriced through the injected deps.
+ *
+ * CONTRACT (the gantt_model.js dual-mode convention, adapted for a stateful block): everything
+ * here was closure-scoped inside navigate_find's init(A,...), so the caller passes each
+ * dependency EXPLICITLY to create(deps) — that plumbing is the survey's stated cost of this move:
+ *   A                     — the viewer APP handle (activeBuilding, status, _SQL, cachedFetch,
+ *                           _hbaTenancySpec, buildingName). A === window.APP in the real viewer
+ *                           (navigate.js hands init the same object), so A.cachedFetch IS the
+ *                           APP.cachedFetch the pre-extraction code called.
+ *   elErpOpen             — #find-erp-open ("open ↗" deep-link, may be null)
+ *   elConstructionOpen    — #find-construction-open (may be null)
+ *   getLastSelSet()       — reads navigate_find's live _lastSelSet (written by _updateSelCost,
+ *                           which stayed behind; a getter because the var is reassigned per tap)
+ *   getLastSelLabel()     — reads _lastSelLabel, same ownership
+ *   selectionPriced(set)  — navigate_find's _selectionPriced (stays inline, see above)
+ *   cur()                 — navigate_find's _cur (currency code; also used by the inline half)
+ * The module holds the ONE piece of state the block always owned: the lazily-loaded writable
+ * ERP db (_bimErpDb). window.* engine globals (ProjFold, ProjControl, BlueFuture/BlueFold,
+ * __sfx, SEQUENCE_RULES, LABOR_RATES, tmJumpTo*) are read at call time exactly as before —
+ * browser-only call paths, honest no-ops when absent.
+ *
+ * NOTHING HERE IS NEW. Every rule and every comment moved verbatim from navigate_find.js
+ * (§FIND_COST / §PROJ_PUSH / §S2 / §GOVERNANCE-GATE blocks); the WHY stays attached to the rule
+ * it explains, because in this lane the comments ARE the provenance.
+ */
+
+(function (global) {
+  'use strict';
+
+  function create(D) {
+    var A = D.A;
+    var elErpOpen = D.elErpOpen || null;
+    var elConstructionOpen = D.elConstructionOpen || null;
+
+    // ── §PROJ_PUSH (BIM→Project TASK C, docs/BIMtoProject.md §C): > to ERP — fold the selection into
+    // an iDempiere C_Project via the proven engine proj_fold.js (window.ProjFold). The fold is the
+    // witnessed part (W-PROJ-PUSH/FOLD/SEQ, tests/poc_proj_push.js); here we wire the UI call path.
+    // The writable ERP db is loaded lazily (fetch erp/ad_seed.db → sql.js) and the folded result is
+    // persisted to OPFS (bim_project_orders.db) — a viewer-owned project-orders store. NOTE: the
+    // cross-page hand-off so the ERP app reads it is the BIMtoERP §B write-path (follow-on).
+    var _bimErpDb = null;
+    function _ensureErpDb() {
+      if (_bimErpDb) return Promise.resolve(_bimErpDb);
+      var SQL = A._SQL || (typeof window !== 'undefined' && (window.SQL || window._SQL_CACHED));   // viewer caches the sql.js factory as A._SQL (streaming.js:1343); window.SQL is only set on the ERP page
+      if (!SQL || !global.ProjFold) return Promise.resolve(null);
+      return A.cachedFetch('../erp/ad_seed.db')
+        .then(function (buf) { _bimErpDb = new SQL.Database(new Uint8Array(buf)); return _bimErpDb; })
+        .catch(function (e) { console.log('[RP-C] §PROJ_PUSH_DBERR ' + e.message); return null; });
+    }
+    function _persistErpDb(db) {
+      try {
+        if (!navigator.storage || !navigator.storage.getDirectory) return Promise.resolve(false);
+        var bytes = db.export();
+        return navigator.storage.getDirectory()
+          .then(function (root) { return root.getDirectoryHandle('bim_analysis', { create: true }); })
+          .then(function (dir) { return dir.getFileHandle('bim_project_orders.db', { create: true }); })
+          .then(function (fh) { return fh.createWritable(); })
+          .then(function (w) { return w.write(bytes).then(function () { return w.close(); }); })
+          .then(function () { return true; }).catch(function () { return false; });
+      } catch (e) { return Promise.resolve(false); }
+    }
+    // ── §S2 (TM_4D5D_VARIANCE_LANE) — Zoom-Across cost fold ─────────────────────────────────────────────────
+    // When the ERP "Zoom Across" pill lands the viewer on an IFC class, fold that class's STORED twin cost into
+    // the #info-panel: the line's PlannedAmt (line grain) + the COMMITTED from its phase (c_projectphase_id →
+    // C_ProjectPhase.CommittedAmt — line CommittedAmt is null on disk BY DESIGN, it earns at S5) + the whole
+    // project pair (header scope). READ-only off the same ../erp/ad_seed.db the push path loaded. NO recompute.
+    function _money(n) { n = Math.round(Number(n) || 0); var a = Math.abs(n), s = n < 0 ? '-' : '';
+      if (a >= 1e6) return s + 'RM' + (a / 1e6).toFixed(1) + 'M'; if (a >= 1e3) return s + 'RM' + Math.round(a / 1e3) + 'K'; return s + 'RM' + a; }
+    function _foldClassTwin(ifcClass) {
+      return _ensureErpDb().then(function (db) {
+        if (!db) return null;
+        var building = A.activeBuilding;
+        function ex(sql, p) { try { var r = db.exec(sql, p || []); return (r.length && r[0].values.length) ? r[0].values : null; } catch (e) { return null; } }
+        var pr = ex("SELECT C_Project_ID,PlannedAmt,CommittedAmt FROM C_Project WHERE Value=?", [building]);
+        if (!pr) return null;   // this building isn't a folded project → no cost fold
+        var pid = pr[0][0], proj = { planned: Number(pr[0][1] || 0), committed: Number(pr[0][2] || 0) };
+        var line = null, phase = null;
+        var ln = ex("SELECT pl.PlannedAmt, pl.c_projectphase_id FROM C_ProjectLine pl JOIN M_Product p ON pl.M_Product_ID=p.M_Product_ID WHERE pl.C_Project_ID=? AND p.Value=?", [pid, ifcClass]);
+        if (ln) {
+          line = { planned: Number(ln[0][0] || 0), phaseId: ln[0][1] };
+          var ph = ex("SELECT Name,PlannedAmt,CommittedAmt,StartDate FROM C_ProjectPhase WHERE C_ProjectPhase_ID=?", [ln[0][1]]);
+          if (ph) phase = { name: ph[0][0], planned: Number(ph[0][1] || 0), committed: Number(ph[0][2] || 0), start: ph[0][3] };
+        }
+        return { building: building, projectId: pid, ifcClass: ifcClass, project: proj, line: line, phase: phase };
+      }).catch(function (e) { console.log('§ZOOM-COST err=' + e.message); return null; });
+    }
+    // BIM→Project (find-erp-deeplink): when the active building ALREADY has a folded C_Project, surface
+    // the existing "open ↗" deep-link on selection — so the user opens that Project Order rather than
+    // re-creating it. PURELY ADDITIVE: reuses the proven _ensureErpDb + the same record URL _pushToErp
+    // builds; only sets the elErpOpen link + tooltips; wrapped so it can NEVER affect cost/push/navigate.
+    // (Slice-1 grain = project-level: the link opens the building's C_Project, window 130. Per-line/guid
+    //  precision + the OPFS cross-session store are noted follow-ups in FIND_OPENLINK_EXISTING_ORDERLINE.md.)
+    function _surfaceExistingOrder(set) {
+      if (!elErpOpen || !set || !set.size) return;
+      var mySet = set;                                   // race guard — selection may change before resolve
+      _ensureErpDb().then(function (db) {
+        if (!db || mySet !== D.getLastSelSet()) return;  // db not available, or selection moved on
+        var pid = null;
+        try {
+          var r = db.exec("SELECT C_Project_ID FROM C_Project WHERE Value=?", [A.activeBuilding]);
+          pid = (r.length && r[0].values.length) ? r[0].values[0][0] : null;
+        } catch (e) { return; }
+        if (pid == null) return;                          // building not folded yet → keep create-push as-is
+        var url = '../erp/idempiere.html?client=garden&window=130&record=' + encodeURIComponent(pid);
+        elErpOpen.setAttribute('href', url);
+        elErpOpen.style.display = 'inline-block';
+        elErpOpen.title = 'Already in a Project Order — open it (no need to push again)';
+        var btn = document.getElementById('find-erp-btn');
+        if (btn) btn.title = 'Already a Project Order — use the “open ↗” link, or push to add more';
+        console.log('[RP-C] §PROJ_LINK_EXISTING building="' + A.activeBuilding + '" project=' + pid + ' url=' + url);
+      }).catch(function () { /* additive — never impact Find */ });
+    }
+    // §2026-07-04 thread A ("zoom to iDempiere" from Room/storey) — a Building already compiles onto a real
+    // M_Warehouse row (HBA's ad_tenancy.js compileBuilding, threaded onto A._hbaTenancySpec.warehouse by
+    // hba_lens.js's bindStoreysFromModel) and a SECOND AD_Window "Construction" now exists over that same
+    // row (scripts/seed_hba_construction.js) alongside window 139. Room-tap/storey-tap surfaces an "iDempiere
+    // ↗" link to it — building-grain (the same warehouse record for every room in this building, honestly;
+    // there is no per-room AD_Window, only per-room M_Locator/M_Product, which is a different, deeper link
+    // not in scope here). PURELY ADDITIVE: only touches #find-construction-open; HBA absent/inactive →
+    // honest no-op (never fabricates a warehouse id), same discipline as _surfaceExistingOrder above.
+    //
+    // §GOVERNANCE-GATE (design review, 2026-07-04): compileBuilding's `warehouse.m_warehouse_id` is a REAL
+    // persisted id only once ERP governance has resolved (`_hbaTenancySpec._governed===true` — a DB hit via
+    // erpQuery, ad_tenancy.js); before that it's a throwaway session-local mint (always the literal `1`) that
+    // matches nothing in the real dictionary. A link built off the ungoverned id would SOMETIMES 404/point at
+    // the wrong record depending on load timing — that's a correctness bug, not a feature gap. Gate on it.
+    function _surfaceConstructionLink(guid, label) {
+      if (!elConstructionOpen) return;
+      elConstructionOpen.style.display = 'none';
+      elConstructionOpen.removeAttribute('href');
+      try {
+        var HL = (typeof HBALens !== 'undefined') ? HBALens : (typeof window !== 'undefined' ? window.HBALens : null);
+        var spec = A._hbaTenancySpec;
+        var whId = spec && spec.warehouse ? spec.warehouse.m_warehouse_id : null;
+        if (!HL || !HL.erpLink || !HL.AD_WINDOWS || whId == null || !spec._governed) {
+          console.log('[RP-TA] §CONSTRUCTION_LINK skip guid=' + guid + ' (HBA inactive, no compiled warehouse, or not yet governed — honest no-op)');
+          return;
+        }
+        var url = HL.erpLink(HL.AD_WINDOWS.CONSTRUCTION, whId);
+        elConstructionOpen.setAttribute('href', url);
+        elConstructionOpen.style.display = 'inline-block';
+        elConstructionOpen.title = 'Open ' + (A.buildingName || 'this building') + ' in iDempiere (Construction) — via ' + (label || guid);
+        console.log('[RP-TA] §CONSTRUCTION_LINK guid=' + guid + ' warehouse=' + whId + ' url=' + url);
+      } catch (e) { console.log('[RP-TA] §CONSTRUCTION_LINK err=' + e.message); }
+    }
+    function _pct(planned, committed) { return planned > 0 ? Math.round((committed - planned) * 100 / planned) : 0; }
+    function _showClassCost(ifcClass, matchCount, guid) {
+      var box = document.getElementById('info-cost'); if (!box) return;
+      box.style.display = 'none';
+      _foldClassTwin(ifcClass).then(function (t) {
+        if (!t) { console.log('§ZOOM-COST skip — no twin for class="' + ifcClass + '"'); return; }
+        var pj = t.project, pjPct = _pct(pj.planned, pj.committed);
+        var html = '<div style="color:#4fc3f7;font-weight:bold;margin-bottom:3px">Cost variance <span style="font-size:9px;color:#888;font-weight:normal">· from records</span></div>';
+        if (t.phase) {   // the committed actual lives at phase/control-account grain
+          var phPct = _pct(t.phase.planned, t.phase.committed), over = t.phase.committed >= t.phase.planned;
+          html += '<div><span class="label">' + ifcClass + '</span>: <span class="value">' + _money(t.line ? t.line.planned : 0) + ' planned</span></div>';
+          html += '<div><span class="label">Phase ' + t.phase.name + '</span>: <span class="value">' + _money(t.phase.planned) + ' → ' + _money(t.phase.committed) +
+            ' <b style="color:' + (over ? '#ff6b6b' : '#26a69a') + '">(' + (phPct >= 0 ? '+' : '') + phPct + '%)</b></span></div>';
+        }
+        html += '<div><span class="label">Project ' + t.building + '</span>: <span class="value">' + _money(pj.planned) + ' → ' + _money(pj.committed) +
+          ' <b style="color:' + (pj.committed >= pj.planned ? '#ff6b6b' : '#26a69a') + '">(' + (pjPct >= 0 ? '+' : '') + pjPct + '%)</b></span></div>';
+        // "View at this moment" — freeze TM on the moment this thing is built. With a guid (a specific picked
+        // element) → §360-IDENTITY tmJumpToElement (the EXACT item); else fall back to the class's phase window.
+        var canElem = guid && typeof window.tmJumpToElement === 'function';
+        var canPhase = t.phase && typeof window.tmJumpToPhase === 'function';
+        if (canElem || canPhase) {
+          html += '<div style="margin-top:6px"><button id="info-cost-tm" style="background:#1565c0;color:#fff;border:none;border-radius:4px;padding:4px 10px;font-size:11px;cursor:pointer">⏱ View at this moment</button></div>';
+        }
+        box.innerHTML = html;
+        box.style.display = 'block';
+        var ipnl = document.getElementById('info-panel'); if (ipnl) ipnl.style.display = 'block';
+        var jb = document.getElementById('info-cost-tm');
+        if (jb) jb.addEventListener('click', function (e) {
+          e.stopPropagation();
+          if (canElem) { console.log('§ZOOM-COST_JUMP_ELEM class="' + ifcClass + '" guid="' + guid + '"'); window.tmJumpToElement(guid); }
+          else { console.log('§ZOOM-COST_JUMP class="' + ifcClass + '" phase="' + t.phase.name + '"'); window.tmJumpToPhase(t.phase.name); }
+        });
+        console.log('§ZOOM-COST class="' + ifcClass + '" matches=' + (matchCount || 0) + ' linePlanned=' + (t.line ? t.line.planned : 'n/a') +
+          ' phase="' + (t.phase ? t.phase.name : '-') + '" phasePlanned=' + (t.phase ? t.phase.planned : '-') + ' phaseCommitted=' + (t.phase ? t.phase.committed : '-') +
+          ' projPlanned=' + pj.planned + ' projCommitted=' + pj.committed + ' projPct=' + pjPct + '%');
+      });
+    }
+
+    // BIM→Project: every › ERP push outcome gets audio + a clear status (user: "good practice — a status
+    // message, with audio feedback; happy audio when it succeeds"). Reuses the SFX engine (window.__sfx,
+    // rows in sfx.json — NOT hardcoded synth, the wh_walk/PRE-PINNED-FACT idiom). Silent if audio is off.
+    function _pushSfx(id) {
+      var sfx = window.__sfx, ok = !!(sfx && typeof sfx.play === 'function' && id);
+      if (ok) { try { sfx.play(id); } catch (e) { ok = false; } }
+      console.log('[RP-C] §PROJ_PUSH_AUDIO id=' + id + ' sfx=' + (ok ? 'played' : 'absent'));
+    }
+    function _pushReject(msg) { if (A.status) A.status.textContent = msg; _pushSfx('erp_reject'); }
+    function _pushToErp() {
+      var set = D.getLastSelSet();
+      if (!set || !set.size) { _pushReject('Select something to push to ERP'); return; }
+      if (!window.ProjFold) { _pushReject('ERP push engine not loaded'); console.log('[RP-C] §PROJ_PUSH_DEFER ProjFold absent'); return; }
+      var building = A.activeBuilding;
+      var priced = D.selectionPriced(set);
+      // no priced rows = nothing costable (e.g. a single element, or an old-schema model whose transforms
+      // carry no bbox sizes). Say so + a low cue, instead of looking like the push silently did nothing.
+      if (!priced || !priced.rows.length) { _pushReject('Nothing costable in selection — pick a type/storey group (this model may lack element sizes)'); console.log('[RP-C] §PROJ_PUSH_DEFER no priced rows (elements=' + (priced ? priced.elements : 0) + ')'); return; }
+      if (A.status) A.status.textContent = 'Folding Project Order…';
+      _ensureErpDb().then(function (db) {
+        if (!db) { _pushReject('ERP db unavailable for push'); console.log('[RP-C] §PROJ_PUSH_DEFER no ERP db'); return; }
+        var opts = {
+          seqRules: window.SEQUENCE_RULES || {}, laborRates: window.LABOR_RATES || {},
+          packCurrencyISO: D.cur(), now: (function () { try { return new Date().toISOString().replace('T', ' ').slice(0, 19); } catch (e) { return '2026-01-01 00:00:00'; } })()
+        };
+        var r = window.ProjFold.foldProjectOrder(db, building, priced.rows, opts);
+        console.log('[RP-C] §PROJ_PUSH project="' + building + '" scope="' + D.getLastSelLabel() + '" phases=+' + r.created.phases +
+          ' tasks=+' + r.created.tasks + ' lines=+' + r.created.lines + ' products=+' + r.created.products +
+          ' order=' + (r.orderId || '-') + ' plannedAmt=' + r.plannedAmt);
+        // §F9 — when BlueFuture is engaged, route the pushed Project Order onto the active blue branch
+        // (op-log + projection tag) so it's a speculative UNOFFICIAL draft, invisible to official chrome
+        // until accepted on the timeline. No-op in the plain viewer (BlueFuture/BlueFold absent → white push).
+        try {
+          var _bf = window.BlueFuture, _bfold = window.BlueFold;
+          if (_bf && _bfold && _bf.isBlue && _bf.isBlue() && r.created.projects) {
+            var _br = _bf.branchId ? _bf.branchId() : (_bf.readBranch && _bf.readBranch());
+            var _tags = [{ table: 'C_Project', idCol: 'C_Project_ID', id: r.projectId }];
+            if (r.orderId) _tags.push({ table: 'C_Order', idCol: 'C_Order_ID', id: r.orderId });
+            _bfold.commitBlue(db, _br, [{ op_type: 'PROJECT_FOLD', output_guid: String(r.projectId), params: { building: building, plannedAmt: String(r.plannedAmt) } }], _tags)
+              .then(function (b) { console.log('[RP-C] §PROJ_PUSH_BLUE branch=' + _br + ' ok=' + (b && b.ok) + ' ops=' + JSON.stringify(b && b.opIds) + ' (speculative — invisible to official chrome)'); });
+          }
+        } catch (e) { console.log('[RP-C] §PROJ_PUSH_BLUE_ERR ' + e.message); }
+        // §F4 — the PM control readout (contract sum + EVM) on the freshly folded project.
+        var ctrl = null;
+        if (window.ProjControl && r.projectId) {
+          try {
+            ctrl = window.ProjControl.projectControl(db, r.projectId);
+            console.log('[RP-C] §PROJ_CONTROL project="' + building + '" original=' + ctrl.contract.original +
+              ' approvedVOs=' + ctrl.contract.approvedVOs + ' revised=' + ctrl.contract.revised +
+              ' bac=' + ctrl.evm.bac + ' pv=' + ctrl.evm.pv + ' ev=' + ctrl.evm.ev + ' ac=' + ctrl.evm.ac +
+              ' cv=' + ctrl.evm.cv + ' sv=' + ctrl.evm.sv + ' cpi=' + ctrl.evm.cpi + ' spi=' + ctrl.evm.spi +
+              ' %complete=' + ctrl.evm.percentComplete + (ctrl.note ? ' note="' + ctrl.note + '"' : ''));
+          } catch (e) { console.log('[RP-C] §PROJ_CONTROL_ERR ' + e.message); }
+        }
+        _persistErpDb(db).then(function (ok) {
+          console.log('[RP-C] §PROJ_PUSH_PERSIST opfs=' + ok + ' store=bim_project_orders.db');
+          var revised = ctrl ? Number(ctrl.contract.revised) : Number(r.plannedAmt);
+          if (A.status) A.status.textContent = 'Project Order: ' + r.created.lines + ' lines · contract ' + D.cur() + ' ' +
+            revised.toLocaleString(undefined, { maximumFractionDigits: 0 }) + (ok ? ' (saved)' : '');
+          // BIM→Project (find-erp-deeplink): surface the created record's deep-link at the ERP spot. The OPFS
+          // store above is overlaid onto GardenWorld at iDempiere boot (bim_orders_overlay.js), so this URL
+          // lands on the real C_Project (window 130) AFTER the standard GW login (role/access kept by design).
+          if (elErpOpen && r && r.projectId != null) {
+            var url = '../erp/idempiere.html?client=garden&window=130&record=' + encodeURIComponent(r.projectId);
+            elErpOpen.setAttribute('href', url);
+            elErpOpen.style.display = 'inline-block';
+            _pushSfx('erp_pushed');   // happy chime — Project Order folded + deep-link ready
+            console.log('[RP-C] §PROJ_PUSH_LINK project=' + r.projectId + ' order=' + (r.orderId || '-') + ' url=' + url);
+          }
+        });
+      });
+    }
+
+    return { ensureErpDb: _ensureErpDb, persistErpDb: _persistErpDb, money: _money,
+             foldClassTwin: _foldClassTwin, surfaceExistingOrder: _surfaceExistingOrder,
+             surfaceConstructionLink: _surfaceConstructionLink, showClassCost: _showClassCost,
+             pushToErp: _pushToErp };
+  }
+
+  var API = { create: create };
+  global.FindErpPush = API;
+  if (typeof module !== 'undefined' && module.exports) module.exports = API;
+})(typeof window !== 'undefined' ? window : (typeof globalThis !== 'undefined' ? globalThis : this));

--- a/viewer/main.js
+++ b/viewer/main.js
@@ -172,7 +172,14 @@ async function initViewer() {
         // (getStairGroups() reuse), so room_graph.js must already exist by the time this runs.
         '../common/hallway_backbone.js?v=1',
         // v49 (FLY_TOUR_CORRIDOR_GRAPH.md, 2026-07-16): A.ensureRooms + A.getRoomGraph extraction.
-        'navigate_find.js?v=57',
+        // §S59 candidate 2 (SCRIPT_LENGTH_REFACTOR_SEAMS.md, 2026-08-23): the Find panel's 5D-cost/
+        // ERP-push block, extracted from navigate_find.js. Must load BEFORE navigate_find.js — its
+        // init() calls FindErpPush.create() at closure-build time (honest §ERP_PUSH_MODULE_ABSENT
+        // no-op if missing, but then every › ERP surface is inert).
+        'find_erp_push.js?v=1',
+        // v58 (§S59, 2026-08-23): ERP-push block extracted to find_erp_push.js above — a stale v57
+        // would still carry its own copy AND the new wiring would never run.
+        'navigate_find.js?v=58',
         'navigate_grid.js?v=1',
         'navigate_path.js?v=1',
         'navigate_engine.js?v=1',

--- a/viewer/navigate_find.js
+++ b/viewer/navigate_find.js
@@ -1763,228 +1763,29 @@
       } catch (e) { el.textContent = ''; console.log('[RP-C] §FIND_COST_ERR ' + e.message); }
     }
 
-    // ── §PROJ_PUSH (BIM→Project TASK C, docs/BIMtoProject.md §C): > to ERP — fold the selection into
-    // an iDempiere C_Project via the proven engine proj_fold.js (window.ProjFold). The fold is the
-    // witnessed part (W-PROJ-PUSH/FOLD/SEQ, tests/poc_proj_push.js); here we wire the UI call path.
-    // The writable ERP db is loaded lazily (fetch erp/ad_seed.db → sql.js) and the folded result is
-    // persisted to OPFS (bim_project_orders.db) — a viewer-owned project-orders store. NOTE: the
-    // cross-page hand-off so the ERP app reads it is the BIMtoERP §B write-path (follow-on).
-    var _bimErpDb = null;
-    function _ensureErpDb() {
-      if (_bimErpDb) return Promise.resolve(_bimErpDb);
-      var SQL = A._SQL || window.SQL || window._SQL_CACHED;   // viewer caches the sql.js factory as A._SQL (streaming.js:1343); window.SQL is only set on the ERP page
-      if (!SQL || !window.ProjFold) return Promise.resolve(null);
-      return APP.cachedFetch('../erp/ad_seed.db')
-        .then(function (buf) { _bimErpDb = new SQL.Database(new Uint8Array(buf)); return _bimErpDb; })
-        .catch(function (e) { console.log('[RP-C] §PROJ_PUSH_DBERR ' + e.message); return null; });
-    }
-    function _persistErpDb(db) {
-      try {
-        if (!navigator.storage || !navigator.storage.getDirectory) return Promise.resolve(false);
-        var bytes = db.export();
-        return navigator.storage.getDirectory()
-          .then(function (root) { return root.getDirectoryHandle('bim_analysis', { create: true }); })
-          .then(function (dir) { return dir.getFileHandle('bim_project_orders.db', { create: true }); })
-          .then(function (fh) { return fh.createWritable(); })
-          .then(function (w) { return w.write(bytes).then(function () { return w.close(); }); })
-          .then(function () { return true; }).catch(function () { return false; });
-      } catch (e) { return Promise.resolve(false); }
-    }
-    // ── §S2 (TM_4D5D_VARIANCE_LANE) — Zoom-Across cost fold ─────────────────────────────────────────────────
-    // When the ERP "Zoom Across" pill lands the viewer on an IFC class, fold that class's STORED twin cost into
-    // the #info-panel: the line's PlannedAmt (line grain) + the COMMITTED from its phase (c_projectphase_id →
-    // C_ProjectPhase.CommittedAmt — line CommittedAmt is null on disk BY DESIGN, it earns at S5) + the whole
-    // project pair (header scope). READ-only off the same ../erp/ad_seed.db the push path loaded. NO recompute.
-    function _money(n) { n = Math.round(Number(n) || 0); var a = Math.abs(n), s = n < 0 ? '-' : '';
-      if (a >= 1e6) return s + 'RM' + (a / 1e6).toFixed(1) + 'M'; if (a >= 1e3) return s + 'RM' + Math.round(a / 1e3) + 'K'; return s + 'RM' + a; }
-    function _foldClassTwin(ifcClass) {
-      return _ensureErpDb().then(function (db) {
-        if (!db) return null;
-        var building = A.activeBuilding;
-        function ex(sql, p) { try { var r = db.exec(sql, p || []); return (r.length && r[0].values.length) ? r[0].values : null; } catch (e) { return null; } }
-        var pr = ex("SELECT C_Project_ID,PlannedAmt,CommittedAmt FROM C_Project WHERE Value=?", [building]);
-        if (!pr) return null;   // this building isn't a folded project → no cost fold
-        var pid = pr[0][0], proj = { planned: Number(pr[0][1] || 0), committed: Number(pr[0][2] || 0) };
-        var line = null, phase = null;
-        var ln = ex("SELECT pl.PlannedAmt, pl.c_projectphase_id FROM C_ProjectLine pl JOIN M_Product p ON pl.M_Product_ID=p.M_Product_ID WHERE pl.C_Project_ID=? AND p.Value=?", [pid, ifcClass]);
-        if (ln) {
-          line = { planned: Number(ln[0][0] || 0), phaseId: ln[0][1] };
-          var ph = ex("SELECT Name,PlannedAmt,CommittedAmt,StartDate FROM C_ProjectPhase WHERE C_ProjectPhase_ID=?", [ln[0][1]]);
-          if (ph) phase = { name: ph[0][0], planned: Number(ph[0][1] || 0), committed: Number(ph[0][2] || 0), start: ph[0][3] };
-        }
-        return { building: building, projectId: pid, ifcClass: ifcClass, project: proj, line: line, phase: phase };
-      }).catch(function (e) { console.log('§ZOOM-COST err=' + e.message); return null; });
-    }
-    // BIM→Project (find-erp-deeplink): when the active building ALREADY has a folded C_Project, surface
-    // the existing "open ↗" deep-link on selection — so the user opens that Project Order rather than
-    // re-creating it. PURELY ADDITIVE: reuses the proven _ensureErpDb + the same record URL _pushToErp
-    // builds; only sets the elErpOpen link + tooltips; wrapped so it can NEVER affect cost/push/navigate.
-    // (Slice-1 grain = project-level: the link opens the building's C_Project, window 130. Per-line/guid
-    //  precision + the OPFS cross-session store are noted follow-ups in FIND_OPENLINK_EXISTING_ORDERLINE.md.)
-    function _surfaceExistingOrder(set) {
-      if (!elErpOpen || !set || !set.size) return;
-      var mySet = set;                                   // race guard — selection may change before resolve
-      _ensureErpDb().then(function (db) {
-        if (!db || mySet !== _lastSelSet) return;        // db not available, or selection moved on
-        var pid = null;
-        try {
-          var r = db.exec("SELECT C_Project_ID FROM C_Project WHERE Value=?", [A.activeBuilding]);
-          pid = (r.length && r[0].values.length) ? r[0].values[0][0] : null;
-        } catch (e) { return; }
-        if (pid == null) return;                          // building not folded yet → keep create-push as-is
-        var url = '../erp/idempiere.html?client=garden&window=130&record=' + encodeURIComponent(pid);
-        elErpOpen.setAttribute('href', url);
-        elErpOpen.style.display = 'inline-block';
-        elErpOpen.title = 'Already in a Project Order — open it (no need to push again)';
-        var btn = document.getElementById('find-erp-btn');
-        if (btn) btn.title = 'Already a Project Order — use the “open ↗” link, or push to add more';
-        console.log('[RP-C] §PROJ_LINK_EXISTING building="' + A.activeBuilding + '" project=' + pid + ' url=' + url);
-      }).catch(function () { /* additive — never impact Find */ });
-    }
-    // §2026-07-04 thread A ("zoom to iDempiere" from Room/storey) — a Building already compiles onto a real
-    // M_Warehouse row (HBA's ad_tenancy.js compileBuilding, threaded onto A._hbaTenancySpec.warehouse by
-    // hba_lens.js's bindStoreysFromModel) and a SECOND AD_Window "Construction" now exists over that same
-    // row (scripts/seed_hba_construction.js) alongside window 139. Room-tap/storey-tap surfaces an "iDempiere
-    // ↗" link to it — building-grain (the same warehouse record for every room in this building, honestly;
-    // there is no per-room AD_Window, only per-room M_Locator/M_Product, which is a different, deeper link
-    // not in scope here). PURELY ADDITIVE: only touches #find-construction-open; HBA absent/inactive →
-    // honest no-op (never fabricates a warehouse id), same discipline as _surfaceExistingOrder above.
-    //
-    // §GOVERNANCE-GATE (design review, 2026-07-04): compileBuilding's `warehouse.m_warehouse_id` is a REAL
-    // persisted id only once ERP governance has resolved (`_hbaTenancySpec._governed===true` — a DB hit via
-    // erpQuery, ad_tenancy.js); before that it's a throwaway session-local mint (always the literal `1`) that
-    // matches nothing in the real dictionary. A link built off the ungoverned id would SOMETIMES 404/point at
-    // the wrong record depending on load timing — that's a correctness bug, not a feature gap. Gate on it.
-    function _surfaceConstructionLink(guid, label) {
-      if (!elConstructionOpen) return;
-      elConstructionOpen.style.display = 'none';
-      elConstructionOpen.removeAttribute('href');
-      try {
-        var HL = (typeof HBALens !== 'undefined') ? HBALens : (typeof window !== 'undefined' ? window.HBALens : null);
-        var spec = A._hbaTenancySpec;
-        var whId = spec && spec.warehouse ? spec.warehouse.m_warehouse_id : null;
-        if (!HL || !HL.erpLink || !HL.AD_WINDOWS || whId == null || !spec._governed) {
-          console.log('[RP-TA] §CONSTRUCTION_LINK skip guid=' + guid + ' (HBA inactive, no compiled warehouse, or not yet governed — honest no-op)');
-          return;
-        }
-        var url = HL.erpLink(HL.AD_WINDOWS.CONSTRUCTION, whId);
-        elConstructionOpen.setAttribute('href', url);
-        elConstructionOpen.style.display = 'inline-block';
-        elConstructionOpen.title = 'Open ' + (A.buildingName || 'this building') + ' in iDempiere (Construction) — via ' + (label || guid);
-        console.log('[RP-TA] §CONSTRUCTION_LINK guid=' + guid + ' warehouse=' + whId + ' url=' + url);
-      } catch (e) { console.log('[RP-TA] §CONSTRUCTION_LINK err=' + e.message); }
-    }
-    function _pct(planned, committed) { return planned > 0 ? Math.round((committed - planned) * 100 / planned) : 0; }
-    function _showClassCost(ifcClass, matchCount, guid) {
-      var box = document.getElementById('info-cost'); if (!box) return;
-      box.style.display = 'none';
-      _foldClassTwin(ifcClass).then(function (t) {
-        if (!t) { console.log('§ZOOM-COST skip — no twin for class="' + ifcClass + '"'); return; }
-        var pj = t.project, pjPct = _pct(pj.planned, pj.committed);
-        var html = '<div style="color:#4fc3f7;font-weight:bold;margin-bottom:3px">Cost variance <span style="font-size:9px;color:#888;font-weight:normal">· from records</span></div>';
-        if (t.phase) {   // the committed actual lives at phase/control-account grain
-          var phPct = _pct(t.phase.planned, t.phase.committed), over = t.phase.committed >= t.phase.planned;
-          html += '<div><span class="label">' + ifcClass + '</span>: <span class="value">' + _money(t.line ? t.line.planned : 0) + ' planned</span></div>';
-          html += '<div><span class="label">Phase ' + t.phase.name + '</span>: <span class="value">' + _money(t.phase.planned) + ' → ' + _money(t.phase.committed) +
-            ' <b style="color:' + (over ? '#ff6b6b' : '#26a69a') + '">(' + (phPct >= 0 ? '+' : '') + phPct + '%)</b></span></div>';
-        }
-        html += '<div><span class="label">Project ' + t.building + '</span>: <span class="value">' + _money(pj.planned) + ' → ' + _money(pj.committed) +
-          ' <b style="color:' + (pj.committed >= pj.planned ? '#ff6b6b' : '#26a69a') + '">(' + (pjPct >= 0 ? '+' : '') + pjPct + '%)</b></span></div>';
-        // "View at this moment" — freeze TM on the moment this thing is built. With a guid (a specific picked
-        // element) → §360-IDENTITY tmJumpToElement (the EXACT item); else fall back to the class's phase window.
-        var canElem = guid && typeof window.tmJumpToElement === 'function';
-        var canPhase = t.phase && typeof window.tmJumpToPhase === 'function';
-        if (canElem || canPhase) {
-          html += '<div style="margin-top:6px"><button id="info-cost-tm" style="background:#1565c0;color:#fff;border:none;border-radius:4px;padding:4px 10px;font-size:11px;cursor:pointer">⏱ View at this moment</button></div>';
-        }
-        box.innerHTML = html;
-        box.style.display = 'block';
-        var ipnl = document.getElementById('info-panel'); if (ipnl) ipnl.style.display = 'block';
-        var jb = document.getElementById('info-cost-tm');
-        if (jb) jb.addEventListener('click', function (e) {
-          e.stopPropagation();
-          if (canElem) { console.log('§ZOOM-COST_JUMP_ELEM class="' + ifcClass + '" guid="' + guid + '"'); window.tmJumpToElement(guid); }
-          else { console.log('§ZOOM-COST_JUMP class="' + ifcClass + '" phase="' + t.phase.name + '"'); window.tmJumpToPhase(t.phase.name); }
-        });
-        console.log('§ZOOM-COST class="' + ifcClass + '" matches=' + (matchCount || 0) + ' linePlanned=' + (t.line ? t.line.planned : 'n/a') +
-          ' phase="' + (t.phase ? t.phase.name : '-') + '" phasePlanned=' + (t.phase ? t.phase.planned : '-') + ' phaseCommitted=' + (t.phase ? t.phase.committed : '-') +
-          ' projPlanned=' + pj.planned + ' projCommitted=' + pj.committed + ' projPct=' + pjPct + '%');
-      });
-    }
+    // ── §PROJ_PUSH / §S2 / §GOVERNANCE-GATE block — EXTRACTED VERBATIM to find_erp_push.js
+    // (bim-compiler prompts/SCRIPT_LENGTH_REFACTOR_SEAMS.md §S59 candidate 2, 2026-08-23). All 8
+    // functions (_ensureErpDb/_persistErpDb/_money/_foldClassTwin/_surfaceExistingOrder/
+    // _surfaceConstructionLink/_showClassCost/_pushToErp) + their private helpers (_pct/_pushSfx/
+    // _pushReject) moved with their comments; every dependency is passed EXPLICITLY below — the
+    // closure-scope plumbing the survey named as this move's real cost. _selectionPriced/
+    // _selectionCost/_updateSelCost deliberately STAYED above: no witness locks them, and per the
+    // survey's own rule low witness coverage DISQUALIFIES a candidate. Locked end-to-end by
+    // poc_find_erp_link_live.js + poc_construction_link_live.js (real browser, §-log asserted).
+    // find_erp_push.js loads BEFORE this file in main.js's A.loadNavigate() module list.
+    var _erpPush = (typeof FindErpPush !== 'undefined' && FindErpPush.create) ? FindErpPush.create({
+      A: A, elErpOpen: elErpOpen, elConstructionOpen: elConstructionOpen,
+      getLastSelSet: function () { return _lastSelSet; },      // selection state stays owned HERE (_updateSelCost writes it)
+      getLastSelLabel: function () { return _lastSelLabel; },
+      selectionPriced: _selectionPriced,                       // the inline pricing half, injected
+      cur: _cur
+    }) : null;
+    if (!_erpPush) console.log('[RP-C] §ERP_PUSH_MODULE_ABSENT find_erp_push.js not loaded — ERP push surfaces inert (honest no-op)');
+    var _surfaceExistingOrder = _erpPush ? _erpPush.surfaceExistingOrder : function () {};
+    var _surfaceConstructionLink = _erpPush ? _erpPush.surfaceConstructionLink : function () {};
+    var _showClassCost = _erpPush ? _erpPush.showClassCost : function () {};
+    var _pushToErp = _erpPush ? _erpPush.pushToErp : function () { if (A.status) A.status.textContent = 'ERP push module not loaded'; };
     A._showClassCost = _showClassCost;   // exposed for applyFindScope + witnesses
-
-    // BIM→Project: every › ERP push outcome gets audio + a clear status (user: "good practice — a status
-    // message, with audio feedback; happy audio when it succeeds"). Reuses the SFX engine (window.__sfx,
-    // rows in sfx.json — NOT hardcoded synth, the wh_walk/PRE-PINNED-FACT idiom). Silent if audio is off.
-    function _pushSfx(id) {
-      var sfx = window.__sfx, ok = !!(sfx && typeof sfx.play === 'function' && id);
-      if (ok) { try { sfx.play(id); } catch (e) { ok = false; } }
-      console.log('[RP-C] §PROJ_PUSH_AUDIO id=' + id + ' sfx=' + (ok ? 'played' : 'absent'));
-    }
-    function _pushReject(msg) { if (A.status) A.status.textContent = msg; _pushSfx('erp_reject'); }
-    function _pushToErp() {
-      var set = _lastSelSet;
-      if (!set || !set.size) { _pushReject('Select something to push to ERP'); return; }
-      if (!window.ProjFold) { _pushReject('ERP push engine not loaded'); console.log('[RP-C] §PROJ_PUSH_DEFER ProjFold absent'); return; }
-      var building = A.activeBuilding;
-      var priced = _selectionPriced(set);
-      // no priced rows = nothing costable (e.g. a single element, or an old-schema model whose transforms
-      // carry no bbox sizes). Say so + a low cue, instead of looking like the push silently did nothing.
-      if (!priced || !priced.rows.length) { _pushReject('Nothing costable in selection — pick a type/storey group (this model may lack element sizes)'); console.log('[RP-C] §PROJ_PUSH_DEFER no priced rows (elements=' + (priced ? priced.elements : 0) + ')'); return; }
-      if (A.status) A.status.textContent = 'Folding Project Order…';
-      _ensureErpDb().then(function (db) {
-        if (!db) { _pushReject('ERP db unavailable for push'); console.log('[RP-C] §PROJ_PUSH_DEFER no ERP db'); return; }
-        var opts = {
-          seqRules: window.SEQUENCE_RULES || {}, laborRates: window.LABOR_RATES || {},
-          packCurrencyISO: _cur(), now: (function () { try { return new Date().toISOString().replace('T', ' ').slice(0, 19); } catch (e) { return '2026-01-01 00:00:00'; } })()
-        };
-        var r = window.ProjFold.foldProjectOrder(db, building, priced.rows, opts);
-        console.log('[RP-C] §PROJ_PUSH project="' + building + '" scope="' + _lastSelLabel + '" phases=+' + r.created.phases +
-          ' tasks=+' + r.created.tasks + ' lines=+' + r.created.lines + ' products=+' + r.created.products +
-          ' order=' + (r.orderId || '-') + ' plannedAmt=' + r.plannedAmt);
-        // §F9 — when BlueFuture is engaged, route the pushed Project Order onto the active blue branch
-        // (op-log + projection tag) so it's a speculative UNOFFICIAL draft, invisible to official chrome
-        // until accepted on the timeline. No-op in the plain viewer (BlueFuture/BlueFold absent → white push).
-        try {
-          var _bf = window.BlueFuture, _bfold = window.BlueFold;
-          if (_bf && _bfold && _bf.isBlue && _bf.isBlue() && r.created.projects) {
-            var _br = _bf.branchId ? _bf.branchId() : (_bf.readBranch && _bf.readBranch());
-            var _tags = [{ table: 'C_Project', idCol: 'C_Project_ID', id: r.projectId }];
-            if (r.orderId) _tags.push({ table: 'C_Order', idCol: 'C_Order_ID', id: r.orderId });
-            _bfold.commitBlue(db, _br, [{ op_type: 'PROJECT_FOLD', output_guid: String(r.projectId), params: { building: building, plannedAmt: String(r.plannedAmt) } }], _tags)
-              .then(function (b) { console.log('[RP-C] §PROJ_PUSH_BLUE branch=' + _br + ' ok=' + (b && b.ok) + ' ops=' + JSON.stringify(b && b.opIds) + ' (speculative — invisible to official chrome)'); });
-          }
-        } catch (e) { console.log('[RP-C] §PROJ_PUSH_BLUE_ERR ' + e.message); }
-        // §F4 — the PM control readout (contract sum + EVM) on the freshly folded project.
-        var ctrl = null;
-        if (window.ProjControl && r.projectId) {
-          try {
-            ctrl = window.ProjControl.projectControl(db, r.projectId);
-            console.log('[RP-C] §PROJ_CONTROL project="' + building + '" original=' + ctrl.contract.original +
-              ' approvedVOs=' + ctrl.contract.approvedVOs + ' revised=' + ctrl.contract.revised +
-              ' bac=' + ctrl.evm.bac + ' pv=' + ctrl.evm.pv + ' ev=' + ctrl.evm.ev + ' ac=' + ctrl.evm.ac +
-              ' cv=' + ctrl.evm.cv + ' sv=' + ctrl.evm.sv + ' cpi=' + ctrl.evm.cpi + ' spi=' + ctrl.evm.spi +
-              ' %complete=' + ctrl.evm.percentComplete + (ctrl.note ? ' note="' + ctrl.note + '"' : ''));
-          } catch (e) { console.log('[RP-C] §PROJ_CONTROL_ERR ' + e.message); }
-        }
-        _persistErpDb(db).then(function (ok) {
-          console.log('[RP-C] §PROJ_PUSH_PERSIST opfs=' + ok + ' store=bim_project_orders.db');
-          var revised = ctrl ? Number(ctrl.contract.revised) : Number(r.plannedAmt);
-          if (A.status) A.status.textContent = 'Project Order: ' + r.created.lines + ' lines · contract ' + _cur() + ' ' +
-            revised.toLocaleString(undefined, { maximumFractionDigits: 0 }) + (ok ? ' (saved)' : '');
-          // BIM→Project (find-erp-deeplink): surface the created record's deep-link at the ERP spot. The OPFS
-          // store above is overlaid onto GardenWorld at iDempiere boot (bim_orders_overlay.js), so this URL
-          // lands on the real C_Project (window 130) AFTER the standard GW login (role/access kept by design).
-          if (elErpOpen && r && r.projectId != null) {
-            var url = '../erp/idempiere.html?client=garden&window=130&record=' + encodeURIComponent(r.projectId);
-            elErpOpen.setAttribute('href', url);
-            elErpOpen.style.display = 'inline-block';
-            _pushSfx('erp_pushed');   // happy chime — Project Order folded + deep-link ready
-            console.log('[RP-C] §PROJ_PUSH_LINK project=' + r.projectId + ' order=' + (r.orderId || '-') + ' url=' + url);
-          }
-        });
-      });
-    }
 
     // solidOpacity (optional): for the kept-solid CONTEXT build (color==null), render it at this
     // opacity instead of fully opaque. Room lens passes 0.3 so the selected room shows THROUGH its

--- a/viewer/navigate_find.js
+++ b/viewer/navigate_find.js
@@ -1773,7 +1773,7 @@
     // survey's own rule low witness coverage DISQUALIFIES a candidate. Locked end-to-end by
     // poc_find_erp_link_live.js + poc_construction_link_live.js (real browser, §-log asserted).
     // find_erp_push.js loads BEFORE this file in main.js's A.loadNavigate() module list.
-    var _erpPush = (typeof FindErpPush !== 'undefined' && FindErpPush.create) ? FindErpPush.create({
+    var _erpPush = (typeof window.FindErpPush !== 'undefined' && window.FindErpPush.create) ? window.FindErpPush.create({
       A: A, elErpOpen: elErpOpen, elConstructionOpen: elConstructionOpen,
       getLastSelSet: function () { return _lastSelSet; },      // selection state stays owned HERE (_updateSelCost writes it)
       getLastSelLabel: function () { return _lastSelLabel; },

--- a/viewer/sw.js
+++ b/viewer/sw.js
@@ -8,7 +8,13 @@
 // Cache-first for heavy assets (.wasm, images). DB files skip SW (IndexedDB handles them).
 //
 // DEPLOY: bump CACHE_VERSION on every OCI upload. Old caches are purged on activate.
-const CACHE_VERSION = 'v1077';   // bump on each deploy; per-change detail is the git commit message.
+const CACHE_VERSION = 'v1078';   // bump on each deploy; per-change detail is the git commit message.
+// v1078 (2026-08-23) SCRIPT_LENGTH_REFACTOR_SEAMS.md §S59 candidate 2 — navigate_find.js's ERP-push
+// block extracted to NEW find_erp_push.js (loaded by main.js's lazy navigate list BEFORE
+// navigate_find.js?v=58). NOT precached ON PURPOSE: none of the lazy navigate_* sub-modules are
+// (navigate_find/grid/path/engine/controls, room_graph, hallway_backbone — only navigate.js is);
+// local .js is network-first, so online users fetch fresh. This bump purges stale runtime caches
+// so an offline fallback can never pair an old self-contained navigate_find.js with the new main.js.
 // v1064 (2026-08-21) 4D_GANTT_TM_REFACTOR.md §S58 — observability hardening, ADDITIVE LOGGING
 // ONLY, no rule or behaviour changed. (a) the three §GANTT_* proof lines now fire on every
 // model REBUILD instead of once per building, so an edit is auditable (rebuild=N ordinal).

--- a/viewer/tests/poc_construction_link_live.js
+++ b/viewer/tests/poc_construction_link_live.js
@@ -43,18 +43,44 @@ const seen = re => log.some(l => re.test(l));
   await page.goto('http://127.0.0.1:' + port + '/viewer/viewer.html?db=buildings/HHS_Office_Federated_extracted.db&bld=HHS_Office_Federated',
     { waitUntil: 'networkidle' });
 
-  let ready = false;
+  // §HBA_LAZY (hba_lens.js, user directive 2026-07-28, PR #1071): HBA no longer compiles at page load —
+  // A._hbaTenancySpec only exists after the Human-Asset pill (or the public wake seam exposed FOR
+  // witnesses, HBALens.ensureHbaData) wakes it. This witness predates that change and was polling for
+  // a spec that can never appear unbidden. Wake it once via the seam, then poll as before — every
+  // assertion below is unchanged (governed warehouse id, §CONSTRUCTION_LINK, link href, 0 pageerrors).
+  let ready = false, woke = false;
   for (let i = 0; i < 60 && !ready; i++) {
     await page.waitForTimeout(1000);
-    try { ready = await page.evaluate(() => !!(window.APP && window.APP.db && window.APP.dbQuery
-      && window.APP._hbaTenancySpec && window.APP._hbaTenancySpec.warehouse)); } catch (e) {}
+    try {
+      if (!woke) woke = await page.evaluate(() => {
+        if (window.APP && window.APP.db && window.HBALens && window.HBALens.ensureHbaData) {
+          window.HBALens.ensureHbaData(window.APP); return true;
+        } return false;
+      });
+      // _governed too, not just .warehouse: _ensureErpGovern's ad_seed.db fetch is async, and before it
+      // resolves the spec carries the throwaway session mint (always literal 1) that §GOVERNANCE-GATE
+      // exists to reject — _surfaceConstructionLink itself refuses to link off it. Asserting on the
+      // ungoverned mint was a race, not a pass.
+      ready = await page.evaluate(() => !!(window.APP && window.APP.db && window.APP.dbQuery
+        && window.APP._hbaTenancySpec && window.APP._hbaTenancySpec.warehouse
+        && window.APP._hbaTenancySpec._governed));
+    } catch (e) {}
   }
-  verdict(ready, 'viewer model + HBA compiled warehouse ready (A._hbaTenancySpec.warehouse)');
+  verdict(ready, 'viewer model + HBA GOVERNED warehouse ready (A._hbaTenancySpec.warehouse + _governed)');
   const whId = await page.evaluate(() => window.APP._hbaTenancySpec.warehouse.m_warehouse_id);
   S('   warehouse m_warehouse_id=' + whId);
 
   await page.evaluate(() => window.APP.openFindPanel());
-  await page.waitForTimeout(1500);
+  // openFindPanel lazy-loads the whole navigate module chain (main.js A.loadNavigate — 9 scripts,
+  // §NAVIGATE_LAZY_LOADED) before the panel exists; a fixed 1500ms loses that race on a loaded
+  // machine (observed: §LENS_AXES rendered AFTER this witness had already polled and given up).
+  // Poll for the axis toggle itself instead — same budget style as the readiness loop above.
+  let panelUp = false;
+  for (let i = 0; i < 30 && !panelUp; i++) {
+    await page.waitForTimeout(1000);
+    try { panelUp = await page.evaluate(() => !!document.getElementById('find-axis-toggle')); } catch (e) {}
+  }
+  verdict(panelUp, 'Find panel + axis toggle rendered (navigate modules lazy-loaded)');
 
   // cycle the single axis-toggle button until it reaches 'room' (storey→disc→[room]→…) — REAL clicks
   // (the row's own tap listener lives on the inner text/badge spans, not the row div — hit-test, don't dispatch)
@@ -70,10 +96,19 @@ const seen = re => log.some(l => re.test(l));
   verdict(axis === 'room', 'Find axis reached "room"', 'axis=' + axis);
 
   await page.waitForTimeout(800);
+  // §LENS_GROUPS (post-2026-07-04 tree): the Room axis now renders STOREY GROUP headers first, with the
+  // room leaves lazy-expanded via each group row's arrow span (a group-header tap = §CATEGORY_REVEAL, NOT
+  // a room select — observed live: tapping the first row fired §CATEGORY_REVEAL and no §CONSTRUCTION_LINK,
+  // because _surfaceConstructionLink is only called from _roomSelect, a LEAF tap). Expand the first group
+  // (arrow = first span, the only expand affordance), then tap a leaf row's text span — leaf rows carry
+  // no data-find-parent attribute. Assertions below are unchanged.
   const rowCount = await page.evaluate(() => document.querySelectorAll('.find-tree-row').length);
+  await page.click('.find-tree-row > span:first-child');   // expand group 1 (arrow pointerup)
+  await page.waitForTimeout(800);
   let tapped = false;
-  if (rowCount > 0) { await page.click('.find-tree-row'); tapped = true; }
-  verdict(tapped, 'a Room/storey tree row was tappable', 'rows=' + rowCount);
+  const leafCount = await page.evaluate(() => document.querySelectorAll('.find-tree-row:not([data-find-parent])').length);
+  if (leafCount > 0) { await page.click('.find-tree-row:not([data-find-parent]) > span:nth-child(2)'); tapped = true; }
+  verdict(tapped, 'a Room LEAF row was tappable (group expanded first)', 'groups+rows=' + rowCount + ' leaves=' + leafCount);
   await page.waitForTimeout(1500);
 
   verdict(seen(/§CONSTRUCTION_LINK guid=.*warehouse=\d+/), '§CONSTRUCTION_LINK logged with a real (numeric) warehouse id');


### PR DESCRIPTION
## What
`SCRIPT_LENGTH_REFACTOR_SEAMS.md` §S59 candidate 2 (bim-compiler survey, 2026-08-21). The Find panel's 5D-cost/ERP-push block moves out of `navigate_find.js`'s 5,400-line `init()` closure into a new dual-mode module `viewer/find_erp_push.js` (the `gantt_model.js` precedent, adapted to a stateful block: `FindErpPush.create(deps)` — every former closure dep passed explicitly, the survey's stated cost of this move).

**Moved verbatim (8 witness-locked functions + private helpers):** `_ensureErpDb`, `_persistErpDb`, `_money`, `_foldClassTwin`, `_surfaceExistingOrder`, `_surfaceConstructionLink`, `_showClassCost`, `_pushToErp` (+ `_pct`/`_pushSfx`/`_pushReject`, used only by them). Comments moved with the rules — they are the provenance. `navigate_find.js` 5,452 → 5,253 lines.

**Deliberately NOT moved** (scope narrowing vs the survey's first draft): `_selectionPriced`/`_selectionCost`/`_updateSelCost` stay inline — no witness locks them, and per the survey's own rule low witness coverage DISQUALIFIES a candidate. `_pushToErp` consumes `_selectionPriced` through the injected deps.

## Wiring
- `main.js`: `find_erp_push.js?v=1` added to the lazy navigate list BEFORE `navigate_find.js` (bumped `?v=57`→`?v=58`).
- `sw.js`: `v1077`→`v1078`. NOT precached on purpose — none of the lazy `navigate_*` family is (only `navigate.js`), and local `.js` is network-first; the bump purges stale runtime caches so old `navigate_find.js` can never pair with new `main.js` offline.

## Witness repair (poc_construction_link_live.js)
On pristine `origin/main` this witness already FAILED its readiness gate — three staleness gaps vs the current viewer, all repaired, no assertion weakened:
1. **§HBA_LAZY** (PR #1071, user directive 2026-07-28): HBA no longer compiles at load; the witness now wakes it via `HBALens.ensureHbaData` — the seam exposed explicitly "for witnesses".
2. **§GOVERNANCE-GATE race**: it read `m_warehouse_id` before async governance resolved, asserting on the throwaway mint (literal `1`) the production code itself rejects. Now waits for `_governed`.
3. **Grouped Room tree**: the first `.find-tree-row` is now a storey GROUP header (tap = §CATEGORY_REVEAL, not `_roomSelect`); the witness expands the group and taps a LEAF.

## Proof (real browser, §-log asserted; logs read per the Log Mandate)
| Witness | Before (pristine code) | After (extracted) |
|---|---|---|
| `poc_find_erp_link_live.js` | PASS (fails=0) | PASS (fails=0) |
| `poc_construction_link_live.js` (repaired) | PASS (fails=0) | PASS (fails=0) |

Key §-lines are **byte-identical** across the move: `§PROJ_PUSH … plannedAmt=236`, `§PROJ_PUSH_PERSIST opfs=true`, `§PROJ_PUSH_LINK project=990001`, `§PROJ_PUSH_AUDIO id=erp_reject/erp_pushed sfx=played`, `§CONSTRUCTION_LINK … warehouse=990000 … window=7800000`. `§ERP_PUSH_MODULE_ABSENT` appears 0 times — the lines came from the module path, not a fallback. 0 pageerrors in all four runs.

Pre-existing, untouched: `tests/audit_specs.js` RULE 2 failure on `38-sh-dx-2d-runtime.spec.js` exists on `origin/main` (tests/ is byte-identical here); my witness changes live in `viewer/tests/`, outside its scan.

🤖 Generated with [Claude Code](https://claude.com/claude-code)