### PR TITLE
fix(4d): §S78 — split-mode Gantt edits now persist under the key the reload reads

### DIFF
--- a/scripts/_fast_static_server.js
+++ b/scripts/_fast_static_server.js
@@ -1,0 +1,24 @@
+#!/usr/bin/env node
+// Minimal concurrent static file server — python3 -m http.server is single-threaded/sequential and
+// was measured (§S78) to make a Hospital/Clinic/even-Duplex page load take 180s+ / never complete,
+// purely from per-request overhead across viewer.html's many <script> tags, unrelated to any product
+// code. Node's http module handles concurrent connections natively; this is the same pattern already
+// used by viewer/tests/witness_real_placement_resolver.js in this repo.
+'use strict';
+const http = require('http');
+const fs = require('fs');
+const path = require('path');
+const PORT = Number(process.argv[2] || process.env.PORT || 8148);
+const ROOT = process.argv[3] || process.env.SERVE_ROOT || process.cwd();
+const MIME = { '.html': 'text/html', '.js': 'application/javascript', '.db': 'application/octet-stream',
+  '.bin': 'application/octet-stream', '.json': 'application/json', '.css': 'text/css', '.wasm': 'application/wasm' };
+http.createServer((req, res) => {
+  let p = decodeURIComponent(req.url.split('?')[0]);
+  const full = path.join(ROOT, p);
+  fs.stat(full, (err, st) => {
+    if (err || !st.isFile()) { res.writeHead(404); res.end('404'); return; }
+    res.writeHead(200, { 'Content-Type': MIME[path.extname(full)] || 'application/octet-stream',
+      'Content-Length': st.size, 'Cache-Control': 'no-store' });
+    fs.createReadStream(full).pipe(res);
+  });
+}).listen(PORT, () => console.log('fast_static_server on :' + PORT + ' root=' + ROOT));

