### PR TITLE
test(4d): wire orphaned band-monotonic witness into suite, fix its shiftHours default

### DIFF
--- a/tests/run_witness_suite.js
+++ b/tests/run_witness_suite.js
@@ -87,6 +87,11 @@ const KNOWN_RED = {
   // C — real assertion reds, reproducible every run.
   'witness_gantt_lock_integrity.js':         'C — G-LI-2e, self-declared KNOWN PRE-EXISTING BUG in its own assert message',
   'witness_door_window_host_wall.js':        'C — assertion red, UNTRIAGED',
+  'witness_4d_band_monotonic.js':            'C — T2a: 0->14,267 non-structure cross-storey inversions (Hospital), bisected to c972778 ' +
+                                              '#1319 §HOSTED_BEFORE_HOST (0->9,171) then a2c30ee #1345 §STAIR_FLIGHT_GRID_VISIBILITY ' +
+                                              '(->14,267). Newly wired in 2026-08-24 (was git-orphaned at repo root since fc58210, ' +
+                                              'per §S66 — suite never ran it, so this went undetected). Cause: 4D_SCHEDULE_PERFECTION.md ' +
+                                              '"REGRESSION FOUND" section.',
   // Reproducible reds whose cause has NOT been established. Labelled honestly rather than guessed:
   // an earlier pass called these "browser/server not up", which was wrong — both are headless.
   'witness_tm_stream_index_defer.js':        'C — reproducible red, cause NOT yet established',

--- a/viewer/tests/witness_4d_band_monotonic.js
+++ b/viewer/tests/witness_4d_band_monotonic.js
@@ -18,8 +18,8 @@
  */
 const { execSync } = require('child_process');
 const fs = require('fs');
-const NEW = require('./viewer/schedule_gate.js');
-const OLD = require('./tests/_schedule_gate_main.js');
+const NEW = require('../schedule_gate.js');
+const OLD = require('../../tests/_schedule_gate_main.js');
 
 const DB = process.env.SCHEDULE_TEST_DB || '/home/red1/bim-compiler/deploy/buildings/Hospital_extracted.db';
 if (!fs.existsSync(DB)) { console.log('§4D_BAND SKIP — no test DB at ' + DB); process.exit(0); }
@@ -111,7 +111,12 @@ console.log('§4D_BAND ladder=' + rows.map(r=>r.ph).join(' < '));
 console.log('--- BEFORE (origin/main scheduler)');
 const sOld = OLD.computeSchedule(elements, base, 1, null);
 console.log('--- AFTER  (scheduler under test)');
-const sNew = NEW.computeSchedule(elements, base, 1, null);
+// shiftHours=24: the live product default (§SHIFT_HOURS, user ruling "24hr is our default",
+// 4D_SCHEDULE_PERFECTION.md) — computeSchedule's own internal default is 8h, and omitting this
+// arg here previously made T4 compare against a schedule ~3x slower than production actually
+// plays (same trap as §GANTT_SHIFT_HOURS_DESYNC #1355, independently found in this witness
+// 2026-08-24). OLD is a frozen pre-shiftHours snapshot and has no such param to match.
+const sNew = NEW.computeSchedule(elements, base, 1, null, 24);
 
 const a = inversions(sOld), b = inversions(sNew);
 const NONST = e => e.seq > 4, STRUCT = e => e.seq <= 4;


### PR DESCRIPTION
## Summary
- `witness_4d_band_monotonic.js` sat at the repo root since `fc58210` (Aug 2), never `git mv`'d into `viewer/tests/` — per §S66 the suite runner (`tests/run_witness_suite.js`) only scans that directory, so it silently never ran again after being written. `git mv`'d in; registered in `KNOWN_RED` with the bisected root cause instead of running invisibly.
- Same fix corrects a second bug in the witness itself: it never passed `shiftHours` to `computeSchedule`, so it silently measured the internal 8h/day default instead of the product's real 24h/day default (`§SHIFT_HOURS`) — the exact same class of bug already fixed once as `§GANTT_SHIFT_HOURS_DESYNC` (#1355), just never ported to this witness. This had made its span check (T4) misreport a false "3.4x blowup" that isn't real at the correct setting (176d → 198d, well within tolerance).
- No product code changed — test visibility only.

Full detail + the bisection (two real, separate defect-fixes — #1319 `§HOSTED_BEFORE_HOST` and #1345 `§STAIR_FLIGHT_GRID_VISIBILITY` — each reintroduce cross-storey band-order inversions as a side effect) is written up in `bim-compiler prompts/4D_SCHEDULE_PERFECTION.md`, "REGRESSION FOUND" section. That underlying scheduler tension is **not fixed by this PR** — `GANTT_ACCURACY.md` already tried and rejected three designs for it; it needs a product decision, not a guess.

## Test plan
- [x] `node tests/run_witness_suite.js --filter witness_4d_band_monotonic` — witness discovered, classified `known_red` with cause message
- [x] `node tests/run_witness_suite.js` (full sweep) — `green=47 new_red=0 known_red=4 fixed=1 flaky=0 total=52`, zero collateral damage
- [x] `node viewer/tests/witness_4d_band_monotonic.js` directly — 5/6 (only T2a, the real known regression), confirms the relocation didn't change its own require-path resolution

🤖 Generated with [Claude Code](https://claude.com/claude-code)