### PR TITLE
feat(tm): Time Machine error handling — silent refusals get tips; a thrown edit recovers and offers closing other panels

### DIFF
--- a/viewer/sw.js
+++ b/viewer/sw.js
@@ -8,7 +8,7 @@
 // Cache-first for heavy assets (.wasm, images). DB files skip SW (IndexedDB handles them).
 //
 // DEPLOY: bump CACHE_VERSION on every OCI upload. Old caches are purged on activate.
-const CACHE_VERSION = 'v1080';   // bump on each deploy; per-change detail is the git commit message.
+const CACHE_VERSION = 'v1081';   // bump on each deploy; per-change detail is the git commit message.
 // v1078 (2026-08-23) SCRIPT_LENGTH_REFACTOR_SEAMS.md §S59 candidate 2 — navigate_find.js's ERP-push
 // block extracted to NEW find_erp_push.js (loaded by main.js's lazy navigate list BEFORE
 // navigate_find.js?v=58). NOT precached ON PURPOSE: none of the lazy navigate_* sub-modules are

--- a/viewer/tests/witness_tm_edit_exception.js
+++ b/viewer/tests/witness_tm_edit_exception.js
@@ -1,0 +1,226 @@
+#!/usr/bin/env node
+/**
+ * witness_tm_edit_exception.js — a Gantt edit that THROWS recovers the display, tells the user in
+ * TM's own voice, and offers (never forces) closing the other open panels.
+ *
+ * Implementing the tm-error-handling spec (feat/tm-error-handling) — Witness: W-TM-EXC
+ *
+ * THE ISSUE EACH CHECK PROVES OR DISPROVES. Before this change the 7 edit pipelines
+ * (commitGanttDrag, shiftGanttSchedule, commitGanttGroupShift, rescheduleGanttAsap, linkGanttBars,
+ * the props-panel Apply, generateGanttSchedule) had NO try/catch: a throw anywhere in
+ * verb → retime → resync → annotate → persist → repaint propagated uncaught to error_reporter.js's
+ * SITEWIDE handler — a generic "Something went wrong" toast, rate-limited to 3 per session across
+ * the whole app — and TM's own panel froze on whatever half-updated frame the throw interrupted.
+ *
+ * W-EXC-1  (static, brace-anchored) every one of the 7 pipelines has the catch wired to
+ *          _tmEditExceptionRecover with its own fn label — a future 8th path is caught by W-TM-SRT's
+ *          sibling philosophy: derive the list from source, never trust a hand-kept one... but the
+ *          7 named here ARE the spec's list, so they are asserted by name.
+ * W-EXC-2  (dynamic) a REAL throw inside the engine verb fires the catch and logs §TM_EDIT_EXCEPTION
+ *          with the right fn= and error=.
+ * W-EXC-3  the recovery re-derivers ALL run after the throw (no stale frame): _tmResyncAfterRetime,
+ *          invalidateGanttModel, computeDays, drawGanttMini, renderAtTime.
+ * W-EXC-4  the tip shown is TM-specific ("Time Machine couldn't complete this edit — <reason>"),
+ *          via #tm-gantt-tip, not the sitewide toast.
+ * W-EXC-5  with other panels visible in window._panels (the REAL scene.js registry shape,
+ *          {id, el, nav, close}), the close-offer appears; clicking it closes exactly the visible
+ *          non-TM entries (close() when present, display='none' otherwise), logs
+ *          §TM_CLOSE_OTHER_PANELS closed=n ids=[...], and NEVER touches the TM panel, hidden
+ *          panels, or zero-width panels.
+ * W-EXC-6  with NO other visible panels, no offer is rendered (no no-op action) and the tip's
+ *          pointer-events contract stays 'none'.
+ * W-EXC-7  closing is user-clicked ONLY: before the click, nothing has been closed.
+ */
+'use strict';
+const fs = require('fs');
+const path = require('path');
+const vm = require('vm');
+
+let pass = 0, fail = 0;
+function assert(cond, msg) { if (cond) { pass++; console.log('  PASS ' + msg); } else { fail++; console.log('  FAIL ' + msg); } }
+
+const tmSrc = fs.readFileSync(path.join(__dirname, '..', 'time_machine.js'), 'utf8');
+
+function sliceFn(src, name) {
+  const idx = src.indexOf('function ' + name + '(');
+  if (idx < 0) throw new Error(name + ' not found in time_machine.js');
+  let d = 0, i = idx, open = false;
+  for (; i < src.length; i++) {
+    if (src[i] === '{') { d++; open = true; }
+    else if (src[i] === '}') { d--; if (open && d === 0) break; }
+  }
+  return src.slice(idx, i + 1);
+}
+
+console.log('── witness_tm_edit_exception (W-TM-EXC) ──');
+
+// ── W-EXC-1 — static: all 7 pipelines carry the catch, each with its own label ─────────────────
+// openGanttProps hosts the typed-apply pipeline (the inline tmp-apply onclick), labelled
+// commitGanttProps per the spec — there is no standalone function of that name.
+const WRAPPED = {
+  commitGanttDrag: 'commitGanttDrag',
+  shiftGanttSchedule: 'shiftGanttSchedule',
+  commitGanttGroupShift: 'commitGanttGroupShift',
+  rescheduleGanttAsap: 'rescheduleGanttAsap',
+  linkGanttBars: 'linkGanttBars',
+  generateGanttSchedule: 'generateGanttSchedule',
+  openGanttProps: 'commitGanttProps'
+};
+for (const fn in WRAPPED) {
+  let body;
+  try { body = sliceFn(tmSrc, fn); } catch (e) { assert(false, 'W-EXC-1 ' + fn + ' exists'); continue; }
+  const wired = body.indexOf("_tmEditExceptionRecover('" + WRAPPED[fn] + "'") >= 0 && /catch\s*\(/.test(body);
+  assert(wired, 'W-EXC-1 ' + fn + ' pipeline is wrapped and its catch calls _tmEditExceptionRecover(\'' + WRAPPED[fn] + '\')');
+}
+
+// ── The sandbox: real helpers + real commitGanttDrag, throwing engine verb, counting recovery ──
+function makeTipEl() {
+  return {
+    id: 'tm-gantt-tip',
+    style: { display: 'none', pointerEvents: 'none', whiteSpace: 'nowrap', overflow: 'hidden' },
+    textContent: '',
+    _children: [],
+    appendChild: function (c) { this._children.push(c); }
+  };
+}
+function makePanel(id, opts) {
+  opts = opts || {};
+  const el = {
+    id: opts.elId !== undefined ? opts.elId : ('panel-' + id),
+    offsetWidth: opts.width !== undefined ? opts.width : 200,
+    style: { display: opts.display !== undefined ? opts.display : '' }
+  };
+  const p = { id: id, el: el, nav: null, close: null, _closed: 0 };
+  if (opts.withClose) p.close = function () { p._closed++; };
+  return p;
+}
+
+function run(opts) {
+  opts = opts || {};
+  const logs = [];
+  const calls = { resync: 0, invalidate: 0, computeDays: 0, draw: 0, render: 0, persist: 0 };
+  const tip = makeTipEl();
+  const createdButtons = [];
+  const sandbox = {
+    console: { log: (...a) => logs.push(a.join(' ')), warn: (...a) => logs.push(a.join(' ')) },
+    Math: Math, Date: Date, JSON: JSON, String: String,
+    setTimeout: () => {},   // the hide timer must never fire inside the assert window
+    document: {
+      getElementById: id => (id === 'tm-gantt-tip' ? tip : null),
+      createElement: function (tag) {
+        const btn = { tag: tag, style: {}, textContent: '', _listeners: {},
+          addEventListener: function (t, f) { this._listeners[t] = f; } };
+        createdButtons.push(btn);
+        return btn;
+      }
+    },
+    window: {
+      _panels: opts.panels || [],
+      ScheduleAuthor: {
+        moveTaskCascade: () => { throw new Error('boom sql.js exploded'); },
+        resizeTask: () => { throw new Error('boom sql.js exploded'); },
+        shiftSchedule: () => { throw new Error('boom shift exploded'); }
+      }
+    },
+    A: () => ({ db: {
+      // commitGanttDrag's tasksBefore snapshot needs the dragged task's REAL dates or it refuses
+      // at no_real_task_snapshot before ever reaching the throwing verb.
+      exec: () => [{ values: [['T1', '2026-01-01', '2026-01-10', 9]] }],
+      run: () => {}, prepare: () => ({ run: () => {}, free: () => {} })
+    } }),
+    _tmEditLocked: () => false,
+    _tmAnnotateCpm: () => {},
+    _tmPersistEdit: () => { calls.persist++; },
+    retimeTaskElements: () => {},
+    _tmResyncAfterRetime: () => { calls.resync++; },
+    invalidateGanttModel: () => { calls.invalidate++; },
+    computeDays: () => { calls.computeDays++; },
+    drawGanttMini: () => { calls.draw++; },
+    renderAtTime: () => { calls.render++; },
+    _cursor: 0,
+    _taskIndex: { scheduleId: 'SCH_X', tasks: {} },
+    _ganttTasks: [],
+    _ops: [],
+    _lastEdit: null
+  };
+  sandbox.window.window = sandbox.window;
+  vm.createContext(sandbox);
+  vm.runInContext(
+    sliceFn(tmSrc, '_tmTipRestore') + '\n' +
+    sliceFn(tmSrc, '_tmSay') + '\n' +
+    sliceFn(tmSrc, '_tmVisibleOtherPanels') + '\n' +
+    sliceFn(tmSrc, '_tmSayException') + '\n' +
+    sliceFn(tmSrc, '_tmEditExceptionRecover') + '\n' +
+    sliceFn(tmSrc, 'commitGanttDrag') + '\n' +
+    sliceFn(tmSrc, 'shiftGanttSchedule') + '\n' +
+    'this.__drag = commitGanttDrag; this.__shift = shiftGanttSchedule;', sandbox);
+  return { sandbox, logs, calls, tip, createdButtons };
+}
+
+// ── W-EXC-2/3/4/6 — throw with NO other panels visible ──────────────────────────────────────────
+{
+  const r = run({ panels: [
+    makePanel('tm-fake', { elId: 'time-machine-panel', withClose: true }),      // TM itself: NEVER "other"
+    makePanel('hiddenone', { display: 'none', withClose: true }),               // display:none: not visible
+    makePanel('zerow', { width: 0, withClose: true })                           // zero width: not visible
+  ] });
+  let ret;
+  try { ret = r.sandbox.__drag({ taskId: 'T1', storey: 'L1', phase: 'Arch' }, 'move', 2); }
+  catch (e) { assert(false, 'W-EXC-2 the throw must be CAUGHT, not propagate (escaped: ' + e.message + ')'); }
+  const excLine = r.logs.find(l => l.indexOf('§TM_EDIT_EXCEPTION ') === 0);
+  assert(!!excLine && excLine.indexOf('fn=commitGanttDrag') > 0 && excLine.indexOf('boom sql.js exploded') > 0,
+    'W-EXC-2 §TM_EDIT_EXCEPTION logged with fn=commitGanttDrag and the real error (' + (excLine || 'NO LINE') + ')');
+  assert(ret === undefined, 'W-EXC-2b a caught throw returns undefined = "did not commit" (§S73 hook contract)');
+  assert(r.calls.resync === 1 && r.calls.invalidate === 1 && r.calls.computeDays === 1 && r.calls.draw === 1 && r.calls.render === 1,
+    'W-EXC-3 ALL five recovery re-derivers ran after the throw — no stale frame (resync=' + r.calls.resync +
+    ' invalidate=' + r.calls.invalidate + ' computeDays=' + r.calls.computeDays + ' draw=' + r.calls.draw + ' render=' + r.calls.render + ')');
+  assert(r.calls.persist === 0, 'W-EXC-3b _tmPersistEdit did NOT run on the failed edit (never persist a state the verb did not commit)');
+  assert(r.tip.style.display === 'block' && r.tip.textContent.indexOf("Time Machine couldn't complete this edit — ") === 0 &&
+    r.tip.textContent.indexOf('boom sql.js exploded') > 0,
+    'W-EXC-4 TM-specific tip shown via #tm-gantt-tip ("' + r.tip.textContent + '")');
+  assert(r.tip._children.length === 0 && r.createdButtons.length === 0,
+    'W-EXC-6 NO close-offer when no other panel is visible (TM itself / hidden / zero-width all filtered)');
+  assert(r.tip.style.pointerEvents === 'none',
+    'W-EXC-6b tip keeps pointer-events:none when no action is offered');
+}
+
+// ── W-EXC-5/7 — throw WITH two visible other panels ────────────────────────────────────────────
+{
+  const withClose = makePanel('clash', { withClose: true });
+  const noClose = makePanel('section', { withClose: false });
+  const tmP = makePanel('tm-fake', { elId: 'time-machine-panel', withClose: true });
+  const hid = makePanel('hiddenone', { display: 'none', withClose: true });
+  const r = run({ panels: [tmP, withClose, noClose, hid] });
+  try { r.sandbox.__drag({ taskId: 'T1', storey: 'L1', phase: 'Arch' }, 'move', 2); }
+  catch (e) { assert(false, 'W-EXC-5 the throw must be CAUGHT (escaped: ' + e.message + ')'); }
+  const btn = r.tip._children[0];
+  assert(r.tip._children.length === 1 && btn && btn.textContent.indexOf('Close other panels (2)') === 0,
+    'W-EXC-5 close-offer rendered in the tip, counting exactly the 2 visible others ("' + (btn ? btn.textContent : 'NONE') + '")');
+  assert(r.tip.style.pointerEvents === 'auto' && r.tip.style.whiteSpace === 'normal',
+    'W-EXC-5b tip is made clickable/wrappable while the offer is up (pointer-events=' + r.tip.style.pointerEvents + ')');
+  assert(withClose._closed === 0 && noClose.el.style.display !== 'none',
+    'W-EXC-7 NOTHING is closed before the user clicks — the offer is explicit, never a side-effect');
+  // The user clicks.
+  btn._listeners.click({ stopPropagation: () => {} });
+  const closeLine = r.logs.find(l => l.indexOf('§TM_CLOSE_OTHER_PANELS') >= 0);
+  assert(withClose._closed === 1, 'W-EXC-5c panel WITH a close fn was closed via close()');
+  assert(noClose.el.style.display === 'none', 'W-EXC-5d panel WITHOUT a close fn was hidden via display=none');
+  assert(tmP._closed === 0 && tmP.el.style.display !== 'none' && hid._closed === 0,
+    'W-EXC-5e the TM panel and the hidden panel were NOT touched');
+  assert(!!closeLine && closeLine.indexOf('closed=2') > 0 && closeLine.indexOf('ids=[clash,section]') > 0,
+    'W-EXC-5f §TM_CLOSE_OTHER_PANELS logged (' + (closeLine || 'NO LINE') + ')');
+  assert(r.tip.style.display === 'none' && r.tip.style.pointerEvents === 'none',
+    'W-EXC-5g tip hidden and its pointer-events contract restored after the action');
+}
+
+// ── W-EXC-2c — a second wrapped pipeline reports its OWN fn label ───────────────────────────────
+{
+  const r = run({});
+  try { r.sandbox.__shift(3); } catch (e) { assert(false, 'W-EXC-2c shift throw must be caught (escaped: ' + e.message + ')'); }
+  const excLine = r.logs.find(l => l.indexOf('§TM_EDIT_EXCEPTION ') === 0);
+  assert(!!excLine && excLine.indexOf('fn=shiftGanttSchedule') > 0,
+    'W-EXC-2c shiftGanttSchedule labels its own catch (' + (excLine || 'NO LINE') + ')');
+}
+
+console.log('§TM_EDIT_EXCEPTION_SUMMARY pass=' + pass + ' fail=' + fail);
+process.exit(fail ? 1 : 0);

--- a/viewer/tests/witness_tm_silent_refusal_tips.js
+++ b/viewer/tests/witness_tm_silent_refusal_tips.js
@@ -1,0 +1,169 @@
+#!/usr/bin/env node
+/**
+ * witness_tm_silent_refusal_tips.js — every user-triggerable refusal in time_machine.js shows a tip.
+ *
+ * Implementing the tm-error-handling spec (feat/tm-error-handling) — Witness: W-TM-SRT
+ *
+ * THE ISSUE EACH CHECK PROVES OR DISPROVES. Before this change, ten refusal paths logged a
+ * §..._REJECT / §..._FAIL line and returned with NO user-visible message: the drag snapped back,
+ * the click did nothing, and only the console knew why (commitGanttDrag's ScheduleAuthor guard /
+ * bar_has_no_task / no_real_task_snapshot / hard engine failure; shiftGanttSchedule's guard +
+ * engine failure; commitGanttGroupShift's guard + engine failure; the dblclick lock gate;
+ * openGanttProps' no_real_task_dates; linkGanttBars' guard). This witness makes that a CLASS
+ * property, not a fixed list: it enumerates every _REJECT/_FAIL log call in the CURRENT source and
+ * requires a tip-set in the same enclosing block — so a FUTURE refusal path added without a message
+ * fails the suite instead of shipping silent.
+ *
+ * ANCHORING (the §4(d) lesson — witness_gantt_lock_integrity.js / G-COH-6 both produced false
+ * results here by text-slicing instead of brace/line-anchoring): this file does NOT slice on text
+ * offsets around a match. It runs a string/comment/template-aware brace scanner over the whole
+ * source, records the innermost enclosing block for each refusal log call, and searches for the
+ * message call INSIDE that block's exact brace span. The scanner self-checks: if its depth at EOF
+ * is not exactly 0 it aborts as infrastructure breakage — it can never silently mis-anchor.
+ *
+ * EXCLUSIONS (each with the reason, house KNOWN_* pattern):
+ *   §GANTT_SCHEDULE_STALE_REGEN_FAIL — load-time self-heal catch inside buildTaskIndex, not a user
+ *     gesture: the drawer (and its #tm-gantt-tip) may not exist yet, and the code continues to a
+ *     working fallback (reads the existing tasks as-is), so there is nothing to tell the user.
+ */
+'use strict';
+const fs = require('fs');
+const path = require('path');
+
+let pass = 0, fail = 0;
+function assert(cond, msg) { if (cond) { pass++; console.log('  PASS ' + msg); } else { fail++; console.log('  FAIL ' + msg); } }
+
+const SRC_PATH = path.join(__dirname, '..', 'time_machine.js');
+const src = fs.readFileSync(SRC_PATH, 'utf8');
+
+// ── The scanner: brace depth per character, skipping strings/comments/templates ────────────────
+// blockOpenAt[i] = source index of the '{' that opened the block containing index i (innermost).
+// Built with an explicit open-brace stack. Regex literals are not tracked: the source was checked
+// (2026-08-24) to contain no regex literal with a brace or quote in it, and the EOF self-check
+// below turns any future violation into a loud abort, never a silent mis-count.
+function scan(s) {
+  const stack = [];            // indices of currently-open '{'
+  const openerOf = new Array(s.length); // innermost opener index at each position (or -1)
+  let mode = 'code';           // code | sq | dq | tpl | line | block
+  for (let i = 0; i < s.length; i++) {
+    const c = s[i], n = s[i + 1];
+    openerOf[i] = stack.length ? stack[stack.length - 1] : -1;
+    if (mode === 'code') {
+      if (c === "'") mode = 'sq';
+      else if (c === '"') mode = 'dq';
+      else if (c === '`') mode = 'tpl';
+      else if (c === '/' && n === '/') mode = 'line';
+      else if (c === '/' && n === '*') mode = 'block';
+      else if (c === '{') stack.push(i);
+      else if (c === '}') stack.pop();
+    } else if (mode === 'sq') {
+      if (c === '\\') i++;
+      else if (c === "'") mode = 'code';
+    } else if (mode === 'dq') {
+      if (c === '\\') i++;
+      else if (c === '"') mode = 'code';
+    } else if (mode === 'tpl') {
+      if (c === '\\') i++;
+      else if (c === '`') mode = 'code';
+    } else if (mode === 'line') {
+      if (c === '\n') mode = 'code';
+    } else if (mode === 'block') {
+      if (c === '*' && n === '/') { mode = 'block-end'; }
+    } else if (mode === 'block-end') { mode = 'code'; }
+  }
+  return { openerOf, eofDepth: stack.length, eofMode: mode };
+}
+
+// closeOf(openIdx): index of the '}' matching the '{' at openIdx — same skip rules.
+function closeOf(s, openIdx) {
+  let d = 0, mode = 'code';
+  for (let i = openIdx; i < s.length; i++) {
+    const c = s[i], n = s[i + 1];
+    if (mode === 'code') {
+      if (c === "'") mode = 'sq';
+      else if (c === '"') mode = 'dq';
+      else if (c === '`') mode = 'tpl';
+      else if (c === '/' && n === '/') mode = 'line';
+      else if (c === '/' && n === '*') mode = 'block';
+      else if (c === '{') d++;
+      else if (c === '}') { d--; if (d === 0) return i; }
+    } else if (mode === 'sq') { if (c === '\\') i++; else if (c === "'") mode = 'code'; }
+    else if (mode === 'dq') { if (c === '\\') i++; else if (c === '"') mode = 'code'; }
+    else if (mode === 'tpl') { if (c === '\\') i++; else if (c === '`') mode = 'code'; }
+    else if (mode === 'line') { if (c === '\n') mode = 'code'; }
+    else if (mode === 'block') { if (c === '*' && n === '/') mode = 'block-end'; }
+    else if (mode === 'block-end') mode = 'code';
+  }
+  return -1;
+}
+
+const lineOf = idx => src.slice(0, idx).split('\n').length;
+
+console.log('── witness_tm_silent_refusal_tips (W-TM-SRT) ──');
+
+// W-SRT-0 — the scanner itself is sound on this source, or nothing below can be believed.
+const scanned = scan(src);
+if (scanned.eofDepth !== 0 || scanned.eofMode !== 'code') {
+  assert(false, 'W-SRT-0 scanner self-check: depth at EOF must be 0 in code mode (got depth=' +
+    scanned.eofDepth + ' mode=' + scanned.eofMode + ') — brace tracking is broken on this source, ABORTING rather than mis-anchoring');
+  console.log('§TM_SILENT_REFUSAL_SUMMARY pass=' + pass + ' fail=' + fail);
+  process.exit(1);
+}
+assert(true, 'W-SRT-0 scanner self-check: EOF depth=0 in code mode — block anchoring is trustworthy');
+
+// W-SRT-1 — the shared tip helper exists (the mechanism every new refusal site uses).
+assert(src.indexOf('function _tmSay(') >= 0, 'W-SRT-1 _tmSay (shared #tm-gantt-tip helper) is defined');
+
+// ── Enumerate every refusal log call in the CURRENT source ─────────────────────────────────────
+const SITE_RE = /console\.(?:log|warn)\('(§[A-Z0-9_]*?(?:_REJECT|_FAIL))\b/g;
+const EXCLUDED = {
+  '§GANTT_SCHEDULE_STALE_REGEN_FAIL': 'load-time self-heal catch (buildTaskIndex), not a user gesture; tip may not exist yet; flow continues to a working fallback',
+  '§LOAD_FAIL': 'missing gantt_model.js script at load — fires on internal recompute paths (computeDays / buildGanttTasks, the latter on EVERY redraw), not on a gesture; a tip would spam and the drawer may not exist yet',
+  '§GHOST_GROUND_TRIGGER_FAIL': 'DB-probe catch inside tmFirstAboveGroundMs/tmGroundSchedule — CPE bake helpers with a documented null-return contract ("treat null as never ghost"), consumed by cinema code, not a TM user gesture'
+};
+// A message reaching the user inside the SAME block: the shared helper, a local say() closure, or
+// a direct tip .textContent set (the file's three real mechanisms — wireGanttDrag uses the third).
+const MSG_RE = /\b_tmSay\s*\(|\bsay\s*\(|\.textContent\s*=/;
+
+let sites = [], m;
+while ((m = SITE_RE.exec(src)) !== null) sites.push({ tag: m[1], idx: m.index });
+
+// W-SRT-2 — the enumerator is not vacuous: the known population is ~21 sites; finding far fewer
+// means the regex rotted and the witness would be gating nothing.
+assert(sites.length >= 18, 'W-SRT-2 enumerator found ' + sites.length + ' _REJECT/_FAIL log sites (>= 18 — not vacuous)');
+
+// W-SRT-3 — every excluded tag still exists in the source (a renamed tag must not leave a stale
+// exclusion silently narrowing the gate).
+for (const tag in EXCLUDED) {
+  assert(sites.some(s => s.tag === tag), 'W-SRT-3 excluded tag ' + tag + ' still exists in source (reason: ' + EXCLUDED[tag] + ')');
+}
+
+// W-SRT-4 — THE GATE. Each non-excluded site's innermost enclosing block must set a message.
+let silent = [], checked = 0;
+for (const s of sites) {
+  if (EXCLUDED[s.tag]) continue;
+  checked++;
+  const open = scanned.openerOf[s.idx];
+  if (open < 0) { silent.push(s.tag + ':' + lineOf(s.idx) + ' (top level?!)'); continue; }
+  const close = closeOf(src, open);
+  if (close < 0) { silent.push(s.tag + ':' + lineOf(s.idx) + ' (unclosed block?!)'); continue; }
+  const block = src.slice(open, close + 1);
+  if (!MSG_RE.test(block)) silent.push(s.tag + ' @ line ' + lineOf(s.idx));
+}
+assert(silent.length === 0, 'W-SRT-4 every user-triggerable refusal shows a tip in its own block' +
+  (silent.length ? ' — SILENT: [' + silent.join(', ') + ']' : ' (' + checked + ' sites checked)'));
+
+// W-SRT-5 — the gate can actually fail (negative control): a synthetic silent site, run through
+// the same anchoring, must be flagged. A checker that cannot flag anything is not a check.
+(function () {
+  const synth = "function _synthetic() {\n  if (!x) {\n    console.log('§SYNTH_TEST_REJECT reason=x');\n    return;\n  }\n}\n";
+  const sc = scan(synth);
+  const mm = /console\.log\('(§[A-Z0-9_]*?_REJECT)/.exec(synth);
+  const open = sc.openerOf[mm.index];
+  const close = closeOf(synth, open);
+  const flagged = !MSG_RE.test(synth.slice(open, close + 1));
+  assert(sc.eofDepth === 0 && flagged, 'W-SRT-5 negative control: a synthetic silent refusal IS flagged by the same anchoring');
+})();
+
+console.log('§TM_SILENT_REFUSAL_SUMMARY pass=' + pass + ' fail=' + fail + ' sites=' + sites.length);
+process.exit(fail ? 1 : 0);

--- a/viewer/time_machine.js
+++ b/viewer/time_machine.js
@@ -6197,17 +6197,126 @@
     });
   }
 
+  // ── §TM_SILENT_REFUSAL — every refusal the user can trigger gets a visible tip ─────────────────
+  // Implementing the tm-error-handling spec (W-TM-SRT / W-TM-EXC). Before this, ten refusal paths
+  // logged a §..._REJECT/§..._FAIL line and returned: the drag snapped back, the click did nothing,
+  // and the user saw NOTHING (commitGanttDrag :6205/:6210/:6243/:6259, shiftGanttSchedule
+  // :6347/:6363, commitGanttGroupShift :6401/:6418, the dblclick lock gate :6852, openGanttProps
+  // :6934, linkGanttBars :6864 — pre-fix line numbers). Same centralization rationale as
+  // _tmEditLocked above: a tip that has to be re-typed at each new refusal site is a tip that
+  // eventually is not (witness_tm_silent_refusal_tips.js now gates that).
+  function _tmTipRestore(tip) {
+    // _tmSayException below loosens these so its inline action is clickable/wrappable; every
+    // hide (and every fresh show) puts the drawer's original inline contract back.
+    tip.style.pointerEvents = 'none';
+    tip.style.whiteSpace = 'nowrap';
+    tip.style.overflow = 'hidden';
+  }
+  function _tmSay(msg, ms) {
+    var tip = document.getElementById('tm-gantt-tip');
+    if (!tip) return;
+    _tmTipRestore(tip);
+    tip.textContent = msg;
+    tip.style.display = 'block';
+    setTimeout(function () { tip.style.display = 'none'; }, ms || 2600);
+  }
+
+  // ── §TM_EDIT_EXCEPTION — an edit pipeline that THROWS must not leave a stale frame ─────────────
+  // Each edit verb runs a multi-step pipeline (engine verb → retimeTaskElements → resync → annotate
+  // → persist → repaint). Before this, a throw anywhere in it propagated uncaught to
+  // error_reporter.js's sitewide handler (generic "Something went wrong", 3-per-session cap, shared
+  // app-wide) and TM's own display froze on whatever half-updated frame the throw interrupted.
+  // On catch: log, then re-derive the display from the DB's REAL current state. Every recovery step
+  // is an idempotent re-deriver (verified by reading each: _tmResyncAfterRetime re-sorts _ops and
+  // nulls caches; invalidateGanttModel nulls flags; computeDays re-reads _placeOps(); drawGanttMini
+  // rebuilds and redraws; renderAtTime paints visibility at the cursor) — the same five calls every
+  // successful edit already ends with, and undoLastGanttEdit already re-runs after restoring the DB.
+  // Each step is individually guarded so one failing step cannot rob the panel of the rest.
+  function _tmEditExceptionRecover(fnName, e) {
+    console.log('§TM_EDIT_EXCEPTION fn=' + fnName + ' error=' + (e && e.message));
+    try { _tmResyncAfterRetime(); } catch (e2) { console.log('§TM_EDIT_EXCEPTION_RECOVER_SKIP step=resync error=' + (e2 && e2.message)); }
+    try { invalidateGanttModel(); } catch (e2) { console.log('§TM_EDIT_EXCEPTION_RECOVER_SKIP step=invalidate error=' + (e2 && e2.message)); }
+    try { computeDays(); } catch (e2) { console.log('§TM_EDIT_EXCEPTION_RECOVER_SKIP step=computeDays error=' + (e2 && e2.message)); }
+    try { drawGanttMini(); } catch (e2) { console.log('§TM_EDIT_EXCEPTION_RECOVER_SKIP step=draw error=' + (e2 && e2.message)); }
+    try { renderAtTime(_cursor); } catch (e2) { console.log('§TM_EDIT_EXCEPTION_RECOVER_SKIP step=render error=' + (e2 && e2.message)); }
+    try { _tmSayException(e); } catch (e2) { console.log('§TM_EDIT_EXCEPTION_RECOVER_SKIP step=tip error=' + (e2 && e2.message)); }
+  }
+
+  // The TM-specific message (never the sitewide generic toast), plus the ONE concrete, low-risk
+  // mitigation that is actually buildable from what exists: offering to close the OTHER open
+  // panels. "Other panels" is grounded in the app's REAL registry — scene.js's _registerPanel /
+  // window._panels ({id, el, nav, close}), using the exact visibility check _cyclePanel already
+  // uses. The TM panel itself is NOT in that registry (hand-built #time-machine-panel appended to
+  // document.body), so the id filter is belt-and-braces. Closing is ONLY ever user-clicked — the
+  // offer is an inline button in the tip, never an automatic side-effect.
+  function _tmVisibleOtherPanels() {
+    var out = [];
+    var reg = (typeof window !== 'undefined' && window._panels) || [];
+    for (var i = 0; i < reg.length; i++) {
+      var p = reg[i];
+      if (!p || !p.el || p.el.id === 'time-machine-panel') continue;
+      if (p.el.style.display !== 'none' && p.el.offsetWidth > 0) out.push(p);   // _cyclePanel's check
+    }
+    return out;
+  }
+  function _tmSayException(e) {
+    var tip = document.getElementById('tm-gantt-tip');
+    if (!tip) return;
+    var shortReason = (e && e.message) ? String(e.message).slice(0, 90) : 'unexpected error';
+    _tmTipRestore(tip);
+    tip.textContent = 'Time Machine couldn\'t complete this edit — ' + shortReason;
+    var others = [];
+    try { others = _tmVisibleOtherPanels(); } catch (e2) {}
+    var hidden = false;
+    function hide() {
+      if (hidden) return;
+      hidden = true;
+      tip.style.display = 'none';
+      _tmTipRestore(tip);
+    }
+    if (others.length) {
+      var btn = document.createElement('button');
+      btn.textContent = 'Close other panels (' + others.length + ')';
+      btn.style.cssText = 'display:block;margin-top:3px;font-size:10px;padding:1px 6px;cursor:pointer';
+      btn.addEventListener('pointerdown', function (ev) { ev.stopPropagation(); });
+      btn.addEventListener('click', function (ev) {
+        ev.stopPropagation();
+        var ids = [], n = 0;
+        for (var i = 0; i < others.length; i++) {
+          var p = others[i];
+          try {
+            if (typeof p.close === 'function') p.close();
+            else p.el.style.display = 'none';
+            ids.push(p.id); n++;
+          } catch (e3) {}
+        }
+        console.log('§TM_CLOSE_OTHER_PANELS closed=' + n + ' ids=[' + ids.join(',') + ']');
+        hide();
+      });
+      tip.appendChild(btn);
+      // The drawer tip ships pointer-events:none + nowrap/ellipsis (fine for passive text, fatal
+      // for a button) — loosen while the offer is up; hide()/_tmTipRestore puts it all back.
+      tip.style.pointerEvents = 'auto';
+      tip.style.whiteSpace = 'normal';
+      tip.style.overflow = 'visible';
+    }
+    tip.style.display = 'block';
+    setTimeout(hide, others.length ? 8000 : 3600);
+  }
+
   function commitGanttDrag(bar, mode, deltaDays) {
     if (_tmEditLocked('commitGanttDrag')) return;
     var app = A();
     var SA = (typeof window !== 'undefined') && window.ScheduleAuthor;
     if (!app || !app.db || !SA || !SA.moveTaskCascade) {
       console.log('§GANTT_DRAG_REJECT reason=ScheduleAuthor_not_loaded');
+      _tmSay('Not available');   // §TM_SILENT_REFUSAL — same wording as setGanttBaseline/rescheduleGanttAsap's SA guard
       return;
     }
     if (!bar.taskId) {
       // Honest refusal: an un-authored bar has no task to move. Never fake the edit.
       console.log('§GANTT_DRAG_REJECT reason=bar_has_no_task storey="' + bar.storey + '" phase="' + bar.phase + '"');
+      _tmSay('Not editable — no schedule task on this bar');   // §TM_SILENT_REFUSAL — same wording as wireGanttDrag's copy of this refusal
       return;
     }
     var schedId = (_taskIndex && _taskIndex.scheduleId) || 'SCH_AUTHORED';
@@ -6241,10 +6350,14 @@
     var tbBar = tasksBefore[bar.taskId];
     if (!tbBar || !tbBar.start || !tbBar.finish) {
       console.log('§GANTT_DRAG_REJECT reason=no_real_task_snapshot task=' + bar.taskId);
+      _tmSay('Cannot edit — no real dates found for this task');   // §TM_SILENT_REFUSAL
       return;
     }
     var realS0 = Date.parse(tbBar.start + 'T00:00:00Z'), realE0 = Date.parse(tbBar.finish + 'T00:00:00Z');
 
+    // §TM_EDIT_EXCEPTION — the whole pipeline (engine verb → retime → resync → annotate → persist →
+    // repaint), so a throw anywhere in it recovers the display instead of freezing a stale frame.
+    try {
     var res;
     if (mode === 'move') {
       res = SA.moveTaskCascade(app.db, schedId, bar.taskId, d(realS0 + deltaDays * 86400000), {});
@@ -6256,7 +6369,10 @@
         d(realE0), {});
     }
     if (!res || !res.ok) {
+      // §TM_SILENT_REFUSAL — the CLAMPED case below always showed a tip; the outright-failure case
+      // (bad_date / no_such_task / no_tasks / cycle from the engine verb) showed nothing at all.
       console.log('§GANTT_DRAG_REJECT task=' + bar.taskId + ' reason=' + ((res && res.reason) || 'unknown'));
+      _tmSay('Rejected: ' + ((res && res.reason) || 'unknown'));   // same format as the props panel's Rejected: line
       return;
     }
     // C2 feedback: the user must SEE that the drag was refused, not silently land somewhere else.
@@ -6301,6 +6417,7 @@
     // §S73 — the ONLY `return true` in this function. Every refusal above returns undefined, so the
     // __tmGanttDrag test hook can report what actually happened instead of "I found the bar."
     return true;
+    } catch (e) { _tmEditExceptionRecover('commitGanttDrag', e); }   // §TM_EDIT_EXCEPTION — undefined return = "did not commit" (§S73)
   }
   // Test hooks (diagnostic only, same contract as __tmZoneProbe) — §S7's live drag reproduction:
   // a headless probe needs the real commit path and the real computed bars, not a DOM gesture.
@@ -6345,6 +6462,7 @@
     var SA = (typeof window !== 'undefined') && window.ScheduleAuthor;
     if (!app || !app.db || !SA || !SA.shiftSchedule) {
       console.log('§TM_RULER_SHIFT_REJECT reason=ScheduleAuthor_not_loaded');
+      _tmSay('Not available');   // §TM_SILENT_REFUSAL
       return;
     }
     if (!deltaDays) return;   // a click, not a drag — nothing to shift
@@ -6358,9 +6476,11 @@
       });
     } catch (e) {}
 
