### PR TITLE
witness_kit: reusable schema+invariant+redControl builder for new witnesses

### DIFF
--- a/viewer/tests/witness_tm_schedule_output_of_truth.js
+++ b/viewer/tests/witness_tm_schedule_output_of_truth.js
@@ -1,0 +1,71 @@
+#!/usr/bin/env node
+// WITNESS — tm_schedule_output_of_truth: the real persisted `tasks` table the TM schedule
+// generates, edits, and reloads — not a derived number three steps removed from it.
+// Spec: bim-compiler prompts/WITNESS_INTERFACE_FRAMEWORK.md §3.
+//
+// ISSUE THIS PROVES OR DISPROVES: the user's own question (2026-08-25) — "does any WITNESS confirm
+// the actual JSON/DB output of truth the 4D schedule runs on — not just some derived number?"
+// WITNESS_CONTRACT_AUDIT.md read all 221 witnesses audited to date and found: no. This is that
+// witness, built on witness_kit (the first framework-authored one).
+//
+// POPULATION: real generated rows, not a fabricated fixture. No shipped on-disk building DB has a
+// populated `tasks` table — verified across all 21 buildings/*.db + modeller/*_meta.db (2026-08-25):
+// every one is either the legacy-thin schema with 0 rows, or has no tasks table at all. The real
+// table only exists at runtime (generative fallback → IndexedDB), so this witness DRIVES the actual
+// production generator — schedule_author.js's materializeDefault() + scheduleContiguous() +
+// computeCpm(), the exact functions time_machine.js calls — against buildings/Duplex_extracted.db's
+// real 1193-row elements_meta and rates.js's real SEQUENCE_RULES/LABOR_RATES (loaded via vm, since
+// rates.js is a browser-global script with no module boundary — same vm.createContext pattern
+// witness_gantt_bars_in_rect.js already uses in this codebase). Nothing here is invented: every rule,
+// rate, and element is the shipped production data; every function call is the shipped production code.
+//
+// Command: node viewer/tests/witness_tm_schedule_output_of_truth.js
+'use strict';
+const fs = require('fs');
+const path = require('path');
+const vm = require('vm');
+const initSqlJs = require('sql.js');
+const SA = require('../schedule_author.js');
+const { Witness } = require('../../witness_kit/contract');
+const { Schedule4DTaskRow } = require('../../witness_kit/schemas/schedule_4d');
+const { datesOrdered, noPre1970Dates, criticalFloatZero } = require('../../witness_kit/invariants/schedule');
+
+const DB_PATH = path.join(__dirname, '..', '..', 'buildings', 'Duplex_extracted.db');
+const RATES_PATH = path.join(__dirname, '..', 'rates.js');
+
+function rowsFromResult(r) {
+  if (!r.length) return [];
+  return r[0].values.map(v => { const o = {}; r[0].columns.forEach((c, i) => o[c] = v[i]); return o; });
+}
+
+function loadRealRates() {
+  const sandbox = { console, window: undefined };
+  vm.createContext(sandbox);
+  vm.runInContext(fs.readFileSync(RATES_PATH, 'utf8'), sandbox);
+  return { rules: sandbox.SEQUENCE_RULES, labor: sandbox.LABOR_RATES, dflt: sandbox.SEQUENCE_DEFAULT };
+}
+
+async function generateRealTasksTable(dbPath) {
+  const SQL = await initSqlJs();
+  const db = new SQL.Database(new Uint8Array(fs.readFileSync(dbPath)));
+  const { rules, labor, dflt } = loadRealRates();
+  SA.materializeDefault(db, rules, { laborRates: labor, rates: {}, defaultRule: dflt });
+  SA.scheduleContiguous(db, 'SCH_AUTHORED', { start: '2026-01-01' });
+  SA.computeCpm(db, 'SCH_AUTHORED', {});
+  const rows = rowsFromResult(db.exec('SELECT * FROM tasks'));
+  db.close();
+  return rows;
+}
+
+(async () => {
+  const rows = await generateRealTasksTable(DB_PATH);
+
+  Witness('tm_schedule_output_of_truth')
+    .population(() => rows)
+    .schema(Schedule4DTaskRow)
+    .invariant('dates-ordered', rs => rs.every(datesOrdered))
+    .invariant('no-1970-dates', rs => rs.every(noPre1970Dates))
+    .invariant('critical-float-zero', criticalFloatZero)
+    .redControl(rs => { const c = rs.map(r => Object.assign({}, r)); if (c[0]) c[0].schedule_start = '1970-01-05'; return c; })
+    .run();
+})();

