### PR TITLE
feat(tm): Office snapshot — TM state leaves the browser as PNG + deep-link (Copy Image / Copy Link)

### DIFF
--- a/viewer/share.js
+++ b/viewer/share.js
@@ -323,6 +323,133 @@ function setupShare(A) {
     }
   };
 
+  // ── TM Office Snapshot — Implementing bim-compiler prompts/TM_OFFICE_SNAPSHOT_LANE.md §3 (SETTLED)
+  // Witness: viewer/tests/witness_tm_office_snapshot.js
+  // Plain PNG + deep-link, no OOXML/OLE (§3). Two explicit actions (Copy Image / Copy Link), not one
+  // combined clipboard write: Word/Excel consume ONE representation per paste (the richest wins), so a
+  // fused image+text write cannot deliver both — and the §3 Office workflow (paste picture, then
+  // Insert→Link onto it) needs the link on the clipboard SEPARATELY at a later moment anyway.
+  // Caption-bar compositing copies sitecam.js A._compositePhoto's fillRect/fillText pattern.
+
+  // Pure — returns the share-sheet section HTML, or '' when the Time Machine is not active
+  // (no snapshot option when there is nothing to snapshot). Sliced + executed by the witness.
+  function tmSnapshotSectionHtml(tmActive) {
+    if (!tmActive) return '';
+    return '<hr class="share-divider">' +
+      '<p class="share-section-label">Office snapshot — Time Machine</p>' +
+      '<div class="share-section">' +
+        '<button class="share-btn" data-share-tm-snapshot>' +
+          '<span class="share-icon" style="background:rgba(255,193,7,0.15);color:#ffc107">4D</span>' +
+          '<span class="share-label">Copy Image<span class="share-sublabel">PNG with day/phase caption — paste into Word/Excel</span></span>' +
+        '</button>' +
+        '<button class="share-btn" data-share-tm-link>' +
+          '<span class="share-icon" style="background:rgba(255,193,7,0.15);color:#ffc107">&#128279;</span>' +
+          '<span class="share-label">Copy Link<span class="share-sublabel">Deep-link to this exact 4D state (Insert→Link onto the picture)</span></span>' +
+        '</button>' +
+      '</div>';
+  }
+
+  function tmSnapshotActive() {
+    return (typeof window.tmGetState === 'function') && !!window.tmGetState().active;
+  }
+
+  // Caption fields = the TM panel's own live-updated text at the moment of capture (spec §5 styling
+  // call: made and shown, not asked). Never re-derive date/phase — these elements are already accurate.
+  A._tmSnapshotCaption = function() {
+    function txt(id) { var el = document.getElementById(id); return el ? (el.textContent || '').trim() : ''; }
+    return {
+      counter: txt('tm-big-counter'),   // e.g. "DAY 64 | HR 0"
+      label: txt('tm-label'),           // short phase/task label
+      status: txt('tm-status'),         // live status line
+      building: A.activeBuilding || ''
+    };
+  };
+
+  // Render a fresh frame (WebGL buffer is not preserved — sitecam.js:90 / quickShare pattern),
+  // copy it to an offscreen 2D canvas, bake the caption bar along the bottom edge.
+  A._tmComposeSnapshot = function() {
+    if (A.renderer && A.scene && A.camera) A.renderer.render(A.scene, A.camera);
+    var src = A.canvas;
+    var c = document.createElement('canvas');
+    c.width = src.width;
+    c.height = src.height;
+    var ctx = c.getContext('2d');
+    ctx.drawImage(src, 0, 0, c.width, c.height);
+
+    var cap = A._tmSnapshotCaption();
+    var s = Math.max(1, c.width / 1280);            // scale text with capture resolution
+    var barH = Math.round(48 * s);
+    var pad = Math.round(10 * s);
+    ctx.fillStyle = 'rgba(0,0,0,0.72)';
+    ctx.fillRect(0, c.height - barH, c.width, barH);
+
+    // Line 1: big counter (cyan, bold) + building name (white)
+    ctx.font = 'bold ' + Math.round(15 * s) + 'px "Segoe UI", sans-serif';
+    ctx.fillStyle = '#4fc3f7';
+    var counterText = cap.counter || 'TIME MACHINE';
+    var y1 = c.height - barH + Math.round(19 * s);
+    ctx.fillText(counterText, pad, y1);
+    if (cap.building) {
+      ctx.fillStyle = '#fff';
+      ctx.fillText(cap.building, pad + ctx.measureText(counterText + '   ').width, y1);
+    }
+
+    // Line 2: phase/task label (left) + status (right, if both present)
+    ctx.font = Math.round(12 * s) + 'px "Segoe UI", sans-serif';
+    var y2 = c.height - barH + Math.round(38 * s);
+    var hasLabel = cap.label && cap.label !== '—';
+    ctx.fillStyle = '#ccc';
+    ctx.fillText(hasLabel ? cap.label : (cap.status || ''), pad, y2);
+    if (hasLabel && cap.status) {
+      ctx.fillStyle = '#999';
+      ctx.fillText(cap.status, c.width - ctx.measureText(cap.status).width - pad, y2);
+    }
+
+    console.log('§TM_SNAPSHOT_COMPOSE w=' + c.width + ' h=' + c.height + ' barH=' + barH +
+      ' counter="' + cap.counter + '" label="' + cap.label + '"');
+    return c;
+  };
+
+  // Primary action: composed PNG onto the clipboard as an image. Fallback (no ClipboardItem, e.g.
+  // older Firefox): save the PNG locally — Word/Excel Insert→Picture accepts the file identically.
+  A.tmCopySnapshotImage = async function(statusEl) {
+    var c = A._tmComposeSnapshot();
+    var blob = await new Promise(function(r) { c.toBlob(r, 'image/png'); });
+    if (!blob) {
+      if (statusEl) statusEl.textContent = 'Capture failed';
+      console.log('§TM_SNAPSHOT_COPY kind=image method=none err=null_blob');
+      return false;
+    }
+    try {
+      if (!(navigator.clipboard && navigator.clipboard.write && window.ClipboardItem)) {
+        throw new Error('ClipboardItem unsupported');
+      }
+      await navigator.clipboard.write([new window.ClipboardItem({ 'image/png': blob })]);
+      if (statusEl) statusEl.textContent = 'Image copied — paste into Word/Excel';
+      console.log('§TM_SNAPSHOT_COPY kind=image method=clipboard bytes=' + blob.size +
+        ' w=' + c.width + ' h=' + c.height);
+      return true;
+    } catch (e) {
+      var a = document.createElement('a');
+      a.href = URL.createObjectURL(blob);
+      a.download = 'TM_' + (A.activeBuilding || 'snapshot').replace(/[^\w.-]+/g, '_') + '.png';
+      document.body.appendChild(a); a.click(); document.body.removeChild(a);
+      setTimeout(function() { URL.revokeObjectURL(a.href); }, 5000);
+      if (statusEl) statusEl.textContent = 'Clipboard unavailable — PNG saved; Insert→Picture in Word/Excel';
+      console.log('§TM_SNAPSHOT_COPY kind=image method=download reason=' + e.message + ' bytes=' + blob.size);
+      return true;
+    }
+  };
+
+  // Secondary action: the deep-link, via the existing data-share-link pattern (buildShareUrl already
+  // carries tm=<cursor> while the Time Machine is active — share.js A.buildShareUrl, §2 of the spec).
+  A.tmCopySnapshotLink = function(statusEl) {
+    var url = A.buildShareUrl();
+    console.log('§TM_SNAPSHOT_COPY kind=link url_len=' + url.length + ' has_tm=' + (url.indexOf('tm=') >= 0));
+    A.shareUrl(url, (A.activeBuilding || 'BIM Model') + ' — 4D snapshot');
+    if (statusEl) statusEl.textContent = 'Link copied — Insert→Link onto the pasted picture';
+  };
+
   // ── URL shortener — TinyURL, no API key needed ──
   // Try to shorten; fall back to long URL if offline or error.
   function shortenUrl(longUrl, callback) {
@@ -437,6 +564,26 @@ function setupShare(A) {
         }, 2000);
       });
     };
