### PR TITLE
feat(erp): wire record-level access gate into commitCrud (T-0 item 4)

### DIFF
--- a/erp/crud_core.js
+++ b/erp/crud_core.js
@@ -746,6 +746,41 @@
   function sessionClientId() { try { if (global.APP && global.APP.clientId != null) return global.APP.clientId; } catch (e) {} try { if (typeof globalThis !== 'undefined' && globalThis.APP && globalThis.APP.clientId != null) return globalThis.APP.clientId; } catch (e2) {} return null; }
   function sessionOrgId()    { try { if (global.APP && global.APP.orgId    != null) return global.APP.orgId;    } catch (e) {} try { if (typeof globalThis !== 'undefined' && globalThis.APP && globalThis.APP.orgId    != null) return globalThis.APP.orgId;    } catch (e2) {} return 0; }
 
+  // ── T-0 item 4 (prompts/RESUME_ERP_T0_TRUTH_MAINTENANCE.md) — record-level access gate on the LIVE write
+  // path. ad_access.js's gateRecord (canView AccessLevel + org/client scope, W-ACCESS-HARDEN-proven headless)
+  // was exposed via idmp_session.js's gateRecordFor but never reached commitCrud — a CRUD write only checked
+  // owner+CAS, never whether the ACTING ROLE may touch this record's org/client at all. Same "the page may
+  // set it" INPUT seam as sessionActor/sessionClientId/sessionOrgId: idempiere.html's applySession sets
+  // window.APP.gateRecordFor (a closure over its db + logged-in role); absent (glassbowl.html and any other
+  // no-login host) → PASS, never a hard dependency on idmp_session.js. NEVER invented — only read.
+  var _tableAccessLevelCache = {};
+  function _getTableAccessLevel(table) {
+    var k = String(table || '').toLowerCase();
+    if (_tableAccessLevelCache.hasOwnProperty(k)) return _tableAccessLevelCache[k];
+    try {
+      var mdb = (typeof globalThis !== 'undefined' && globalThis.__idmpDb) || null;
+      if (!mdb) return null;
+      var r = mdb.exec("SELECT AccessLevel FROM AD_Table WHERE UPPER(TableName)=UPPER('" + k.replace(/'/g, "''") + "') LIMIT 1");
+      var lvl = (r.length && r[0].values.length) ? String(r[0].values[0][0]) : null;
+      _tableAccessLevelCache[k] = lvl; return lvl;
+    } catch (e) { return null; }
+  }
+  // recordAccessGate(table, record) — record is the fetched row (crud_overlay.js's getRecord shape: keys
+  // exposed both original-case and lower-case, per §ADORGID-CASING). Reads ad_org_id/ad_client_id lower-case
+  // (this codebase's established convention throughout, ERP_BUSINESS_CYCLE_E2E.md §Fix 2026-07-22).
+  function recordAccessGate(table, record) {
+    try {
+      var fn = (global.APP && global.APP.gateRecordFor) ||
+               (typeof globalThis !== 'undefined' && globalThis.APP && globalThis.APP.gateRecordFor);
+      if (typeof fn !== 'function') return { allowed: true, reason: 'no-gate-available' };
+      var lvl = _getTableAccessLevel(table);
+      if (lvl == null) return { allowed: true, reason: 'no-accesslevel-data' };
+      var rec = record || {};
+      return fn(lvl, { AD_Org_ID: rec.ad_org_id != null ? rec.ad_org_id : rec.AD_Org_ID,
+                        AD_Client_ID: rec.ad_client_id != null ? rec.ad_client_id : rec.AD_Client_ID });
+    } catch (e) { return { allowed: true, reason: 'gate-error' }; }
+  }
+
   // ── Task 2 — changeLog: op-log CRUD trail for one record, AD-config-filtered (iDempiere AD_ChangeLog parity)
   // Returns [{opId,ts,actor,column,old,new}] for logged columns only; null if table not in IsChangeLog=Y.
   // NON-INVENT: the IsAllowLogging/IsChangeLog filter is READ from the main db (global.__idmpDb); we follow AD.
@@ -992,6 +1027,7 @@
   CORE.sessionActor = sessionActor;     // §0.21 recorded-identity reads — buildOp/_gateCtxFor deps
   CORE.sessionClientId = sessionClientId;
   CORE.sessionOrgId = sessionOrgId;
+  CORE.recordAccessGate = recordAccessGate;   // T-0 item 4 — record-level canView + org/client scope
 
   // dual-mode export (gantt_model.js pattern; footer binding preserved — see header note).
   global.CrudCore = CORE;

--- a/erp/crud_overlay.js
+++ b/erp/crud_overlay.js
@@ -1532,9 +1532,13 @@
   // _gateReject — surface a REJECT in the UI: a toast + NO history dot (the write never happened), and the
   // §-log line the witness asserts. Replaces the old silent dry fallback for an ownerGated denial.
   function _gateReject(op, gate) {
-    console.log('§CRUD-GATE key=' + op.key + ' ownerGated=Y verdict=REJECT reason=' + gate.reason);
-    toast((op.verb ? op.verb.toUpperCase() + ' ' : '') + fname(op.key) + ' — REJECTED (' +
-          (gate.reason === 'owner' ? 'not the owner' : 'stale write — record changed') + ')');
+    console.log('§CRUD-GATE key=' + op.key + ' ownerGated=' + (op.ownerGated ? 'Y' : 'N') + ' verdict=REJECT reason=' + gate.reason);
+    var msg = gate.reason === 'owner' ? 'not the owner'
+      : gate.reason === 'wrong-accesslevel' ? "access denied — outside your role's access level"
+      : gate.reason === 'wrong-org' ? "access denied — outside your role's org scope"
+      : gate.reason === 'wrong-client' ? "access denied — outside your role's client scope"
+      : 'stale write — record changed';
+    toast((op.verb ? op.verb.toUpperCase() + ' ' : '') + fname(op.key) + ' — REJECTED (' + msg + ')');
   }
   // _gateForOwnedWrite — run the pre-seal owner/CAS check for an ownerGated mutating op; resolves the ctx
   // from the record (getRecord layers read-the-tip), then cb(gate). Non-gated ops short-circuit to PASS.
@@ -1546,6 +1550,23 @@
       if (gate.ok) console.log('§CRUD-GATE key=' + op.key + ' ownerGated=Y verdict=PASS actor=' + ctx.actor + ' owner=' + ctx.owner + (ctx.casCol ? ' cas=' + ctx.casCol : ''));
       cb(gate);
     });