--- a/witness_kit/contract.js
+++ b/witness_kit/contract.js
@@ -1,0 +1,95 @@
+// witness_kit/contract.js — the Witness() builder.
+// Spec: bim-compiler prompts/WITNESS_INTERFACE_FRAMEWORK.md §2.3.
+//
+// JS has no compiler to refuse an incomplete implementer, so the guarantee is moved here instead:
+// one shared function every witness is forced to go through, that refuses to run without a
+// population, a schema, and a redControl — and that PROVES the redControl actually fails, so a
+// witness that cannot fail (§W-REDCONTROL, WITNESS_CONTRACT_AUDIT.md §1) is caught at author time,
+// not by luck.
+'use strict';
+const Ajv = require('ajv');
+
+function Witness(name) {
+  const spec = { name, _population: null, _schema: null, _invariants: [], _redControl: null };
+
+  const api = {
+    population(fn) { spec._population = fn; return api; },
+    schema(s) { spec._schema = s; return api; },
+    invariant(label, fn) { spec._invariants.push({ label, fn }); return api; },
+    redControl(fn) { spec._redControl = fn; return api; },
+
+    run() {
+      if (!spec._population) throw new Error(`Witness(${name}): .population() is required`);
+      if (!spec._schema) throw new Error(`Witness(${name}): .schema() is required`);
+      if (!spec._redControl) throw new Error(
+        `Witness(${name}): .redControl() is required — a witness that cannot fail is not a witness`);
+
+      let pass = 0, fail = 0;
+      function ok(label) { pass++; console.log('  PASS ' + label); }
+      function bad(label, detail) { fail++; console.log('  FAIL ' + label + (detail ? ' — ' + detail : '')); }
+
+      const ajv = new Ajv({ allErrors: true });
+      const validate = ajv.compile(spec._schema);
+
+      function checkPopulation(rows) {
+        // returns true iff rows is non-empty, schema-valid throughout, and every invariant holds
+        if (!rows || rows.length === 0) return false;
+        for (const row of rows) if (!validate(row)) return false;
+        for (const { fn } of spec._invariants) {
+          let r; try { r = fn(rows); } catch (e) { r = false; }
+          if (!r) return false;
+        }
+        return true;
+      }
+
+      // 1. population — §W-EMPTY-POP: throw loud, not a silent exit-0.
+      const rows = spec._population();
+      if (!rows || rows.length === 0) {
+        bad('population-nonempty', 'population() returned 0 rows — closes §W-EMPTY-POP');
+      } else {
+        ok(`population-nonempty (${rows.length} rows)`);
+      }
+
+      // 2. schema — every row, real persisted shape, not a mocked return value.
+      if (rows && rows.length > 0) {
+        let schemaFails = 0;
+        rows.forEach((row, i) => {
+          if (!validate(row)) {
+            schemaFails++;
+            console.log('    schema error row[' + i + ']: ' + ajv.errorsText(validate.errors));
+          }
+        });
+        if (schemaFails === 0) ok(`schema-valid (all ${rows.length} rows)`);
+        else bad('schema-valid', `${schemaFails}/${rows.length} rows failed schema`);
+      }
+
+      // 3. invariants — reusable, imported by name, never hand-copied.
+      spec._invariants.forEach(({ label, fn }) => {
+        let result;
+        try { result = fn(rows || []); } catch (e) { result = false; }
+        if (result) ok(label); else bad(label);
+      });
+
+      // 4. redControl — must demonstrably fail schema+invariants, or the witness itself is the defect.
+      let redFailed;
+      try {
+        const redRows = spec._redControl((rows || []).map(r => Object.assign({}, r)));
+        redFailed = !checkPopulation(redRows);
+      } catch (e) {
+        redFailed = true; // a thrown redControl also counts as "demonstrably fails"
+      }
+      if (redFailed) ok('redControl-detected (witness can fail)');
+      else bad('redControl-detected',
+        'redControl() population passed schema+invariants unchanged — this witness cannot fail, closes §W-REDCONTROL');
+
+      // 5. one summary line — ran>0 is baked in, can't be omitted the way run_witness_suite.js's
+      //    audit found 12+ files omitting it (WITNESS_CONTRACT_AUDIT.md §RESULTS 2026-08-24).
+      console.log(`§WITNESS_${name.toUpperCase()} pass=${pass} fail=${fail} ran=${(rows || []).length}`);
+      if (fail > 0) process.exitCode = 1;
+      return { pass, fail, ran: (rows || []).length };
+    }
+  };
+  return api;
+}
+
+module.exports = { Witness };