--- a/scripts/probe_gantt_hospital_persist.js
+++ b/scripts/probe_gantt_hospital_persist.js
@@ -49,7 +49,16 @@ const check = (name, cond, detail) => {
   check('H0 page loads with no JS error', errs.length === 0, errs.length ? errs[0] : '(0 page errors), loadMs=' + loadMs);
 
   await page.evaluate(() => window.toggleTimeMachine());
-  await new Promise(r => setTimeout(r, 15000));
+  // §S78 diagnostic: this environment's cold page-load already consumes ~180s (reproduced
+  // identically on unmodified origin/main — not a fix regression); bars=0 with the original 15s
+  // wait suggests the Gantt data (schedule/tasks) simply hadn't finished materializing yet.
+  // Poll instead of a fixed sleep so we don't guess a magic number twice.
+  let _barsSeen = 0;
+  for (let _w = 0; _w < 24; _w++) {
+    await new Promise(r => setTimeout(r, 5000));
+    _barsSeen = await page.evaluate(() => (window.__tmGanttBars || []).filter(b => b.taskId).length).catch(() => 0);
+    if (_barsSeen > 1) { console.log('§S78_BARS_POLL ready after ' + ((_w + 1) * 5) + 's bars=' + _barsSeen); break; }
+  }
   await page.evaluate(() => { const g = document.getElementById('tm-gantt'); g && g.dispatchEvent(new PointerEvent('pointerup', { bubbles: true })); });
   await new Promise(r => setTimeout(r, 8000));
   await page.evaluate(() => { const l = document.getElementById('tm-gantt-editlock'); l && l.dispatchEvent(new PointerEvent('pointerup', { bubbles: true })); });
@@ -118,9 +127,16 @@ const check = (name, cond, detail) => {
   const reloadMs = Date.now() - t3;
 
   const allCacheLines = lines.filter(l => /§CACHE_HIT/.test(l));
-  const extractedCacheLine = allCacheLines.find(l => /Hospital_extracted/.test(l)) || '(none — extracted.db not cache-hit by name)';
-  check('H5 reload hits the IDB cache for the EXTRACTED db specifically (not just geo/positions)',
-    /Hospital_extracted/.test(extractedCacheLine), 'all §CACHE_HIT lines: ' + JSON.stringify(allCacheLines));
+  // §S78 CORRECTION: this check originally asserted a hit on Hospital_extracted.db — but that was
+  // never the right expectation. In split mode APP.db is loaded from meta.db BY DESIGN (that is not
+  // the bug; extracted.db is bypassed entirely for split buildings, geo.db separately for geometry).
+  // The actual invariant the fix must prove is that the RELOAD's cache lookup for the tasks-bearing
+  // db (meta.db) is a HIT — i.e. the persist actually landed in the slot the loader reads, not a
+  // miss that silently re-fetches a pristine copy from the network and masks data loss as "it loaded
+  // fine." A miss here would mean H6 passing is not even testing what we think it's testing.
+  const metaCacheLine = allCacheLines.find(l => /Hospital_meta/.test(l)) || '(none — meta.db not cache-hit)';
+  check('H5 reload hits the IDB cache for meta.db (the db split mode actually loads tasks from)',
+    /Hospital_meta/.test(metaCacheLine), 'all §CACHE_HIT lines: ' + JSON.stringify(allCacheLines));
 
   const schemaCheck = await page2.evaluate((taskId) => {
     try {

--- a/scripts/probe_splitmode_persist_direct.js
+++ b/scripts/probe_splitmode_persist_direct.js
@@ -1,0 +1,164 @@
+#!/usr/bin/env node
+// PROBE (§S78) — direct data-level proof of the split-mode persist-key fix, bypassing the Gantt
+// canvas UI and the full 3D render pipeline entirely. §S76's own probe (probe_gantt_hospital_persist.js)
+// drives the drawer via toggleTimeMachine()+canvas pointer events, which on THIS machine never
+// becomes ready inside any reasonable budget for Hospital's element count — reproduced identically
+// on UNMODIFIED origin/main (git stash test, 3 runs, loadMs=180327-180446 every time, bars=0 every
+// time even after 120s of extra polling), matching this project's own prior documented finding that
+// Hospital/LTU-scale headless swiftshader rendering does not complete on this machine
+// (TM_INCREMENTAL_RENDER_PERF.md, "Hospital cannot be witnessed headless on this machine at all").
+//
+// The actual bug and fix are about DATA (which IDB slot app.db gets read from / written to), not
+// rendering — so this probe never calls toggleTimeMachine() or touches the canvas. It waits only for
+// window.APP.db + window.APP._dbPersistUrl (set right after streaming.js's Phase 1 meta.db load,
+// which happens BEFORE the slow geo.db/geometry phase), then exercises persistDb DIRECTLY the same
+// way _tmPersistEdit does, and proves the write key and the reload's read key are the SAME slot.
+//
+//   node scripts/probe_splitmode_persist_direct.js <BuildingName>
+//   SERVE_ROOT must be the repo root (viewer/ needs its erp/ sibling for other scripts to resolve,
+//   same §S72 lesson every other probe in this lane already encodes).
+'use strict';
+const { spawn } = require('child_process');
+const puppeteer = require(process.env.PUPPETEER || 'puppeteer');
+const PORT = Number(process.env.PORT || 8147);
+const ROOT = process.env.SERVE_ROOT || process.cwd();
+const BUILDING = process.argv[2] || 'Hospital';
+const URL = `http://localhost:${PORT}/viewer/viewer.html?db=/buildings/${BUILDING}_extracted.db`;
+const fs = require('fs');
+const os = require('os');
+const PROFILE_DIR = fs.mkdtempSync(require('path').join(os.tmpdir(), 'splitmode-persist-direct-'));
+
+let pass = 0, fail = 0;
+const check = (name, cond, detail) => {
+  if (cond) { pass++; console.log('  PASS ' + name + (detail ? '  ' + detail : '')); }
+  else { fail++; console.log('  FAIL ' + name + (detail ? '  ' + detail : '')); }
+};
+
+(async () => {
+  const server = spawn('node', [__dirname + '/_fast_static_server.js', String(PORT), ROOT], { stdio: 'ignore' });
+  await new Promise(r => setTimeout(r, 1500));
+  const browser = await puppeteer.launch({ headless: 'new', userDataDir: PROFILE_DIR, protocolTimeout: 480000, executablePath: '/home/red1/.cache/puppeteer/chrome/linux-152.0.7977.42/chrome-linux64/chrome',
+    args: ['--no-sandbox', '--disable-dev-shm-usage', '--use-angle=swiftshader', '--enable-unsafe-swiftshader'] });
+  const page = await browser.newPage();
+  let lines = [], errs = [];
+  page.on('console', m => { const t = m.text(); if (t.indexOf('§') >= 0) lines.push(t); });
+  page.on('pageerror', e => errs.push(String(e).slice(0, 200)));
+  const since = n => lines.slice(n);
+  const grab = (n, re) => (since(n).filter(l => re.test(l)).pop() || '');
+
+  console.log(`── probe_splitmode_persist_direct (§S78) — ${BUILDING}, data-level only, no UI/render ──`);
+
+  const t0 = Date.now();
+  await page.goto(URL, { waitUntil: 'domcontentloaded', timeout: 60000 });
+  // Wait only for the DATA to be ready — Phase 1 (meta.db) completes well before Phase 2 (geo.db).
+  await page.waitForFunction(() => window.APP && window.APP.db, { timeout: 240000 });
+  const dataReadyMs = Date.now() - t0;
+  check('D0 page loads with no JS error', errs.length === 0, errs.length ? errs[0] : '(0 page errors)');
+
+  const state = await page.evaluate(() => ({
+    dbUrl: window.APP.DB_URL,
+    persistUrl: window.APP._dbPersistUrl,
+    splitHasMeta: window.APP._splitHasMeta,
+    tables: (window.APP.db.exec("SELECT name FROM sqlite_master WHERE type='table'")[0] || { values: [] }).values.map(v => v[0])
+  }));
+  console.log('§S78_STATE dataReadyMs=' + dataReadyMs + ' ' + JSON.stringify(state));
+
+  const isSplit = !!(state.persistUrl && state.persistUrl !== state.dbUrl);
+  check('D1 A._dbPersistUrl is set (the fix — was undefined before this change)', !!state.persistUrl, JSON.stringify(state));
+  check('D2 has a tasks table to prove against', state.tables.indexOf('tasks') >= 0, JSON.stringify(state.tables));
+
+  // ── activate() materializes the tasks table (schedule generation) — tasks is empty until this
+  // runs. Calling it directly, but everything AFTER this is still direct SQL, never the canvas/DOM.
+  const activateT0 = Date.now();
+  await page.evaluate(() => window.toggleTimeMachine());
+  await page.waitForFunction(() => {
+    try { const r = window.APP.db.exec('SELECT COUNT(*) FROM tasks'); return r[0] && r[0].values[0][0] > 0; }
+    catch (e) { return false; }
+  }, { timeout: 60000, polling: 500 });
+  console.log('§S78_ACTIVATE ms=' + (Date.now() - activateT0));
+
+  // ── mutate a task's start-date column directly (same effect a drag has, no canvas needed).
+  // Schema-agnostic on purpose: meta.db's independently-generated tasks table uses start_date/
+  // finish_date, not the schedule_start/schedule_finish shape the whole-db path uses (§S76) — the
+  // fix under test is about which CACHE KEY gets used, not the column shape, so detect whichever
+  // date column is actually present rather than assuming one.
+  const dateCol = await page.evaluate(() => {
+    const cols = (window.APP.db.exec("PRAGMA table_info(tasks)")[0] || { values: [] }).values.map(v => v[1]);
+    return cols.indexOf('schedule_start') >= 0 ? 'schedule_start' : (cols.indexOf('start_date') >= 0 ? 'start_date' : null);
+  });
+  check('D2b date column found on tasks', !!dateCol, 'dateCol=' + dateCol);
+  const before = await page.evaluate((col) => {
+    const r = window.APP.db.exec('SELECT task_id, ' + col + ' FROM tasks LIMIT 1');
+    return r[0] ? r[0].values[0] : null;
+  }, dateCol);
+  check('D3 baseline task row read', !!before, JSON.stringify(before));
+  if (!before) { throw new Error('no task row — cannot proceed'); }
+
+  const NEW_DATE = '2026-12-25';
+  await page.evaluate((taskId, newDate, col) => {
+    window.APP.db.run('UPDATE tasks SET ' + col + ' = ? WHERE task_id = ?', [newDate, taskId]);
+  }, before[0], NEW_DATE, dateCol);
+
+  // ── persist exactly the way _tmPersistEdit does: SA.persistDb(app.db, app._dbPersistUrl||app.DB_URL, {}) ──
+  let mark = lines.length;
+  const persistResult = await page.evaluate(() => {
+    const SA = window.ScheduleAuthor;
+    const url = window.APP._dbPersistUrl || window.APP.DB_URL;
+    return SA.persistDb(window.APP.db, url, { immediate: true }).then(ok => ({ ok, url }));
+  });
+  await new Promise(r => setTimeout(r, 500));
+  const persistLine = grab(mark, /§SCHED_PERSIST/);
+  check('D4 persistDb wrote successfully', persistResult.ok === true, JSON.stringify(persistResult) + ' | ' + persistLine);
+
+  // ── compute what the RELOAD path will look up: DbResolve.cacheKey(metaUrl or DB_URL, PROD_BASE),
+  //    the exact same derivation streaming.js's split-mode detection + A.cachedFetch both use ──
+  const keyCheck = await page.evaluate(() => {
+    const DR = window.DbResolve;
+    const writeKey = DR.cacheKey(window.APP._dbPersistUrl || window.APP.DB_URL, window.APP.PROD_BASE);
+    // reproduce streaming.js's own metaUrl derivation verbatim (the read side re-derives this
+    // from DB_URL on every load — it is not stored, so re-derive it the same way to compute the
+    // key the RELOAD will actually look up under)
+    let metaUrl = window.APP.DB_URL.replace('_extracted.db', '_meta.db');
+    if (metaUrl === window.APP.DB_URL) metaUrl = window.APP.DB_URL.replace(/\.db$/, '_meta.db');
+    const readKeySplit = DR.cacheKey(metaUrl, window.APP.PROD_BASE);
+    const readKeyWhole = DR.cacheKey(window.APP.DB_URL, window.APP.PROD_BASE);
+    return { writeKey, readKeySplit, readKeyWhole, splitHasMeta: window.APP._splitHasMeta };
+  });
+  console.log('§S78_KEYS ' + JSON.stringify(keyCheck));
+  const expectedReadKey = isSplit ? keyCheck.readKeySplit : keyCheck.readKeyWhole;
+  check('D5 THE FIX — write key matches the key the reload will actually read (' + (isSplit ? 'split' : 'whole-db') + ' mode)',
+    keyCheck.writeKey === expectedReadKey, 'write=' + keyCheck.writeKey + ' expectedRead=' + expectedReadKey);
+
+  await browser.close();
+
+  // ── RELOAD: fresh browser, same profile, confirm the cache actually holds it under that key + the edit reads back ──
+  const browser2 = await puppeteer.launch({ headless: 'new', userDataDir: PROFILE_DIR, protocolTimeout: 480000, executablePath: '/home/red1/.cache/puppeteer/chrome/linux-152.0.7977.42/chrome-linux64/chrome',
+    args: ['--no-sandbox', '--disable-dev-shm-usage', '--use-angle=swiftshader', '--enable-unsafe-swiftshader'] });
+  const page2 = await browser2.newPage();
+  lines = []; errs = [];
+  page2.on('console', m => { const t = m.text(); if (t.indexOf('§') >= 0) lines.push(t); });
+  page2.on('pageerror', e => errs.push(String(e).slice(0, 200)));
+  await page2.goto(URL, { waitUntil: 'domcontentloaded', timeout: 60000 });
+  await page2.waitForFunction(() => window.APP && window.APP.db, { timeout: 240000 });
+
+  const afterReload = await page2.evaluate((taskId, col) => {
+    const r = window.APP.db.exec("SELECT task_id, " + col + " FROM tasks WHERE task_id = '" + taskId.replace(/'/g, "''") + "'");
+    return r[0] ? r[0].values[0] : null;
+  }, before[0], dateCol);
+  const cacheHitLines = lines.filter(l => /§CACHE_HIT/.test(l));
+  console.log('§S78_RELOAD_CACHE ' + JSON.stringify(cacheHitLines));
+
+  const survived = afterReload && String(afterReload[1]) === NEW_DATE;
+  check('D6 THE ROUND TRIP — edit survives a real reload (this is the proof)', survived,
+    'expected=' + NEW_DATE + ' got=' + (afterReload && afterReload[1]));
+
+  console.log('§S78_SUMMARY building=' + BUILDING + ' isSplit=' + isSplit + ' pass=' + pass + ' fail=' + fail);
+  await browser2.close();
+  server.kill();
+  try { fs.rmSync(PROFILE_DIR, { recursive: true, force: true }); } catch (e) {}
+  process.exit(fail ? 1 : 0);
+})().catch(e => {
+  console.error('§S78_FATAL ' + e.stack);
+  try { fs.rmSync(PROFILE_DIR, { recursive: true, force: true }); } catch (e2) {}
+  process.exit(1);
+});

--- a/viewer/kernel_ops.js
+++ b/viewer/kernel_ops.js
@@ -126,7 +126,11 @@
     _persistTimer = setTimeout(function() {
       sealChain(db).then(function() {
         try {
-          var dbUrl = window.APP && APP.DB_URL;
+          // §TM_SPLITMODE_PERSIST_KEY (§S78): a split-mode building's APP.db is loaded from
+          // metaUrl, not APP.DB_URL (streaming.js) — APP._dbPersistUrl is set at the exact point
+          // APP.db is assigned, in both the split and whole-db branches, so it always names the
+          // url APP.db's bytes actually came from. Same field ScheduleAuthor.persistDb now uses.
+          var dbUrl = window.APP && (APP._dbPersistUrl || APP.DB_URL);
           if (!dbUrl) return;
           if (window.APP && APP._cacheDisabled) return;   // incognito / low quota → no IDB
           // §SCHED_PERSIST_KEY (§S70): cachedFetch reads under DbResolve.cacheKey(url), not the raw

--- a/viewer/streaming.js
+++ b/viewer/streaming.js
@@ -2308,6 +2308,12 @@ function setupStreaming(A) {
       if (A.libDb && A.libDb !== A.db && typeof A.libDb.close === 'function') { try { A.libDb.close(); } catch (e) {} }
       A.libDb = A.db;
       A._splitHasMeta = true;
+      // §TM_SPLITMODE_PERSIST_KEY (4D_GANTT_TM_REFACTOR.md §S78): A.db's content just came from
+      // metaUrl, not A.DB_URL — a persist keyed on A.DB_URL writes a slot this same loader never
+      // reads back (cachedFetch(metaUrl) above resolves its OWN key from metaUrl, never A.DB_URL,
+      // in split mode). One source of truth: whoever persists app.db reads THIS field instead of
+      // re-deriving split state, so read-key and write-key can never drift apart.
+      A._dbPersistUrl = metaUrl;
       console.log(`[S192] §DB_META_LOADED size=${(metaBuf.byteLength/1024/1024).toFixed(1)}MB`);
 
       // §S260b: Set activeBuilding + _hasBbox early so 4D5D relay + clash work during geo download
@@ -2474,6 +2480,9 @@ function setupStreaming(A) {
       }
       A.db = new SQL.Database(new Uint8Array(dbBuf));
       if (A.composeGhostsFromAggregates) A.composeGhostsFromAggregates(A.db);
+      // §TM_SPLITMODE_PERSIST_KEY — whole-db path: A.db's content IS A.DB_URL's bytes, set
+      // explicitly (not left unset) so this field is never stale from a prior split-mode load.
+      A._dbPersistUrl = A.DB_URL;
       console.log(`[S192] §DB_LOADED size=${(dbBuf.byteLength/1024/1024).toFixed(0)}MB`);
       // §S283: Remember last building URL for PWA resume
       try { localStorage.setItem('pwa_last_db', A.DB_URL); } catch(e) {}

--- a/viewer/sw.js
+++ b/viewer/sw.js
@@ -8,7 +8,7 @@
 // Cache-first for heavy assets (.wasm, images). DB files skip SW (IndexedDB handles them).
 //
 // DEPLOY: bump CACHE_VERSION on every OCI upload. Old caches are purged on activate.
-const CACHE_VERSION = 'v1078';   // bump on each deploy; per-change detail is the git commit message.
+const CACHE_VERSION = 'v1079';   // bump on each deploy; per-change detail is the git commit message.
 // v1078 (2026-08-23) SCRIPT_LENGTH_REFACTOR_SEAMS.md §S59 candidate 2 — navigate_find.js's ERP-push
 // block extracted to NEW find_erp_push.js (loaded by main.js's lazy navigate list BEFORE
 // navigate_find.js?v=58). NOT precached ON PURPOSE: none of the lazy navigate_* sub-modules are

--- a/viewer/time_machine.js
+++ b/viewer/time_machine.js
@@ -6168,9 +6168,17 @@
   // MEASURED cost of persistDb's whole-db export on the real fleet: Duplex 3ms, Terminal 10ms,
   // LTU 26ms, Clinic 47ms, JKR 70ms, Hospital (252MB) 86ms — one dropped frame at the worst, and
   // persistDb debounces 1200ms on top, so a burst of drags collapses to a single write.
-  // Guards mirror §KRN_PERSIST_GUARD: only APP.db under APP.DB_URL, never a foreign db (a lens
-  // committing its own op-db under the building's key cost a P0 in kernel_ops.js), and never when
-  // _cacheDisabled (incognito / low quota).
+  // Guards mirror §KRN_PERSIST_GUARD: only APP.db under the url APP.db's own bytes came from,
+  // never a foreign db (a lens committing its own op-db under the building's key cost a P0 in
+  // kernel_ops.js), and never when _cacheDisabled (incognito / low quota).
+  // §TM_SPLITMODE_PERSIST_KEY (4D_GANTT_TM_REFACTOR.md §S78): a split-mode building's A.db is
+  // loaded from metaUrl, not A.DB_URL (streaming.js) — persisting under A.DB_URL writes a slot
+  // the reload path's cachedFetch(metaUrl) never reads, so the edit survives the write and is
+  // silently unreachable on reload (measured on Hospital/Clinic, §S76). app._dbPersistUrl is set
+  // by streaming.js at the exact point app.db is assigned, in BOTH the split and whole-db
+  // branches — it is the one url that is always guaranteed to describe app.db's actual content,
+  // so persisting under it (falling back to app.DB_URL only if a pre-this-fix build never set it)
+  // keeps read-key and write-key derived from the same fact, not two independent guesses.
   function _tmPersistEdit(what) {
     var app = A(), SA = (typeof window !== 'undefined') && window.ScheduleAuthor;
     if (!app || !app.db || !SA || !SA.persistDb) {
@@ -6179,8 +6187,9 @@
     }
     if (!app.DB_URL) { console.log('§GANTT_EDIT_PERSIST_SKIP what=' + what + ' reason=no_db_url'); return; }
     if (app._cacheDisabled) { console.log('§GANTT_EDIT_PERSIST_SKIP what=' + what + ' reason=cache_disabled'); return; }
-    SA.persistDb(app.db, app.DB_URL, {}).then(function (ok) {
-      console.log('§GANTT_EDIT_PERSIST what=' + what + ' url=' + app.DB_URL + ' ok=' + ok);
+    var persistUrl = app._dbPersistUrl || app.DB_URL;
+    SA.persistDb(app.db, persistUrl, {}).then(function (ok) {
+      console.log('§GANTT_EDIT_PERSIST what=' + what + ' url=' + persistUrl + ' ok=' + ok);
     });
   }
 


### PR DESCRIPTION
## Summary
- §S76 found and named a P0, unfixed at the time: Hospital and Clinic (the fleet's 2 split-mode buildings) silently lost every persisted Gantt edit on reload.
- Root cause: `A.db` is loaded from `_meta.db` in split mode, but the persist path wrote under `A.DB_URL`'s (extracted.db) key — two correct pieces that never knew about each other.
- Fix (project owner's decision — option 1 of 3 named in §S76): `streaming.js` now sets `A._dbPersistUrl` at the exact point `A.db` is assigned, in both branches. Every persist call site reads this one field instead of independently guessing.
- Also fixed `kernel_ops.js`'s `_persistToIdb`, same `APP.db` object, same latent bug — left unfixed here would have reintroduced the asymmetry this PR exists to close.
- `schedule_editor_ui.js` (standalone Editor tab) deliberately NOT touched — it has no split-mode detection of its own; whether it even correctly opens split-mode task data is a separate, unverified question, named not assumed.

## Proof
Real fleet DBs, real fresh-browser reload, direct data-level (bypasses the Gantt canvas — see PR body / §S78 for why: a Chrome-version/WebGL environment issue on the dev machine, diagnosed and unrelated to this fix, made the canvas-driven probe unusable here):

```
Hospital (252MB, split):  D5 write=buildings/Hospital_meta.db expectedRead=buildings/Hospital_meta.db  MATCH
                          D6 ROUND TRIP expected=2026-12-25 got=2026-12-25   PASS  8/8
Clinic (130MB, split):    D5 write=buildings/Clinic_meta.db expectedRead=buildings/Clinic_meta.db      MATCH
                          D6 ROUND TRIP expected=2026-12-25 got=2026-12-25   PASS  8/8
Duplex (9MB, whole-db, §S70 non-regression check): D5 MATCH, D6 PASS  8/8
```

Full trail, including the Chrome/WebGL diagnostic detour: `prompts/4D_GANTT_TM_REFACTOR.md` §S78 (bim-compiler repo).

## Test plan
- [x] `node --check` on all changed files
- [x] `npx eslint` clean on changed viewer/*.js
- [x] Live proof on Hospital, Clinic (split-mode, the actual bug) — 8/8 each
- [x] Live proof on Duplex (whole-db, non-regression) — 8/8
- [x] `sw.js` `CACHE_VERSION` bumped v1078→v1079 (streaming.js/time_machine.js/kernel_ops.js all changed)
- [ ] Human review

Claude-Session: https://claude.ai/code/session_01GmNVMG9ZGcKygz4zXuCe6m