+    // TM Office Snapshot (spec §3): quickShare's desktop card is where the Word/Excel user lands —
+    // offer Copy Image ahead of Copy Link while the Time Machine is active. Additive only.
+    if (tmSnapshotActive()) {
+      var tmImgBtn = document.createElement('button');
+      tmImgBtn.style.cssText = 'flex:1;padding:12px;border:none;border-radius:8px;' +
+        'background:#ffc107;color:#000;font-size:14px;font-weight:600;cursor:pointer';
+      tmImgBtn.textContent = 'Copy Image';
+      tmImgBtn.onclick = function() {
+        A.tmCopySnapshotImage(null).then(function(ok) {
+          if (!ok) { tmImgBtn.textContent = 'Failed'; return; }
+          tmImgBtn.textContent = 'Copied!';
+          tmImgBtn.style.background = '#4caf50';
+          setTimeout(function() {
+            tmImgBtn.textContent = 'Copy Image';
+            tmImgBtn.style.background = '#ffc107';
+          }, 2000);
+        });
+      };
+      btnRow.appendChild(tmImgBtn);
+    }
     btnRow.appendChild(shareBtn);
 
     // Cancel button
@@ -627,6 +774,9 @@ function setupShare(A) {
         '</button>' +
       '</div>' +
 
+      // TM Office Snapshot section — only rendered while the Time Machine is active (spec §3)
+      tmSnapshotSectionHtml(tmSnapshotActive()) +
+
       '<div class="share-status" data-share-status></div>';
 
     overlay.appendChild(sheet);
@@ -664,6 +814,12 @@ function setupShare(A) {
       A.shareUrl(url, displayName + ' — BIM OOTB');
       statusEl.textContent = 'Shared!';
     };
+
+    // TM Office Snapshot — rows exist only while TM is active, so guard the bindings
+    var tmSnapBtn = sheet.querySelector('[data-share-tm-snapshot]');
+    if (tmSnapBtn) tmSnapBtn.onclick = function() { A.tmCopySnapshotImage(statusEl); };
+    var tmLinkBtn = sheet.querySelector('[data-share-tm-link]');
+    if (tmLinkBtn) tmLinkBtn.onclick = function() { A.tmCopySnapshotLink(statusEl); };
   };
 
   console.log('§SHARE_LOADED share.js v2 (S265 Phase 3 — navigator.share + buildShareUrl)');

