### PR TITLE
feat(gantt): ⏪ Pull Back — explicit reschedule-as-early-as-possible (§GANTT_RESCHEDULE_ASAP)

### DIFF
--- a/scripts/probe_gantt_reschedule_asap.js
+++ b/scripts/probe_gantt_reschedule_asap.js
@@ -1,0 +1,109 @@
+#!/usr/bin/env node
+// PROBE — §GANTT_RESCHEDULE_ASAP live round-trip: push a real task late, pull the schedule back
+// through the REAL commit path (__tmRescheduleAsap → rescheduleGanttAsap → ScheduleAuthor verb →
+// retime → persist), reload, and prove the compressed dates came back from the cache slot.
+// Same contract as probe_gantt_gestures.js: verdicts read from §-log lines and SQL values, never a
+// screenshot. The node witness (witness_gantt_reschedule_asap.js) is the hard gate for the verb's
+// semantics; THIS is the half only a real browser proves — the 7-step pipeline against a real
+// building db, and §S70 persistence across a reload.
+//
+//   SERVE_ROOT must be the REPO ROOT, not viewer/ — the page loads ../erp/bigdecimal.js; serving
+//   viewer/ alone manufactures spurious "RoundingMode" errors (§S72 lesson).
+//   PUPPETEER=<path to a puppeteer install> if not resolvable; CHROME=<executable> to pin a build
+//   (older bundled Chromiums have failed WebGL2 creation on this box — use ~152).
+'use strict';
+const { spawn } = require('child_process');
+const puppeteer = require(process.env.PUPPETEER || 'puppeteer');
+const fs = require('fs');
+const PORT = Number(process.env.PORT || 8149);
+const ROOT = process.env.SERVE_ROOT || process.cwd();
+const BLD = process.env.BLD || 'Duplex_extracted';
+const URL = `http://localhost:${PORT}/viewer/viewer.html?db=/buildings/${BLD}.db`;
+const CHROME = process.env.CHROME ||
+  (fs.existsSync('/home/red1/.cache/puppeteer/chrome/linux-152.0.7977.42/chrome-linux64/chrome')
+    ? '/home/red1/.cache/puppeteer/chrome/linux-152.0.7977.42/chrome-linux64/chrome' : undefined);
+
+let pass = 0, fail = 0;
+const check = (name, cond, detail) => {
+  if (cond) { pass++; console.log('  PASS ' + name + (detail ? '  ' + detail : '')); }
+  else { fail++; console.log('  FAIL ' + name + (detail ? '  ' + detail : '')); }
+};
+
+(async () => {
+  const server = spawn('python3', ['-m', 'http.server', String(PORT), '--directory', ROOT], { stdio: 'ignore' });
+  await new Promise(r => setTimeout(r, 1500));
+  const browser = await puppeteer.launch({ headless: 'new', executablePath: CHROME,
+    args: ['--no-sandbox', '--disable-dev-shm-usage', '--use-angle=swiftshader', '--enable-unsafe-swiftshader'] });
+  const page = await browser.newPage();
+  const lines = [], errs = [];
+  page.on('console', m => { const t = m.text(); if (t.indexOf('§') >= 0) lines.push(t); });
+  page.on('pageerror', e => errs.push(String(e).slice(0, 160)));
+  const has = (n, re) => lines.slice(n).some(l => re.test(l));
+  const grab = (n, re) => (lines.slice(n).filter(l => re.test(l)).pop() || '');
+
+  await page.goto(URL, { waitUntil: 'domcontentloaded', timeout: 60000 });
+  await page.waitForFunction(() => typeof window.toggleTimeMachine === 'function', { timeout: 180000 });
+  await page.waitForFunction(() => window.APP && window.APP.db, { timeout: 240000 }).catch(() => {});
+  await new Promise(r => setTimeout(r, 12000));
+  check('P0 page loads with no JS error', errs.length === 0, errs.length ? errs[0] : '(0 page errors)');
+
+  await page.evaluate(() => window.toggleTimeMachine());
+  await new Promise(r => setTimeout(r, 15000));
+  await page.evaluate(() => { const g = document.getElementById('tm-gantt'); g && g.dispatchEvent(new PointerEvent('pointerup', { bubbles: true })); });
+  await new Promise(r => setTimeout(r, 6000));
+  const bars = await page.evaluate(() => (window.__tmGanttWindows ? window.__tmGanttWindows() : []).filter(b => b.taskId).length);
+  check('P1 gantt drawer open with real task bars', bars > 1, 'bars=' + bars);
+  check('P1b the transport row carries the new button', await page.evaluate(() => !!document.getElementById('tm-reschedule-asap')), '#tm-reschedule-asap');
+
+  // Pick a LATE task that HAS predecessors (a root would anchor and never move), then push it +30d
+  // with the real drag verb so the schedule provably carries closable float.
+  const victim = await page.evaluate(() => {
+    const q = window.APP.db.exec(
+      'SELECT t.task_id, t.schedule_start, t.schedule_finish FROM tasks t ' +
+      'WHERE t.task_id IN (SELECT successor_id FROM task_sequences) ' +
+      'AND (t.is_summary IS NULL OR t.is_summary=0) ORDER BY t.schedule_finish DESC LIMIT 1');
+    return q.length && q[0].values.length ? { id: q[0].values[0][0], start: q[0].values[0][1], finish: q[0].values[0][2] } : null;
+  });
+  check('P2 found a successor task to push late', !!victim, victim ? victim.id + ' @ ' + victim.start : '(none)');
+
+  let mark = lines.length;
+  const dragged = await page.evaluate(id => window.__tmGanttDrag(id, 'move', 30), victim.id);
+  await new Promise(r => setTimeout(r, 5000));
+  check('P3 real drag pushed it +30d (§GANTT_DRAG_COMMIT)', dragged === true && has(mark, /§GANTT_DRAG_COMMIT/),
+    grab(mark, /§GANTT_DRAG_COMMIT/) || '(no commit line)');
+
+  // ── The feature: pull back through the REAL commit path ─────────────────────────────────────────
+  mark = lines.length;
+  const pulled = await page.evaluate(() => window.__tmRescheduleAsap());
+  await new Promise(r => setTimeout(r, 6000));
+  const asapLine = grab(mark, /§GANTT_RESCHEDULE_ASAP schedule=/);
+  const movedN = Number((asapLine.match(/moved=(\d+)/) || [0, 0])[1]);
+  check('P4 pull-back committed through the real path', pulled === true && movedN >= 1, asapLine || '(no § line)');
+  check('P4b the victim was pulled back off its pushed position', await page.evaluate(v => {
+    const q = window.APP.db.exec('SELECT schedule_start FROM tasks WHERE task_id=?', [v.id]);
+    const now = q.length && q[0].values.length ? q[0].values[0][0] : null;
+    window.__probePulledStart = now;
+    return now !== null && now <= v.start;   // back at (or before — pre-existing float) its pre-drag start
+  }, victim), 'preDrag=' + victim.start + ' afterPull=' + await page.evaluate(() => window.__probePulledStart));
+  check('P5 the edit persisted (§GANTT_EDIT_PERSIST what=rescheduleAsap ok=true)',
+    /what=rescheduleAsap[^\n]*ok=true/.test(grab(mark, /§GANTT_EDIT_PERSIST /)), grab(mark, /§GANTT_EDIT_PERSIST /));
+  const pulledStart = await page.evaluate(() => window.__probePulledStart);
+
+  // ── §S70 round trip: reload, the compressed date must come back from the cache ─────────────────
+  mark = lines.length;
+  await page.goto(URL, { waitUntil: 'domcontentloaded', timeout: 60000 });
+  await page.waitForFunction(() => window.APP && window.APP.db, { timeout: 240000 });
+  await new Promise(r => setTimeout(r, 8000));
+  check('P6 reload served from cache (§CACHE_HIT)', has(mark, /§CACHE_HIT/), grab(mark, /§CACHE_HIT/) || '(no cache-hit line)');
+  const afterReload = await page.evaluate(id => {
+    const q = window.APP.db.exec('SELECT schedule_start FROM tasks WHERE task_id=?', [id]);
+    return q.length && q[0].values.length ? q[0].values[0][0] : null;
+  }, victim.id);
+  check('P7 the pulled-back date SURVIVED the reload', afterReload === pulledStart,
+    'afterPull=' + pulledStart + ' afterReload=' + afterReload);
+
+  check('P8 no JS error across the whole cycle', errs.length === 0, errs.length ? errs[0] : '(0 page errors)');
+  console.log('§GANTT_RESCHEDULE_ASAP_PROBE_SUMMARY pass=' + pass + ' fail=' + fail);
+  await browser.close(); server.kill();
+  process.exit(fail ? 1 : 0);
+})().catch(e => { console.error('ERR ' + (e && e.stack || e)); process.exit(2); });