+    try {   // §TM_EDIT_EXCEPTION — engine verb through final repaint
     var res = SA.shiftSchedule(app.db, schedId, deltaDays);
     if (!res || !res.ok) {
       console.log('§TM_RULER_SHIFT_REJECT reason=' + ((res && res.reason) || 'unknown'));
+      _tmSay('Cannot shift — ' + ((res && res.reason) || 'no schedule'));   // §TM_SILENT_REFUSAL — same shape as "Cannot compress"
       return;
     }
 
@@ -6387,6 +6507,7 @@
     computeDays();
     drawGanttMini();
     renderAtTime(_cursor);
+    } catch (e) { _tmEditExceptionRecover('shiftGanttSchedule', e); }   // §TM_EDIT_EXCEPTION
   }
 
   // §GANTT_GROUP_MOVE — same shape as shiftGanttSchedule, scoped to an explicit marquee-selected
@@ -6399,6 +6520,7 @@
     var SA = (typeof window !== 'undefined') && window.ScheduleAuthor;
     if (!app || !app.db || !SA || !SA.shiftTasks) {
       console.log('§GANTT_GROUP_SHIFT_REJECT reason=ScheduleAuthor_not_loaded');
+      _tmSay('Not available');   // §TM_SILENT_REFUSAL
       return;
     }
     if (!deltaDays || !taskIds || !taskIds.length) return;
