### PR TITLE
docs(witness-kit): JSDoc for Witness() builder contract

### DIFF
--- a/witness_kit/contract.js
+++ b/witness_kit/contract.js
@@ -9,15 +9,64 @@
 'use strict';
 const Ajv = require('ajv');
 
+/**
+ * Witness(name) — chained builder for a schema+invariant+redControl witness.
+ * Call `.population()`, `.schema()`, and `.redControl()` (required) plus any number of
+ * `.invariant()` (optional), then `.run()` to execute. Each chained method returns the
+ * same `api` object, so calls can be composed in any order before `.run()`.
+ *
+ * @param {string} name - Witness name, used in the `§WITNESS_<NAME>` summary line and in
+ *   the `run()`-time error messages if a required method was never called.
+ * @returns {{
+ *   population: (fn: () => object[]) => object,
+ *   schema: (schema: object) => object,
+ *   invariant: (label: string, fn: (rows: object[]) => boolean) => object,
+ *   redControl: (fn: (rows: object[]) => object[]) => object,
+ *   run: () => { pass: number, fail: number, ran: number }
+ * }} the chainable builder api.
+ */
 function Witness(name) {
   const spec = { name, _population: null, _schema: null, _invariants: [], _redControl: null };
 
   const api = {
+    /**
+     * Required. Registers the function that produces the real population of rows to test —
+     * must be actual persisted/generated data, not a mocked fixture.
+     * @param {() => object[]} fn - Zero-arg function returning the row array to check.
+     * @returns {object} the api, for chaining.
+     */
     population(fn) { spec._population = fn; return api; },
+    /**
+     * Required. Registers the JSON Schema (compiled via Ajv) every row must validate against.
+     * @param {object} s - A JSON Schema object.
+     * @returns {object} the api, for chaining.
+     */
     schema(s) { spec._schema = s; return api; },
+    /**
+     * Optional, repeatable. Registers one named invariant check run against the full row set.
+     * @param {string} label - Short label printed next to PASS/FAIL for this invariant.
+     * @param {(rows: object[]) => boolean} fn - Receives all rows, returns true if the
+     *   invariant holds (a thrown error counts as false).
+     * @returns {object} the api, for chaining.
+     */
     invariant(label, fn) { spec._invariants.push({ label, fn }); return api; },
+    /**
+     * Required. Registers a function that mutates a deep-ish copy of the real rows into a
+     * deliberately-broken population — proves the witness can actually fail (§W-REDCONTROL).
+     * `.run()` fails the whole witness if this population does NOT fail schema/invariants.
+     * @param {(rows: object[]) => object[]} fn - Receives a shallow copy of each row (via
+     *   `Object.assign({}, r)`), returns the mutated (broken) rows.
+     * @returns {object} the api, for chaining.
+     */
     redControl(fn) { spec._redControl = fn; return api; },
 
+    /**
+     * Executes the witness: population → schema → invariants → redControl, in that order,
+     * printing PASS/FAIL lines plus one `§WITNESS_<NAME> pass=.. fail=.. ran=..` summary line.
+     * Sets `process.exitCode = 1` if anything failed.
+     * @throws {Error} if `.population()`, `.schema()`, or `.redControl()` was never called.
+     * @returns {{ pass: number, fail: number, ran: number }} counts from this run.
+     */
     run() {
       if (!spec._population) throw new Error(`Witness(${name}): .population() is required`);
       if (!spec._schema) throw new Error(`Witness(${name}): .schema() is required`);


### PR DESCRIPTION
## Summary
- Adds JSDoc (`@param`/`@returns`/`@throws`) to `witness_kit/contract.js`'s `Witness(name)` and its chained methods (`.population()`, `.schema()`, `.invariant()`, `.redControl()`, `.run()`) — comment-only, no executable code changed.
- Goal: a future session opening this file (or hovering it in an editor) sees the contract's shape immediately, without reading the implementation — improves discoverability of the framework shipped in #1511, since a git-hook-based enforcement mechanism was ruled out (too easy to false-positive on witness shapes that don't fit the schema/invariant/redControl model, e.g. pixel-diff or DOM-interaction witnesses).

## Test plan
- [x] `node viewer/tests/witness_tm_schedule_output_of_truth.js` — unchanged: `pass=6 fail=0 ran=7`, exit 0
- [x] `node tests/run_witness_suite.js --filter witness_tm_schedule_output_of_truth` — unchanged: `green=1 new_red=0 known_red=0 fixed=0 flaky=0 total=1`, exit 0
- [x] `git diff` confirms every changed line is an added JSDoc comment; no existing line altered

🤖 Generated with [Claude Code](https://claude.com/claude-code)