--- a/viewer/sw.js
+++ b/viewer/sw.js
@@ -8,7 +8,7 @@
 // Cache-first for heavy assets (.wasm, images). DB files skip SW (IndexedDB handles them).
 //
 // DEPLOY: bump CACHE_VERSION on every OCI upload. Old caches are purged on activate.
-const CACHE_VERSION = 'v1081';   // bump on each deploy; per-change detail is the git commit message.
+const CACHE_VERSION = 'v1082';   // bump on each deploy; per-change detail is the git commit message.
 // v1078 (2026-08-23) SCRIPT_LENGTH_REFACTOR_SEAMS.md §S59 candidate 2 — navigate_find.js's ERP-push
 // block extracted to NEW find_erp_push.js (loaded by main.js's lazy navigate list BEFORE
 // navigate_find.js?v=58). NOT precached ON PURPOSE: none of the lazy navigate_* sub-modules are

--- a/viewer/tests/witness_tm_office_snapshot.js
+++ b/viewer/tests/witness_tm_office_snapshot.js
@@ -1,0 +1,237 @@
+#!/usr/bin/env node
+// witness_tm_office_snapshot.js — §TM_SNAPSHOT (2026-08-24, bim-compiler
+// prompts/TM_OFFICE_SNAPSHOT_LANE.md §3 SETTLED: plain PNG + deep-link, no OOXML/OLE).
+// Proves the TM Office Snapshot feature: a share-sheet row that captures the canvas, bakes the
+// TM panel's own caption text onto it, and puts image + deep-link into the user's hands as TWO
+// explicit clipboard actions (Copy Image / Copy Link) — the shape Word/Excel can actually consume.
+//
+// Names the issues it tests:
+//   TOS-1  Conditional row: the share sheet must offer the snapshot ONLY while the Time Machine
+//          is active — a snapshot option with nothing to snapshot is a broken affordance.
+//          (a) tmSnapshotSectionHtml(false) === '' — no rows rendered when TM inactive.
+//          (b) tmSnapshotSectionHtml(true) carries both data-share-tm-snapshot and
+//              data-share-tm-link rows in the house share-section structure.
+//          (c) openShareSheet actually calls it gated on tmSnapshotActive() and null-guards the
+//              handler bindings (rows may not exist).
+//          (d) tmSnapshotActive() is false with no tmGetState, false when inactive, true when active.
+//   TOS-2  Regression-proof: A.buildShareUrl() still emits tm=<cursor> when TM active and omits
+//          it when inactive — the deep-link half of the feature (spec §2, pre-existing).
+//   TOS-3  The caption is actually DRAWN onto the composed canvas, not just "no exception":
+//          recording mock ctx proves (in order) a fresh renderer.render, drawImage of A.canvas,
+//          a full-width caption bar fillRect at the bottom edge, and fillText of the TM panel's
+//          exact counter + label + status text with y-coords INSIDE the bar region.
+//          (No node-canvas lib exists in this repo, so a literal pixel diff is not possible
+//          headlessly — call-level recording is the equivalent proof, and stronger than
+//          exception-free execution: it asserts the text and region, not merely survival.)
+//   TOS-4  The copy actions do what they log:
+//          (a) Copy Image writes ONE ClipboardItem carrying image/png and logs
+//              §TM_SNAPSHOT_COPY kind=image method=clipboard.
+//          (b) With ClipboardItem unavailable (older Firefox) it falls back to a local .png save
+//              (click on a download anchor) and logs method=download — never silently no-ops.
+//          (c) Copy Link routes A.buildShareUrl() (tm= included) through the existing
+//              A.shareUrl pattern and logs §TM_SNAPSHOT_COPY kind=link.
+//
+// §S73 lesson (witness_gantt_lock_integrity.js / G-COH-6): all slicing below is LINE-ANCHORED and
+// brace-balanced — a plain indexOf can match a comment that merely mentions the function.
+// Read the § log lines, not exit code alone.
+'use strict';
+const fs = require('fs');
+const path = require('path');
+const vm = require('vm');
+
+let pass = 0, fail = 0;
+function assert(cond, msg) { if (cond) { pass++; console.log('  PASS ' + msg); } else { fail++; console.log('  FAIL ' + msg); } }
+
+const shareSrc = fs.readFileSync(path.join(__dirname, '..', 'share.js'), 'utf8');
+
+// Line-anchored, brace-balanced slice. `head` is the exact start-of-line text of the definition,
+// e.g. 'function tmSnapshotSectionHtml(' or 'A.buildShareUrl = function'.
+function slice(src, head) {
+  const esc = head.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+  const m = new RegExp('^[ \\t]*' + esc, 'm').exec(src);
+  if (!m) throw new Error('no line-anchored definition for: ' + head);
+  const start = m.index + m[0].search(/\S/);
+  let depth = 0, seenOpen = false;
+  for (let i = m.index; i < src.length; i++) {
+    if (src[i] === '{') { depth++; seenOpen = true; }
+    else if (src[i] === '}') { depth--; if (seenOpen && depth === 0) return src.slice(start, i + 1); }
+  }
+  throw new Error('unbalanced braces for: ' + head);
+}
+
+/* ── TOS-1a/b: tmSnapshotSectionHtml is conditional and carries both rows ─────────────────── */
+{
+  const fn = slice(shareSrc, 'function tmSnapshotSectionHtml(');
+  const sb = {};
+  vm.runInNewContext(fn + '; __out = tmSnapshotSectionHtml;', sb);
+  const off = sb.__out(false), on = sb.__out(true);
+  assert(off === '', 'TOS-1a inactive TM renders NO section (got ' + JSON.stringify(off.slice(0, 40)) + ')');
+  assert(on.indexOf('data-share-tm-snapshot') >= 0 && on.indexOf('data-share-tm-link') >= 0,
+    'TOS-1b active TM renders both rows (snapshot=' + (on.indexOf('data-share-tm-snapshot') >= 0) +
+    ' link=' + (on.indexOf('data-share-tm-link') >= 0) + ')');
+  assert(on.indexOf('share-section-label') >= 0 && on.indexOf('share-divider') >= 0,
+    'TOS-1b2 section uses the house share-section-label/share-divider structure');
+}
+
+/* ── TOS-1c: openShareSheet wires the section + guards the bindings ───────────────────────── */
+{
+  const sheetFn = slice(shareSrc, 'A.openShareSheet = async function');
+  assert(sheetFn.indexOf('tmSnapshotSectionHtml(tmSnapshotActive())') >= 0,
+    'TOS-1c1 openShareSheet renders the section via tmSnapshotSectionHtml(tmSnapshotActive())');
+  assert(sheetFn.indexOf('if (tmSnapBtn)') >= 0 && sheetFn.indexOf('if (tmLinkBtn)') >= 0,
+    'TOS-1c2 handler bindings are null-guarded (rows absent when TM inactive)');
+  // Existing rows untouched — additive contract
+  ['data-share-ifc', 'data-share-db', 'data-share-ootb', 'data-share-link'].forEach(function(r) {
+    assert(sheetFn.indexOf(r) >= 0, 'TOS-1c3 existing row ' + r + ' still present');
+  });
+}
+
+/* ── TOS-1d: tmSnapshotActive gates on tmGetState().active ────────────────────────────────── */
+{
+  const fn = slice(shareSrc, 'function tmSnapshotActive(');
+  function run(win) {
+    const sb = { window: win };
+    vm.runInNewContext(fn + '; __out = tmSnapshotActive();', sb);
+    return sb.__out;
+  }
+  assert(run({}) === false, 'TOS-1d1 no tmGetState → inactive (no crash)');
+  assert(run({ tmGetState: () => ({ active: false }) }) === false, 'TOS-1d2 tmGetState().active=false → inactive');
+  assert(run({ tmGetState: () => ({ active: true }) }) === true, 'TOS-1d3 tmGetState().active=true → active');
+}
+
+/* ── TOS-2: buildShareUrl regression — tm= in, tm= out ────────────────────────────────────── */
+{
+  const fn = slice(shareSrc, 'A.buildShareUrl = function');
+  function build(tmState) {
+    const logs = [];
+    const sb = {
+      A: { camera: { position: { x: 1, y: 2, z: 3 } }, controls: { target: { x: 4, y: 5, z: 6 } },
+           activeStoreyFilter: null, xrayOn: false, _currentClashes: null, flyActive: false,
+           measureActive: false, walkModeActive: false },
+      window: { tmGetState: () => tmState },
+      location: { origin: 'http://x', pathname: '/v', search: '' },
+      document: { getElementById: () => null },
+      URLSearchParams: URLSearchParams,
+      console: { log: (s) => logs.push(s) },
+    };
+    vm.runInNewContext(fn + '; __url = A.buildShareUrl();', sb);
+    return { url: sb.__url, logs };
+  }
+  const on = build({ active: true, cursor: 86400000 });
+  assert(on.url.indexOf('tm=86400000') >= 0, 'TOS-2a TM active → tm=86400000 in URL: ' + on.url);
+  assert(on.url.indexOf('cam=1.0,2.0,3.0') >= 0, 'TOS-2a2 camera still captured alongside tm');
+  const off = build({ active: false, cursor: 86400000 });
+  assert(off.url.indexOf('tm=') === -1, 'TOS-2b TM inactive → no tm= param: ' + off.url);
+}
+
+/* ── TOS-3: caption actually drawn onto the composed canvas, inside the bar region ────────── */
+{
+  const capFn = slice(shareSrc, 'A._tmSnapshotCaption = function');
+  const compFn = slice(shareSrc, 'A._tmComposeSnapshot = function');
+  const seq = [];            // ordered event log
+  const rects = [], texts = [];
+  const W = 1280, H = 720;   // s=1 → barH=48, bar spans y∈[672,720]
+  const mockCtx = {
+    font: '', fillStyle: '',
+    measureText: (t) => ({ width: String(t).length * 7 }),
+    fillRect: (x, y, w, h) => { seq.push('fillRect'); rects.push({ x, y, w, h }); },
+    fillText: (t, x, y) => { seq.push('fillText'); texts.push({ t: String(t), x, y }); },
+    drawImage: (img) => { seq.push(img === srcCanvas ? 'drawImage:src' : 'drawImage:other'); },
+  };
+  const srcCanvas = { width: W, height: H };
+  const madeCanvas = { width: 0, height: 0, getContext: () => mockCtx };
+  const tmText = { 'tm-big-counter': 'DAY 64 | HR 0', 'tm-label': 'Foundation — footings', 'tm-status': '32 of 214 built' };
+  const logs = [];
+  const sb = {
+    A: { canvas: srcCanvas, activeBuilding: 'Duplex_A',
+         renderer: { render: () => seq.push('render') }, scene: {}, camera: {} },
+    document: {
+      getElementById: (id) => (id in tmText ? { textContent: tmText[id] } : null),
+      createElement: (tag) => (tag === 'canvas' ? madeCanvas : null),
+    },
+    Math: Math,
+    console: { log: (s) => logs.push(s) },
+  };
+  vm.runInNewContext(capFn + ';\n' + compFn + ';\n__out = A._tmComposeSnapshot();', sb);
+
+  assert(sb.__out === madeCanvas && madeCanvas.width === W && madeCanvas.height === H,
+    'TOS-3a composed canvas is a NEW canvas at source size ' + madeCanvas.width + 'x' + madeCanvas.height);
+  assert(seq.indexOf('render') >= 0 && seq.indexOf('render') < seq.indexOf('drawImage:src'),
+    'TOS-3b fresh renderer.render BEFORE reading the WebGL canvas (seq=' + seq.slice(0, 3).join(',') + ')');
+  const bar = rects.find((r) => r.x === 0 && r.w === W && r.y === H - 48 && r.h === 48);
+  assert(!!bar, 'TOS-3c full-width caption bar fillRect at bottom edge (rects=' + JSON.stringify(rects) + ')');
+  const inBar = (e) => e.y > H - 48 && e.y <= H;
+  const counter = texts.find((e) => e.t === 'DAY 64 | HR 0');
+  const label = texts.find((e) => e.t === 'Foundation — footings');
+  const status = texts.find((e) => e.t === '32 of 214 built');
+  assert(counter && inBar(counter), 'TOS-3d tm-big-counter text drawn INSIDE the bar (y=' + (counter && counter.y) + ')');
+  assert(label && inBar(label), 'TOS-3e tm-label text drawn INSIDE the bar (y=' + (label && label.y) + ')');
+  assert(status && inBar(status) && status.x > W / 2, 'TOS-3f tm-status drawn right-aligned in the bar (x=' + (status && status.x) + ')');
+  const bld = texts.find((e) => e.t === 'Duplex_A');
+  assert(bld && inBar(bld), 'TOS-3g building name drawn in the bar');
+  assert(logs.some((l) => l.indexOf('§TM_SNAPSHOT_COMPOSE') === 0), 'TOS-3h §TM_SNAPSHOT_COMPOSE logged: ' + logs[0]);
+}
+
+/* ── TOS-4a/b: Copy Image — clipboard primary, local-save fallback ────────────────────────── */
+async function runCopyImage(withClipboardItem) {
+  const fn = slice(shareSrc, 'A.tmCopySnapshotImage = async function');
+  const logs = [], writes = [], clicks = [];
+  function CI(o) { this.parts = o; }
+  const anchor = { href: '', download: '', click: () => clicks.push(1) };
+  const sb = {
+    A: { activeBuilding: 'Duplex A',
+         _tmComposeSnapshot: () => ({ width: 1280, height: 720, toBlob: (cb) => cb({ size: 4321 }) }) },
+    navigator: { clipboard: { write: async (items) => { writes.push(items); } } },
+    window: withClipboardItem ? { ClipboardItem: CI } : {},
+    document: { createElement: () => anchor, body: { appendChild: () => {}, removeChild: () => {} } },
+    URL: { createObjectURL: () => 'blob:tm', revokeObjectURL: () => {} },
+    setTimeout: () => {},
+    Error: Error, Object: Object, Promise: Promise,
+    console: { log: (s) => logs.push(s) },
+  };
+  vm.runInNewContext(fn + ';\n__p = A.tmCopySnapshotImage(null);', sb);
+  const ok = await sb.__p;
+  return { ok, logs, writes, clicks, anchor, CI };
+}
+(async function() {
+  const a = await runCopyImage(true);
+  assert(a.ok === true && a.writes.length === 1 && a.writes[0].length === 1 &&
+    a.writes[0][0] instanceof a.CI && 'image/png' in a.writes[0][0].parts,
+    'TOS-4a ONE ClipboardItem written carrying image/png');
+  assert(a.logs.some((l) => l.indexOf('§TM_SNAPSHOT_COPY kind=image method=clipboard') === 0),
+    'TOS-4a2 §TM_SNAPSHOT_COPY kind=image method=clipboard logged: ' + a.logs.filter((l) => l.indexOf('§TM_SNAPSHOT_COPY') === 0));
+  const b = await runCopyImage(false);
+  assert(b.ok === true && b.clicks.length === 1 && /\.png$/.test(b.anchor.download),
+    'TOS-4b no ClipboardItem → local .png save clicked (download=' + b.anchor.download + ')');
+  assert(b.logs.some((l) => l.indexOf('§TM_SNAPSHOT_COPY kind=image method=download') === 0),
+    'TOS-4b2 fallback logged method=download: ' + b.logs.filter((l) => l.indexOf('§TM_SNAPSHOT_COPY') === 0));
+
+  /* ── TOS-4c: Copy Link — buildShareUrl through the existing shareUrl pattern ─────────────── */
+  {
+    const fn = slice(shareSrc, 'A.tmCopySnapshotLink = function');
+    const logs = [], shared = [];
+    const sb = {
+      A: { activeBuilding: 'Duplex A',
+           buildShareUrl: () => 'http://x/v#cam=1.0,2.0,3.0&tm=86400000',
+           shareUrl: (url, title) => shared.push({ url, title }) },
+      console: { log: (s) => logs.push(s) },
+    };
+    vm.runInNewContext(fn + ';\nA.tmCopySnapshotLink(null);', sb);
+    assert(shared.length === 1 && shared[0].url.indexOf('tm=86400000') >= 0,
+      'TOS-4c link routed through A.shareUrl with tm= intact: ' + (shared[0] && shared[0].url));
+    assert(logs.some((l) => l.indexOf('§TM_SNAPSHOT_COPY kind=link') === 0 && l.indexOf('has_tm=true') > 0),
+      'TOS-4c2 §TM_SNAPSHOT_COPY kind=link has_tm=true logged: ' + logs);
+  }
+
+  /* ── TOS-1e: quickShare desktop card offers Copy Image only while TM active ──────────────── */
+  {
+    const prevFn = slice(shareSrc, 'function showSharePreview(');
+    const gateIdx = prevFn.indexOf('if (tmSnapshotActive())');
+    const btnIdx = prevFn.indexOf('tmImgBtn');
+    assert(gateIdx >= 0 && btnIdx > gateIdx,
+      'TOS-1e showSharePreview adds the Copy Image button INSIDE the tmSnapshotActive() gate');
+  }
+
+  console.log('\n§TM_SNAPSHOT witness: ' + pass + ' pass, ' + fail + ' fail');
+  process.exit(fail > 0 ? 1 : 0);
+})();


