### PR TITLE
fix(tm): Alt+C bake loads the schedule silently, never opens the TM panel

### DIFF
--- a/viewer/cinema_maxq.js
+++ b/viewer/cinema_maxq.js
@@ -1471,6 +1471,11 @@
       if (_bkState && typeof window.tmRestoreDerivedOrder === 'function') {
         window.tmRestoreDerivedOrder(); _bkState = null;
       }
+      // §CPE_BUILDUP_ACTIVATE_POPS_PANEL: same contract — a bake that silently turned Time Machine
+      // on (tmActivateForBake, no real Play involved) must silently turn it back off, or the scene
+      // is left mid-construction with nothing offering to restore it (the panel was never shown, so
+      // there's no close button to do it).
+      try { if (typeof window.tmDeactivateIfBakeOwned === 'function') window.tmDeactivateIfBakeOwned(); } catch (eTM) {}
       // §CPE_GHOST_GROUND: same contract, same exit — a ghosted ground left behind would follow the
       // user into normal navigation for the rest of the session.
       try { _ghostGroundRestore(); } catch (eGG) {}
@@ -1527,6 +1532,8 @@
       // §CPE_BUILDUP: same restore on the THROW path. A re-keyed op-log left behind by a crashed
       // bake would look like a corrupted schedule to the next person who opens the timeline.
       try { if (_bkState && window.tmRestoreDerivedOrder) { window.tmRestoreDerivedOrder(); _bkState = null; } } catch (e3) {}
+      // §CPE_BUILDUP_ACTIVATE_POPS_PANEL: same restore on the THROW path — see the in-try comment above.
+      try { if (window.tmDeactivateIfBakeOwned) window.tmDeactivateIfBakeOwned(); } catch (eTM2) {}
       try { _ghostGroundRestore(); } catch (e4) {}
       try { if (A.cpeRevealApplyVisual) A.cpeRevealApplyVisual(null, 0); } catch (eRV2) {}
       try { _workPacingReset(); } catch (e5) {}

--- a/viewer/sw.js
+++ b/viewer/sw.js
@@ -8,7 +8,17 @@
 // Cache-first for heavy assets (.wasm, images). DB files skip SW (IndexedDB handles them).
 //
 // DEPLOY: bump CACHE_VERSION on every OCI upload. Old caches are purged on activate.
-const CACHE_VERSION = 'v1082';   // bump on each deploy; per-change detail is the git commit message.
+const CACHE_VERSION = 'v1083';   // bump on each deploy; per-change detail is the git commit message.
+// v1083 (2026-08-25) §CPE_BUILDUP_ACTIVATE_POPS_PANEL (CINEMA_PATH_EDITOR.md): Alt+C's bake
+// (tmActivateForBake) no longer calls the real, panel-popping activate() — a new `silent` param
+// threaded through activate()->_activateAsync()->_finishActivate() loads the same schedule data
+// (_ops/_projectStart/_projectEnd, xray cache, computeDays, saveVisibility) without ever touching
+// the Time Machine panel DOM/canvas (no setToolbarHighlight/_panel.display/switchMode/renderAtTime/
+// updateStatus/drawGanttMini/drawDashboard/_loadTwin fetch). A real user Play is unaffected (silent
+// is falsy for every other caller). New window.tmDeactivateIfBakeOwned() (cinema_maxq.js, called on
+// every bake exit path) turns TM back off ONLY if the bake itself silently turned it on — a bake
+// that reuses an already-open real TM session leaves it untouched. Witness:
+// witness_cpe_buildup_activate_silent.js.
 // v1078 (2026-08-23) SCRIPT_LENGTH_REFACTOR_SEAMS.md §S59 candidate 2 — navigate_find.js's ERP-push
 // block extracted to NEW find_erp_push.js (loaded by main.js's lazy navigate list BEFORE
 // navigate_find.js?v=58). NOT precached ON PURPOSE: none of the lazy navigate_* sub-modules are

