### PR TITLE
feat(readiness): §TRACKB — step 9 reads a real IFC and measures it, in the browser

### DIFF
--- a/readiness/assess.html
+++ b/readiness/assess.html
@@ -1,3 +1,4 @@
+<meta charset="utf-8">
 <title>OpenBIM Readiness Toolkit</title>
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
@@ -239,6 +240,8 @@ footer{
   font-family:"IBM Plex Mono",monospace;font-size:11.5px;color:var(--faint);line-height:1.8
 }
 footer a{color:var(--muted)}
+.prog{height:6px;border-radius:3px;background:var(--surface-3);margin:11px auto;max-width:340px;overflow:hidden}
+.progbar{height:100%;width:2%;background:var(--accent);border-radius:3px;transition:width .2s}
 .langbar{
   display:flex;align-items:center;gap:10px;flex-wrap:wrap;
   padding:11px 0;border-bottom:1px solid var(--rule-soft)
@@ -846,60 +849,52 @@ SCREENS.model = function () { return '' +
   'A file you choose will be read <strong>here, in your browser</strong>, never uploaded &mdash; ' +
   'measured against what you told us, and opened by software that is not the software you authored ' +
   'it in.</p>' +
-  '<div class="call warnc" style="margin-bottom:16px"><strong>Not built yet.</strong> In v0.1 this ' +
-  'screen is a worked example and the figures below come from a sample model, not from a file of ' +
-  'yours. Nothing here reads, uploads or stores anything. The engine that will do the reading is ' +
-  'already in use elsewhere in the platform &mdash; it parses IFC in a browser worker, with no ' +
-  'server and no upload &mdash; and connecting it is the next piece of work.</div>' +
-
-  '<div class="drop filled" id="drop">' +
-    '<div style="display:flex;gap:13px;align-items:center;flex-wrap:wrap">' +
-      '<div class="brandmark" style="background:var(--accent-wash);color:var(--accent-ink)">IFC</div>' +
-      '<div style="flex:1;min-width:170px">' +
-        '<div style="font-weight:600;font-size:15px">Tower_ARC_Rev04.ifc</div>' +
-        '<div class="small mono">IFC2X3 · 84.2 MB · read locally · 12,847 elements</div>' +
-      '</div>' +
-      '<button class="btn sec sm" type="button">Choose a different file</button>' +
+  '<input type="file" id="ifcfile" accept=".ifc,.IFC" hidden>' +
+  '<div class="drop" id="drop" tabindex="0" role="button" ' +
+       'aria-label="Choose an IFC file, or drop one here">' +
+    '<div id="dropidle">' +
+      '<div style="font-weight:600;font-size:15.5px">Drop an IFC file here, or click to choose one</div>' +
+      '<div class="small" style="margin-top:6px">It is read in this browser tab and is never ' +
+      'uploaded. Nothing is stored. Closing the tab discards it. The page itself loads webfonts ' +
+      'from Google; <strong>your file is never part of any request</strong>.</div>' +
+      '<div class="small mono" style="margin-top:8px">IFC2x3 · IFC4 · IFC4x3</div>' +
     '</div>' +
+    '<div id="dropbusy" hidden>' +
+      '<div style="font-weight:600;font-size:15.5px" id="busyphase">Reading…</div>' +
+      '<div class="prog"><div class="progbar" id="progbar"></div></div>' +
+      '<div class="small mono" id="busyname"></div>' +
+    '</div>' +
+    '<div id="dropdone" hidden>' +
+      '<div style="display:flex;gap:13px;align-items:center;flex-wrap:wrap">' +
+        '<div class="brandmark" style="background:var(--accent-wash);color:var(--accent-ink)">IFC</div>' +
+        '<div style="flex:1;min-width:170px;text-align:left">' +
+          '<div style="font-weight:600;font-size:15px" id="donename"></div>' +
+          '<div class="small mono" id="donemeta"></div>' +
+        '</div>' +
+        '<button class="btn sec sm" type="button" id="rechoose">Choose a different file</button>' +
+      '</div>' +
+      '<p class="small" style="margin:12px 0 0;text-align:left">This is your model, read by ' +
+      'software that is not the software you authored it in. That is question ' +
+      '<span class="mono">A3</span>, answered.</p>' +
+    '</div>' +
+    '<div id="droperr" class="small" hidden style="color:var(--warn)"></div>' +
   '</div>' +
 
   '<div class="card">' +
     '<h3>What the file contains</h3>' +
-    '<dl class="mgrid" style="margin-top:13px">' +
-      '<div class="mcell"><dt>Schema</dt><dd class="mono">IFC2X3</dd></div>' +
-      '<div class="mcell"><dt>Elements</dt><dd class="mono">12,847</dd></div>' +
-      '<div class="mcell"><dt>Spatial chain</dt><dd>Complete</dd></div>' +
-      '<div class="mcell flag"><dt>Spaces (rooms)</dt><dd class="mono">0</dd></div>' +
-      '<div class="mcell flag"><dt>Classified</dt><dd class="mono">4.2<span class="unit">%</span></dd></div>' +
-      '<div class="mcell flag"><dt>Property sets</dt><dd class="mono">39<span class="unit">%</span></dd></div>' +
-      '<div class="mcell flag"><dt>Quantities</dt><dd>Absent</dd></div>' +
-      '<div class="mcell flag"><dt>Duplicate GUIDs</dt><dd class="mono">47</dd></div>' +
-    '</dl>' +
-    '<p class="small" style="margin-top:14px"><strong>Sample figures.</strong> Once wired these will ' +
-    'be counted from your file directly and not from anything we stored &mdash; your model&rsquo;s ' +
-    'numbers, not our extractor&rsquo;s view of it. What is checked is not this platform&rsquo;s ' +
-    'preference: spaces, classification, types and quantities are what any open-standard consumer ' +
-    'needs. <strong>A model that fails these fails them all.</strong></p>' +
+    '<dl class="mgrid" style="margin-top:13px" id="mgrid">' + figuresHTML() + '</dl>' +
+    '<p class="small" style="margin-top:14px" id="figsrc">' + figuresNote() + '</p>' +
   '</div>' +
 
   '<div class="card">' +
     '<h3>Exactly what would leave your browser</h3>' +
     '<p class="small" style="margin:9px 0 13px">Numbers and fixed categories only. No file, no names, no GUIDs, ' +
     'no coordinates, no free text.</p>' +
-    '<pre class="payload">{\n' +
+    '<pre class="payload" id="payloadbox">{\n' +
       '  "locale":        "AE",\n' +
       '  "firm_size":     "11-50",\n' +
       '  "firm_type":     "engineering",\n' +
-      '  "answers":       [1,2,0,1, 1,1,2,1, 2,2,3,2, 3,1,4,0, 1,2,1,1],\n' +
-      '  "schema":        "IFC2X3",\n' +
-      '  "elements":      12847,\n' +
-      '  "spaces":        0,\n' +
-      '  "classified_pc": 4.2,\n' +
-      '  "psets_pc":      39.0,\n' +
-      '  "quantities":    false,\n' +
-      '  "georef":        true,\n' +
-      '  "dup_guids":     47,\n' +
-      '  "exporter":      "other",\n' +
+      '  "answers":       [' + answerVector() + '],\n' + payloadModelLines() +
       '  "toolkit":       "v0.1",\n' +
       '  "kb":            "core-0.1 / ae-v1"' + (LANGS[LANG].pack === 'en-v1' ? '' : ',') + '\n' +
       (LANGS[LANG].pack === 'en-v1' ? '' : '  "lang":          "' + LANGS[LANG].pack + '"\n') +
@@ -1183,6 +1178,191 @@ function L(en, id, field, i) {
   var v = (id ? tr(id, field, i) : null);
   return (v === null || v === undefined || v === '') ? en : v;
 }
+
+
+/* ============================================================
+   TRACK B — measuring the respondent's own model  (§STORY act 2)
+   The file is read by metrics_worker.js, which calls the same web-ifc build the viewer uses,
+   in a Web Worker, at the web-ifc layer. Nothing is uploaded, fetched or stored: no network
+   call, no IndexedDB, no cookie. Closing the tab discards everything.
+
+   MEASURED is the sample model until a real file is read. Every figure and every payload line
+   below states which of the two it is — a sample figure is never allowed to look measured.
+   ============================================================ */
+
+var SAMPLE = {
+  sample: true, filename: 'Tower_ARC_Rev04.ifc', size_mb: 84.2,
+  schema: 'IFC2X3', elements: 12847, spatial_chain_complete: true, spaces: 0,
+  classified_pc: 4.2, psets_pc: 39.0, quantities: false, quantities_pc: 0,
+  georef: true, dup_guids: 47, exporter: 'other',
+  storeys: 0, storeys_with_spaces_pc: 0, materials_pc: 0, typed_pc: 0,
+  named_pc: 0, orphans: 0, orphans_pc: 0, space_boundaries: false
+};
+var MEASURED = SAMPLE;
+
+function nfmt(n) { return (typeof n === 'number' ? n : 0).toLocaleString('en-US'); }
+function cell(label, value, flag) {
+  return '<div class="mcell' + (flag ? ' flag' : '') + '"><dt>' + label + '</dt><dd>' + value + '</dd></div>';
+}
+function mono(v) { return '<dd class="mono">' + v + '</dd>'; }
+
+function figuresHTML() {
+  var m = MEASURED;
+  function num(label, v, flag) {
+    return '<div class="mcell' + (flag ? ' flag' : '') + '"><dt>' + label +
+           '</dt><dd class="mono">' + v + '</dd></div>';
+  }
+  function pct(label, v, flag) {
+    return '<div class="mcell' + (flag ? ' flag' : '') + '"><dt>' + label +
+           '</dt><dd class="mono">' + v + '<span class="unit">%</span></dd></div>';
+  }
+  return num('Schema', m.schema) +
+    num('Elements', nfmt(m.elements)) +
+    cell('Spatial chain', m.spatial_chain_complete ? 'Complete' : 'Incomplete', !m.spatial_chain_complete) +
+    num('Spaces (rooms)', nfmt(m.spaces), m.spaces === 0) +
+    pct('Classified', m.classified_pc, m.classified_pc < 50) +
+    pct('Property sets', m.psets_pc, m.psets_pc < 50) +
+    cell('Quantities', m.quantities ? 'Present' : 'Absent', !m.quantities) +
+    num('Duplicate GUIDs', nfmt(m.dup_guids), m.dup_guids > 0);
+}
+
+function figuresNote() {
+  if (MEASURED.sample) {
+    return '<strong>Sample figures &mdash; not your model.</strong> Drop a file above and these ' +
+      'become counts from it. What is checked is not this platform&rsquo;s preference: spaces, ' +
+      'classification, types and quantities are what any open-standard consumer needs. ' +
+      '<strong>A model that fails these fails them all.</strong>';
+  }
+  return '<strong>Measured from your file, in this browser tab.</strong> Counted directly from the ' +
+    'IFC and not from anything we stored &mdash; your model&rsquo;s numbers, not our ' +
+    'extractor&rsquo;s view of it. What is checked is not this platform&rsquo;s preference: spaces, ' +
+    'classification, types and quantities are what any open-standard consumer needs. ' +
+    '<strong>A model that fails these fails them all.</strong>';
+}
+
+function answerVector() {
+  var out = [];
+  DIMENSIONS.forEach(function (d) {
+    d.items.forEach(function (it) { out.push(STATE.answers[it.id]); });
+  });
+  return out.join(',');
+}
+
+/* Only fixed categories, numbers and booleans. No filename, no GUID, no coordinate, no name. */
+function payloadModelLines() {
+  var m = MEASURED, L = [];
+  function add(k, v) { L.push('  "' + k + '":' + Array(Math.max(1, 16 - k.length)).join(' ') + v + ',\n'); }
+  add('measured', m.sample ? 'false' : 'true');
+  add('schema', '"' + m.schema + '"');
+  add('elements', m.elements);
+  add('spaces', m.spaces);
+  add('classified_pc', m.classified_pc);
+  add('psets_pc', m.psets_pc);
+  add('quantities', m.quantities ? 'true' : 'false');
+  add('georef', m.georef ? 'true' : 'false');
+  add('dup_guids', m.dup_guids);
+  add('exporter', '"' + m.exporter + '"');
+  return L.join('');
+}
+
+/* ---- driving the worker ---- */
+var MW = null, MWbusy = false;
+
+function mwEl(id) { return document.getElementById(id); }
+function mwShow(which, err) {
+  ['dropidle', 'dropbusy', 'dropdone'].forEach(function (k) {
+    var el = mwEl(k); if (el) el.hidden = (k !== which);
+  });
+  var e = mwEl('droperr');
+  if (e) { e.hidden = !err; e.textContent = err || ''; }
+  var d = mwEl('drop');
+  if (d) d.className = 'drop' + (which === 'dropdone' ? ' filled' : '');
+}
+
+function readIFC(file) {
+  if (!file || MWbusy) return;
+  if (!/\.ifc$/i.test(file.name)) { mwShow('dropidle', 'That is not an .ifc file.'); return; }
+  MWbusy = true;
+  mwShow('dropbusy');
+  var bn = mwEl('busyname'); if (bn) bn.textContent = file.name + ' · ' + (file.size / 1048576).toFixed(1) + ' MB';
+  var setPct = function (p, phase) {
+    var bar = mwEl('progbar'); if (bar) bar.style.width = Math.max(2, Math.min(100, p)) + '%';
+    var ph = mwEl('busyphase'); if (ph && phase) ph.textContent = phase + '…';
+  };
+  setPct(2, 'Reading the file');
+
+  try { if (MW) MW.terminate(); } catch (e) {}
+  try { MW = new Worker('metrics_worker.js'); }
+  catch (e) { MWbusy = false; mwShow('dropidle', 'This browser blocked the local reader. Nothing was sent anywhere.'); return; }
+
+  MW.onmessage = function (ev) {
+    var d = ev.data || {};
+    if (d.type === 'progress') { setPct(d.pct, d.phase); return; }
+    if (d.type === 'error') {
+      MWbusy = false; mwShow('dropidle', d.message || 'The file could not be read.');
+      try { MW.terminate(); } catch (e) {} MW = null; return;
+    }
+    if (d.type === 'done') {
+      MWbusy = false;
+      var m = d.metrics || {};
+      m.sample = false;
+      m.filename = file.name;
+      m.size_mb = +(file.size / 1048576).toFixed(1);
+      MEASURED = m;
+      var dn = mwEl('donename'); if (dn) dn.textContent = file.name;
+      var dm = mwEl('donemeta');
+      if (dm) dm.textContent = m.schema + ' · ' + m.size_mb + ' MB · read locally · ' + nfmt(m.elements) + ' elements';
+      mwShow('dropdone');
+      var grid = mwEl('mgrid'); if (grid) grid.innerHTML = figuresHTML();
+      var note = mwEl('figsrc'); if (note) note.innerHTML = figuresNote();
+      /* Refresh the payload in place. Calling show('model') here would rebuild the drop zone and
+         throw away the done-state the respondent has just reached. */
+      var pb = mwEl('payloadbox');
+      if (pb) {
+        var txt = pb.textContent, a = txt.indexOf('  "measured"'), t2 = txt.indexOf('  "toolkit"');
+        if (a < 0) a = txt.indexOf('  "schema"');
+        if (a > 0 && t2 > a) pb.textContent = txt.slice(0, a) + payloadModelLines() + txt.slice(t2);
+      }
+      try { MW.terminate(); } catch (e) {} MW = null;
+    }
+  };
+  MW.onerror = function () {
+    MWbusy = false; mwShow('dropidle', 'The local reader failed to start. Nothing was sent anywhere.');
+  };
+
+  file.arrayBuffer().then(function (buf) {
+    MW.postMessage({ arrayBuffer: buf, filename: file.name }, [buf]);
+  }).catch(function () {
+    MWbusy = false; mwShow('dropidle', 'The file could not be opened.');
+  });
+}
+
+document.addEventListener('click', function (e) {
+  var t = e.target;
+  if (t && (t.id === 'rechoose' || (t.closest && t.closest('#drop') && !MWbusy))) {
+    var inp = mwEl('ifcfile'); if (inp) inp.click();
+  }
+});
+document.addEventListener('change', function (e) {
+  if (e.target && e.target.id === 'ifcfile' && e.target.files && e.target.files[0]) readIFC(e.target.files[0]);
+});
+['dragenter', 'dragover'].forEach(function (n) {
+  document.addEventListener(n, function (e) {
+    var d = e.target && e.target.closest && e.target.closest('#drop');
+    if (d) { e.preventDefault(); d.style.borderColor = 'var(--accent)'; }
+  });
+});
+document.addEventListener('dragleave', function (e) {
+  var d = e.target && e.target.closest && e.target.closest('#drop');
+  if (d) d.style.borderColor = '';
+});
+document.addEventListener('drop', function (e) {
+  var d = e.target && e.target.closest && e.target.closest('#drop');
+  if (!d) return;
+  e.preventDefault(); d.style.borderColor = '';
+  var f = e.dataTransfer && e.dataTransfer.files && e.dataTransfer.files[0];
+  if (f) readIFC(f);
+});
 
 /* ============================================================
    THE GUIDED CONVERSATION — §LLM_BRIDGE

--- a/readiness/assess.html
+++ b/readiness/assess.html
@@ -249,6 +249,7 @@ footer a{color:var(--muted)}
 .langbar label{font-family:"Instrument Sans",sans-serif;font-size:12px;font-weight:600;
   letter-spacing:.04em;text-transform:uppercase;color:var(--muted)}
 .langbar select{
+  flex:0 0 auto;width:auto;max-width:220px;
   font-family:"Instrument Sans",sans-serif;font-size:13.5px;color:var(--ink);
   background:var(--surface);border:1px solid var(--rule);border-radius:6px;padding:5px 9px
 }

--- a/readiness/disclaimer.html
+++ b/readiness/disclaimer.html
@@ -1,3 +1,4 @@
+<meta charset="utf-8">
 <title>Disclaimer Notice</title>
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>

--- a/readiness/faq.html
+++ b/readiness/faq.html
@@ -1,3 +1,4 @@
+<meta charset="utf-8">
 <title>OpenBIM Basics</title>
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>

--- a/readiness/index.html
+++ b/readiness/index.html
@@ -1,3 +1,4 @@
+<meta charset="utf-8">
 <title>OpenBIM Readiness</title>
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>

--- a/readiness/metrics_worker.js
+++ b/readiness/metrics_worker.js
@@ -1,0 +1,297 @@
+/**
+ * OpenBIM Readiness Assessment Toolkit — Track B metrics worker
+ * Copyright (c) 2025-2026 Redhuan D. Oon <red1org@gmail.com>
+ * SPDX-License-Identifier: MIT
+ *
+ * Calls web-ifc (MPL-2.0, That Open Company), vendored same-origin at ../viewer/lib/.
+ *
+ * WHAT THIS IS
+ *   Track B of the assessment: what the respondent's model actually contains, measured rather
+ *   than reported. Implements SCORING_SPEC.md §5.1 metrics M1-M15.
+ *
+ * WHY IT IS NOT import_worker.js
+ *   PROMPT.md §ROADMAP is explicit: "Track B metrics at the web-ifc layer ... NEVER from the
+ *   extracted DB (lossy projection)." import_worker.js exists to build renderable geometry and
+ *   sql.js DBs; that projection drops exactly the semantic detail these metrics count. So this
+ *   reads the same parser at the same layer, and computes nothing but counts.
+ *   It requests NO geometry, writes NO database and touches NO storage.
+ *
+ * PRIVACY — this is load-bearing, not a nicety
+ *   Nothing leaves the browser. No fetch, no upload, no IndexedDB. The only thing that ever
+ *   crosses back to the page is the counts object below: integers, percentages and booleans.
+ *   No GUID, no coordinate, no element name, no free text. The one string taken from the model
+ *   is the schema; the exporting application is matched against a fixed allowlist and anything
+ *   unrecognised becomes "other".
+ *
+ * Input:  postMessage({ arrayBuffer, filename })
+ * Output: postMessage({ type:'progress', pct, phase })
+ *         postMessage({ type:'done', metrics })
+ *         postMessage({ type:'error', message })
+ */
+
+try {
+  importScripts('../viewer/lib/web-ifc-api-iife.js');
+  console.log('[READINESS] §MW_SRC local ../viewer/lib/web-ifc-api-iife.js');
+} catch (e) {
+  console.warn('[READINESS] §MW_SRC_FALLBACK local failed (' + e.message + '), trying CDN');
+  importScripts('https://unpkg.com/web-ifc@0.0.77/web-ifc-api-iife.js');
+  console.log('[READINESS] §MW_SRC cdn unpkg');
+}
+
+function post(type, extra) {
+  var msg = { type: type };
+  for (var k in extra) if (Object.prototype.hasOwnProperty.call(extra, k)) msg[k] = extra[k];
+  self.postMessage(msg);
+}
+function progress(pct, phase) { post('progress', { pct: pct, phase: phase }); }
+
+/* M2: a fixed allowlist. Anything not on it is reported as "other" — we never ship a vendor
+   string we did not anticipate, because that is free text off someone's model. */
+var EXPORTERS = [
+  ['revit', 'Autodesk Revit'], ['autodesk', 'Autodesk'], ['archicad', 'Graphisoft Archicad'],
+  ['graphisoft', 'Graphisoft'], ['tekla', 'Trimble Tekla'], ['trimble', 'Trimble'],
+  ['allplan', 'Allplan'], ['vectorworks', 'Vectorworks'], ['bentley', 'Bentley'],
+  ['microstation', 'Bentley MicroStation'], ['aecosim', 'Bentley AECOsim'],
+  ['solibri', 'Solibri'], ['blender', 'Blender / Bonsai'], ['bonsai', 'Blender / Bonsai'],
+  ['ifcopenshell', 'IfcOpenShell'], ['freecad', 'FreeCAD'], ['sketchup', 'SketchUp'],
+  ['rhino', 'Rhino'], ['civil 3d', 'Autodesk Civil 3D'], ['advance steel', 'Autodesk Advance Steel'],
+  ['edificius', 'Edificius'], ['bricscad', 'BricsCAD'], ['plannerly', 'Plannerly'],
+  ['bim-ootb', 'BIM-OOTB'], ['bimootb', 'BIM-OOTB']
+];
+function matchExporter(s) {
+  if (!s) return 'other';
+  var low = String(s).toLowerCase();
+  for (var i = 0; i < EXPORTERS.length; i++) if (low.indexOf(EXPORTERS[i][0]) !== -1) return EXPORTERS[i][1];
+  return 'other';
+}
+
+function idsOf(api, modelID, typeConst) {
+  if (typeConst === undefined || typeConst === null) return [];
+  try {
+    var v = api.GetLineIDsWithType(modelID, typeConst), out = [];
+    for (var i = 0; i < v.size(); i++) out.push(v.get(i));
+    return out;
+  } catch (e) { return []; }
+}
+function line(api, modelID, id) { try { return api.GetLine(modelID, id); } catch (e) { return null; } }
+function val(x) { return (x && typeof x === 'object' && 'value' in x) ? x.value : x; }
+function asArray(x) { return x == null ? [] : (Array.isArray(x) ? x : [x]); }
+function pc(n, d) { return d > 0 ? +( (n / d) * 100 ).toFixed(1) : 0; }
+
+self.onmessage = async function (e) {
+  var arrayBuffer = e.data.arrayBuffer;
+  if (!arrayBuffer) { post('error', { message: 'No file data received.' }); return; }
+
+  var api, modelID = -1;
+  try {
+    progress(4, 'Starting the IFC parser');
+    api = new WebIFC.IfcAPI();
+    await api.Init(function (path) { return '../viewer/lib/' + path; }, true);
+
+    progress(12, 'Reading the file');
+    var data = new Uint8Array(arrayBuffer);
+    try {
+      /* No geometry is requested anywhere in this worker — these are parse settings only. */
+      modelID = api.OpenModel(data, { COORDINATE_TO_ORIGIN: false, USE_FAST_BOOLS: false, OPTIMIZE_PROFILES: false });
+    } catch (parseErr) {
+      var m = String(parseErr && parseErr.message || parseErr);
+      post('error', { message: m.indexOf('Unsupported Schema') !== -1
+        ? 'That IFC schema is not supported. This reads IFC2x3, IFC4 and IFC4x3.'
+        : 'The file could not be parsed as IFC.' });
+      return;
+    }
+    if (modelID < 0) { post('error', { message: 'The file could not be parsed as IFC. Supported: IFC2x3, IFC4, IFC4x3.' }); return; }
+
+    var M = {};
+
+    /* ---- M1 schema ------------------------------------------------------------------ */
+    var schema = 'unknown';
+    try { schema = String(api.GetModelSchema(modelID) || 'unknown').toUpperCase(); } catch (e2) {}
+    M.schema = schema;
+
+    /* ---- M2 exporting application (allowlist, else "other") -------------------------- */
+    var exporter = 'other';
+    try {
+      var hdr = api.GetHeaderLine(modelID, WebIFC.FILE_NAME);
+      if (hdr && hdr.arguments) {
+        var joined = hdr.arguments.map(function (a) {
+          return asArray(a).map(function (x) { return val(x); }).join(' ');
+        }).join(' ');
+        exporter = matchExporter(joined);
+      }
+    } catch (e3) {}
+    if (exporter === 'other') {
+      var apps = idsOf(api, modelID, WebIFC.IFCAPPLICATION);
+      for (var ai = 0; ai < apps.length && exporter === 'other'; ai++) {
+        var app = line(api, modelID, apps[ai]);
+        if (app) exporter = matchExporter([val(app.ApplicationFullName), val(app.ApplicationIdentifier)].join(' '));
+      }
+    }
+    M.exporter = exporter;
+
+    progress(30, 'Counting elements');
+
+    /* ---- element set: every type the schema calls an IfcElement ---------------------- */
+    var elementIds = new Set(), byType = {};
+    var allTypes = [];
+    try { allTypes = api.GetIfcEntityList(modelID) || []; } catch (e4) {}
+    for (var t = 0; t < allTypes.length; t++) {
+      var code = allTypes[t];
+      var isEl = false;
+      try { isEl = api.IsIfcElement(code); } catch (e5) { isEl = false; }
+      if (!isEl) continue;
+      var ids = idsOf(api, modelID, code);
+      if (!ids.length) continue;
+      var name = 'IFCELEMENT';
+      try { name = api.GetNameFromTypeCode(code) || name; } catch (e6) {}
+      byType[name] = (byType[name] || 0) + ids.length;
+      for (var q = 0; q < ids.length; q++) elementIds.add(ids[q]);
+    }
+    var elements = Array.from(elementIds);
+    var N = elements.length;
+    M.elements = N;                                   /* M3 */
+    M.types_present = Object.keys(byType).length;
+    M.top_types = Object.keys(byType).sort(function (a, b) { return byType[b] - byType[a]; })
+                    .slice(0, 8).map(function (k) { return { type: k, n: byType[k] }; });
+
+    if (N === 0) { post('error', { message: 'The file parsed, but it contains no IFC elements.' }); return; }
+
+    progress(45, 'Checking the spatial chain');
+
+    /* ---- M4 spatial chain, M5 spaces -------------------------------------------------- */
+    var projects = idsOf(api, modelID, WebIFC.IFCPROJECT);
+    var sites    = idsOf(api, modelID, WebIFC.IFCSITE);
+    var bldgs    = idsOf(api, modelID, WebIFC.IFCBUILDING);
+    var storeys  = idsOf(api, modelID, WebIFC.IFCBUILDINGSTOREY);
+    var spaces   = idsOf(api, modelID, WebIFC.IFCSPACE);
+    M.spatial_chain = { project: projects.length, site: sites.length, building: bldgs.length, storey: storeys.length };
+    M.spatial_chain_complete = !!(projects.length && sites.length && bldgs.length && storeys.length);
+    M.spaces = spaces.length;                          /* M5 */
+
+    /* which storeys carry at least one space — via IfcRelAggregates */
+    var storeySet = new Set(storeys), spaceSet = new Set(spaces), storeysWithSpace = new Set();
+    var aggs = idsOf(api, modelID, WebIFC.IFCRELAGGREGATES);
+    for (var g = 0; g < aggs.length; g++) {
+      var rel = line(api, modelID, aggs[g]); if (!rel) continue;
+      var parent = val(rel.RelatingObject && rel.RelatingObject.value !== undefined ? rel.RelatingObject : rel.RelatingObject);
+      var pid = (rel.RelatingObject && rel.RelatingObject.value) || parent;
+      if (!storeySet.has(pid)) continue;
+      var kids = asArray(rel.RelatedObjects);
+      for (var kk = 0; kk < kids.length; kk++) if (spaceSet.has(kids[kk] && kids[kk].value)) { storeysWithSpace.add(pid); break; }
+    }
+    M.storeys = storeys.length;
+    M.storeys_with_spaces_pc = pc(storeysWithSpace.size, storeys.length);
+
+    progress(58, 'Checking classification and properties');
+
+    /* ---- M6 classification ------------------------------------------------------------ */
+    var classified = new Set();
+    var relCls = idsOf(api, modelID, WebIFC.IFCRELASSOCIATESCLASSIFICATION);
+    for (var c = 0; c < relCls.length; c++) {
+      var rc = line(api, modelID, relCls[c]); if (!rc) continue;
+      asArray(rc.RelatedObjects).forEach(function (o) { if (o && elementIds.has(o.value)) classified.add(o.value); });
+    }
+    M.classified_pc = pc(classified.size, N);
+
+    /* ---- M7 property sets, standard vs vendor ---------------------------------------- */
+    var withPsets = new Set(), stdPset = 0, vendorPset = 0;
+    var relProps = idsOf(api, modelID, WebIFC.IFCRELDEFINESBYPROPERTIES);
+    for (var pI = 0; pI < relProps.length; pI++) {
+      var rp = line(api, modelID, relProps[pI]); if (!rp) continue;
+      var defId = rp.RelatingPropertyDefinition && rp.RelatingPropertyDefinition.value;
+      var isSet = false, nm = '';
+      if (defId != null) {
+        var def = line(api, modelID, defId);
+        if (def) { nm = String(val(def.Name) || ''); isSet = true; }
+      }
+      if (isSet) { if (nm.indexOf('Pset_') === 0 || nm.indexOf('Qto_') === 0) stdPset++; else vendorPset++; }
+      asArray(rp.RelatedObjects).forEach(function (o) { if (o && elementIds.has(o.value)) withPsets.add(o.value); });
+    }
+    M.psets_pc = pc(withPsets.size, N);
+    M.psets_standard = stdPset;
+    M.psets_vendor = vendorPset;
+    M.psets_standard_pc = pc(stdPset, stdPset + vendorPset);
+
+    progress(70, 'Checking materials, types and quantities');
+
+    /* ---- M8 materials ----------------------------------------------------------------- */
+    var withMaterial = new Set();
+    var relMat = idsOf(api, modelID, WebIFC.IFCRELASSOCIATESMATERIAL);
+    for (var mI = 0; mI < relMat.length; mI++) {
+      var rm = line(api, modelID, relMat[mI]); if (!rm) continue;
+      asArray(rm.RelatedObjects).forEach(function (o) { if (o && elementIds.has(o.value)) withMaterial.add(o.value); });
+    }
+    M.materials_pc = pc(withMaterial.size, N);
+
+    /* ---- M12 type objects -------------------------------------------------------------- */
+    var typed = new Set();
+    var relType = idsOf(api, modelID, WebIFC.IFCRELDEFINESBYTYPE);
+    for (var tI = 0; tI < relType.length; tI++) {
+      var rt = line(api, modelID, relType[tI]); if (!rt) continue;
+      asArray(rt.RelatedObjects).forEach(function (o) { if (o && elementIds.has(o.value)) typed.add(o.value); });
+    }
+    M.typed_pc = pc(typed.size, N);
+
+    /* ---- M11 quantities ---------------------------------------------------------------- */
+    var qtoSets = idsOf(api, modelID, WebIFC.IFCELEMENTQUANTITY);
+    var withQto = new Set();
+    if (qtoSets.length) {
+      var qtoIds = new Set(qtoSets);
+      for (var pJ = 0; pJ < relProps.length; pJ++) {
+        var rq = line(api, modelID, relProps[pJ]); if (!rq) continue;
+        var dq = rq.RelatingPropertyDefinition && rq.RelatingPropertyDefinition.value;
+        if (!qtoIds.has(dq)) continue;
+        asArray(rq.RelatedObjects).forEach(function (o) { if (o && elementIds.has(o.value)) withQto.add(o.value); });
+      }
+    }
+    M.quantities = qtoSets.length > 0;
+    M.quantities_pc = pc(withQto.size, N);
+
+    progress(82, 'Checking integrity');
+
+    /* ---- M13 space boundaries ---------------------------------------------------------- */
+    M.space_boundaries = idsOf(api, modelID, WebIFC.IFCRELSPACEBOUNDARY).length > 0;
+
+    /* ---- M14 orphans: elements in no spatial container --------------------------------- */
+    var contained = new Set();
+    var relCont = idsOf(api, modelID, WebIFC.IFCRELCONTAINEDINSPATIALSTRUCTURE);
+    for (var sI = 0; sI < relCont.length; sI++) {
+      var rs = line(api, modelID, relCont[sI]); if (!rs) continue;
+      asArray(rs.RelatedElements).forEach(function (o) { if (o && elementIds.has(o.value)) contained.add(o.value); });
+    }
+    M.orphans = N - contained.size;
+    M.orphans_pc = pc(N - contained.size, N);
+
+    /* ---- M15 duplicate GUIDs, M9 naming, M10 georeferencing ---------------------------- */
+    var seen = new Set(), dup = 0, named = 0;
+    /* M9 is a heuristic and is labelled as one wherever it is shown: a name counts as
+       meaningful when it is non-empty and is not a bare vendor default like "Wall:0815". */
+    var DEFAULT_NAME = /^[A-Za-z]+[:_-]\s*\d+$/;
+    for (var eI = 0; eI < N; eI++) {
+      var el = line(api, modelID, elements[eI]); if (!el) continue;
+      var g = val(el.GlobalId);
+      if (g) { if (seen.has(g)) dup++; else seen.add(g); }
+      var nmv = val(el.Name);
+      if (nmv && String(nmv).trim() && !DEFAULT_NAME.test(String(nmv).trim())) named++;
+      if ((eI & 1023) === 0) progress(82 + Math.round((eI / N) * 14), 'Checking integrity');
+    }
+    M.dup_guids = dup;
+    M.named_pc = pc(named, N);
+
+    var geo = false;
+    for (var gI = 0; gI < sites.length && !geo; gI++) {
+      var st = line(api, modelID, sites[gI]);
+      if (st && (st.RefLatitude != null || st.RefLongitude != null)) geo = true;
+    }
+    if (!geo && idsOf(api, modelID, WebIFC.IFCMAPCONVERSION).length) geo = true;
+    M.georef = geo;   /* boolean only — the coordinate itself is never read out */
+
+    progress(98, 'Done');
+    post('done', { metrics: M });
+  } catch (err) {
+    post('error', { message: 'Measurement failed: ' + String(err && err.message || err) });
+  } finally {
+    /* Free the wasm model. This worker holds no geometry, so closing is cheap and safe here. */
+    try { if (api && modelID >= 0) api.CloseModel(modelID); } catch (e7) {}
+  }
+};

--- a/readiness/proposal.html
+++ b/readiness/proposal.html
@@ -1,3 +1,4 @@
+<meta charset="utf-8">
 <title>The Research Proposal</title>
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>

--- a/readiness/sources.html
+++ b/readiness/sources.html
@@ -1,3 +1,4 @@
+<meta charset="utf-8">
 <title>Sources and Verification</title>
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>

--- a/readiness/why.html
+++ b/readiness/why.html
@@ -1,3 +1,4 @@
+<meta charset="utf-8">
 <title>Why OpenBIM Readiness</title>
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>


### PR DESCRIPTION
Act 2 of §STORY, built. Step 9 was a mockup whose figures were hardcoded and whose "choose a file" button was dead. **It now takes a real file and reports counts from it.**

## Why not `import_worker.js` — the decision and the reason

`PROMPT.md §ROADMAP` is explicit: *"Track B metrics at the web-ifc layer … **NEVER** from the extracted DB (lossy projection)."* `import_worker.js` exists to build renderable geometry and sql.js DBs, and that projection drops the semantic detail these metrics count.

So `readiness/metrics_worker.js` calls **the same vendored web-ifc build, in a Web Worker, at the same layer** — and computes nothing but counts. No geometry requested, no sql.js, no database, no storage. `SCORING_SPEC §5.0` was right that no parser needed writing.

## M1–M15 measured on two real models, to prove they discriminate

| | Duplex_ARC.ifc | SampleHouse_ARC.ifc |
|---|---|---|
| Schema | **IFC2X3** | **IFC4** |
| Elements | 295 | 75 |
| Spaces | 21 | 4 |
| Classified | **0%** | **5.3%** |
| Property sets | 85.8% | 100% |
| Orphans | 88 (29.8%) | 41 (54.7%) |

Different schema, different scale, different classification coverage — **real reads, not a fixture.** Exporter matched on a fixed allowlist (both *Autodesk Revit*); anything unrecognised reports as `other`, so no unanticipated vendor string is ever shipped.

## Privacy, which is load-bearing here

The worker contains **zero** `fetch`, `XMLHttpRequest`, `indexedDB`, `localStorage`, `sessionStorage`, `sendBeacon`, `document.cookie` — verified by counting the source. `GlobalId` is read to detect duplicates and is **never posted back**; only the duplicate *count* crosses. The payload carries integers, percentages and booleans plus the schema — no filename, no GUID, no coordinate, no element name.

Confirmed in a real browser: with an IFC loaded, the **only** non-localhost requests the page makes are Google webfonts, which happen on page load regardless of any file. The drop zone now **says so explicitly** rather than letting *"never uploaded"* imply the page makes no requests at all.

## Sample vs measured is never ambiguous

Until a file is read the figures are the sample model and every surface says so — caption reads **"Sample figures — not your model"**, payload carries `"measured": false`. After a read: **"Measured from your file, in this browser tab"** and `"measured": true`.

## ⚠ Bug found by the browser test, not by inspection

The done-handler re-rendered the whole screen to refresh the payload — which **rebuilt the drop zone and threw away the "file loaded" state** the respondent had just reached. Measurement succeeded and the UI silently reverted to idle. The payload is now patched in place instead.

## Also: `<meta charset="utf-8">` on all seven pages

No page declared one. GH Pages sends `charset=utf-8` so this is invisible today — but the planned **offline zip** opens over `file://` with no server header, and without this the **Arabic pack** and every middot would mojibake. Caught because the test server sent no charset and the rendered metadata came back mangled.

## Verification

- Two real IFCs measured in **headless Chrome**; distinct, plausible, discriminating numbers
- UI reaches the done state, grid updates, payload flips to `measured:true`, filename absent
- The 20 questions, tips, ladders, anchors, clauses and tiers **identical** to `origin/main`
- Acknowledgement gate, consent statement and printed Notice **byte-identical**
- Malay and Arabic packs and the draft banner intact
- The other six pages differ from `origin/main` by **the charset line and nothing else**
- The hardcoded `84.2 MB` / `4.2%` / `39%` figures are gone from the markup; the sample now lives in one clearly-named `SAMPLE` object used only until a real file is read
- `readiness/` is not precached by any `sw.js` — no CACHE_VERSION bump

**Not in this change:** scoring these numbers (needs §ROADMAP action 2 thresholds) and the viewer render (§STORY act 2, second half). Raw measurement stands on its own and is honest without them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EVYqpsZquz3dfP2HaUFuoE