@@ -6413,9 +6535,11 @@
       });
     } catch (e) {}
 
+    try {   // §TM_EDIT_EXCEPTION — engine verb through final repaint
     var res = SA.shiftTasks(app.db, taskIds, deltaDays);
     if (!res || !res.ok) {
       console.log('§GANTT_GROUP_SHIFT_REJECT reason=' + ((res && res.reason) || 'unknown'));
+      _tmSay('Cannot move group — ' + ((res && res.reason) || 'no schedule'));   // §TM_SILENT_REFUSAL
       return;
     }
 
@@ -6442,6 +6566,7 @@
     computeDays();
     drawGanttMini();
     renderAtTime(_cursor);
+    } catch (e) { _tmEditExceptionRecover('commitGanttGroupShift', e); }   // §TM_EDIT_EXCEPTION
   }
 
   // §GANTT_EDIT_UNDO — reverse the single most recent commitGanttDrag edit. Restores both halves
@@ -6564,6 +6689,7 @@
       });
     } catch (e) {}
 
+    try {   // §TM_EDIT_EXCEPTION — engine verb through final repaint; a throw returns undefined = "refused" (§S73)
     var res = SA.rescheduleAsap(app.db, schedId, {});
     if (!res || !res.ok) {
       console.log('§GANTT_RESCHEDULE_ASAP_REJECT reason=' + ((res && res.reason) || 'unknown'));
@@ -6605,6 +6731,7 @@
       (res.daysCompressed > 0 ? ' — project finish moved up ' + res.daysCompressed + ' day' + (res.daysCompressed === 1 ? '' : 's')
                               : ' — project finish unchanged (internal float closed)'));
     return true;
+    } catch (e) { _tmEditExceptionRecover('rescheduleGanttAsap', e); }   // §TM_EDIT_EXCEPTION
   }
   // Test hook (diagnostic only, same contract as __tmGanttDrag / __tmZoneProbe): a headless probe
   // needs the REAL commit path — lock check, engine verb, retime, resync, annotate, persist — not a