--- a/viewer/tests/witness_cpe_buildup_activate_silent.js
+++ b/viewer/tests/witness_cpe_buildup_activate_silent.js
@@ -1,0 +1,227 @@
+#!/usr/bin/env node
+// witness_cpe_buildup_activate_silent.js — W-ACTIVATE-SILENT
+// Implementing bim-compiler prompts/CINEMA_PATH_EDITOR.md §CPE_BUILDUP_ACTIVATE_POPS_PANEL
+//
+// THE ISSUE THIS WITNESS PROVES OR DISPROVES:
+//   Alt+C's bake (tmActivateForBake) used to call the real, panel-popping activate() to get the
+//   schedule ready — every bake visibly opened the Time Machine panel, drew the mini-Gantt and
+//   dashboard, and fetched the twin-cost drawer, none of which a camera-only bake needs. The fix
+//   threads a `silent` flag through activate()->_activateAsync()->_finishActivate() so the bake
+//   path loads the same _ops/_projectStart/_projectEnd data WITHOUT touching panel DOM, and a
+//   companion tmDeactivateIfBakeOwned() turns TM back off afterward ONLY if the bake itself was
+//   the one that turned it on (never touching a real user's already-open session).
+//
+//   A witness that only checks "_ops got populated" would PASS on the broken build — the data
+//   loaded fine before this fix too. The assertion here is the panel-facing call COUNTS:
+//   setToolbarHighlight/_panel.display/switchMode/renderAtTime/updateStatus/drawGanttMini/
+//   drawDashboard/_loadTwin must be ZERO on a silent activation and UNCHANGED (>0, same as a
+//   plain call) on a real one.
+//
+// HOW IT FALSIFIES: Gate A runs against both `origin/main` (shipped, no `silent` param — must
+// FAIL, panel calls fire regardless of the flag) and the working tree (must PASS, panel calls
+// fire only when NOT silent). A run where shipped also passes is not evidence — it means the RED
+// case stopped reproducing and the witness is blind. Gate B (deactivate ownership) only exists in
+// the working tree; shipped has no tmDeactivateIfBakeOwned to test at all.
+//
+// Run (from the repo root): node witness_cpe_buildup_activate_silent.js
+// Read the log, not the exit code.
+'use strict';
+const fs = require('fs');
+const path = require('path');
+const vm = require('vm');
+const cp = require('child_process');
+
+const TM = path.join(__dirname, '..', 'time_machine.js');
+const workingSrc = fs.readFileSync(TM, 'utf8');
+const shippedSrc = cp.execFileSync('git', ['show', 'origin/main:viewer/time_machine.js'],
+  { cwd: __dirname, maxBuffer: 1 << 28 }).toString();
+
+function slice(src, marker, optional) {
+  const idx = src.indexOf(marker);
+  if (idx < 0) {
+    if (optional) return '';
+    throw new Error('marker not found: ' + marker);
+  }
+  let depth = 0, seen = false, i = idx;
+  for (; i < src.length; i++) {
+    if (src[i] === '{') { depth++; seen = true; }
+    else if (src[i] === '}') { depth--; if (seen && depth === 0) break; }
+  }
+  return src.slice(idx, i + 1) + ';';
+}
+
+// ── Gate A: activate()/_activateAsync()/_finishActivate() — panel calls gated on `silent` ──────
+function makeActivateHarness(src) {
+  const calls = { setToolbarHighlight: 0, panelDisplaySets: [], switchMode: 0, renderAtTime: 0,
+                  updateStatus: 0, drawGanttMini: 0, drawDashboard: 0, loadTwin: 0,
+                  xrayCache: 0, computeDays: 0, saveVisibility: 0 };
+  const _panel = { style: {} };
+  Object.defineProperty(_panel.style, 'display', {
+    set(v) { calls.panelDisplaySets.push(v); this._v = v; },
+    get() { return this._v; },
+  });
+  const ctx = {
+    _ops: [], _active: false, _projectStart: 0, _projectEnd: 0, _days: [],
+    _lastEdit: null, _ganttAutoGenAttempted: false, _ganttSelected: {}, _marquee: null, _groupDrag: null,
+    _s4ActT0: 0, _tmEnabledGI: false, _activeBuildingCount: 0, _isLargeBuilding: false,
+    _dlodProxyOn: false, _anchorDay: null, _anchorHr: null, _ganttVisible: false, _dashVisible: false,
+    _panel,
+    LARGE_BUILDING: 50000, DLOD_TM_MIN_ELEMENTS: 1000,
+    performance: { now: () => Date.now() },
+    console: { log: () => {}, warn: (m) => console.warn(String(m)) },
+    document: { getElementById: () => null },
+    setInterval, clearInterval,
+    setToolbarHighlight: (on) => { calls.setToolbarHighlight++; },
+    switchMode: () => { calls.switchMode++; },
+    renderAtTime: () => { calls.renderAtTime++; },
+    updateStatus: () => { calls.updateStatus++; },
+    drawGanttMini: () => { calls.drawGanttMini++; },
+    drawDashboard: () => { calls.drawDashboard++; },
+    _loadTwin: () => { calls.loadTwin++; return Promise.resolve(null); },
+    _tmRebuildXrayCache: () => { calls.xrayCache++; },
+    computeDays: () => {
+      calls.computeDays++;
+      // Real computeDays derives projectStart/projectEnd from _ops — the bake NEEDS this to keep
+      // working under `silent`, so the stub reproduces exactly that side effect.
+      if (ctx._ops.length) {
+        ctx._projectStart = Math.min.apply(null, ctx._ops.map(o => o.start_ts));
+        ctx._projectEnd = Math.max.apply(null, ctx._ops.map(o => o.end_ts));
+        ctx._days = [ctx._projectStart, ctx._projectEnd];
+      }
+    },
+    saveVisibility: () => { calls.saveVisibility++; },
+    viewerStatus: () => {},
+    cacheGet: (k) => Promise.resolve(ctx._cachedOps || null),
+    cacheDel: () => {},
+    cachePut: () => {},
+    loadOps: () => ctx._cachedOps || [],   // simulates "the DB now reflects what cache-hit just inserted"
+    A: () => ({
+      db: {
+        run: () => {},
+        prepare: () => ({ run: () => {}, free: () => {} }),
+      },
+      _tmOn: false,
+    }),
+  };
+  ctx.window = ctx;
+  ctx.window.ScheduleAuthor = { activeSchedule: () => ({ id: 1 }) }; // keep the cache-hit path live
+
+  vm.createContext(ctx);
+  vm.runInContext([
+    slice(src, 'function activate('),
+    slice(src, 'function _activateAsync('),
+    slice(src, 'function _finishActivate('),
+  ].join('\n'), ctx);
+
+  return { ctx, calls };
+}
+
+const HOSPITAL_OPS = [
+  { output_guid: 'g1', input_guids: [], start_ts: 1.7e12, end_ts: 1.7e12 + 86400000, parameters: {}, op_type: 'ELEMENT_PLACE' },
+  { output_guid: 'g2', input_guids: [], start_ts: 1.7e12 + 86400000, end_ts: 1.7e12 + 2 * 86400000, parameters: {}, op_type: 'ELEMENT_PLACE' },
+];
+
+async function gateA(src, label) {
+  const out = { label };
+  // Real Play (no arg) — panel calls must fire, exactly as before this fix.
+  {
+    const h = makeActivateHarness(src);
+    h.ctx._cachedOps = HOSPITAL_OPS;
+    h.ctx.activate();
+    for (let i = 0; i < 30 && !h.ctx._active; i++) await new Promise(r => setImmediate(r));
+    const panelFired = h.calls.setToolbarHighlight > 0 && h.calls.panelDisplaySets.includes('flex') &&
+      h.calls.switchMode > 0 && h.calls.updateStatus > 0;
+    const dataOk = h.ctx._ops.length === 2 && h.ctx._projectEnd > h.ctx._projectStart;
+    out.realPlay = panelFired && dataOk;
+    console.log('§ACTIVATE_SILENT G-A1 ' + label + ' realPlay panelCalls=' + JSON.stringify(h.calls) +
+      ' data(ops=' + h.ctx._ops.length + ' span=' + (h.ctx._projectEnd - h.ctx._projectStart) + 'ms)' +
+      ' → ' + (out.realPlay ? 'panel shown as before (PASS)' : 'FAIL — real Play stopped opening the panel'));
+  }
+  // Silent bake activation — panel calls must be ZERO; data must still populate.
+  {
+    const h = makeActivateHarness(src);
+    h.ctx._cachedOps = HOSPITAL_OPS;
+    h.ctx.activate(true);
+    for (let i = 0; i < 30 && !h.ctx._active; i++) await new Promise(r => setImmediate(r));
+    const panelSilent = h.calls.setToolbarHighlight === 0 && h.calls.panelDisplaySets.length === 0 &&
+      h.calls.switchMode === 0 && h.calls.renderAtTime === 0 && h.calls.updateStatus === 0 &&
+      h.calls.drawGanttMini === 0 && h.calls.drawDashboard === 0 && h.calls.loadTwin === 0;
+    const dataOk = h.ctx._ops.length === 2 && h.ctx._projectEnd > h.ctx._projectStart &&
+      h.calls.xrayCache > 0 && h.calls.computeDays > 0 && h.calls.saveVisibility > 0;
+    out.silent = panelSilent && dataOk;
+    console.log('§ACTIVATE_SILENT G-A2 ' + label + ' silentBake panelCalls=' + JSON.stringify(h.calls) +
+      ' data(ops=' + h.ctx._ops.length + ' span=' + (h.ctx._projectEnd - h.ctx._projectStart) + 'ms)' +
+      ' → ' + (out.silent ? 'zero panel footprint, data still real (PASS)' : 'FAIL — silent activation still touched the panel, or lost the data'));
+  }
+  return out;
+}
+
+// ── Gate B: tmActivateForBake / tmDeactivateIfBakeOwned ownership — working tree only ──────────
+function makeOwnershipHarness(src) {
+  const spy = { activateCalls: 0, activateSilent: null, deactivateCalls: 0 };
+  const ctx = {
+    _ops: [1], _active: false, _projectStart: 0, _projectEnd: 100, _bakeOwnsActivation: false,
+    console: { log: () => {}, warn: () => {} },
+    setInterval, clearInterval,
+    activate: (silent) => { spy.activateCalls++; spy.activateSilent = silent; ctx._active = true; },
+    deactivate: () => { spy.deactivateCalls++; ctx._active = false; },
+  };
+  ctx.window = ctx;
+  vm.createContext(ctx);
+  vm.runInContext([
+    slice(src, 'function _bakeTimelineReady()'),
+    slice(src, 'window.tmActivateForBake = function'),
+    slice(src, 'window.tmDeactivateIfBakeOwned = function'),
+  ].join('\n'), ctx);
+  return { ctx, spy };
+}
+
+async function gateB() {
+  // B1 — TM was OFF: the bake must be the one to turn it on, and tmDeactivateIfBakeOwned must turn it off after.
+  {
+    const h = makeOwnershipHarness(workingSrc);
+    const ok = await h.ctx.window.tmActivateForBake();
+    h.ctx.window.tmDeactivateIfBakeOwned();
+    const pass = ok === true && h.spy.activateCalls === 1 && h.spy.activateSilent === true && h.spy.deactivateCalls === 1;
+    console.log('§ACTIVATE_SILENT G-B1 TM-was-off armed=' + ok + ' activate(silent=' + h.spy.activateSilent +
+      ')x' + h.spy.activateCalls + ' deactivate x' + h.spy.deactivateCalls +
+      ' → ' + (pass ? 'bake owned + cleaned up its own activation (PASS)' : 'FAIL'));
+    return pass;
+  }
+}
+async function gateB2() {
+  // B2 — a real user session was ALREADY active: the bake must not call activate(), and must NEVER
+  // deactivate a session it did not open.
+  const h = makeOwnershipHarness(workingSrc);
+  h.ctx._active = true;
+  const ok = await h.ctx.window.tmActivateForBake();
+  h.ctx.window.tmDeactivateIfBakeOwned();
+  const pass = ok === true && h.spy.activateCalls === 0 && h.spy.deactivateCalls === 0 && h.ctx._active === true;
+  console.log('§ACTIVATE_SILENT G-B2 TM-already-on armed=' + ok + ' activateCalls=' + h.spy.activateCalls +
+    ' deactivateCalls=' + h.spy.deactivateCalls + ' stillActive=' + h.ctx._active +
+    ' → ' + (pass ? "left the user's real session untouched (PASS)" : 'FAIL — bake stole or closed a real TM session'));
+  return pass;
+}
+
+(async function () {
+  console.log('§ACTIVATE_SILENT W-ACTIVATE-SILENT — §CPE_BUILDUP_ACTIVATE_POPS_PANEL, two sources, one harness\n');
+  const shipped = await gateA(shippedSrc, 'SHIPPED(origin/main)');
+  console.log('');
+  const fixed = await gateA(workingSrc, 'FIXED(working-tree)');
+  console.log('');
+  const b1 = await gateB();
+  const b2 = await gateB2();
+
+  // RED control: shipped has no `silent` concept, so calling activate(true) on it must still pop
+  // the panel exactly like a real Play — i.e. shipped's "silent" gate must FAIL.
+  const redReproduces = shipped.realPlay === true && shipped.silent === false;
+  console.log('\n§ACTIVATE_SILENT_RESULT red=' + (redReproduces
+    ? 'shipped ignores the flag, panel still pops on a "silent" call (the bug reproduces)'
+    : 'WITNESS IS BLIND — shipped source unexpectedly passed the silent gate'));
+  const green = fixed.realPlay && fixed.silent && b1 && b2;
+  console.log('§ACTIVATE_SILENT_RESULT green=' + (green ? 'all gates pass on the fix' : 'FIX INCOMPLETE') +
+    ' (realPlay=' + fixed.realPlay + ' silent=' + fixed.silent + ' ownershipOn=' + b1 + ' ownershipAlreadyOn=' + b2 + ')');
+  const verdict = redReproduces && green;
+  console.log('§ACTIVATE_SILENT_VERDICT ' + (verdict ? 'GREEN — falsifiable and fixed' : 'RED — see gates above'));
+  process.exit(verdict ? 0 : 1);
+})();