--- a/viewer/schedule_author.js
+++ b/viewer/schedule_author.js
@@ -1358,6 +1358,128 @@
     return moveTaskCascade(db, scheduleId, taskId, _dayStr(s), opts);
   }
 
+  // rescheduleAsap(db, scheduleId, opts) — §GANTT_RESCHEDULE_ASAP, the EXPLICIT pull-back verb.
+  // moveTaskCascade above is push-only BY DESIGN (its own header: "Successors are only ever pushed
+  // LATER, never pulled earlier") — an ordinary drag must never silently re-optimise the schedule.
+  // The product decision (4D_GANTT_TM_REFACTOR.md lane, user-decided) is that "reschedule as early
+  // as possible" ships as a deliberate, user-triggered action instead — THIS verb — so the
+  // annotate-only drag contract (§S68) stays intact.
+  //
+  // SEMANTICS — compression only:
+  //   · Forward topological pass over task_sequences, the same Kahn sort + IfcSequenceEnum ES math
+  //     computeCpm's non-fixedDates forward pass runs (_fwdES semantics, re-expressed over the
+  //     tasks' REAL current day positions rather than a zero-anchored es/ef frame).
+  //   · A task with NO predecessors (in this schedule's leaf set) keeps its CURRENT start — roots
+  //     anchor the project; this closes gaps CPM can prove are pure float, it does not re-baseline
+  //     the whole programme to day zero.
+  //   · A task is NEVER moved later: if its derived ES is >= its current start (including a task
+  //     already sitting ahead of a violated constraint), it is left byte-identical.
+  //   · Summaries (is_summary=1) are skipped — they roll up, same as moveTaskCascade.
+  //   · Duration preserved; same BEGIN/prepare/run/free/COMMIT write shape as moveTaskCascade.
+  // opts.dryRun — compute and report without writing (witness convention, same as moveTaskCascade).
+  // → { ok, moved:[{id,start,finish,days,daysPulled}], projectDurationBefore, projectDurationAfter,
+  //     daysCompressed, finishBefore, finishAfter }  |  { ok:false, reason }
+  function rescheduleAsap(db, scheduleId, opts) {
+    opts = opts || {};
+    var tr;
+    try {
+      tr = db.exec('SELECT task_id, schedule_start, schedule_finish, schedule_duration, is_summary ' +
+        'FROM tasks WHERE schedule_id=?', [scheduleId]);
+    } catch (e) { console.log('§GANTT_RESCHEDULE_ASAP_FAIL schedule=' + scheduleId + ' reason=no_tasks'); return { ok: false, reason: 'no_tasks' }; }
+    if (!tr.length || !tr[0].values.length) { console.log('§GANTT_RESCHEDULE_ASAP_FAIL schedule=' + scheduleId + ' reason=no_tasks'); return { ok: false, reason: 'no_tasks' }; }
+    var T = {}, ids = [];
+    tr[0].values.forEach(function (row) {
+      if (row[4] === 1) return;                       // summaries are rolled up, never moved directly
+      var s = _dayNum(row[1]); if (s === null) return;
+      var dur = _durDays(row[3], row[1], row[2]);
+      T[row[0]] = { id: row[0], start: s, finish: s + dur, dur: dur, preds: [], succs: [] };
+      ids.push(row[0]);
+    });
+    if (!ids.length) { console.log('§GANTT_RESCHEDULE_ASAP_FAIL schedule=' + scheduleId + ' reason=no_tasks'); return { ok: false, reason: 'no_tasks' }; }
+    try {
+      var er = db.exec('SELECT predecessor_id, successor_id, sequence_type, lag_days FROM task_sequences');
+      if (er.length && er[0].values.length) er[0].values.forEach(function (row) {
+        if (!T[row[0]] || !T[row[1]]) return;          // edge leaving this schedule's leaf set
+        var e = { pred: row[0], succ: row[1], type: (row[2] || 'FS').toUpperCase(), lag: row[3] != null ? row[3] : 0 };
+        T[row[1]].preds.push(e); T[row[0]].succs.push(e);
+      });
+    } catch (e) {
+      // Unlike moveTaskCascade's §CASCADE_BLIND (where a blind move is still the user's own explicit
+      // one-bar edit), a blind PULL-BACK would compress every task onto its own start — a no-op — so
+      // refuse loudly instead of "succeeding" at nothing.
+      console.log('§GANTT_RESCHEDULE_ASAP_FAIL schedule=' + scheduleId + ' reason=no_sequences — ' + (e && e.message));
+      return { ok: false, reason: 'no_sequences' };
+    }
+    // Kahn topo sort — same cycle/orphan bail computeCpm runs (§SE-1 guards authored edges, but a
+    // captured import can carry anything; never iterate a cyclic graph).
+    var indeg = {}, queue = [], topo = [];
+    ids.forEach(function (id) { indeg[id] = T[id].preds.length; if (indeg[id] === 0) queue.push(id); });
+    while (queue.length) {
+      var cur = queue.shift(); topo.push(cur);
+      T[cur].succs.forEach(function (e) { if (--indeg[e.succ] === 0) queue.push(e.succ); });
+    }
+    if (topo.length !== ids.length) {
+      console.log('§GANTT_RESCHEDULE_ASAP_FAIL schedule=' + scheduleId + ' reason=cycle topo=' + topo.length + ' tasks=' + ids.length);
+      return { ok: false, reason: 'cycle' };
+    }
+    var minStartBefore = Infinity, finishBefore = -Infinity;
+    ids.forEach(function (id) {
+      if (T[id].start < minStartBefore) minStartBefore = T[id].start;
+      if (T[id].finish > finishBefore) finishBefore = T[id].finish;
+    });
+    // FORWARD pass in topo order, over the working (already-compressed-upstream) positions.
+    // newStart[id] is the task's post-compression start; a root keeps its current start, a task with
+    // predecessors takes max(candidate ES over preds) capped at its own current start (never later).
+    var newStart = {};
+    topo.forEach(function (id) {
+      var t = T[id];
+      if (!t.preds.length) { newStart[id] = t.start; return; }
+      var es = null;
+      t.preds.forEach(function (e) {
+        var P = T[e.pred];
+        var pS = newStart[e.pred] != null ? newStart[e.pred] : P.start;
+        var pF = pS + P.dur, c;
+        switch (e.type) {                              // same four IfcSequenceEnum cases as _fwdES
+          case 'SS': c = pS + e.lag; break;
+          case 'FF': c = pF + e.lag - t.dur; break;
+          case 'SF': c = pS + e.lag - t.dur; break;
+          default:   c = pF + e.lag;                   // FS
+        }
+        if (es === null || c > es) es = c;
+      });
+      newStart[id] = (es !== null && es < t.start) ? es : t.start;   // compression only, never later
+    });
+    var moved = [];
+    topo.forEach(function (id) {
+      var t = T[id];
+      if (newStart[id] >= t.start) return;             // untouched (roots, tight tasks, ES>=current)
+      var daysPulled = t.start - newStart[id];
+      t.start = newStart[id]; t.finish = t.start + t.dur;
+      moved.push({ id: id, start: _dayStr(t.start), finish: _dayStr(t.finish), days: t.dur, daysPulled: daysPulled });
+    });
+    var minStartAfter = Infinity, finishAfter = -Infinity;
+    ids.forEach(function (id) {
+      if (T[id].start < minStartAfter) minStartAfter = T[id].start;
+      if (T[id].finish > finishAfter) finishAfter = T[id].finish;
+    });
+    if (moved.length && !opts.dryRun) {
+      db.run('BEGIN');
+      var st = db.prepare('UPDATE tasks SET schedule_start=?, schedule_finish=?, schedule_duration=? WHERE task_id=?');
+      moved.forEach(function (m) { st.run([m.start, m.finish, 'P' + m.days + 'D', m.id]); });
+      st.free();
+      db.run('COMMIT');
+    }
+    var daysCompressed = finishBefore - finishAfter;
+    console.log('§GANTT_RESCHEDULE_ASAP schedule=' + scheduleId + ' moved=' + moved.length +
+      ' finishBefore=' + _dayStr(finishBefore) + ' finishAfter=' + _dayStr(finishAfter) +
+      ' daysCompressed=' + daysCompressed + (opts.dryRun ? ' (dryRun)' : ''));
+    return { ok: true, moved: moved,
+      projectDurationBefore: finishBefore - minStartBefore,
+      projectDurationAfter: finishAfter - minStartAfter,
+      daysCompressed: daysCompressed,
+      finishBefore: _dayStr(finishBefore), finishAfter: _dayStr(finishAfter) };
+  }
+
   // setBaseline(db, scheduleId) — §GANTT_EDIT_UNDO's transport-row sibling, ⚑ Set Baseline
   // (4D_SCHEDULE_PERFECTION.md "the transport row's two buttons"). P6 baseline = a frozen snapshot
   // of every task's dates, taken at a deliberate moment, compared against the live (possibly
