### PR TITLE
feat(readiness): §HANDOVER — the visitor leaves holding their own model, as SQLite

### DIFF
--- a/readiness/README.md
+++ b/readiness/README.md
@@ -1,0 +1,83 @@
+# `readiness/` — OpenBIM Readiness Assessment Toolkit
+
+A research instrument, funded under a grant, published at
+<https://red1oon.github.io/bim-ootb/readiness/>. Seven static pages, no build step, no server.
+
+Source of truth for the page content is `~/Projects/Dubai/plan/toolkit_*.html`; the lane record and
+every design decision is in `~/Projects/Dubai/PROMPT.md`, and the evidentiary register is
+`~/Projects/Dubai/plan/CITATIONS.md`.
+
+## The boundary — read this before adding anything
+
+The assessment and the Viewer are **separate**, deliberately.
+
+| | |
+|---|---|
+| **The Viewer** | As-is, where-is. A visitor may enjoy it. It receives nothing from the assessment |
+| **The analysis** | Lands in the assessment report and goes **no further** |
+| **The handover** | The visitor's own model, compiled to SQLite, downloaded to **their** Downloads folder |
+
+Nothing about a respondent's answers, scores, profile or recommendations is written into the
+database, passed to the Viewer, or stored anywhere. If a future change would create a data path
+between the assessment and the Viewer, that is a boundary change and needs saying out loud.
+
+## Why the assessment does not use `import_worker.js` for measurement
+
+`PROMPT.md §ROADMAP` is explicit: *Track B metrics at the web-ifc layer — **never** from the
+extracted DB (lossy projection).* The extraction that builds renderable geometry drops exactly the
+semantic detail the metrics count. So:
+
+- **`metrics_worker.js`** (this folder) — measures. Calls web-ifc directly, at the web-ifc layer.
+  No geometry, no sql.js, no storage. This is Track B, metrics M1–M15 of `SCORING_SPEC.md §5.1`.
+- **`../viewer/import_worker.js`** — compiles. Used **unmodified**, only for the SQLite handover,
+  and only after the visitor acknowledges it.
+
+## Reused from the platform, never copied
+
+The handover loads three viewer modules directly. They are **not** duplicated here, and the Viewer
+is **not** modified:
+
+| Path | Role |
+|---|---|
+| `../viewer/import_worker.js` | IFC → intermediate structures, in a Worker |
+| `../viewer/import_db_builder.js` | `buildImportDBs(SQL, data)` → the SQLite database. Self-contained, no viewer globals |
+| `../viewer/lib/sql-wasm.js`, `../viewer/lib/web-ifc-api-iife.js` | sql.js and web-ifc, vendored same-origin |
+
+If any of those move, the handover breaks loudly at load rather than drifting out of sync. That is
+intentional. **Do not copy them into this folder to "fix" a break** — fix the path.
+
+## Privacy, and how to keep it true
+
+- No `fetch`, no `XMLHttpRequest`, no `indexedDB`, no `localStorage`, no cookie in
+  `metrics_worker.js`. Verified by counting the source, not by assertion.
+- `GlobalId` is read to detect duplicates and is **never** posted back — only the count crosses.
+- The submission payload carries integers, percentages, booleans and the schema string. No filename,
+  no GUID, no coordinate, no element name. Exporter is matched against a fixed allowlist; anything
+  unrecognised reports as `other`.
+- The only third-party requests the pages make are **Google Fonts**, on page load, regardless of any
+  file. The drop zone discloses this. Removing that dependency is open work — it is also what the
+  offline zip needs.
+- The assessment itself stores nothing. **The Viewer does** — `viewer/import.js` keeps imports in
+  IndexedDB. That difference is real and must stay disclosed wherever the two meet.
+
+## Language packs
+
+`assess.html` carries inline `ms` and `ar` packs — 160 strings each. **Both are unadjudicated
+drafts** and the page says so, in the target language and in English, whenever one is active.
+Adjudication by a qualified translator is outstanding: roughly 2,150 words per language.
+
+The acknowledgement gate, the consent statement and the printed Notice are **deliberately not
+translated**. They are legally load-bearing and need a qualified legal translator, not a model.
+Do not "finish the job" by drafting them.
+
+## Things that will bite
+
+- **`<meta charset="utf-8">` must stay on every page.** GH Pages sends the header so it looks
+  redundant — until the offline zip opens over `file://` and the Arabic pack mojibakes.
+- **A parse check is not a test.** Converting a screen to a render-time function once left
+  `return ''` without its `+`: it parsed cleanly and silently returned an empty string. Exercise the
+  built screens, do not just lint them.
+- **`readiness/` is not precached by any `sw.js`**, so changes here need no `CACHE_VERSION` bump.
+  Check before assuming that is still true.
+- Four of the twenty criteria carry **no external anchor** (A3, C1, C3, C4). Never describe the
+  instrument as "anchored" without stating the 16/4 split.