--- a/viewer/tests/witness_cpe_buildup_activate_silent.js
+++ b/viewer/tests/witness_cpe_buildup_activate_silent.js
@@ -128,7 +128,7 @@ async function gateA(src, label) {
     const h = makeActivateHarness(src);
     h.ctx._cachedOps = HOSPITAL_OPS;
     h.ctx.activate();
-    for (let i = 0; i < 30 && !h.ctx._active; i++) await new Promise(r => setImmediate(r));
+    for (let i = 0; i < 30 && !h.ctx._active; i++) await new Promise(r => setTimeout(r, 0));
     const panelFired = h.calls.setToolbarHighlight > 0 && h.calls.panelDisplaySets.includes('flex') &&
       h.calls.switchMode > 0 && h.calls.updateStatus > 0;
     const dataOk = h.ctx._ops.length === 2 && h.ctx._projectEnd > h.ctx._projectStart;
@@ -142,7 +142,7 @@ async function gateA(src, label) {
     const h = makeActivateHarness(src);
     h.ctx._cachedOps = HOSPITAL_OPS;
     h.ctx.activate(true);
-    for (let i = 0; i < 30 && !h.ctx._active; i++) await new Promise(r => setImmediate(r));
+    for (let i = 0; i < 30 && !h.ctx._active; i++) await new Promise(r => setTimeout(r, 0));
     const panelSilent = h.calls.setToolbarHighlight === 0 && h.calls.panelDisplaySets.length === 0 &&
       h.calls.switchMode === 0 && h.calls.renderAtTime === 0 && h.calls.updateStatus === 0 &&
       h.calls.drawGanttMini === 0 && h.calls.drawDashboard === 0 && h.calls.loadTwin === 0;

--- a/viewer/time_machine.js
+++ b/viewer/time_machine.js
@@ -8269,7 +8269,11 @@
   }
 
   var _s4ActT0 = 0;   // §S4_ACTIVATION_TIMING — shared with _finishActivate below (measure-first, additive only)
-  function activate() {
+  // §CPE_BUILDUP_ACTIVATE_POPS_PANEL (2026-08-25, bim-compiler prompts/CINEMA_PATH_EDITOR.md):
+  // silent=true loads the schedule DATA only, never touches the panel DOM — for tmActivateForBake,
+  // per G-CPE-SOLE-OWNER ("only a real Play opens Time Machine"). Every other caller passes
+  // nothing, so silent is falsy and behavior is byte-identical to before this flag existed.
+  function activate(silent) {
     if (_active) return;
     _s4ActT0 = performance.now();
     _lastEdit = null;   // §GANTT_EDIT_UNDO — a stale snapshot from a prior building must never apply here
@@ -8304,24 +8308,27 @@
         if (app.buildingsRendered && app.buildingsRendered.size > 0 && !app.streaming) {
           clearInterval(_reWait);
           console.log('§TM_UNMERGE done bld=' + (bld || '?') + ' ms=' + (performance.now() - _umT0).toFixed(1));
-          activate();
+          activate(silent);
         }
       }, 500);
       return;
     }