+  }
+  // _gateRecordAccess — T-0 item 4 (prompts/RESUME_ERP_T0_TRUTH_MAINTENANCE.md): record-level canView +
+  // org/client scope, via CORE.recordAccessGate (host-injected window.APP.gateRecordFor, absent → PASS).
+  // UPDATE/DELETE only — CREATE has no prior record to check org/client against; the new row is stamped
+  // with the ACTOR's own scope via stdDefaults (buildOp Task 1), inherently self-consistent. CREATE-time
+  // accesslevel gating is a named residual, not this pass.
+  function _gateRecordAccess(op, cb) {
+    if (op.op_type !== 'CRUD_UPDATE' && op.op_type !== 'CRUD_DELETE') { cb({ ok: true }); return; }
+    // explicit op.id (not the no-arg curChain-guessing form _gateForOwnedWrite uses) — a write triggered
+    // by a host call (hostUpdate/hostDelete) rather than a UI click never updates curChain, so the no-arg
+    // form would gate whatever record curChain last pointed at, not the one actually being written
+    // (found live while building this witness — poc_record_gate_live.js).
+    getRecord(op.key, function (rec) {
+      var g = CORE.recordAccessGate(op.table, rec || {});
+      if (g.allowed) { cb({ ok: true }); return; }
+      cb({ ok: false, reason: g.reason });
+    }, op.id != null ? op.id : undefined);
   }
 
   // commitCrud — the REAL signed write for a CRUD field verb (CREATE/UPDATE/DELETE), the field-value peer
@@ -1574,9 +1595,14 @@
         // BEFORE the seal — a non-owner / stale-CAS write is REJECTED (toast, NO dot), never silently sealed.
         // CREATE has no prior owner to gate (the creator becomes the owner) → passes through.
         var gatedVerb = op.ownerGated && (op.op_type === 'CRUD_UPDATE' || op.op_type === 'CRUD_DELETE');
-        _gateForOwnedWrite(gatedVerb ? op : { ownerGated: false }, freshDb, function (gate) {
-          if (!gate.ok) { _gateReject(op, gate); done(); return; }   // REJECT — no dry fallback, no dot
-          _commitCrudSealed(op, K, freshDb, done);
+        // Record-access gate runs FIRST (role's org/client scope for the record at all) — a role outside
+        // scope is rejected before the owner/CAS check even asks whose write it is.
+        _gateRecordAccess(op, function (recGate) {
+          if (!recGate.ok) { _gateReject(op, recGate); done(); return; }
+          _gateForOwnedWrite(gatedVerb ? op : { ownerGated: false }, freshDb, function (gate) {
+            if (!gate.ok) { _gateReject(op, gate); done(); return; }   // REJECT — no dry fallback, no dot
+            _commitCrudSealed(op, K, freshDb, done);
+          });
         });
       });
     });

--- a/erp/idempiere.html
+++ b/erp/idempiere.html
@@ -1133,7 +1133,14 @@ if (typeof qrcode !== "undefined") window.qrcode = qrcode;
     window.APP.actor   = _session.user.id;
     window.APP.clientId = _session.client.id;
     window.APP.orgId   = _session.org ? _session.org.id : 0;