--- a/witness_kit/invariants/schedule.js
+++ b/witness_kit/invariants/schedule.js
@@ -1,0 +1,15 @@
+// witness_kit/invariants/schedule.js — reusable domain predicates, written once.
+// Imported by name, never hand-copied — the #1 rot source WITNESS_CONTRACT_AUDIT.md found
+// repeatedly across ~340 witnesses (hand-mirrored predicates drifting from the real gate).
+'use strict';
+
+const datesOrdered = row => new Date(row.schedule_start) <= new Date(row.schedule_finish);
+
+// Not hypothetical — this project's own already-shipped defect (4D_GANTT_TM_REFACTOR.md §S67-era
+// "1970-date typed edits"). Encoded here so it can never silently reappear unnoticed.
+const noPre1970Dates = row => new Date(row.schedule_start).getFullYear() > 1971;
+
+const criticalFloatZero = rows =>
+  rows.filter(r => r.is_critical === 1).every(r => Math.abs(Number(r.total_float || 0)) < 1e-6);
+
+module.exports = { datesOrdered, noPre1970Dates, criticalFloatZero };

--- a/witness_kit/schemas/schedule_4d.js
+++ b/witness_kit/schemas/schedule_4d.js
@@ -1,0 +1,24 @@
+// witness_kit/schemas/schedule_4d.js — the contract, as data.
+// Grounded against the REAL DDL, not invented: viewer/schedule_author.js:247's
+// `CREATE TABLE IF NOT EXISTS tasks (...)` (identical DDL repeated at :262). is_critical/total_float
+// are nullable because a REAL generated schedule has them so on WBS-summary rows (is_summary=1) —
+// computeCpm never rates a rollup row, only leaves — verified against a real materializeDefault() +
+// scheduleContiguous() + computeCpm() run on buildings/Duplex_extracted.db's real elements_meta,
+// not assumed.
+'use strict';
+const Schedule4DTaskRow = {
+  type: 'object',
+  required: ['task_id', 'schedule_id', 'schedule_start', 'schedule_finish', 'is_summary'],
+  properties: {
+    task_id: { type: 'string', minLength: 1 },
+    schedule_id: { type: 'string', minLength: 1 },
+    schedule_start: { type: 'string', minLength: 1 },
+    schedule_finish: { type: 'string', minLength: 1 },
+    is_summary: { type: ['integer', 'null'], enum: [0, 1, null] },
+    is_critical: { type: ['integer', 'null'], enum: [0, 1, null] },
+    total_float: { type: ['string', 'number', 'null'] }
+  },
+  additionalProperties: true // a floor, not a ceiling — legacy/extra columns don't fail the row
+};
+
+module.exports = { Schedule4DTaskRow };


### PR DESCRIPTION
## Summary
- Adds `witness_kit/` (`contract.js`, `schemas/schedule_4d.js`, `invariants/schedule.js`) — the `Witness(name).population().schema().invariant().redControl().run()` builder from bim-compiler `prompts/WITNESS_INTERFACE_FRAMEWORK.md`. It throws at author time if `.population()`/`.schema()`/`.redControl()` are omitted, and it PROVES `.redControl()` actually breaks the population before trusting the witness — closing §W-REDCONTROL and §W-EMPTY-POP at the source instead of by author discipline (`WITNESS_CONTRACT_AUDIT.md` read 221 witnesses and found both classes repeatedly).
- Adds `viewer/tests/witness_tm_schedule_output_of_truth.js`, the first witness authored on the framework — closes the coverage gap the audit named: nothing today checks the actual persisted `tasks` table as one declared contract, only derived numbers.
- Ajv is already a vendored transitive dependency (eslint); this is its first direct use, zero new install.

## Notable finding during build
No shipped `buildings/*.db`/`modeller/*_meta.db` has a populated `tasks` table on disk (checked all 21) — the real schedule only exists at runtime via the generative fallback. So the witness's `population()` drives the actual production generator (`schedule_author.js`'s `materializeDefault`/`scheduleContiguous`/`computeCpm`) against real `elements_meta` + `rates.js` data, rather than reading a static fixture that doesn't exist. Schema's `is_critical`/`total_float` are nullable because that's the real, verified value on WBS-summary rows post-CPM, not an assumption.

## Test plan
- [x] `node viewer/tests/witness_tm_schedule_output_of_truth.js` — green, `§WITNESS_TM_SCHEDULE_OUTPUT_OF_TRUTH pass=6 fail=0 ran=7`
- [x] `node tests/run_witness_suite.js --filter tm_schedule_output_of_truth` — auto-discovered, green
- [x] Framework self-test: confirmed `.run()` throws when `.redControl()` is omitted, and correctly flags a no-op `.redControl()` and an empty population as failures (not silently green)

🤖 Generated with [Claude Code](https://claude.com/claude-code)