### PR DESCRIPTION
## What

Implements **bim-compiler `prompts/TM_OFFICE_SNAPSHOT_LANE.md`** (§3 SETTLED: plain image + hyperlink, no OOXML, no OLE, no `.docx`/`.xlsx` generation; user re-confirmed "just embed image"). While the Time Machine is active, the share surfaces offer an **Office snapshot** pair:

- **Copy Image** — fresh `renderer.render` → offscreen canvas → caption bar baked along the bottom edge carrying the TM panel's own live text (`#tm-big-counter`, `#tm-label`, `#tm-status`, building name — read at the moment of capture, never re-derived) → `navigator.clipboard.write([new ClipboardItem({'image/png': blob})])`. Paste straight into Word or Excel; Office's native picture handling does the rest (§3). Fallback when `ClipboardItem` is unavailable (older Firefox): local `.png` save — Insert→Picture consumes the file identically.
- **Copy Link** — `A.buildShareUrl()` (already carries `tm=<cursor>` while TM is active, spec §2 — the link half was pre-existing, nothing re-derived) routed through the existing `A.shareUrl` clipboard pattern.

Shown **only while `tmGetState().active`** — no snapshot option when there is nothing to snapshot.

## Reuse points (per spec §2, "reuse don't reinvent")

- Deep-link: `share.js` `A.buildShareUrl()` `tm=` param (unchanged, regression-proofed).
- Canvas capture + caption compositing: `sitecam.js` `A._compositePhoto` fillRect/fillText bar pattern + the render-before-read discipline (`sitecam.js:90`, WebGL buffer not preserved).
- Packaging surface: the existing share UI, additive only — `openShareSheet` gets a conditional `share-section` ("Office snapshot — Time Machine", rows `data-share-tm-snapshot` / `data-share-tm-link`, house label/divider structure); `showSharePreview` gets a gated **Copy Image** button. Existing `data-share-ifc`/`data-share-db`/`data-share-ootb`/`data-share-link` rows and handlers untouched (witness-asserted).