@@ -1730,6 +1852,7 @@
     shiftSchedule: shiftSchedule,       // §TM_RULER_SHIFT — uniform whole-project date shift
     shiftTasks: shiftTasks,             // §GANTT_GROUP_MOVE — uniform date shift over an explicit task_id list
     resizeTask: resizeTask,             // §GANTT_EDIT E2 — edge-pull, duration changes
+    rescheduleAsap: rescheduleAsap,     // §GANTT_RESCHEDULE_ASAP — explicit pull-back, compression only
     setBaseline: setBaseline,           // ⚑ Set Baseline — schedule variance snapshot, single baseline
     getBaselineVariance: getBaselineVariance,
     addTask: addTask,

--- a/viewer/sw.js
+++ b/viewer/sw.js
@@ -8,7 +8,7 @@
 // Cache-first for heavy assets (.wasm, images). DB files skip SW (IndexedDB handles them).
 //
 // DEPLOY: bump CACHE_VERSION on every OCI upload. Old caches are purged on activate.
-const CACHE_VERSION = 'v1079';   // bump on each deploy; per-change detail is the git commit message.
+const CACHE_VERSION = 'v1080';   // bump on each deploy; per-change detail is the git commit message.
 // v1078 (2026-08-23) SCRIPT_LENGTH_REFACTOR_SEAMS.md §S59 candidate 2 — navigate_find.js's ERP-push
 // block extracted to NEW find_erp_push.js (loaded by main.js's lazy navigate list BEFORE
 // navigate_find.js?v=58). NOT precached ON PURPOSE: none of the lazy navigate_* sub-modules are

