### PR TITLE
fix(erp-seed): bake AD_Form + ad_val_rule into ad_seed.db additively (§8)

### DIFF
--- a/erp/erp.html
+++ b/erp/erp.html
@@ -277,7 +277,7 @@ var _shellReady = false;
 
     if (!hasAD) {
       _t0 = performance.now();
-      var cached = await idbGet('ad_seed_v16');
+      var cached = await idbGet('ad_seed_v17');
       var cacheValid = false;
       if (cached && cached.byteLength > 1000) {
         var header = new Uint8Array(cached, 0, 16);
@@ -318,7 +318,7 @@ var _shellReady = false;
           }
           db.close();
           db = new SQL.Database(new Uint8Array(seedBuf));
-          idbPut('ad_seed_v16', seedBuf);
+          idbPut('ad_seed_v17', seedBuf);
           _bench.db_fetch = Math.round(performance.now() - _t0);
           _bench.db_size = Math.round(seedBuf.byteLength / 1024);
           _bench.db_source = 'network';

--- a/erp/idempiere.html
+++ b/erp/idempiere.html
@@ -665,7 +665,7 @@ if (typeof qrcode !== "undefined") window.qrcode = qrcode;
   function el(tag, cls, txt) { var e = document.createElement(tag); if (cls) e.className = cls; if (txt != null) e.textContent = txt; return e; }
   function status(main) { if (main != null) $('idmp-status-main').textContent = main; }
 
-  // ── IndexedDB cache (shares 'ad_seed_v16' with erp.html) ──
+  // ── IndexedDB cache (shares 'ad_seed_v17' with erp.html) ──
   function idbGet(key) {
     return new Promise(function (resolve) {
       try {
@@ -760,8 +760,8 @@ if (typeof qrcode !== "undefined") window.qrcode = qrcode;
       // clobber a ?seed= gen db), and only when rows actually merged. INSERT OR IGNORE upstream keeps it idempotent.
       var persisted = false;
       if (mRow > 0 && (!seedParam || seedFile === 'ad_seed.db')) {
-        try { idbPut('ad_seed_v16', db.export().buffer); persisted = true;
-          console.log('§IDEMPIERE shard-persist key=ad_seed_v16 rows=' + mRow + ' resident=Y');
+        try { idbPut('ad_seed_v17', db.export().buffer); persisted = true;
+          console.log('§IDEMPIERE shard-persist key=ad_seed_v17 rows=' + mRow + ' resident=Y');
           // CONSISTENCY_FINISH.md §K-3 — a tenant becoming resident is the largest state change a user
           // can make; it earns a World-history dot like any doc moment. Guarded, best-effort, NOT a
           // signed op (install = infrastructure, deliberately outside the Z fold lane).
@@ -801,8 +801,8 @@ if (typeof qrcode !== "undefined") window.qrcode = qrcode;
     console.log('§GENESIS-RESIDENT-LIVE install name=' + name + ' client=' + newId + ' rows=' + rows + ' grants=' + grants + ' clients→' + clAfter);
     var persisted = false;
     if (rows > 0) {
-      try { idbPut('ad_seed_v16', db.export().buffer); persisted = true;
-        console.log('§GENESIS-RESIDENT-LIVE persist key=ad_seed_v16 client=' + newId + ' resident=Y');
+      try { idbPut('ad_seed_v17', db.export().buffer); persisted = true;
+        console.log('§GENESIS-RESIDENT-LIVE persist key=ad_seed_v17 client=' + newId + ' resident=Y');
         try { if (window.WholeHistory) window.WholeHistory.record({ page: 'idempiere', kind: 'op',
           label: 'Installed tenant ' + name + ' (' + rows + ' rows, client ' + newId + ')' }); } catch (e2) {} }
       catch (e) { console.warn('§GENESIS-RESIDENT-LIVE persist failed ' + e.message); }
@@ -865,7 +865,7 @@ if (typeof qrcode !== "undefined") window.qrcode = qrcode;
     var seedFile = (seedParam && /^[\w.-]+\.db$/.test(seedParam)) ? seedParam : 'ad_seed.db';
     var src = seedParam ? 'gen:' + seedFile : 'network';
     if (!seedParam) {
-      var cached = await idbGet('ad_seed_v16');
+      var cached = await idbGet('ad_seed_v17');
       if (cached && cached.byteLength > 1000) {
         var sig = String.fromCharCode.apply(null, new Uint8Array(cached, 0, 6));
         if (sig === 'SQLite') { db = new SQL.Database(new Uint8Array(cached)); src = 'idb_cache'; }
@@ -874,7 +874,7 @@ if (typeof qrcode !== "undefined") window.qrcode = qrcode;
     if (!db) {
       var resp = await fetch(seedFile); var buf = await resp.arrayBuffer();
       db = new SQL.Database(new Uint8Array(buf));
-      if (!seedParam) idbPut('ad_seed_v16', buf);   // cache only the real seed, never a ?seed= override
+      if (!seedParam) idbPut('ad_seed_v17', buf);   // cache only the real seed, never a ?seed= override
     }
     window.__idmpDb = db;
     // BIM→Project round-trip §B (docs/BIMtoERP.md): overlay the viewer-folded Project Orders + VO amendments
@@ -1067,7 +1067,7 @@ if (typeof qrcode !== "undefined") window.qrcode = qrcode;
     $('idmp-del-go').onclick = function () {
       var res = SES.deleteClient(db, c.id);
       if (!res.ok) { closeOv(); return; }
-      try { idbPut('ad_seed_v16', db.export().buffer); } catch (e) {}
+      try { idbPut('ad_seed_v17', db.export().buffer); } catch (e) {}
       console.log('§IDEMPIERE tenant-deleted client=' + c.id + ' rows=' + res.deleted + ' tables=' + res.tables + ' persisted=Y');
       try { if (window.WholeHistory) window.WholeHistory.record({ page: 'idempiere', kind: 'op',
         label: 'Deleted tenant ' + c.name + ' (Client ' + c.id + ', ' + res.deleted + ' rows)' }); } catch (e) {}

--- a/erp/sw.js
+++ b/erp/sw.js
@@ -10,7 +10,9 @@
 // init-bubble must be INSTANT, ERP_INIT_BUBBLE_INSTANT.md); network-first for non-precached .js (fresh on
 // deploy); cache-first for precached assets/.wasm/images. Freshness on deploy is carried by the SW version
 // bump (skipWaiting+clients.claim precache the new shell), so SWR strands a user at most one load post-deploy.
-const CACHE_VERSION = 'v767';   // bump on each deploy; per-change detail is the git commit message.
+const CACHE_VERSION = 'v768';   // bump on each deploy; per-change detail is the git commit message.
+// v768 (2026-08-23) ad_seed.db gains AD_Form (49) + ad_val_rule (332) — see erp/tests/bake_forms_valrules_seed.js.
+// ad_seed_v16 -> ad_seed_v17 IDB cache key bump forces re-fetch of the seed for returning users.
 const CACHE_PREFIX = 'erp-ootb-';
 const CACHE_NAME = CACHE_PREFIX + CACHE_VERSION;
 

--- a/erp/tests/bake_forms_valrules_seed.js
+++ b/erp/tests/bake_forms_valrules_seed.js
@@ -1,0 +1,184 @@
+// Copyright (c) 2025-2026 Redhuan D. Oon <red1org@gmail.com>
+// SPDX-License-Identifier: MIT
+// bake_forms_valrules_seed.js — additively CREATE + fill AD_Form and ad_val_rule in ad_seed.db.
+//
+// WHY a narrow additive bake, not scripts/export_ad_seed.js: a full re-export against the live
+// docker PG regresses production data badly (ad_client 6→1, ad_role 14→4, C_BPartner 113→18,
+// ad_window_access 4448→1080, fact_acct/HR_*/C_Subscription* missing) — the shipped ad_seed.db is
+// a hand-accumulated artifact (one full export, fd09ad1/#265, plus ~20 incremental "bake X into
+// ad_seed.db" commits since), not reproducible from a single pipeline run. See
+// bim-compiler docs/ERP_PROJECT_REVIEW.md §7 for the full finding.
+//
+// AD_Form and ad_val_rule are safe to pull fresh: pure declarative base-schema reference data
+// (Form/ValRule DEFINITIONS, not operational transaction data), currently ABSENT from ad_seed.db
+// entirely (nothing to regress), same table set/case/WHERE contract as scripts/ad_seed_manifest.json
+// (bim-compiler PR #91): AD_Form canonical-case + activeOnly=true, ad_val_rule lower-case + all rows.
+// Column DDL/case/PK logic ported verbatim from scripts/export_ad_seed.js (proven, PR #265/#266 ship).
+//
+// Never CREATEs a table that already exists (idempotent on re-run: DROP+recreate only if the two
+// target tables are already present with the same row count, otherwise a fresh CREATE).
+// EXTRACT, DON'T INVENT — every row/column from the live docker PG. READ THE LOG.
+//
+// Run: node erp/tests/bake_forms_valrules_seed.js   (edits ad_seed.db in place, in cwd)
+'use strict';
+var initSqlJs = require('/home/red1/bim-ootb/node_modules/sql.js');
+var fs = require('fs');
+var execFileSync = require('child_process').execFileSync;
+
+var CONTAINER = process.env.ERP_PG_CONTAINER || 'postgres';
+var DB = process.env.ERP_PG_DB || 'idempiere';
+var PGUSER = process.env.ERP_PG_USER || 'adempiere';
+var SCHEMA = process.env.ERP_PG_SCHEMA || 'adempiere';
+var SEED = process.env.ERP_SEED || 'ad_seed.db';
+var MAXBUF = 512 * 1024 * 1024;
+
+var TABLES = [
+  { table: 'AD_Form', case: 'canonical', where: null, activeOnly: true },
+  { table: 'ad_val_rule', case: 'lower', where: null, activeOnly: false }
+];
+
+function pgMeta(sql) {
+  var out = execFileSync('docker',
+    ['exec', CONTAINER, 'psql', '-U', PGUSER, '-d', DB, '-t', '-A', '-F', '\t', '-c', sql],
+    { maxBuffer: MAXBUF, encoding: 'utf8' });
+  return out.split('\n').filter(function (l) { return l.length > 0; })
+    .map(function (l) { return l.split('\t'); });
+}
+function pgCopy(sql) {
+  return execFileSync('docker',
+    ['exec', CONTAINER, 'psql', '-U', PGUSER, '-d', DB, '-c', sql],
+    { maxBuffer: MAXBUF, encoding: 'utf8' });
+}
+// COPY TEXT unescape (PostgreSQL copy.c rules) — verbatim from migrate_pg_to_sqlite.js / export_ad_seed.js.
+function unescape(s) {
+  if (s === '\\N') return null;
+  if (s.indexOf('\\') === -1) return s;
+  var out = '';
+  for (var i = 0; i < s.length; i++) {
+    var c = s[i];
+    if (c !== '\\') { out += c; continue; }
+    var n = s[++i];
+    switch (n) {
+      case 'n': out += '\n'; break;
+      case 't': out += '\t'; break;
+      case 'r': out += '\r'; break;
+      case 'b': out += '\b'; break;
+      case 'f': out += '\f'; break;
+      case 'v': out += '\v'; break;
+      case '\\': out += '\\'; break;
+      default: out += (n === undefined ? '\\' : n); break;
+    }
+  }
+  return out;
+}
+function affinity(t) {
+  if (t === 'bytea') return 'BLOB';
+  if (t === 'smallint' || t === 'integer' || t === 'bigint') return 'INTEGER';
+  if (t === 'numeric' || t === 'decimal' || t === 'real' || t === 'double precision') return 'NUMERIC';
+  return 'TEXT';
+}
+function q(id) { return '"' + String(id).replace(/"/g, '""') + '"'; }
+
+(async function () {
+  var SQL = await initSqlJs({ locateFile: f => require('path').join('/home/red1/bim-ootb/node_modules/sql.js/dist', f) });
+
+  // §BEFORE — row-count every existing table, for the regression proof.
+  var seedBuf = fs.readFileSync(SEED);
+  var seed = new SQL.Database(new Uint8Array(seedBuf));
+  function allTables(db) {
+    var r = db.exec("SELECT name FROM sqlite_master WHERE type='table'");
+    return r.length ? r[0].values.map(v => String(v[0])) : [];
+  }
+  function rowCount(db, t) {
+    try { return db.exec('SELECT count(*) FROM "' + t + '"')[0].values[0][0]; }
+    catch (e) { return -1; }
+  }
+  var before = {};
+  allTables(seed).forEach(function (t) { before[t] = rowCount(seed, t); });
+  console.log('§BAKE_FV_BEFORE tables=' + Object.keys(before).length + ' bytes=' + seedBuf.length);
+
+  if (allTables(seed).indexOf('AD_Form') >= 0 || allTables(seed).indexOf('ad_val_rule') >= 0) {
+    console.log('§BAKE_FV_ALREADY_PRESENT — one or both target tables already exist, aborting to stay idempotent-safe (no DROP performed). Inspect manually.');
+    process.exit(1);
+  }
+
+  // PG catalog: columns + types for exactly the 2 target tables, PKs, canonical AD_Column case.
+  var tnList = TABLES.map(e => "'" + e.table.toLowerCase() + "'").join(',');
+  var colRows = pgMeta(
+    "SELECT table_name, column_name, data_type FROM information_schema.columns " +
+    "WHERE table_schema='" + SCHEMA + "' AND table_name IN (" + tnList + ") ORDER BY table_name, ordinal_position");
+  var cols = {};
+  colRows.forEach(function (r) { (cols[r[0]] = cols[r[0]] || []).push({ name: r[1], type: r[2] }); });
+  var pkRows = pgMeta(
+    "SELECT tc.table_name, kcu.column_name FROM information_schema.table_constraints tc " +
+    "JOIN information_schema.key_column_usage kcu ON kcu.constraint_name=tc.constraint_name " +
+    "AND kcu.table_schema=tc.table_schema WHERE tc.table_schema='" + SCHEMA + "' " +
+    "AND tc.constraint_type='PRIMARY KEY' AND tc.table_name IN (" + tnList + ") ORDER BY tc.table_name, kcu.ordinal_position");
+  var pks = {};
+  pkRows.forEach(function (r) { (pks[r[0]] = pks[r[0]] || []).push(r[1]); });
+  var caseRows = pgMeta(
+    "SELECT lower(t.tablename), lower(c.columnname), c.columnname FROM " + q(SCHEMA) +
+    ".ad_column c JOIN " + q(SCHEMA) + ".ad_table t ON c.ad_table_id=t.ad_table_id " +
+    "WHERE lower(t.tablename) IN (" + tnList + ")");
+  var canon = {};
+  caseRows.forEach(function (r) { canon[r[0] + '.' + r[1]] = r[2]; });
+
+  var totalRows = 0;
+  TABLES.forEach(function (e) {
+    var tn = e.table.toLowerCase();
+    var cs = cols[tn];
+    if (!cs || !cs.length) { console.log('§BAKE_FV_MISSING_IN_PG table=' + e.table); process.exit(1); }
+
+    function disp(c) { if (e.case !== 'canonical') return c; return canon[tn + '.' + c] || c; }
+    var pk = pks[tn] || [];
+    var ddl = 'CREATE TABLE ' + q(e.table) + ' (' +
+      cs.map(function (c) { return q(disp(c.name)) + ' ' + affinity(c.type); }).join(', ') +
+      (pk.length ? ', PRIMARY KEY (' + pk.map(function (c) { return q(disp(c)); }).join(', ') + ')' : '') + ')';
+    seed.run(ddl);
+
+    var where = e.where || '1=1';
+    if (e.activeOnly) where += " AND isactive='Y'";
+    var collist = cs.map(function (c) { return q(c.name); }).join(',');
+    var payload = pgCopy('COPY (SELECT ' + collist + ' FROM ' + q(SCHEMA) + '.' + q(tn) +
+      ' WHERE ' + where + ') TO STDOUT');
+
+    var blobIdx = cs.map(function (c, i) { return c.type === 'bytea' ? i : -1; }).filter(function (i) { return i >= 0; });
+    var placeholders = cs.map(function () { return '?'; }).join(',');
+    var stmt = seed.prepare('INSERT INTO ' + q(e.table) + ' VALUES (' + placeholders + ')');
+    var lines = payload.length ? payload.split('\n') : [];
+    if (lines.length && lines[lines.length - 1] === '') lines.pop();
+    var n = 0;
+    lines.forEach(function (line) {
+      var fields = line.split('\t');
+      var vals = new Array(cs.length);
+      for (var fi = 0; fi < cs.length; fi++) {
+        var v = unescape(fields[fi]);
+        if (v !== null && blobIdx.indexOf(fi) >= 0) {
+          v = (v.slice(0, 2) === '\\x') ? Buffer.from(v.slice(2), 'hex') : Buffer.from(v, 'binary');
+        }
+        vals[fi] = v;
+      }
+      stmt.run(vals);
+      n++;
+    });
+    stmt.free();
+    totalRows += n;
+    console.log('§BAKE_FV table=' + e.table + ' rows=' + n + ' cols=' + cs.length + ' pk=' + (pk.join('+') || 'none'));
+  });
+
+  fs.writeFileSync(SEED, Buffer.from(seed.export()));
+
+  // §AFTER — re-open from disk, prove every OTHER table is byte-identical in row count.
+  var after = new SQL.Database(new Uint8Array(fs.readFileSync(SEED)));
+  var afterCounts = {};
+  allTables(after).forEach(function (t) { afterCounts[t] = rowCount(after, t); });
+  var regressed = [];
+  Object.keys(before).forEach(function (t) {
+    if (afterCounts[t] !== before[t]) regressed.push(t + ' ' + before[t] + '→' + afterCounts[t]);
+  });
+  console.log('§BAKE_FV_REGRESSION_CHECK other_tables=' + Object.keys(before).length +
+    ' regressed=' + regressed.length + (regressed.length ? ' [' + regressed.join(', ') + ']' : ''));
+  console.log('§BAKE_FV_DONE new_tables=2 total_rows=' + totalRows +
+    ' bytes=' + fs.statSync(SEED).size + ' (' + (fs.statSync(SEED).size / 1048576).toFixed(1) + 'MB)');
+  if (regressed.length) process.exit(1);
+})();


### PR DESCRIPTION
## Summary
- Root cause found: `ad_seed.db` is a hand-accumulated artifact (1 full export + ~20 incremental "bake X" commits), not reproducible from a single pipeline run — a fresh `export_ad_seed.js` run was tried in a sibling session and correctly refused after it regressed production data (ad_client 6→1, ad_role 14→4, C_BPartner 113→18, ad_window_access 4448→1080, fact_acct/HR_*/C_Subscription* missing).
- This PR takes the safe path instead: `erp/tests/bake_forms_valrules_seed.js` additively CREATEs just `AD_Form` (49 rows) and `ad_val_rule` (332 rows) — both pure declarative reference data, currently absent entirely, so nothing to regress.
- Zero regression proven across all 399 pre-existing tables (row-counted before/after).
- Consumption verified live: `ad_val_rule` feeds `crud_core.js`'s validation engine (was running against an empty table); `AD_Form` feeds `genesis.js`'s access-grant provisioning. No Form-screen renderer exists yet — named as a separate follow-on, not claimed here.
- `ad_seed_v16→v17` IDB cache bump, `sw.js` v767→v768.

Full trail: bim-compiler `docs/ERP_PROJECT_REVIEW.md` §8.

## Test plan
- [x] `node erp/tests/bake_forms_valrules_seed.js` — `§BAKE_FV_REGRESSION_CHECK other_tables=399 regressed=0`
- [x] `node erp/tests/poc_ad_displaylogic.js` — 🟢 PASS live against the modified seed
- [ ] CI

Claude-Session: https://claude.ai/code/session_01GmNVMG9ZGcKygz4zXuCe6m