### PR TITLE
fix(viewer): §S76 — cacheKey K3 no-leading-slash gap closed; Hospital persistence probe finds a real split-mode P0

### DIFF
--- a/scripts/probe_gantt_hospital_persist.js
+++ b/scripts/probe_gantt_hospital_persist.js
@@ -1,0 +1,158 @@
+#!/usr/bin/env node
+// PROBE (§S76, gap 4 of §S72) — the live drag→persist→reload round trip proven by §S70 (W-PERS-4)
+// has only ever been run on Duplex (9MB). This runs the SAME proof on Hospital (252MB, the largest
+// building in the fleet) — the case §S72 flagged as "persistence proven on Duplex only... never run
+// on a big building." Reports by §-log, gates on the round trip actually surviving.
+//
+//   SERVE_ROOT must be the REPO ROOT, not viewer/ — same §S72 lesson probe_gantt_gestures.js already
+//   encodes: the page loads ../erp/bigdecimal.js and ../erp/ad_seed.db, and Hospital's own
+//   _extracted.db/_geo.db/_meta.db must be present under SERVE_ROOT/buildings/.
+'use strict';
+const { spawn } = require('child_process');
+const puppeteer = require(process.env.PUPPETEER || 'puppeteer');
+const PORT = Number(process.env.PORT || 8146);
+const ROOT = process.env.SERVE_ROOT || process.cwd();
+const URL = `http://localhost:${PORT}/viewer/viewer.html?db=/buildings/Hospital_extracted.db`;
+const fs = require('fs');
+const os = require('os');
+// Both browser launches MUST share this profile dir — that IS the IndexedDB the round trip proves
+// survives. Two independent puppeteer.launch() calls with no userDataDir get two independent (empty)
+// profiles, which would make "H5/H6 reload" pass or fail for the wrong reason entirely.
+const PROFILE_DIR = fs.mkdtempSync(require('path').join(os.tmpdir(), 'hospital-persist-profile-'));
+
+let pass = 0, fail = 0;
+const check = (name, cond, detail) => {
+  if (cond) { pass++; console.log('  PASS ' + name + (detail ? '  ' + detail : '')); }
+  else { fail++; console.log('  FAIL ' + name + (detail ? '  ' + detail : '')); }
+};
+
+(async () => {
+  const server = spawn('python3', ['-m', 'http.server', String(PORT), '--directory', ROOT], { stdio: 'ignore' });
+  await new Promise(r => setTimeout(r, 1500));
+  const browser = await puppeteer.launch({ headless: 'new', userDataDir: PROFILE_DIR,
+    args: ['--no-sandbox', '--disable-dev-shm-usage', '--use-angle=swiftshader', '--enable-unsafe-swiftshader'] });
+  const page = await browser.newPage();
+  let lines = [], errs = [];
+  page.on('console', m => { const t = m.text(); if (t.indexOf('§') >= 0) lines.push(t); });
+  page.on('pageerror', e => errs.push(String(e).slice(0, 200)));
+  const since = n => lines.slice(n);
+  const has = (n, re) => since(n).some(l => re.test(l));
+  const grab = (n, re) => (since(n).filter(l => re.test(l)).pop() || '');
+
+  console.log('── probe_gantt_hospital_persist (§S76) — Hospital 252MB drag → persist → reload ──');
+
+  const t0 = Date.now();
+  await page.goto(URL, { waitUntil: 'domcontentloaded', timeout: 60000 });
+  await page.waitForFunction(() => typeof window.toggleTimeMachine === 'function', { timeout: 180000 });
+  await page.waitForFunction(() => window.APP && window.APP.db, { timeout: 300000 }).catch(() => {});
+  const loadMs = Date.now() - t0;
+  check('H0 page loads with no JS error', errs.length === 0, errs.length ? errs[0] : '(0 page errors), loadMs=' + loadMs);
+
+  await page.evaluate(() => window.toggleTimeMachine());
+  await new Promise(r => setTimeout(r, 15000));
+  await page.evaluate(() => { const g = document.getElementById('tm-gantt'); g && g.dispatchEvent(new PointerEvent('pointerup', { bubbles: true })); });
+  await new Promise(r => setTimeout(r, 8000));
+  await page.evaluate(() => { const l = document.getElementById('tm-gantt-editlock'); l && l.dispatchEvent(new PointerEvent('pointerup', { bubbles: true })); });
+  await new Promise(r => setTimeout(r, 4000));
+  const barCount = await page.evaluate(() => (window.__tmGanttBars || []).filter(b => b.taskId).length);
+  check('H1 gantt drawer open, editable, bars present', barCount > 1, 'bars=' + barCount);
+
+  // ── pick the first real task bar and read its schedule_start BEFORE the drag, straight from sql.js
+  const before = await page.evaluate(() => {
+    const b = (window.__tmGanttBars || []).find(x => x.taskId);
+    if (!b) return null;
+    const r = window.APP.db.exec("SELECT task_id, schedule_start FROM tasks WHERE task_id = '" + b.taskId.replace(/'/g, "''") + "'");
+    return { taskId: b.taskId, x: b.x, y: b.y, w: b.w, h: b.h, row: r[0] ? r[0].values[0] : null };
+  });
+  check('H2 baseline task + schedule_start read from live sql.js', !!(before && before.row), JSON.stringify(before && before.row));
+
+  // ── drag it 5 days' worth of pixels to the right ──────────────────────────────────────────────
+  let mark = lines.length;
+  const t1 = Date.now();
+  await page.evaluate((b) => {
+    const c = document.getElementById('tm-gantt-canvas'), r = c.getBoundingClientRect();
+    const midY = b.y + b.h / 2, x0 = b.x + b.w / 2;
+    const ev = (ty, x, y) => c.dispatchEvent(new PointerEvent(ty, { bubbles: true, clientX: r.left + x, clientY: r.top + y, pointerId: 1, isPrimary: true, button: 0, buttons: 1 }));
+    ev('pointerdown', x0, midY);
+    for (let dx = 20; dx <= 100; dx += 20) ev('pointermove', x0 + dx, midY);
+    ev('pointerup', x0 + 100, midY);
+  }, before);
+  await new Promise(r => setTimeout(r, 4000));
+  const dragMs = Date.now() - t1;
+
+  const persistLine = grab(mark, /§(SCHED_PERSIST|GANTT_EDIT_PERSIST)/);
+  check('H3 drag fires a persist call', /ok=true/.test(persistLine) || /§SCHED_PERSIST/.test(persistLine), persistLine || '(no persist line seen)');
+
+  // §SCHED_PERSIST is debounced 1200ms per §S70 — wait past it, then read the size/key it reported.
+  await new Promise(r => setTimeout(r, 2000));
+  const t2 = Date.now();
+  const schedLine = grab(mark, /§SCHED_PERSIST/);
+  const sizeM = schedLine.match(/size=(\d+)KB/);
+  const persistKB = sizeM ? Number(sizeM[1]) : null;
+
+  const after = await page.evaluate((taskId) => {
+    const r = window.APP.db.exec("SELECT task_id, schedule_start FROM tasks WHERE task_id = '" + taskId.replace(/'/g, "''") + "'");
+    return r[0] ? r[0].values[0] : null;
+  }, before ? before.taskId : '');
+  const changed = before && before.row && after && String(after[1]) !== String(before.row[1]);
+  check('H4 in-memory schedule_start actually changed after drag', changed,
+    'before=' + (before && before.row && before.row[1]) + ' after=' + (after && after[1]));
+
+  console.log('§HOSPITAL_PERSIST_COST loadMs=' + loadMs + ' dragToCommitMs=' + dragMs + ' persistKB=' + persistKB +
+    ' schedLine="' + schedLine + '"');
+
+  await browser.close();
+
+  // ── RELOAD: fresh browser+page, same URL, force a real cache round trip, not an in-memory reuse ─
+  const browser2 = await puppeteer.launch({ headless: 'new', userDataDir: PROFILE_DIR,
+    args: ['--no-sandbox', '--disable-dev-shm-usage', '--use-angle=swiftshader', '--enable-unsafe-swiftshader'] });
+  const page2 = await browser2.newPage();
+  lines = []; errs = [];
+  page2.on('console', m => { const t = m.text(); if (t.indexOf('§') >= 0) lines.push(t); });
+  page2.on('pageerror', e => errs.push(String(e).slice(0, 200)));
+
+  const t3 = Date.now();
+  await page2.goto(URL, { waitUntil: 'domcontentloaded', timeout: 60000 });
+  await page2.waitForFunction(() => typeof window.toggleTimeMachine === 'function', { timeout: 180000 });
+  await page2.waitForFunction(() => window.APP && window.APP.db, { timeout: 300000 }).catch(() => {});
+  const reloadMs = Date.now() - t3;
+
+  const allCacheLines = lines.filter(l => /§CACHE_HIT/.test(l));
+  const extractedCacheLine = allCacheLines.find(l => /Hospital_extracted/.test(l)) || '(none — extracted.db not cache-hit by name)';
+  check('H5 reload hits the IDB cache for the EXTRACTED db specifically (not just geo/positions)',
+    /Hospital_extracted/.test(extractedCacheLine), 'all §CACHE_HIT lines: ' + JSON.stringify(allCacheLines));
+
+  const schemaCheck = await page2.evaluate((taskId) => {
+    try {
+      const cols = window.APP.db.exec("PRAGMA table_info(tasks)");
+      const colNames = cols[0] ? cols[0].values.map(v => v[1]) : [];
+      const dbUrl = window.APP.DB_URL;
+      const tableList = window.APP.db.exec("SELECT name FROM sqlite_master WHERE type='table'")[0];
+      return { colNames, dbUrl, tables: tableList ? tableList.values.map(v => v[0]) : [] };
+    } catch (e) { return { error: e.message }; }
+  }, before ? before.taskId : '');
+  console.log('§HOSPITAL_RELOAD_SCHEMA ' + JSON.stringify(schemaCheck));
+
+  const afterReload = await page2.evaluate((taskId) => {
+    try {
+      const r = window.APP.db.exec("SELECT task_id, schedule_start FROM tasks WHERE task_id = '" + taskId.replace(/'/g, "''") + "'");
+      return r[0] ? r[0].values[0] : null;
+    } catch (e) { return { error: e.message }; }
+  }, before ? before.taskId : '');
+
+  const survived = before && before.row && afterReload && String(afterReload[1]) === String(after && after[1]) && String(afterReload[1]) !== String(before.row[1]);
+  check('H6 THE ROUND TRIP — the dragged date survived the reload (this is the proof)', survived,
+    'preDrag=' + (before && before.row && before.row[1]) + ' postDrag=' + (after && after[1]) + ' postReload=' + (afterReload && afterReload[1]));
+
+  console.log('§HOSPITAL_PERSIST_ROUNDTRIP loadMs=' + loadMs + ' reloadMs=' + reloadMs + ' total=' + (Date.now() - t0) + 'ms errs=' + errs.length);
+  console.log('§HOSPITAL_PERSIST_SUMMARY pass=' + pass + ' fail=' + fail);
+
+  await browser2.close();
+  server.kill();
+  try { fs.rmSync(PROFILE_DIR, { recursive: true, force: true }); } catch (e) {}
+  process.exit(fail ? 1 : 0);
+})().catch(e => {
+  console.error('§HOSPITAL_PERSIST_FATAL ' + e.stack);
+  try { fs.rmSync(PROFILE_DIR, { recursive: true, force: true }); } catch (e2) {}
+  process.exit(1);
+});

--- a/viewer/db_resolve.js
+++ b/viewer/db_resolve.js
@@ -35,9 +35,15 @@
 //   K1 import:// url                  → verbatim   (IDB-only identity; never rewritten)
 //   K2 production buildings/<file>    → 'buildings/<file>'  (folds ../buildings, buildings, /buildings,
 //                                                            and <prodBase>buildings onto ONE key)
-//   K3 /deploy/ or /modeller/ path    → verbatim   (dev bench serves deploy/dev/buildings/Terminal…
+//   K3 deploy/ or modeller/ path seg  → verbatim   (dev bench serves deploy/dev/buildings/Terminal…
 //                                                   AND deploy/buildings/Hospital… — same filenames,
-//                                                   DIFFERENT bytes. Folding those = wrong geometry.)
+//                                                   DIFFERENT bytes. Folding those = wrong geometry.
+//                                                   Matches the segment with OR without a leading '/' —
+//                                                   ?db=deploy/dev/buildings/X.db (no leading slash,
+//                                                   e.g. hand-typed against a repo-root-relative local
+//                                                   server) folded onto the shipped K2 key until this
+//                                                   fix; every KNOWN tool (dlod_bench.html) already used
+//                                                   a leading slash and was never affected. §S76.)
 //   K4 anything else                  → verbatim   (../erp/ad_seed.db, non-buildings/ assets)
 // NON-INVENT: the key is built from the url's own filename; no path is fabricated, nothing is guessed.
 (function () {
@@ -63,8 +69,10 @@
     if (!url || typeof url !== 'string') return url;
     if (url.indexOf('import://') === 0) return url;                  // K1
     // K3 — dev/authoring trees keep their full path: deploy/dev/buildings/Terminal_extracted.db and
-    // deploy/buildings/Terminal_extracted.db are different bytes behind the same filename.
-    if (/\/deploy\/|\/modeller\//.test(url)) return url;             // K3
+    // deploy/buildings/Terminal_extracted.db are different bytes behind the same filename. Matches
+    // 'deploy/'/'modeller/' as a path segment whether or not the url has a leading slash — a bare
+    // '?db=deploy/...' (no leading '/') must be caught the same as '/deploy/...' (§S76).
+    if (/(^|\/)(deploy|modeller)\//.test(url)) return url;           // K3
     // K2 — the shipped production set, however it was addressed. Strip the query/hash first so a
     // cache-busted '?v=' link folds onto the same key as the plain one.
     var bare = url.split('#')[0].split('?')[0];

--- a/viewer/tests/witness_db_cache_key.js
+++ b/viewer/tests/witness_db_cache_key.js
@@ -30,6 +30,14 @@ const cases = [
   { id: 'K3-devbench', url: '/bim-compiler/deploy/dev/buildings/Terminal_extracted.db', want: '/bim-compiler/deploy/dev/buildings/Terminal_extracted.db' },
   { id: 'K3-prodbench', url: '/bim-compiler/deploy/buildings/Terminal_extracted.db',    want: '/bim-compiler/deploy/buildings/Terminal_extracted.db' },
   { id: 'K3-modeller', url: '/modeller/Duplex_extracted.db',            want: '/modeller/Duplex_extracted.db' },
+  // §S76 — the same K3 protection MUST hold with no leading slash too. Reachable today via the
+  // viewer's own ?db= query param (viewer/config.js:28 passes _params.get('db') straight through,
+  // unvalidated) — a hand-typed 'deploy/dev/buildings/X.db' against a repo-root-relative local server
+  // has no leading '/'. No KNOWN shipped tool triggers this (dlod_bench.html always uses a leading
+  // slash) but nothing guarded against a future one that doesn't.
+  { id: 'K3-devbench-noslash', url: 'deploy/dev/buildings/Terminal_extracted.db', want: 'deploy/dev/buildings/Terminal_extracted.db' },
+  { id: 'K3-prodbench-noslash', url: 'deploy/buildings/Terminal_extracted.db',    want: 'deploy/buildings/Terminal_extracted.db' },
+  { id: 'K3-modeller-noslash', url: 'modeller/Duplex_extracted.db',              want: 'modeller/Duplex_extracted.db' },
   // K1 — import:// is an IDB-only identity, never rewritten.
   { id: 'K1-import',   url: 'import://myhouse/myhouse_extracted.db',    want: 'import://myhouse/myhouse_extracted.db' },
   // K4 — anything that isn't a buildings/ asset is left exactly as it was.
@@ -62,6 +70,15 @@ const kept = kDev !== kPrd;
 kept ? pass++ : fail++;
 console.log(`§CACHEKEY ${kept ? 'PASS' : 'FAIL'} GUARD-dev-vs-prod-bench  dev=${kDev}  prod=${kPrd}` +
             (kept ? '  → kept apart' : '  → COLLIDED: dev bench would serve prod geometry'));
+
+// §S76 — the real reachable path: ?db= passed straight through with no leading slash colliding with
+// the shipped production key. This IS the bug the noslash cases above generalize from.
+const kDevNoSlash = cacheKey('deploy/dev/buildings/Terminal_extracted.db', PROD);
+const kProdOCI = cacheKey(BLD + 'Terminal_extracted.db', PROD);
+const keptNoSlash = kDevNoSlash !== kProdOCI;
+keptNoSlash ? pass++ : fail++;
+console.log(`§CACHEKEY ${keptNoSlash ? 'PASS' : 'FAIL'} GUARD-dev-noslash-vs-prod  dev=${kDevNoSlash}  prod=${kProdOCI}` +
+            (keptNoSlash ? '  → kept apart' : '  → COLLIDED: ?db=deploy/... (no leading slash) would silently serve prod-cached geometry'));
 
 console.log(`§CACHEKEY-SUMMARY ${pass}/${pass + fail} pass`);
 process.exit(fail === 0 ? 0 : 1);


### PR DESCRIPTION
## Summary
Dispatched to extend §S70's persistence-round-trip proof to Hospital (252MB — the case §S72 flagged as never actually run at scale) and to check whether §S72's "harmless today, a trap later" read of the `DbResolve.cacheKey` K3 rule was accurate.

**Gap 7 (K3 no-leading-slash) — fixed, small, proven both directions.**
**Gap 4 (Hospital persistence) — NOT fixed. Found a real P0 instead: split-mode buildings (Hospital + Clinic, confirmed against the current deploy fleet) silently lose every persisted Gantt edit on reload.** Named precisely with full mechanism in `prompts/4D_GANTT_TM_REFACTOR.md` §S76 (bim-compiler, separate PR) — three candidate fixes listed, none picked; this is an architecture decision, not a bounded fix.

## What shipped here
- `viewer/db_resolve.js` — K3 regex now matches `deploy/`/`modeller/` as a path segment with or without a leading `/`. Reachable today via `?db=` (config.js:28, unvalidated), even though no known shipped tool currently triggers it.
- `viewer/tests/witness_db_cache_key.js` — 3 new no-leading-slash cases + a direct collision-guard assertion. Proven red before the fix (reverted the regex, re-ran: 17/20), green after (20/20).
- `scripts/probe_gantt_hospital_persist.js` (new) — real puppeteer, real 252MB+229MB+25MB Hospital fleet files, drag→persist→reload with two browser instances correctly pinned to the same `--user-data-dir`. This is what found the P0.

## Test plan
- [x] `witness_db_cache_key.js` 20/20, sibling `witness_db_404_oci_retry.js` 12/12 unaffected
- [x] Falsifiability: reverted the K3 fix, confirmed the new case goes red (17/20), restored
- [x] Hospital probe run twice (first crashed cleanly on the schema mismatch — that crash IS the finding; second run has full diagnostics)
- [x] eslint clean on both changed viewer files

No TimeMachine/Gantt-core files touched beyond `db_resolve.js` (shared utility) and the new probe.

Claude-Session: https://claude.ai/code/session_01GmNVMG9ZGcKygz4zXuCe6m