--- a/viewer/tests/witness_gantt_gesture_wiring.js
+++ b/viewer/tests/witness_gantt_gesture_wiring.js
@@ -78,7 +78,8 @@ const NEED = [
   ['commitGanttGroupShift', ['_tmEditLocked(', '_tmResyncAfterRetime(', '_tmAnnotateCpm(', '_tmPersistEdit(']],
   ['linkGanttBars',         ['_tmEditLocked(', '_tmResyncAfterRetime(', '_tmAnnotateCpm(', '_tmPersistEdit(']],
   ['openGanttProps',        ['_tmEditLocked(', '_tmResyncAfterRetime(', '_tmAnnotateCpm(', '_tmPersistEdit(']],
-  ['commitGanttDrag',       ['_tmEditLocked(', '_tmResyncAfterRetime(', '_tmAnnotateCpm(', '_tmPersistEdit(']]
+  ['commitGanttDrag',       ['_tmEditLocked(', '_tmResyncAfterRetime(', '_tmAnnotateCpm(', '_tmPersistEdit(']],
+  ['rescheduleGanttAsap',   ['_tmEditLocked(', '_tmResyncAfterRetime(', '_tmAnnotateCpm(', '_tmPersistEdit(']]
 ];
 NEED.forEach(function (spec) {
   const body = fnBody(spec[0]);

--- a/viewer/tests/witness_gantt_reschedule_asap.js
+++ b/viewer/tests/witness_gantt_reschedule_asap.js
@@ -1,0 +1,192 @@
+#!/usr/bin/env node
+// WITNESS — W-ASAP — §GANTT_RESCHEDULE_ASAP: explicit pull-back ("reschedule as early as possible")
+// Spec: bim-compiler prompts/4D_GANTT_TM_REFACTOR.md lane — pull-back ships as a DELIBERATE,
+// user-triggered action, never as a side-effect of an ordinary drag (§S68's annotate-only contract:
+// moveTaskCascade is push-only by design, its own header says "never pull a successor earlier").
+//
+// ISSUE THIS PROVES OR DISPROVES:
+//   The open product gap was that a task whose predecessor finished long ago keeps its late
+//   persisted start forever — nothing in the edit surface could CLOSE provable float. The decided
+//   shape is a new engine verb, ScheduleAuthor.rescheduleAsap, compression-only. Each check names
+//   the property that would silently break the product decision if it regressed:
+//
+//   W-ASAP-1  gap closes      — a task with huge float (pred finished long before its stored start)
+//                               is pulled back exactly onto its predecessor floor. Without this the
+//                               button is a no-op and the feature does not exist.
+//   W-ASAP-2  roots anchor    — a task with NO predecessors keeps its CURRENT start. Without this
+//                               "compress" silently re-baselines the whole project to day zero.
+//   W-ASAP-3  never later     — a task already AHEAD of its derived ES (violated constraint) is left
+//                               byte-identical. Moving it later would turn compression into a
+//                               generic re-solve — explicitly out of scope.
+//   W-ASAP-4  transitive      — B's successor C is pulled through B's NEW position, not B's old one.
+//                               A one-hop-only pass would leave downstream float unclosed.
+//   W-ASAP-5  dryRun is dry   — opts.dryRun computes the same moved-set and writes NOTHING (the
+//                               witness convention every other verb honours).
+//   W-ASAP-6  real write      — without dryRun the dates land in `tasks`, duration-preserving, and
+//                               untouched rows (root, summary, tight, ahead-of-floor) stay
+//                               byte-identical.
+//   W-ASAP-7  idempotent      — a second run reports moved=0: the schedule is at earliest float.
+//   W-ASAP-8  wiring          — time_machine.js carries the transport-row button + a commit path
+//                               with the full 7-step pipeline (lock → verb → retime → resync →
+//                               annotate → persist → redraw). BRACE-MATCHED via namedFns, never a
+//                               fixed slice window (§S65 G-COH-6 false-negative class, bitten twice).
+//   W-ASAP-9  drag untouched  — moveTaskCascade still declares push-only. The explicit action must
+//                               not have changed the implicit drag's semantics.
+//
+// Command: node viewer/tests/witness_gantt_reschedule_asap.js     (no browser, no building fixture)
+'use strict';
+const fs = require('fs');
+const path = require('path');
+const initSqlJs = require(path.join(__dirname, '..', '..', 'modeller', 'lib', 'sql-wasm.js'));
+
+let pass = 0, fail = 0;
+function assert(cond, msg) { if (cond) { pass++; console.log('  PASS ' + msg); } else { fail++; console.log('  FAIL ' + msg); } }
+
+// ── W-ASAP-8 / W-ASAP-9: source gates, brace-matched (same namedFns as witness_gantt_edit_persist) ──
+const TM = path.join(__dirname, '..', 'time_machine.js');
+const src = fs.readFileSync(TM, 'utf8');
+function namedFns(text) {
+  const out = [];
+  const re = /\bfunction\s+([A-Za-z_$][\w$]*)\s*\(/g;
+  let m;
+  while ((m = re.exec(text))) {
+    const open = text.indexOf('{', m.index);
+    if (open < 0) continue;
+    let depth = 0, end = -1;
+    for (let i = open; i < text.length; i++) {
+      if (text[i] === '{') depth++;
+      else if (text[i] === '}') { depth--; if (depth === 0) { end = i + 1; break; } }
+    }
+    if (end > 0) out.push({ name: m[1], start: m.index, end: end, body: text.slice(m.index, end) });
+  }
+  return out;
+}
+const FNS = namedFns(src);
+const fn = FNS.find(f => f.name === 'rescheduleGanttAsap');
+assert(!!fn, 'W-ASAP-8a rescheduleGanttAsap is defined in time_machine.js (brace-matched, not a comment mention)');
+const PIPELINE = ['_tmEditLocked(', '.rescheduleAsap(', 'retimeTaskElements(', '_tmResyncAfterRetime(',
+  '_tmAnnotateCpm(', '_tmPersistEdit(', 'invalidateGanttModel(', 'computeDays(', 'drawGanttMini(', 'renderAtTime('];
+const missing = PIPELINE.filter(c => !fn || fn.body.indexOf(c) < 0);
+console.log('§GANTT_RESCHEDULE_ASAP_WIRING pipelineCalls=' + (PIPELINE.length - missing.length) + '/' + PIPELINE.length +
+  (missing.length ? ' MISSING [' + missing.join(' | ') + ']' : ''));
+assert(missing.length === 0, 'W-ASAP-8b the commit path carries the FULL 7-step pipeline — a missing step here is the ' +
+  '§S67/§S70 class of bug (stale canvas, unpersisted edit, stale critical path), not a style nit' +
+  (missing.length ? ' — MISSING: ' + missing.join(', ') : ''));
+// The lock must be checked BEFORE the verb runs — a lock check after the write is decoration.
+assert(!!fn && fn.body.indexOf('_tmEditLocked(') < fn.body.indexOf('.rescheduleAsap('),
+  'W-ASAP-8c _tmEditLocked is checked BEFORE the engine verb runs (mid-bake refusal, §S69 — the 9th edit path must not ship unlocked)');
+assert(!!fn && /_lastEdit\s*=\s*\{/.test(fn.body),
+  'W-ASAP-8d the edit is captured into _lastEdit — pull-back is undoable via ↺ Undo exactly like a drag (its restore loop is mode-agnostic)');
+assert(/id="tm-reschedule-asap"/.test(src), 'W-ASAP-8e the transport-row button markup exists (#tm-reschedule-asap)');
+assert(/getElementById\('tm-reschedule-asap'\)/.test(src) && /rescheduleGanttAsap\(\);/.test(src),
+  'W-ASAP-8f the button is wired to the commit path (a button nothing listens to is not the feature)');
+
+const SA_SRC = fs.readFileSync(path.join(__dirname, '..', 'schedule_author.js'), 'utf8');
+const SA_FNS = namedFns(SA_SRC);
+const verbFn = SA_FNS.find(f => f.name === 'rescheduleAsap');
+assert(!!verbFn, 'W-ASAP-8g ScheduleAuthor.rescheduleAsap is a REAL brace-matched function in schedule_author.js');
+assert(/rescheduleAsap:\s*rescheduleAsap/.test(SA_SRC), 'W-ASAP-8h it is exported on the API map (an unexported verb is unreachable from the TM)');
+const mtcFn = SA_FNS.find(f => f.name === 'moveTaskCascade');
+assert(!!mtcFn && mtcFn.body.indexOf('push-only: never pull a successor earlier') >= 0,
+  'W-ASAP-9 moveTaskCascade STILL declares push-only — the explicit action did not change the implicit drag\'s ' +
+  'semantics (the product decision: pull-back is a deliberate trigger, never a drag side-effect)');
+
+// ─────────────────────────── behaviour: synthetic fixture, real verb ───────────────────────────
+const ScheduleAuthor = require(path.join(__dirname, '..', 'schedule_author.js'));
+
+initSqlJs({ wasmBinary: fs.readFileSync(path.join(__dirname, '..', '..', 'modeller', 'lib', 'sql-wasm.wasm')) }).then(function (SQL) {
+  const db = new SQL.Database();
+  const SCH = 'SCH_TEST';
+  db.run('CREATE TABLE tasks (task_id TEXT PRIMARY KEY, schedule_id TEXT, name TEXT, is_summary INTEGER, ' +
+    'schedule_start TEXT, schedule_finish TEXT, schedule_duration TEXT)');
+  db.run('CREATE TABLE task_sequences (predecessor_id TEXT, successor_id TEXT, sequence_type TEXT, lag_days INTEGER)');
+  // The fixture, one row per property under test:
+  //   A     root, 2026-01-01 +10d → finishes 2026-01-11.
+  //   B     pred A (FS). Stored start 2026-03-01 — a 49-day pure-float gap. MUST pull to 2026-01-11.
+  //   C     pred B (FS lag 2). Stored 2026-03-15. MUST pull transitively through B's NEW finish
+  //         (2026-01-16 + 2 = 2026-01-18), not B's old one (2026-03-06 + 2).
+  //   R     root, no preds, 2026-02-01. MUST NOT move (anchor — W-ASAP-2).
+  //   D     pred A (FS), stored start exactly 2026-01-11 (tight). MUST NOT move (ES == current).
+  //   E     pred A (FS lag 30) ⇒ ES 2026-02-10, but stored 2026-01-20 (already AHEAD of its floor,
+  //         an existing violation). MUST NOT move later (W-ASAP-3).
+  //   S     summary row. MUST stay byte-identical (rolls up, never moved directly).
+  const rows = [
+    ['A', 0, '2026-01-01', '2026-01-11', 'P10D'],
+    ['B', 0, '2026-03-01', '2026-03-06', 'P5D'],
+    ['C', 0, '2026-03-15', '2026-03-20', 'P5D'],
+    ['R', 0, '2026-02-01', '2026-02-08', 'P7D'],
+    ['D', 0, '2026-01-11', '2026-01-14', 'P3D'],
+    ['E', 0, '2026-01-20', '2026-01-25', 'P5D'],
+    ['S', 1, '2026-01-01', '2026-03-20', null]
+  ];
+  const ins = db.prepare('INSERT INTO tasks VALUES (?,?,?,?,?,?,?)');
+  rows.forEach(r => ins.run([r[0], SCH, 'task ' + r[0], r[1], r[2], r[3], r[4]]));
+  ins.free();
+  db.run("INSERT INTO task_sequences VALUES ('A','B','FS',0), ('B','C','FS',2), ('A','D','FS',0), ('A','E','FS',30)");
+
+  const readAll = () => {
+    const out = {};
+    db.exec('SELECT task_id, schedule_start, schedule_finish, schedule_duration FROM tasks WHERE schedule_id=?', [SCH])[0]
+      .values.forEach(r => { out[r[0]] = r[1] + '|' + r[2] + '|' + r[3]; });
+    return out;
+  };
+  const before = readAll();
+
+  // ── W-ASAP-5 + W-ASAP-1/2/3/4 computed half: dryRun.
+  const dry = ScheduleAuthor.rescheduleAsap(db, SCH, { dryRun: true });
+  assert(dry && dry.ok === true, 'RED-CONTROL: the verb ran on the fixture (ok=' + (dry && dry.ok) + ' reason=' + (dry && dry.reason) + ')');
+  const dryById = {};
+  (dry.moved || []).forEach(m => { dryById[m.id] = m; });
+  console.log('§GANTT_RESCHEDULE_ASAP_DRY moved=[' + (dry.moved || []).map(m => m.id + '→' + m.start + '(-' + m.daysPulled + 'd)').join(' ') + ']' +
+    ' PFbefore=' + dry.projectDurationBefore + 'd PFafter=' + dry.projectDurationAfter + 'd daysCompressed=' + dry.daysCompressed);
+  assert(!!dryById.B && dryById.B.start === '2026-01-11',
+    'W-ASAP-1 B\'s computed ES (' + (dryById.B && dryById.B.start) + ') is its predecessor floor 2026-01-11 — EARLIER than its stored 2026-03-01: the 49-day pure-float gap closes');
+  assert(!!dryById.B && dryById.B.daysPulled === 49 && dryById.B.finish === '2026-01-16',
+    'W-ASAP-1b B pulled exactly 49 days, duration preserved (finish=' + (dryById.B && dryById.B.finish) + ', 5d after start)');
+  assert(!dryById.R, 'W-ASAP-2 root R (no predecessors) is NOT in the moved set — roots anchor, no silent re-baseline to day zero');
+  assert(!dryById.A, 'W-ASAP-2b root A stays put too (both roots untouched, not just one lucky one)');
+  assert(!dryById.E, 'W-ASAP-3 E (stored AHEAD of its 2026-02-10 floor) is NOT moved later — compression only, never a generic re-solve');
+  assert(!dryById.D, 'W-ASAP-3b D (already tight on its floor, ES == current) is left alone');
+  assert(!!dryById.C && dryById.C.start === '2026-01-18',
+    'W-ASAP-4 C pulled TRANSITIVELY through B\'s NEW finish + lag 2 (got ' + (dryById.C && dryById.C.start) + ', want 2026-01-18) — a one-hop pass would have left C on B\'s OLD finish');
+  assert((dry.moved || []).length === 2, 'W-ASAP-4b the moved set is EXACTLY {B, C} (n=' + (dry.moved || []).length + ') — nothing else in the fixture has closable float');
+  const afterDry = readAll();
+  const dryChanged = Object.keys(before).filter(id => before[id] !== afterDry[id]);
+  assert(dryChanged.length === 0,
+    'W-ASAP-5 dryRun wrote NOTHING — every tasks row byte-identical (changed=' + (dryChanged.length ? dryChanged.join(',') : 'none') + ')');
+
+  // ── W-ASAP-6: the real write.
+  const wet = ScheduleAuthor.rescheduleAsap(db, SCH, {});
+  assert(wet && wet.ok && wet.moved.length === 2, 'W-ASAP-6a real run moved the same 2 tasks the dryRun computed');
+  const afterWet = readAll();
+  assert(afterWet.B === '2026-01-11|2026-01-16|P5D',
+    'W-ASAP-6b B persisted at its floor, duration-preserving (got ' + afterWet.B + ')');
+  assert(afterWet.C === '2026-01-18|2026-01-23|P5D',
+    'W-ASAP-6c C persisted at its transitive floor (got ' + afterWet.C + ')');
+  const untouched = ['A', 'R', 'D', 'E', 'S'].filter(id => before[id] !== afterWet[id]);
+  assert(untouched.length === 0,
+    'W-ASAP-6d every non-moved row (roots, tight, ahead-of-floor, summary) is byte-identical (changed=' + (untouched.length ? untouched.join(',') : 'none') + ')');
+  // Old project finish = C's 2026-03-20. New project finish is NOT C's 2026-01-23 — after the pull,
+  // the ANCHORED root R (untouched, finishing 2026-02-08) is the latest leaf, and the project finish
+  // is max over ALL leaves. Mar 20 → Feb 8 = 40 days. This is itself a property under test: the
+  // reported compression is bounded by what the anchors allow, never the naive moved-task delta.
+  assert(wet.daysCompressed === 40 && wet.finishBefore === '2026-03-20' && wet.finishAfter === '2026-02-08',
+    'W-ASAP-6e daysCompressed=' + wet.daysCompressed + ' (finish ' + wet.finishBefore + ' → ' + wet.finishAfter + ') — project finish is max over ALL leaves, so the anchored root R (2026-02-08) bounds it, want 40');
+
+  // ── W-ASAP-7: idempotence.
+  const again = ScheduleAuthor.rescheduleAsap(db, SCH, {});
+  assert(again && again.ok && again.moved.length === 0 && again.daysCompressed === 0,
+    'W-ASAP-7 a second run reports moved=0, compressed=0 — the schedule is AT earliest float, the verb converges (moved=' + (again && again.moved.length) + ')');
+
+  // ── refusal shape: a schedule with no rows refuses loudly, never half-computes.
+  const none = ScheduleAuthor.rescheduleAsap(db, 'SCH_NO_SUCH', {});
+  assert(!!none && none.ok === false && none.reason === 'no_tasks',
+    'W-ASAP-10 unknown schedule refuses with {ok:false, reason:no_tasks} — same honest-refusal convention as every other verb');
+
+  console.log('§GANTT_RESCHEDULE_ASAP_SUMMARY pass=' + pass + ' fail=' + fail);
+  if (fail) { console.error('FAIL — ' + fail + ' check(s) failed'); process.exit(1); }
+  console.log('PASS — pull-back closes provable float only: roots anchor, nothing moves later, dryRun is dry, the drag stays push-only');
+}).catch(function (e) {
+  console.error('FAIL — witness threw: ' + (e && e.stack || e));
+  process.exit(1);
+});

--- a/viewer/tests/witness_tm_bake_lock.js
+++ b/viewer/tests/witness_tm_bake_lock.js
@@ -167,7 +167,7 @@ function namedFns(text) {
 }
 const FNS = namedFns(tmSrc);
 const MUTATORS = ['retimeTaskElements(', '.moveTaskCascade(', '.shiftSchedule(', '.shiftTasks(',
-                  '.materializeZones(', '.addDependency(', '.removeDependency('];
+                  '.rescheduleAsap(', '.materializeZones(', '.addDependency(', '.removeDependency('];
 // Skip the wrappers that are not user-facing edit ENTRY points: the pre-materialize bootstrap runs
 // before any film exists, and the helper/model builders below are called BY the guarded verbs.
 // _materializeNativeSchedule is the ONLY name-based exemption, and W-TBL-5d below asserts the

--- a/viewer/time_machine.js
+++ b/viewer/time_machine.js
@@ -2764,6 +2764,7 @@
         '<button id="tm-end-btn" style="width:30px;font-size:14px" title="Jump to end">&#x25B6;&#x25B6;</button>' +
         '<button id="tm-undo" style="flex:1;font-size:9px" title="Undo the last Gantt drag/resize">&#x21BA; Undo edit</button>' +
         '<button id="tm-baseline" style="flex:1;font-size:9px" title="Snapshot current dates as the baseline for schedule variance">&#x2691; Set Baseline</button>' +
+        '<button id="tm-reschedule-asap" style="flex:1;font-size:9px" title="Pull every task back to the earliest start its predecessors allow (compression only — never moves a task later)">&#x23EA; Pull Back</button>' +
       '</div>' +
       '<div id="tm-gantt-box" class="tm-drawer-bottom">' +
         // §GANTT_PALETTE 2026-08-04: phase legend strip removed — the hover tooltip already reports
@@ -2926,6 +2927,9 @@
     });
     document.getElementById('tm-baseline').addEventListener('pointerup', function(e) {
       e.stopPropagation(); setGanttBaseline();
+    });
+    document.getElementById('tm-reschedule-asap').addEventListener('pointerup', function(e) {
+      e.stopPropagation(); rescheduleGanttAsap();
     });
     document.getElementById('tm-sun').addEventListener('pointerup', function(e) {
       e.stopPropagation();
@@ -6522,6 +6526,90 @@
     if (!res.ok) { say('No schedule to baseline yet — generate a 4D schedule first'); return; }
     say('Baseline set — ' + res.taskCount + ' tasks');
   }
+
+  // ⏪ Pull Back — §GANTT_RESCHEDULE_ASAP. The EXPLICIT "reschedule as early as possible" action.
+  // moveTaskCascade is push-only by design (§S68's annotate-only drag contract: a drag moves ONE
+  // bar and pushes violated successors, it never silently re-optimises the rest of the programme).
+  // The user-decided product shape for pull-back is therefore a deliberate transport-row button —
+  // same surface as ⚑ Set Baseline — not a side-effect of every drag. Same 7-step commit pipeline
+  // as every other edit path (lock → verb → retime → resync → annotate → persist → redraw); W-CPM-1
+  // / W-PERS-1 / W-TBL-5 derive their caller lists from the source and hold this function to it.
+  function rescheduleGanttAsap() {
+    if (_tmEditLocked('rescheduleGanttAsap')) return;   // §TM_BAKE_LOCK (§S69)
+    var app = A();
+    var SA = (typeof window !== 'undefined') && window.ScheduleAuthor;
+    var tip = document.getElementById('tm-gantt-tip');
+    function say(msg) {
+      if (!tip) return;
+      tip.textContent = msg; tip.style.display = 'block';
+      setTimeout(function () { tip.style.display = 'none'; }, 2600);
+    }
+    if (!app || !app.db || !SA || !SA.rescheduleAsap) {
+      console.log('§GANTT_RESCHEDULE_ASAP_REJECT reason=ScheduleAuthor_not_loaded');
+      say('Not available'); return;
+    }
+    // (returns: true = committed, 'nothing' = zero float to close, undefined = refused — §S73's
+    // convention, so the __tmRescheduleAsap probe hook reports what HAPPENED, not "I was called".)
+    var schedId = (_taskIndex && _taskIndex.scheduleId) || 'SCH_AUTHORED';
+
+    // §GANTT_EDIT_UNDO — snapshot BEFORE the engine verb mutates `tasks`. This action can move MANY
+    // leaf tasks, so the snapshot covers every leaf in the schedule (same scope commitGanttDrag
+    // already uses for exactly this reason: "cascade scope isn't known until the verb returns").
+    var tasksBefore = {};
+    try {
+      var tb = app.db.exec('SELECT task_id, schedule_start, schedule_finish, schedule_duration ' +
+        'FROM tasks WHERE schedule_id=? AND (is_summary IS NULL OR is_summary=0)', [schedId]);
+      if (tb.length) tb[0].values.forEach(function (row) {
+        tasksBefore[row[0]] = { start: row[1], finish: row[2], duration: row[3] };
+      });
+    } catch (e) {}
+
+    var res = SA.rescheduleAsap(app.db, schedId, {});
+    if (!res || !res.ok) {
+      console.log('§GANTT_RESCHEDULE_ASAP_REJECT reason=' + ((res && res.reason) || 'unknown'));
+      say('Cannot compress — ' + ((res && res.reason) || 'no schedule'));
+      return;
+    }
+    if (!res.moved.length) {
+      // The verb wrote nothing (compression found zero float to close) — honest no-op, no retime,
+      // no persist, no undo entry to clobber the user's real last edit.
+      say('Nothing to compress — schedule is already at earliest float');
+      return 'nothing';
+    }
+
+    var barsByTask = {};
+    for (var i = 0; i < _ganttTasks.length; i++) if (_ganttTasks[i].taskId) barsByTask[_ganttTasks[i].taskId] = _ganttTasks[i];
+    var opsBefore = {};
+    var _opByGuidForUndo = {};
+    for (var oi4 = 0; oi4 < _ops.length; oi4++) if (_ops[oi4].output_guid) _opByGuidForUndo[_ops[oi4].output_guid] = _ops[oi4];
+    res.moved.forEach(function (m) {
+      var bar4 = barsByTask[m.id]; if (!bar4 || !bar4.guids) return;
+      bar4.guids.forEach(function (g) {
+        var op = _opByGuidForUndo[g];
+        if (op) opsBefore[g] = { start_ts: op.start_ts, end_ts: op.end_ts, parameters: JSON.stringify(op.parameters) };
+      });
+    });
+
+    retimeTaskElements(app.db, barsByTask, res.moved, tasksBefore);
+    _lastEdit = { schedId: schedId, taskId: '(' + res.moved.length + ' pulled back)', mode: 'asap', tasksBefore: tasksBefore, opsBefore: opsBefore };
+    console.log('§GANTT_RESCHEDULE_ASAP_COMMIT schedule=' + schedId + ' tasks=' + res.moved.length +
+      ' daysCompressed=' + res.daysCompressed);
+    _tmResyncAfterRetime();   // §GANTT_RETIME_RESYNC — without this the canvas plays the OLD times
+    _tmAnnotateCpm(schedId);   // §GANTT_CPM_ANNOTATE (§S68) — re-derive float/critical FROM the new dates
+    _tmPersistEdit('rescheduleAsap');   // §S70 — the edit must survive a reload
+    invalidateGanttModel();
+    computeDays();
+    drawGanttMini();
+    renderAtTime(_cursor);
+    say('Compressed ' + res.moved.length + ' task' + (res.moved.length === 1 ? '' : 's') +
+      (res.daysCompressed > 0 ? ' — project finish moved up ' + res.daysCompressed + ' day' + (res.daysCompressed === 1 ? '' : 's')
+                              : ' — project finish unchanged (internal float closed)'));
+    return true;
+  }
+  // Test hook (diagnostic only, same contract as __tmGanttDrag / __tmZoneProbe): a headless probe
+  // needs the REAL commit path — lock check, engine verb, retime, resync, annotate, persist — not a
+  // DOM gesture. §S73 semantics: true = committed, 'nothing' = zero closable float, false = refused.
+  window.__tmRescheduleAsap = function () { return rescheduleGanttAsap() || false; };
 
   // §GANTT_AUTHOR_ENTRY (native, §GANTT_EDIT_LOCK 2026-08-05 dropped the last old-panel fallback) —
   // called automatically by drawGanttMini when the drawer has nothing editable to show, no button,


### PR DESCRIPTION
## What

A new transport-row button in the Time Machine's Gantt drawer — **⏪ Pull Back** (`#tm-reschedule-asap`, next to ⚑ Set Baseline) — that reschedules the whole schedule "as early as possible": a full forward topological pass over `task_sequences` (the same Kahn sort + IfcSequenceEnum ES math `computeCpm`'s non-fixedDates forward pass runs) pulls every leaf task back onto its predecessor floor. Compression only:

- a task with **no predecessors keeps its current start** (roots anchor — this closes gaps CPM can prove are pure float, it does not re-baseline the project to day zero)
- **no task ever moves later** (a task already ahead of a violated constraint is left byte-identical)
- summaries skipped (they roll up), durations preserved, same transaction shape as `moveTaskCascade`

## Why explicit, not implicit

`moveTaskCascade` is push-only **by design** — its own header: "Successors are only ever pushed LATER, never pulled earlier" (§S68's annotate-only drag contract, bim-compiler `prompts/4D_GANTT_TM_REFACTOR.md`). The user-decided product shape for pull-back is a deliberate, user-triggered action, never a side-effect of an ordinary drag. Ordinary drags are untouched, and the new witness asserts the push-only declaration is still present (W-ASAP-9).

## Wiring

`rescheduleGanttAsap()` carries the full 7-step pipeline every other edit path uses: `_tmEditLocked` (§S69 — the 9th edit path does not ship unlocked) → engine verb `ScheduleAuthor.rescheduleAsap` → `retimeTaskElements` → `_tmResyncAfterRetime` → `_tmAnnotateCpm` (annotate-only) → `_tmPersistEdit` (§S70) → invalidate/redraw. **Undo works**: the edit is captured into the same `_lastEdit` single-level undo (tasksBefore = every leaf task, opsBefore = touched guids) — the restore loop is mode-agnostic, so ↺ Undo reverses a pull-back exactly like a drag. No known gap. The zero-float case is an honest no-op (tip only, no retime/persist, no undo-entry clobber). `__tmRescheduleAsap` probe hook added, §S73 return semantics.

The derived-wiring gates were extended, not bypassed: `.rescheduleAsap(` added to `witness_tm_bake_lock.js`'s MUTATORS derivation, `rescheduleGanttAsap` added to `witness_gantt_gesture_wiring.js`'s NEED list.

## CACHE_VERSION

`viewer/sw.js` v1079 → **v1080**, same PR (mandatory for any `time_machine.js`/`schedule_author.js` change or the fix never reaches existing users).

## Witness proof

`node viewer/tests/witness_gantt_reschedule_asap.js` — 26/26 (synthetic 7-task fixture: 49-day pure-float gap, transitive successor, two roots, tight task, ahead-of-floor task, summary; brace-matched source gates per the §S65 lesson):

```
§GANTT_RESCHEDULE_ASAP_WIRING pipelineCalls=10/10
§GANTT_RESCHEDULE_ASAP schedule=SCH_TEST moved=2 finishBefore=2026-03-20 finishAfter=2026-02-08 daysCompressed=40 (dryRun)
§GANTT_RESCHEDULE_ASAP_DRY moved=[B→2026-01-11(-49d) C→2026-01-18(-56d)] PFbefore=78d PFafter=38d daysCompressed=40
  PASS W-ASAP-1 B's computed ES (2026-01-11) is its predecessor floor 2026-01-11 — EARLIER than its stored 2026-03-01: the 49-day pure-float gap closes
  PASS W-ASAP-2 root R (no predecessors) is NOT in the moved set — roots anchor, no silent re-baseline to day zero
  PASS W-ASAP-3 E (stored AHEAD of its 2026-02-10 floor) is NOT moved later — compression only, never a generic re-solve
  PASS W-ASAP-4 C pulled TRANSITIVELY through B's NEW finish + lag 2 (got 2026-01-18, want 2026-01-18)
  PASS W-ASAP-5 dryRun wrote NOTHING — every tasks row byte-identical (changed=none)
  PASS W-ASAP-6b B persisted at its floor, duration-preserving (got 2026-01-11|2026-01-16|P5D)
  PASS W-ASAP-7 a second run reports moved=0, compressed=0 — the schedule is AT earliest float, the verb converges
§GANTT_RESCHEDULE_ASAP_SUMMARY pass=26 fail=0
PASS — pull-back closes provable float only: roots anchor, nothing moves later, dryRun is dry, the drag stays push-only
```

Live headless round-trip (`scripts/probe_gantt_reschedule_asap.js`, Duplex, Chrome 152) — 11/11:

```
  PASS P3 real drag pushed it +30d (§GANTT_DRAG_COMMIT)  §GANTT_DRAG_COMMIT task=TASK_Finishes_Level_2 mode=move deltaDays=30 start=2026-09-28 clamped=false cascaded=0
  PASS P4 pull-back committed through the real path  §GANTT_RESCHEDULE_ASAP schedule=SCH_AUTHORED moved=1 finishBefore=2026-10-01 finishAfter=2026-09-01 daysCompressed=30
  PASS P5 the edit persisted (§GANTT_EDIT_PERSIST what=rescheduleAsap ok=true)  §GANTT_EDIT_PERSIST what=rescheduleAsap url=/buildings/Duplex_extracted.db ok=true
  PASS P6 reload served from cache (§CACHE_HIT)  [S203] §CACHE_HIT Duplex_extracted.db size=9.9MB
  PASS P7 the pulled-back date SURVIVED the reload  afterPull=2026-08-29 afterReload=2026-08-29
§GANTT_RESCHEDULE_ASAP_PROBE_SUMMARY pass=11 fail=0
```

Full suite (`node tests/run_witness_suite.js`): **green=47 new_red=0 known_red=3** — the same 3 known-reds as the origin/main baseline run (baseline: green=46 new_red=0 known_red=3, before this branch added its witness).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