**Structural note vs the dispatch brief:** the `data-share-*` rows and the quickShare sheet are two different UIs — `openShareSheet` is only reachable from import cards (`import.js:667`), while the `/` key / Share pill path (`panels.js:1360` → `A.quickShare`) opens `showSharePreview` on desktop. Both got the affordance under one gate so the Word/Excel desktop user actually reaches Copy Image. (On desktops where `navigator.share` + `canShare(files)` exist, quickShare still takes the native share first — unchanged behavior.)

## Clipboard shape: two explicit actions, not one combined write

§3 allowed either. Decided **Copy Image / Copy Link** because:
1. A single `ClipboardItem` holds multiple *representations of one payload*; Word/Excel consume **one** representation per paste (the richest wins) — a fused image+text write cannot deliver both to the user, and which representation wins varies by host (Excel's formula bar takes text, Word's canvas takes the image).
2. §3's own Office workflow — *paste the picture, then Insert→Link onto it* — needs the link on the clipboard **separately, at a later moment** than the image paste anyway. Fusing them serves no step of the actual workflow.
3. Cross-browser: image clipboard writes need `ClipboardItem` (absent in Firefox <127) — a separate image action can fall back to a local `.png` save without dragging the link action down with it.

Each action logs `§TM_SNAPSHOT_COPY kind=image|link …` so it is provable, not claimed.