--- a/readiness/assess.html
+++ b/readiness/assess.html
@@ -877,6 +877,38 @@ SCREENS.model = function () { return '' +
       '<p class="small" style="margin:12px 0 0;text-align:left">This is your model, read by ' +
       'software that is not the software you authored it in. That is question ' +
       '<span class="mono">A3</span>, answered.</p>' +
+
+      /* §HANDOVER — the visitor leaves holding their own data. */
+      '<div style="margin-top:14px;text-align:left">' +
+        '<button class="btn sec sm" type="button" id="convbtn">Take your model with you &mdash; ' +
+        'compile it to SQLite</button>' +
+        '<div class="small" id="convstate" style="margin-top:8px"></div>' +
+        '<div class="prog" id="convprog" hidden style="margin-left:0"><div class="progbar" id="convbar"></div></div>' +
+      '</div>' +
+
+      '<div class="call warnc" id="convgate" hidden style="margin-top:14px;text-align:left">' +
+        '<strong>Before it downloads &mdash; what you are about to get.</strong>' +
+        '<p style="margin:9px 0 0">Your IFC is compiled to a <strong>SQLite database</strong> that you ' +
+        'may open and use thereof. It is written straight to your Downloads folder. The conversion ' +
+        'runs in this browser tab: nothing is uploaded and no copy is kept here.</p>' +
+        '<p style="margin:9px 0 0"><strong>This concludes the assessment.</strong> The analysis has ' +
+        'landed in your report and is not written into the database.</p>' +
+        '<p style="margin:9px 0 0">A <strong>README</strong> arrives in the same folder beside your ' +
+        'database, yours to use or dispose of. <strong>No back door and no lock-in exists.</strong></p>' +
+        '<p style="margin:9px 0 0" class="small">Large models take a few minutes and the tab must ' +
+        'stay open. Your browser may ask permission to save more than one file.</p>' +
+        '<div class="actions" style="margin-top:12px">' +
+          '<button class="btn" type="button" id="convgo">Compile and download</button>' +
+          '<button class="btn sec" type="button" id="convcancel">Not now</button>' +
+        '</div>' +
+      '</div>' +
+
+      '<div class="call" id="convdone" hidden style="margin-top:14px;text-align:left">' +
+        '<span class="lab">Saved to your Downloads folder</span>' +
+        '<p>Your model is now a SQLite database, and a README sits beside it explaining what it is ' +
+        'and how to open it. It needs no licence, expires never, and answers to nobody &mdash; ' +
+        'including us. <strong>That is the whole argument for open standards, in a file you can hold.</strong></p>' +
+      '</div>' +
     '</div>' +
     '<div id="droperr" class="small" hidden style="color:var(--warn)"></div>' +
   '</div>' +
@@ -1284,6 +1316,7 @@ function readIFC(file) {
   if (!file || MWbusy) return;
   if (!/\.ifc$/i.test(file.name)) { mwShow('dropidle', 'That is not an .ifc file.'); return; }
   MWbusy = true;
+  LASTFILE = file;
   mwShow('dropbusy');
   var bn = mwEl('busyname'); if (bn) bn.textContent = file.name + ' · ' + (file.size / 1048576).toFixed(1) + ' MB';
   var setPct = function (p, phase) {
@@ -1363,6 +1396,167 @@ document.addEventListener('drop', function (e) {
   e.preventDefault(); d.style.borderColor = '';
   var f = e.dataTransfer && e.dataTransfer.files && e.dataTransfer.files[0];
   if (f) readIFC(f);
+});
+
+
+/* ============================================================
+   TAKE YOUR MODEL WITH YOU  (§HANDOVER)
+   The last act of the assessment. Their IFC is compiled to a SQLite database and downloaded to
+   their own Downloads folder, with a README beside it. Nothing is kept here and nothing is sent
+   anywhere: the conversion runs in a Web Worker in this tab and the result goes straight to disk.
+
+   This is the anti-lock-in claim demonstrated rather than asserted. A visitor arrives for a
+   readiness assessment and leaves holding their own model in an open, queryable format that
+   this project cannot reach, revoke or charge for.
+
+   ⚠ Everything below reuses the platform's own modules UNMODIFIED — ../viewer/import_worker.js,
+   ../viewer/import_db_builder.js, ../viewer/lib/sql-wasm.js. Nothing is copied and the viewer is
+   not touched. If those move, this breaks loudly rather than drifting out of sync.
+   ============================================================ */
+
+var LASTFILE = null;          /* the File the respondent chose, kept only in this tab's memory */
+var CONVERTING = false;
+
+function readmeText(name, m) {
+  var when = new Date().toISOString().slice(0, 10);
+  return [
+    'YOUR MODEL, AS A DATABASE',
+    '=========================',
+    '',
+    'Source file : ' + name,
+    'Converted   : ' + when + ', in your own browser',
+    'Schema      : ' + (m && m.schema || 'IFC'),
+    'Elements    : ' + (m && m.elements != null ? m.elements : 'n/a'),
+    '',
+    'WHAT THIS IS',
+    'Your IFC has been compiled to a SQLite database. It is an ordinary .db file. Open it with',
+    'any SQLite tool — the sqlite3 command line, DB Browser for SQLite, Python\'s sqlite3 module,',
+    'or anything else that reads SQLite. Nothing proprietary is involved.',
+    '',
+    'WHERE IT CAME FROM',
+    'The conversion ran inside your browser tab. Your IFC was never uploaded, and neither was the',
+    'database. No account was created. No server saw either file.',
+    '',
+    'WHAT IT IS NOT',
+    'This is not your assessment. Your readiness profile, gap analysis and recommendations stayed',
+    'in the report on the assessment page and were not written into this database.',
+    '',
+    'NO BACK DOOR, NO LOCK-IN',
+    'This file is yours. It phones nothing home, needs no licence and will not expire. Keep it,',
+    'move it, query it, or delete it. Nothing here depends on us and nothing about it can be',
+    'revoked. That is the point of open standards, and it is the point this toolkit was written',
+    'to make.',
+    '',
+    'A note on honesty: this database is a projection of your IFC, not a replacement for it. Keep',
+    'the original IFC as your source of truth.',
+    '',
+    'You may notice the database holds fewer elements than the assessment reported. That is not a',
+    'loss and not an error: the assessment counts every entity the IFC schema calls an element,',
+    'while the database stores the ones that carry geometry, and it de-duplicates repeated shapes.',
+    'Two different counts, for two different jobs, both taken from the same file.',
+    '',
+    'IF YOU DO SO WISH TO PROGRESS ON YOUR OWN',
+    'The same open-source platform that compiled this file can open it, and its user guide is here:',
+    '',
+    '    https://red1oon.github.io/BIMCompiler/BIMUserGuide/',
+    '',
+    'You are under no obligation to use it. The database is plain SQLite and owes nothing to the',
+    'tool that produced it — that is rather the point.',
+    '',
+    'OpenBIM Readiness Assessment Toolkit v0.1 — a research instrument.',
+    'https://red1oon.github.io/bim-ootb/readiness/'
+  ].join('\n');
+}
+
+function saveBlob(data, filename, mime) {
+  var blob = new Blob([data], { type: mime || 'application/octet-stream' });
+  var a = document.createElement('a');
+  a.href = URL.createObjectURL(blob);
+  a.download = filename;
+  document.body.appendChild(a); a.click(); a.remove();
+  setTimeout(function () { URL.revokeObjectURL(a.href); }, 4000);
+}
+
+function loadScriptOnce(src) {
+  return new Promise(function (resolve, reject) {
+    if (document.querySelector('script[data-src="' + src + '"]')) return resolve();
+    var el = document.createElement('script');
+    el.src = src; el.setAttribute('data-src', src);
+    el.onload = function () { resolve(); };
+    el.onerror = function () { reject(new Error('could not load ' + src)); };
+    document.head.appendChild(el);
+  });
+}
+
+function convStatus(msg, pct, bad) {
+  var el = document.getElementById('convstate');
+  if (el) { el.textContent = msg || ''; el.style.color = bad ? 'var(--warn)' : 'var(--muted)'; }
+  var bar = document.getElementById('convbar');
+  if (bar) bar.style.width = Math.max(2, Math.min(100, pct || 2)) + '%';
+  var wrap = document.getElementById('convprog');
+  if (wrap) wrap.hidden = (pct == null);
+}
+
+async function convertAndDownload() {
+  if (CONVERTING || !LASTFILE) return;
+  CONVERTING = true;
+  var name = LASTFILE.name, base = name.replace(/\.ifc$/i, '');
+  try {
+    convStatus('Loading the compiler', 4);
+    await loadScriptOnce('../viewer/lib/sql-wasm.js');
+    await loadScriptOnce('../viewer/import_db_builder.js');
+
+    convStatus('Reading your file', 8);
+    var buf = await LASTFILE.arrayBuffer();
+
+    var msg = await new Promise(function (resolve, reject) {
+      var w = new Worker('../viewer/import_worker.js');
+      w.onmessage = function (ev) {
+        var d = ev.data || {};
+        if (d.type === 'progress') { convStatus(d.phase || 'Compiling', 8 + Math.round((d.pct || 0) * 0.72)); return; }
+        if (d.type === 'error') { w.terminate(); reject(new Error(d.message || 'conversion failed')); return; }
+        if (d.type === 'done') { w.terminate(); resolve(d); }
+      };
+      w.onerror = function () { w.terminate(); reject(new Error('the compiler could not start')); };
+      w.postMessage({ arrayBuffer: buf, filename: name }, [buf]);
+    });
+
+    convStatus('Building the database', 86);
+    var SQL = await initSqlJs({ locateFile: function (f) { return '../viewer/lib/' + f; } });
+    var dbs = buildImportDBs(SQL, msg);
+
+    convStatus('Saving to your Downloads folder', 96);
+    if (dbs.metaDb && dbs.geoDb) {
+      saveBlob(dbs.metaDb, base + '_meta.db');
+      saveBlob(dbs.geoDb, base + '_geo.db');
+    } else {
+      saveBlob(dbs.extractedDb, base + '.db');
+    }
+    saveBlob(readmeText(name, MEASURED), 'README_' + base + '.txt', 'text/plain');
+
+    convStatus('', null);
+    var done = document.getElementById('convdone');
+    if (done) done.hidden = false;
+    var btn = document.getElementById('convbtn');
+    if (btn) btn.hidden = true;
+  } catch (err) {
+    convStatus('Conversion failed: ' + String(err && err.message || err) + '. Nothing was sent anywhere.', 100, true);
+  } finally {
+    CONVERTING = false;
+  }
+}
+
+document.addEventListener('click', function (e) {
+  var t = e.target;
+  if (t && t.id === 'convbtn') { var g = document.getElementById('convgate'); if (g) g.hidden = false; t.disabled = true; return; }
+  if (t && t.id === 'convcancel') {
+    var g2 = document.getElementById('convgate'); if (g2) g2.hidden = true;
+    var b2 = document.getElementById('convbtn'); if (b2) b2.disabled = false; return;
+  }
+  if (t && t.id === 'convgo') {
+    var g3 = document.getElementById('convgate'); if (g3) g3.hidden = true;
+    convertAndDownload(); return;
+  }
 });
 
 /* ============================================================


### PR DESCRIPTION
The last act of the assessment, and the one that **makes** the argument instead of stating it.

After the model check, the respondent can compile their own IFC to a **SQLite database, downloaded to their own Downloads folder**, with a README beside it. Gated behind an acknowledgement that says in plain words what is about to happen:

> *"Your IFC is compiled to a SQLite database that you may open and use thereof … **This concludes the assessment.** The analysis has landed in your report and is not written into the database … A README arrives in the same folder beside your database, yours to use or dispose of. **No back door and no lock-in exists.**"*

## Why this is the right ending

A visitor arrives for a readiness assessment **about vendor neutrality** and leaves holding their own model in an open, queryable format this project cannot reach, revoke, expire or charge for. The anti-lock-in claim stops being a sentence on a page and becomes **a file on their disk**.

It also resolves a contradiction noted earlier in this lane: the assessment promises *"nothing is stored"*, while the Viewer legitimately keeps imports in IndexedDB. Downloading to the visitor's own folder sidesteps it — the assessment still stores nothing, and what the visitor keeps is under **their** control.

## Reused, never copied — and the Viewer is not modified

**2 files touched, both under `readiness/`.**

| Loaded lazily, after the ack | Role |
|---|---|
| `../viewer/import_worker.js` | IFC parse, in a Worker, **unmodified** |
| `../viewer/import_db_builder.js` | `buildImportDBs()` — already a shared module, zero viewer globals |
| `../viewer/lib/sql-wasm.js` | sql.js, vendored same-origin |

If they move, this breaks **loudly at load** rather than drifting. `readiness/README.md` says so, and says not to "fix" a break by copying them here.

## The downloaded README

What the file is, that any SQLite tool opens it, that nothing was uploaded and no account exists, that it is not the assessment, and that it phones nothing home. Carries the Viewer user-guide link under **"IF YOU DO SO WISH TO PROGRESS ON YOUR OWN"**, obligation explicitly disclaimed — *the database owes nothing to the tool that produced it, which is rather the point.*

It also discloses, **unprompted**, that the database holds fewer elements than the assessment reported (215 vs 295 on Duplex_ARC). Two element definitions for two jobs: the metrics pass counts every `IfcElement` subtype; the extractor stores what carries geometry and de-duplicates repeated shapes. A visitor comparing the two numbers would otherwise think something had been lost.

## Also adds `readiness/README.md`

The boundary (Viewer as-is · analysis no further · handover to the visitor's own folder), why measurement does not use `import_worker.js`, the reuse contract, the privacy surface, language-pack status, and four things that will bite.

## Verified end to end in headless Chrome, on a real IFC

- The gate appears with the intended wording and **blocks until confirmed**
- `Duplex_ARC.ifc` → `Duplex_ARC.db` (1.5 MB) + `README_Duplex_ARC.txt`, both in Downloads
- **The `.db` opens in `sqlite3`**: 11 tables — 215 `element_instances`, 215 `elements_meta`, 170 `component_geometries`, 11 `bom_tree`. Real, populated, queryable
- Magic header `SQLite format 3\0` — a genuine SQLite file, not a shaped blob
- README carries the user-guide link
- Only non-localhost requests remain Google Fonts, on load, regardless of any file
- Zero page errors

**Additive only: 194 lines added to `assess.html`, 0 removed.** The 20 questions, tips, ladders, anchors, clauses and tiers identical to `origin/main`; acknowledgement gate, consent statement and printed Notice **byte-identical**; Track B and the ms/ar packs intact.

> Rebased onto fresh `origin/main` — the first push of this work was orphaned when #1502 squash-merged mid-push, exactly as `CLAUDE.md` warns.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EVYqpsZquz3dfP2HaUFuoE