-    console.log('§ACTOR login user=' + _session.user.id + ' app.actor=' + window.APP.actor + ' client=' + window.APP.clientId + ' org=' + window.APP.orgId);
+    window.APP.roleId  = _session.role.id;
+    // T-0 item 4 (prompts/RESUME_ERP_T0_TRUTH_MAINTENANCE.md) — record-level access gate seam for
+    // crud_core.js's recordAccessGate (canView AccessLevel + org/client scope, W-ACCESS-HARDEN-proven
+    // headless). A closure over THIS session's db + role so crud_core.js never needs a raw db handle.
+    window.APP.gateRecordFor = function (tableAccessLevel, record) {
+      return SES.gateRecordFor(db, _session.role.id, tableAccessLevel, record);
+    };
+    console.log('§ACTOR login user=' + _session.user.id + ' app.actor=' + window.APP.actor + ' client=' + window.APP.clientId + ' org=' + window.APP.orgId + ' role=' + window.APP.roleId);
     _buildUserNameMap();   // Task 2 — AD_User_ID → Name for the change-log (iDempiere shows names, not ids)
     // header context bar — live Client · Role · Org (replaces the old static string)
     var orgLabel = _session.org ? _session.org.name.replace(/\s*\(.*\)/, '') : '—';

--- a/erp/sw.js
+++ b/erp/sw.js
@@ -10,7 +10,11 @@
 // init-bubble must be INSTANT, ERP_INIT_BUBBLE_INSTANT.md); network-first for non-precached .js (fresh on
 // deploy); cache-first for precached assets/.wasm/images. Freshness on deploy is carried by the SW version
 // bump (skipWaiting+clients.claim precache the new shell), so SWR strands a user at most one load post-deploy.
-const CACHE_VERSION = 'v769';   // bump on each deploy; per-change detail is the git commit message.
+const CACHE_VERSION = 'v770';   // bump on each deploy; per-change detail is the git commit message.
+// v770 (T-0 item 4, prompts/RESUME_ERP_T0_TRUTH_MAINTENANCE.md): commitCrud's UPDATE/DELETE path now
+//   consults ad_access.js's gateRecord (canView AccessLevel + org/client scope) before sealing, not just
+//   owner/CAS — idempiere.html's applySession wires window.APP.gateRecordFor; crud_core.js/crud_overlay.js
+//   gain recordAccessGate/_gateRecordAccess. New witness: scripts/poc_record_gate_live.js (bim-compiler).
 // v769 (2026-08-23) merge of two independent v768 bumps — both applied, neither dropped:
 // v768a: ad_seed.db gains AD_Form (49) + ad_val_rule (332) — see erp/tests/bake_forms_valrules_seed.js.
 //   ad_seed_v16 -> ad_seed_v17 IDB cache key bump forces re-fetch of the seed for returning users.


### PR DESCRIPTION
## Summary
- `gateRecordFor` (canView AccessLevel + org/client scope, W-ACCESS-HARDEN-proven headless) was exposed by `idmp_session.js` but never reached the live write path — a CRUD write only checked owner/CAS, never whether the acting role may touch this record's client/org at all.
- Wires it in via the same "the page may set it" INPUT seam as `sessionActor`/`sessionClientId`/`sessionOrgId`: `idempiere.html`'s `applySession` sets `window.APP.gateRecordFor`; `crud_core.js` gains `recordAccessGate`; `crud_overlay.js`'s `commitCrud` runs it before the owner/CAS gate for UPDATE/DELETE.
- CREATE is out of scope for this pass (the new row is stamped with the actor's own scope, inherently self-consistent) — named as a residual, not silently skipped.

## Test plan
- [x] New live witness `scripts/poc_record_gate_live.js` (bim-compiler repo): logged in as a GardenWorld User role (client 13), an out-of-client `c_bpartner` write (client 12, Odoo tenant) is REJECTED before the seal (`reason=wrong-client`, no `§CRUD-PERSIST`); the same edit on the role's own tenant still commits. Run twice for determinism.
- [x] Ran the 9 existing live CRUD-path witnesses (`poc_ad_modelval_live`, `witness_e2e_n_converge`, `witness_e2e_n10_concurrent_today`, `witness_e2e_crud_blob_race`, `witness_e2e_business_cycle`, `witness_e2e_multiuser_login_fork`, `witness_e2e_rebase_attrib`, `witness_p2p_invoice_match`, `witness_so_child_bind`) against this branch — 2 pre-existing failures confirmed identical on an unmodified control worktree at the same base commit (not caused by this change).
- [x] `sw.js` CACHE_VERSION v769→v770 (both edited files were already precached).

🤖 Generated with [Claude Code](https://claude.com/claude-code)