-    setToolbarHighlight(true);
-    _panel.style.display = 'flex';
-    var st = document.getElementById('tm-status');
-    if (st) st.textContent = 'Loading timeline...';
+    var st = null;
+    if (!silent) {
+      setToolbarHighlight(true);
+      _panel.style.display = 'flex';
+      st = document.getElementById('tm-status');
+      if (st) st.textContent = 'Loading timeline...';
+    }
 
     // §S260c: Try IDB cache first, then kernel_ops table, then full recompute
-    _activateAsync(st).then(function(ok) {
-      if (!ok) { setToolbarHighlight(false); _panel.style.display = 'none'; return; }
+    _activateAsync(st, silent).then(function(ok) {
+      if (!ok && !silent) { setToolbarHighlight(false); _panel.style.display = 'none'; return; }
     });
     return; // async continuation below
   }
 
-  function _activateAsync(st) {
+  function _activateAsync(st, silent) {
     return new Promise(function(resolve) {
     var app = A();
 
@@ -8372,7 +8379,7 @@
         _ops = loadOps(); _ganttDirty = true;
         if (st) st.textContent = '';
         viewerStatus('Time Machine: ' + _ops.length + ' elements (cached)');
-        _finishActivate(app);
+        _finishActivate(app, silent);
         resolve(true);
         return;
       }
@@ -8434,20 +8441,20 @@
         viewerStatus('Time Machine: ' + _ops.length + ' elements scheduled');
       }
 
-      _finishActivate(app);
+      _finishActivate(app, silent);
       resolve(true);
     }).catch(async function(e) {   // §GANTT_REFOLD_HANG: awaits chunked injectGantt in the fallback
       console.warn('§GANTT_CACHE_ERR ' + e.message);
       // Fallback: compute without cache
       _ops = loadOps(); _ganttDirty = true;
       if (!_ops.length) { _materializeNativeSchedule(A()); await injectGantt(); _ops = loadOps(); _ganttDirty = true; }  // §GANTT_SINGLE_LOAD, same as the main path (await: loadOps must see the chunked writes)
-      if (_ops.length) { _finishActivate(app); resolve(true); }
+      if (_ops.length) { _finishActivate(app, silent); resolve(true); }
       else resolve(false);
     });
     });
   }
 