## CACHE_VERSION

`viewer/sw.js` **v1081 → v1082** (mandatory same-PR bump for `share.js` changes).

## Witness proof (`viewer/tests/witness_tm_office_snapshot.js`, headless node, 30/30)

Line-anchored brace-balanced slicing per the repo's own §S73/G-COH-6 lesson; sliced functions **executed** in vm with recording mocks. No node-canvas lib exists in this repo, so the compositing proof is call-level recording (asserts the exact caption text lands inside the bar region — stronger than "no exception"), not a literal pixel diff.

```
  PASS TOS-1a inactive TM renders NO section (got "")
  PASS TOS-1b active TM renders both rows (snapshot=true link=true)
  PASS TOS-1b2 section uses the house share-section-label/share-divider structure
  PASS TOS-1c1 openShareSheet renders the section via tmSnapshotSectionHtml(tmSnapshotActive())
  PASS TOS-1c2 handler bindings are null-guarded (rows absent when TM inactive)
  PASS TOS-1c3 existing row data-share-ifc still present
  PASS TOS-1c3 existing row data-share-db still present
  PASS TOS-1c3 existing row data-share-ootb still present
  PASS TOS-1c3 existing row data-share-link still present
  PASS TOS-1d1 no tmGetState → inactive (no crash)
  PASS TOS-1d2 tmGetState().active=false → inactive
  PASS TOS-1d3 tmGetState().active=true → active
  PASS TOS-2a TM active → tm=86400000 in URL: http://x/v#cam=1.0,2.0,3.0&tgt=4.0,5.0,6.0&tm=86400000
  PASS TOS-2a2 camera still captured alongside tm
  PASS TOS-2b TM inactive → no tm= param: http://x/v#cam=1.0,2.0,3.0&tgt=4.0,5.0,6.0
  PASS TOS-3a composed canvas is a NEW canvas at source size 1280x720
  PASS TOS-3b fresh renderer.render BEFORE reading the WebGL canvas (seq=render,drawImage:src,fillRect)
  PASS TOS-3c full-width caption bar fillRect at bottom edge (rects=[{"x":0,"y":672,"w":1280,"h":48}])
  PASS TOS-3d tm-big-counter text drawn INSIDE the bar (y=691)
  PASS TOS-3e tm-label text drawn INSIDE the bar (y=710)
  PASS TOS-3f tm-status drawn right-aligned in the bar (x=1165)
  PASS TOS-3g building name drawn in the bar
  PASS TOS-3h §TM_SNAPSHOT_COMPOSE logged: §TM_SNAPSHOT_COMPOSE w=1280 h=720 barH=48 counter="DAY 64 | HR 0" label="Foundation — footings"
  PASS TOS-4a ONE ClipboardItem written carrying image/png
  PASS TOS-4a2 §TM_SNAPSHOT_COPY kind=image method=clipboard logged: §TM_SNAPSHOT_COPY kind=image method=clipboard bytes=4321 w=1280 h=720
  PASS TOS-4b no ClipboardItem → local .png save clicked (download=TM_Duplex_A.png)
  PASS TOS-4b2 fallback logged method=download: §TM_SNAPSHOT_COPY kind=image method=download reason=ClipboardItem unsupported bytes=4321
  PASS TOS-4c link routed through A.shareUrl with tm= intact: http://x/v#cam=1.0,2.0,3.0&tm=86400000
  PASS TOS-4c2 §TM_SNAPSHOT_COPY kind=link has_tm=true logged: §TM_SNAPSHOT_COPY kind=link url_len=38 has_tm=true
  PASS TOS-1e showSharePreview adds the Copy Image button INSIDE the tmSnapshotActive() gate

§TM_SNAPSHOT witness: 30 pass, 0 fail
```

Full headless suite on this branch: `§SUITE_SUMMARY green=50 new_red=0 known_red=3 fixed=1 flaky=0 total=54`, exit 0 — no new red vs `origin/main` (the 3 known_red are pre-existing KNOWN_RED entries; the 1 fixed, `witness_gantt_lock_integrity.js`, went green independently of this branch and its KNOWN_RED drain belongs to the PR that fixed it).

## Out of scope (spec §0/§4)

No daily-checklist / permit-checkpoint riders, no P6/XML work, no native Office file generation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017tZaBhZUdSQMcYnPqyApfN