@@ -6662,6 +6789,7 @@
     // in the gantt chart itself"): a captured schedule is left exactly as imported (never
     // regenerated) and is edited through the SAME drawer lock/drag/link/props surface as any other
     // schedule, once its bars carry real task_ids via the normal cap/injectGantt load path.
+    try {   // §TM_EDIT_EXCEPTION — schedule probe + materialize verb through the refresh
     var act = SA.activeSchedule ? SA.activeSchedule(app.db) : null;
     if (act && act.captured) {
       console.log('§GANTT_AUTHOR_ENTRY captured=' + act.id + ' — leaving it as imported, not regenerating');
@@ -6691,6 +6819,7 @@
     // lighter-weight refresh path whose correctness would need its own separate proof.
     if (typeof window.tmRefoldSchedule === 'function') window.tmRefoldSchedule();
     else { invalidateGanttModel(); computeDays(); drawGanttMini(); renderAtTime(_cursor); }
+    } catch (e) { _tmEditExceptionRecover('generateGanttSchedule', e); }   // §TM_EDIT_EXCEPTION
   }
 
   function wireGanttDrag() {
@@ -6850,6 +6979,15 @@
       if (!hit || !hit.bar.taskId) return;
       if (!_ganttEditable) {  // §GANTT_EDIT_LOCK — same gate as drag, props panel also edits (typed retime + unlink)
         console.log('§GANTT_PROPS_REJECT reason=locked');
+        // §TM_SILENT_REFUSAL — every OTHER lock refusal already says this. Inline tip-set (not
+        // _tmSay) on purpose: wireGanttDrag's sibling refusals use this exact self-contained
+        // pattern, and witness_gantt_edit_lock.js slices this function alone into its sandbox.
+        var t2 = document.getElementById('tm-gantt-tip');
+        if (t2) {
+          t2.textContent = 'Locked — click 🔒 Locked to enable editing';
+          t2.style.display = 'block';
+          setTimeout(function () { t2.style.display = 'none'; }, 2200);
+        }
         return;
       }
       _dragConsumed = true; openGanttProps(hit.bar);
@@ -6861,9 +6999,12 @@
   function linkGanttBars(predBar, succBar) {
     if (_tmEditLocked('linkGanttBars')) return;   // §TM_BAKE_LOCK (§S69)
     var app = A(), SA = (typeof window !== 'undefined') && window.ScheduleAuthor;
-    if (!app || !app.db || !SA || !SA.addDependency) { console.log('§GANTT_LINK_REJECT reason=ScheduleAuthor_not_loaded'); return; }
+    // §TM_SILENT_REFUSAL — this guard returns before the local say() below exists, so it uses the
+    // module-scope _tmSay (the guard used to be the one refusal in this function with no tip).
+    if (!app || !app.db || !SA || !SA.addDependency) { console.log('§GANTT_LINK_REJECT reason=ScheduleAuthor_not_loaded'); _tmSay('Not available'); return; }
     var tip = document.getElementById('tm-gantt-tip');
     function say(msg) { if (tip) { tip.textContent = msg; tip.style.display = 'block'; setTimeout(function () { tip.style.display = 'none'; }, 2600); } }
+    try {   // §TM_EDIT_EXCEPTION — cycle probe + addDependency verb through the final repaint
     if (SA.wouldCycle && SA.wouldCycle(app.db, predBar.taskId, succBar.taskId)) {
       console.log('§GANTT_EDIT_CYCLE_BLOCKED pred=' + predBar.taskId + ' succ=' + succBar.taskId);
       say('Refused — that link would create a cycle');
@@ -6904,6 +7045,7 @@
     _tmAnnotateCpm(schedId);
     _tmPersistEdit('link');   // §S70 — the edit must survive a reload
     invalidateGanttModel(); computeDays(); drawGanttMini(); renderAtTime(_cursor);
+    } catch (e) { _tmEditExceptionRecover('linkGanttBars', e); }   // §TM_EDIT_EXCEPTION
   }
 
   // §GANTT_PROPS (E7) — typed editing + the dependency list (E4 unlink lives here rather than on a
@@ -6932,6 +7074,7 @@
       // Honest refusal, same shape as commitGanttDrag's no_real_task_snapshot: a panel that cannot
       // read the task's real dates must not offer to edit them with made-up ones.
       console.log('§GANTT_PROPS_REJECT reason=no_real_task_dates task=' + bar.taskId);
+      _tmSay('Cannot edit — no real dates found for this task');   // §TM_SILENT_REFUSAL
       return;
     }
     var box = document.getElementById('tm-gantt-props') || (function () {
@@ -7006,6 +7149,7 @@
       // Compare against the REAL dates the panel was populated with (§S72) — comparing the typed
       // value against the TM-clock d(bar.startTs) made "start changed, finish didn't" always true,
       // so a pure finish edit was routed through moveTaskCascade as if it were a move.
+      try {   // §TM_EDIT_EXCEPTION — typed-apply pipeline: engine verb through the final repaint
       var res = (s !== realS && f === realF && SA.moveTaskCascade)
         ? SA.moveTaskCascade(app.db, schedId, bar.taskId, s, {})
         : SA.resizeTask(app.db, schedId, bar.taskId, s, f, {});
@@ -7021,6 +7165,7 @@
       console.log('§GANTT_PROPS_APPLY task=' + bar.taskId + ' start=' + res.start +
         ' clamped=' + res.clamped + ' cascaded=' + res.cascaded);
       invalidateGanttModel(); computeDays(); drawGanttMini(); renderAtTime(_cursor);
+      } catch (e) { _tmEditExceptionRecover('commitGanttProps', e); }   // §TM_EDIT_EXCEPTION — the typed-apply path (props panel Apply)
     };
   }
 


### PR DESCRIPTION
## What

Time Machine error handling, two layers (`viewer/time_machine.js`):

### Part A — silent refusals now show a tip (§TM_SILENT_REFUSAL)

Ten refusal paths logged a `§..._REJECT`/`§..._FAIL` line and returned with **no user-visible message** — the drag snapped back, the click did nothing, only the console knew why. Each now shows a `#tm-gantt-tip` message via a new shared `_tmSay()` helper (same centralization rationale as `_tmEditLocked`), matching the tone/wording of the file's existing tips (pre-fix line numbers):

| Site | Reason | Message now shown |
|---|---|---|
| `commitGanttDrag` :6205 | `ScheduleAuthor_not_loaded` | `Not available` (same wording as setGanttBaseline/rescheduleGanttAsap's SA guard) |
| `commitGanttDrag` :6210 | `bar_has_no_task` (extra site, found by the re-grep) | `Not editable — no schedule task on this bar` (same wording as wireGanttDrag's copy) |
| `commitGanttDrag` :6243 | `no_real_task_snapshot` | `Cannot edit — no real dates found for this task` |
| `commitGanttDrag` :6259 | hard engine failure (`bad_date`/`no_such_task`/`no_tasks`/`cycle`) — only the *clamped* case had a tip | `Rejected: <reason>` (same format as the props panel) |
| `shiftGanttSchedule` :6347 | `ScheduleAuthor_not_loaded` | `Not available` |
| `shiftGanttSchedule` :6363 | engine-verb failure | `Cannot shift — <reason>` |
| `commitGanttGroupShift` :6401 | `ScheduleAuthor_not_loaded` | `Not available` |
| `commitGanttGroupShift` :6418 | engine-verb failure | `Cannot move group — <reason>` |
| dblclick lock gate :6852 | `locked` | `Locked — click 🔒 Locked to enable editing` (matches every other lock refusal; inline tip-set, not `_tmSay` — the first cut used `_tmSay` and the suite caught it crashing `witness_gantt_edit_lock.js`, which slices `wireGanttDrag` alone into its sandbox) |
| `openGanttProps` :6934 | `no_real_task_dates` | `Cannot edit — no real dates found for this task` |
| `linkGanttBars` :6864 | `ScheduleAuthor_not_loaded` (guard ran before the local `say()` existed) | `Not available` via module-scope `_tmSay` |

### Part B — a thrown edit recovers instead of freezing (§TM_EDIT_EXCEPTION)

The 7 edit pipelines (`commitGanttDrag`, `shiftGanttSchedule`, `commitGanttGroupShift`, `rescheduleGanttAsap`, `linkGanttBars`, the props-panel Apply — labelled `commitGanttProps`; there is no standalone function of that name — and `generateGanttSchedule`) each run engine verb → `retimeTaskElements` → `_tmResyncAfterRetime` → `_tmAnnotateCpm` → `_tmPersistEdit` → repaint with **no try/catch**: a throw propagated uncaught to `error_reporter.js`'s sitewide handler (generic "Something went wrong" toast, rate-limited to 3 per session across the whole app) and TM froze on a half-updated frame.

Now each pipeline is wrapped (verb through final repaint). On catch, `_tmEditExceptionRecover(fn, e)`:
1. logs `§TM_EDIT_EXCEPTION fn=<name> error=<msg>`;
2. re-runs the five idempotent re-derivers (`_tmResyncAfterRetime`, `invalidateGanttModel`, `computeDays`, `drawGanttMini`, `renderAtTime(_cursor)`) — each individually guarded — so the panel re-renders from the DB's real current state (idempotency verified by reading each: they re-derive, never accumulate; they're the same five calls every successful edit already ends with, and undo already re-runs them after a DB restore);
3. shows a **TM-specific** tip: `Time Machine couldn't complete this edit — <shortReason>`;
4. when 1+ *other* panels are visible, offers (never auto-executes) `Close other panels (n)` as an inline button in the tip. "Other panels" is grounded in the real registry — `scene.js` `_registerPanel`/`window._panels` (`{id, el, nav, close}`), filtered with the exact visibility check `_cyclePanel` uses (`display !== 'none' && offsetWidth > 0`) and excluding `time-machine-panel` (confirmed still hand-built and appended to `document.body`, never registered). Clicking closes each via `.close()` when present else `display='none'`, and logs `§TM_CLOSE_OTHER_PANELS closed=n ids=[...]`.

Deliberately scoped to catching a genuine mid-edit JS exception — no memory-pressure prediction heuristics.

`viewer/sw.js` `CACHE_VERSION` v1080 → **v1081** (mandatory same-PR bump for any `time_machine.js` change).

## Witness proof

**`viewer/tests/witness_tm_silent_refusal_tips.js` (W-TM-SRT)** — enumerates every `_REJECT`/`_FAIL` log call in the *current* source and requires a tip-set inside the same brace-anchored enclosing block, so a future refusal path added without a message fails the suite instead of shipping silent. Anchoring follows the §4(d) lesson (no text-slicing): a string/comment/template-aware brace scanner with an EOF `depth===0` self-check, plus a negative control proving the gate can actually flag a synthetic silent site. It caught 4 sites beyond the brief's list on its first run (`§LOAD_FAIL` ×2, `§GHOST_GROUND_TRIGGER_FAIL` ×2) — all four verified non-gesture paths and excluded with stated reasons.

```
── witness_tm_silent_refusal_tips (W-TM-SRT) ──
  PASS W-SRT-0 scanner self-check: EOF depth=0 in code mode — block anchoring is trustworthy
  PASS W-SRT-1 _tmSay (shared #tm-gantt-tip helper) is defined
  PASS W-SRT-2 enumerator found 25 _REJECT/_FAIL log sites (>= 18 — not vacuous)
  PASS W-SRT-3 excluded tag §GANTT_SCHEDULE_STALE_REGEN_FAIL still exists in source (...)
  PASS W-SRT-3 excluded tag §LOAD_FAIL still exists in source (...)
  PASS W-SRT-3 excluded tag §GHOST_GROUND_TRIGGER_FAIL still exists in source (...)
  PASS W-SRT-4 every user-triggerable refusal shows a tip in its own block (20 sites checked)
  PASS W-SRT-5 negative control: a synthetic silent refusal IS flagged by the same anchoring
§TM_SILENT_REFUSAL_SUMMARY pass=8 fail=0 sites=25
```

**`viewer/tests/witness_tm_edit_exception.js` (W-TM-EXC)** — static brace-anchored check that all 7 pipelines carry the labelled catch, plus a vm run of the REAL `commitGanttDrag`/`shiftGanttSchedule` + real recovery helpers with a throwing engine verb:

```
  PASS W-EXC-1 ×7 (all pipelines wrapped, each with its own fn label)
  PASS W-EXC-2 §TM_EDIT_EXCEPTION logged with fn=commitGanttDrag and the real error
  PASS W-EXC-2b a caught throw returns undefined = "did not commit" (§S73 hook contract)
  PASS W-EXC-3 ALL five recovery re-derivers ran after the throw — no stale frame
  PASS W-EXC-3b _tmPersistEdit did NOT run on the failed edit
  PASS W-EXC-4 TM-specific tip shown via #tm-gantt-tip
  PASS W-EXC-6 NO close-offer when no other panel is visible
  PASS W-EXC-6b tip keeps pointer-events:none when no action is offered
  PASS W-EXC-5 close-offer rendered, counting exactly the 2 visible others
  PASS W-EXC-5b tip made clickable/wrappable while the offer is up
  PASS W-EXC-7 NOTHING is closed before the user clicks
  PASS W-EXC-5c panel WITH a close fn closed via close()
  PASS W-EXC-5d panel WITHOUT a close fn hidden via display=none
  PASS W-EXC-5e the TM panel and the hidden panel were NOT touched
  PASS W-EXC-5f §TM_CLOSE_OTHER_PANELS closed=2 ids=[clash,section]
  PASS W-EXC-5g tip hidden and pointer-events contract restored after the action
  PASS W-EXC-2c shiftGanttSchedule labels its own catch
§TM_EDIT_EXCEPTION_SUMMARY pass=23 fail=0
```

**Full suite** (`node tests/run_witness_suite.js`), baseline on origin/main 0632985 vs. this branch:

```
baseline: §SUITE_SUMMARY green=47 new_red=0 known_red=3 fixed=1 flaky=0 total=51   (exit 0)
after:    §SUITE_SUMMARY green=49 new_red=0 known_red=3 fixed=1 flaky=0 total=53   (exit 0)
```

+2 green = the two new witnesses, both gating (headless class). An intermediate suite run also earned its keep: the first cut of the dblclick lock tip used `_tmSay` and crashed `witness_gantt_edit_lock.js` (which slices `wireGanttDrag` alone into its vm sandbox) — fixed by using the function's own self-contained inline tip pattern, and the suite re-run confirms zero new red.

(`fixed=1` = `witness_gantt_lock_integrity.js`, already green on origin/main before this branch — its KNOWN_RED drain belongs to the lane that fixed it, not this PR.)

`witness_tm_bake_lock.js` re-run directly against the modified source: 17/17 PASS (its idle-path asserts anchor on downstream logs/stub counts that still fire before any new free-var reference).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017tZaBhZUdSQMcYnPqyApfN