-  function _finishActivate(app) {
+  function _finishActivate(app, silent) {
     _active = true;
     app._tmOn = true;  // exposed for pill isActive highlight (panels.js 'tm' entry)
     // §TM_GI_AUTO RETIRED (2026-07-18, user: "its up to user to turn Shadow, G and audio"):
@@ -8496,6 +8503,18 @@
     console.log('§MOBILE_TM_TOGGLE method=setVisibleAt|setMatrixAt mobile=' + !!app._isMobile + ' dlod=' + !!app._useDlodPath);
     _anchorDay = _days.length ? _days[_days.length - 1] : null;
     _anchorHr = 15;
+    // §CPE_BUILDUP_ACTIVATE_POPS_PANEL: everything below this line is panel DOM/canvas work — the
+    // bake path (silent=true) needs only _ops/_projectStart/_projectEnd, already populated above by
+    // computeDays(). Skipping it here means Alt+C's bake never shows, draws into, or fetches for a
+    // TM panel the user never asked to see; cinema_maxq drives the real per-frame render itself via
+    // tmSetCursor()→renderAtTime(), so the initial renderAtTime(_projectEnd) below would be thrown
+    // away by that first frame anyway.
+    if (silent) {
+      _s4faMark('silentSkipPanel');
+      console.log('§TIME_MACHINE ON (silent, bake-owned) — ' + _ops.length + ' ops, ' + _days.length +
+        ' days, project: ' + new Date(_projectStart).toLocaleDateString() + ' → ' + new Date(_projectEnd).toLocaleDateString());
+      return;
+    }
     _panel.style.display = 'flex';
     switchMode('DAY');
     renderAtTime(_projectEnd); // §S260c: initial render so Gantt + status populate immediately
@@ -8855,10 +8874,18 @@
   // waits for the condition it always meant. A real timeline always has span > 0 (`_projectStart =
   // _ops[0].start_ts - 1`, `_projectEnd` = max end_ts), so this cannot reject a usable state.
   function _bakeTimelineReady() { return !!_ops.length && _projectEnd > _projectStart; }
+  // §CPE_BUILDUP_ACTIVATE_POPS_PANEL: true only while THIS bake is the reason TM is _active — a bake
+  // that started while a real user Play/TM session was already open must never turn that off underneath
+  // them. window.tmDeactivateIfBakeOwned() (below) is the paired cleanup cinema_maxq calls on every
+  // bake exit path (normal end, cancel, throw) — same contract as tmRestoreDerivedOrder/_ghostGroundRestore.
+  var _bakeOwnsActivation = false;
   window.tmActivateForBake = function() {
     return new Promise(function(resolve) {
       if (_active && _bakeTimelineReady()) return resolve(true);
-      if (!_active) { try { activate(); } catch (e) { console.warn('§MAXQ_TIME_ABORT reason=activate ' + e.message); return resolve(false); } }
+      if (!_active) {
+        _bakeOwnsActivation = true;
+        try { activate(true); } catch (e) { _bakeOwnsActivation = false; console.warn('§MAXQ_TIME_ABORT reason=activate ' + e.message); return resolve(false); }
+      }
       var n = 0, iv = setInterval(function() {
         if (_bakeTimelineReady() || ++n > 60) {
           clearInterval(iv);
@@ -8870,6 +8897,13 @@
         }
       }, 500);
     });
+  };
+  // Paired with tmActivateForBake — call once on every bake exit path (normal end, cancel, throw).
+  // No-op unless THIS bake was the one that silently turned TM on; a bake that reused an
+  // already-open real TM session leaves it exactly as the user had it.
+  window.tmDeactivateIfBakeOwned = function() {
+    if (_bakeOwnsActivation && _active) deactivate();
+    _bakeOwnsActivation = false;
   };
 
   // ── §TM_WARM (2026-08-12, bim-compiler prompts/CPE_4D_PERF_MEM_FINDINGS.md §3c —

--- a/viewer/viewer.html
+++ b/viewer/viewer.html
@@ -828,7 +828,7 @@ html.bim-embedded, html.bim-embedded body { background: #0b0b0b; }
 <script src="cinema_path_editor.js?v=15" onerror="console.warn('§LOAD_FAIL cinema_path_editor.js — Alt+C path editing disabled')"></script>
 <script src="cpe_walk.js?v=6" onerror="console.warn('§LOAD_FAIL cpe_walk.js — CPE walk-mode disabled')"></script>
 <script src="cpe_xr.js?v=1" onerror="console.warn('§LOAD_FAIL cpe_xr.js — VR entry disabled')"></script>
-<script src="cinema_maxq.js?v=5" onerror="console.warn('§LOAD_FAIL cinema_maxq.js — Alt+M MaxQ export disabled')"></script>
+<script src="cinema_maxq.js?v=6" onerror="console.warn('§LOAD_FAIL cinema_maxq.js — Alt+M MaxQ export disabled')"></script>
 <script src="input_registry.js?v=1" onerror="console.warn('§LOAD_FAIL input_registry.js')"></script>
 <script src="../common/pill_builder.js?v=1" onerror="console.warn('§LOAD_FAIL pill_builder.js')"></script>
 <script src="list_builder.js?v=1" onerror="console.warn('§LOAD_FAIL list_builder.js')"></script>
@@ -950,7 +950,7 @@ html.bim-embedded, html.bim-embedded body { background: #0b0b0b; }
      Must load BEFORE time_machine.js — its _zoneIndexBuild wrapper calls it. -->
 <script src="zone_index.js?v=1" onerror="console.warn('§LOAD_FAIL zone_index.js — storey banding unavailable (zone inference falls back to declared storey)')"></script>
 <script src="support_sweep.js?v=1" onerror="console.warn('§LOAD_FAIL support_sweep.js — support-order physics unavailable (schedule repair, judge parity, lock-gate midair audit)')"></script>
-<script src="time_machine.js?v=75" onerror="console.warn('§LOAD_FAIL time_machine.js')"></script>
+<script src="time_machine.js?v=76" onerror="console.warn('§LOAD_FAIL time_machine.js')"></script>
 <script src="dlod_nav.js?v=2" onerror="console.warn('§LOAD_FAIL dlod_nav.js')"></script>
 <script src="schedule_author.js?v=14" onerror="console.warn('§LOAD_FAIL schedule_author.js')"></script>
 <script src="schedule_sync.js?v=3" onerror="console.warn('§LOAD_FAIL schedule_sync.js')"></script>


### PR DESCRIPTION
## Summary
- `tmActivateForBake()` used to call the real, panel-popping `activate()` just to read the 4D schedule — Alt+C's bake visibly opened the Time Machine panel, drew the mini-Gantt/dashboard, and fetched the twin-cost drawer, none of which a camera-only bake needs.
- New `silent` param threads through `activate()` -> `_activateAsync()` -> `_finishActivate()`: the bake still gets real data prep (xray cache, `computeDays()`, `saveVisibility()`) but skips every panel-DOM call. Real Play is byte-identical (every other caller passes no arg).
- New `window.tmDeactivateIfBakeOwned()` (called by `cinema_maxq.js` on every bake exit path — normal end, cancel, throw) turns TM back off only if the bake itself silently turned it on, never touching an already-open real session. Without this, a silent bake would leave TM stuck "on" forever with no panel ever shown to close it.

Ref: `prompts/CINEMA_PATH_EDITOR.md` §CPE_BUILDUP_ACTIVATE_POPS_PANEL (bim-compiler repo).

## Test plan
- [x] `node -c viewer/time_machine.js` / `cinema_maxq.js` / `sw.js` — syntax clean
- [x] New witness `viewer/tests/witness_cpe_buildup_activate_silent.js` — two-source falsification vs `origin/main`: shipped reproduces the bug (panel calls fire regardless of the flag), working tree passes all 4 gates (real Play unchanged, silent bake zero panel calls + real data, bake-owned cleanup, real session left untouched). `§ACTIVATE_SILENT_VERDICT GREEN`.
- [x] Full suite `node tests/run_witness_suite.js`: `green=53 new_red=0 known_red=4 fixed=0` — zero regressions.
- [x] `viewer.html` script versions bumped (`time_machine.js?v=76`, `cinema_maxq.js?v=6`) + `sw.js CACHE_VERSION v1083`, same PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)