### PR TITLE
witness_kit: multi-building black-box schedule-output-of-truth sweep (incl. HHS Office)

### DIFF
--- a/viewer/tests/witness_tm_schedule_output_of_truth.js
+++ b/viewer/tests/witness_tm_schedule_output_of_truth.js
@@ -23,7 +23,10 @@ const { Schedule4DTaskRow } = require('../../witness_kit/schemas/schedule_4d');
 const { datesOrdered, noPre1970Dates, criticalFloatZero } = require('../../witness_kit/invariants/schedule');
 const { generateRealTasksTable } = require('../../witness_kit/generators/schedule_4d');
 
-const DB_PATH = path.join(__dirname, '..', '..', 'buildings', 'Duplex_extracted.db');
+// BLD_DIR — same house convention witness_door_window_host_wall.js etc use, and what
+// run_witness_suite.js sets when it spawns this file.
+const BLD_DIR = process.env.BLD_DIR || path.join(require('os').homedir(), 'bim-ootb', 'buildings');
+const DB_PATH = path.join(BLD_DIR, 'Duplex_extracted.db');
 
 (async () => {
   const rows = await generateRealTasksTable(DB_PATH);

--- a/viewer/tests/witness_tm_schedule_output_of_truth.js
+++ b/viewer/tests/witness_tm_schedule_output_of_truth.js
@@ -8,54 +8,22 @@
 // WITNESS_CONTRACT_AUDIT.md read all 221 witnesses audited to date and found: no. This is that
 // witness, built on witness_kit (the first framework-authored one).
 //
-// POPULATION: real generated rows, not a fabricated fixture. No shipped on-disk building DB has a
-// populated `tasks` table — verified across all 21 buildings/*.db + modeller/*_meta.db (2026-08-25):
-// every one is either the legacy-thin schema with 0 rows, or has no tasks table at all. The real
-// table only exists at runtime (generative fallback → IndexedDB), so this witness DRIVES the actual
-// production generator — schedule_author.js's materializeDefault() + scheduleContiguous() +
-// computeCpm(), the exact functions time_machine.js calls — against buildings/Duplex_extracted.db's
-// real 1193-row elements_meta and rates.js's real SEQUENCE_RULES/LABOR_RATES (loaded via vm, since
-// rates.js is a browser-global script with no module boundary — same vm.createContext pattern
-// witness_gantt_bars_in_rect.js already uses in this codebase). Nothing here is invented: every rule,
-// rate, and element is the shipped production data; every function call is the shipped production code.
+// POPULATION: real generated rows, not a fabricated fixture, via witness_kit/generators/schedule_4d.js
+// — see that file's header for why a static fixture read doesn't work here. Single-building case
+// (Duplex, 1193 real elements_meta rows). For the multi-building black-box version (same generator,
+// looped over every building fixture with a populated elements_meta) see
+// witness_tm_schedule_output_of_truth_all_buildings.js — a separate, reusable script, not folded
+// into this one, so a single-building failure and a fleet-wide sweep stay independently readable.
 //
 // Command: node viewer/tests/witness_tm_schedule_output_of_truth.js
 'use strict';
-const fs = require('fs');
 const path = require('path');
-const vm = require('vm');
-const initSqlJs = require('sql.js');
-const SA = require('../schedule_author.js');
 const { Witness } = require('../../witness_kit/contract');
 const { Schedule4DTaskRow } = require('../../witness_kit/schemas/schedule_4d');
 const { datesOrdered, noPre1970Dates, criticalFloatZero } = require('../../witness_kit/invariants/schedule');
+const { generateRealTasksTable } = require('../../witness_kit/generators/schedule_4d');
 
 const DB_PATH = path.join(__dirname, '..', '..', 'buildings', 'Duplex_extracted.db');
-const RATES_PATH = path.join(__dirname, '..', 'rates.js');
-
-function rowsFromResult(r) {
-  if (!r.length) return [];
-  return r[0].values.map(v => { const o = {}; r[0].columns.forEach((c, i) => o[c] = v[i]); return o; });
-}
-
-function loadRealRates() {
-  const sandbox = { console, window: undefined };
-  vm.createContext(sandbox);
-  vm.runInContext(fs.readFileSync(RATES_PATH, 'utf8'), sandbox);
-  return { rules: sandbox.SEQUENCE_RULES, labor: sandbox.LABOR_RATES, dflt: sandbox.SEQUENCE_DEFAULT };
-}
-
-async function generateRealTasksTable(dbPath) {
-  const SQL = await initSqlJs();
-  const db = new SQL.Database(new Uint8Array(fs.readFileSync(dbPath)));
-  const { rules, labor, dflt } = loadRealRates();
-  SA.materializeDefault(db, rules, { laborRates: labor, rates: {}, defaultRule: dflt });
-  SA.scheduleContiguous(db, 'SCH_AUTHORED', { start: '2026-01-01' });
-  SA.computeCpm(db, 'SCH_AUTHORED', {});
-  const rows = rowsFromResult(db.exec('SELECT * FROM tasks'));
-  db.close();
-  return rows;
-}
 
 (async () => {
   const rows = await generateRealTasksTable(DB_PATH);

--- a/viewer/tests/witness_tm_schedule_output_of_truth_all_buildings.js
+++ b/viewer/tests/witness_tm_schedule_output_of_truth_all_buildings.js
@@ -17,6 +17,17 @@
 // Duplex is INCLUDED here (unlike the support-invariant witness) because output-of-truth persistence
 // is not an engine-scale claim — it's whether small buildings persist correctly too, and Duplex is
 // this witness_kit's own original worked case (WITNESS_INTERFACE_FRAMEWORK.md §3).
+// Command: BLD_DIR=~/bim-ootb/buildings node viewer/tests/witness_tm_schedule_output_of_truth_all_buildings.js
+// BLD_DIR — same house convention witness_door_window_host_wall.js/witness_hosted_before_host.js
+// etc already use (and what run_witness_suite.js sets when it spawns this file), so this script
+// runs unmodified both standalone and under the real suite runner.
+//
+// Quiets schedule_author.js's own §CLASS_UNMATCHED/§PHASE_*/§AUTHOR_* diagnostic logging while
+// generating (not this witness's own PASS/FAIL/§WITNESS lines) — real, not cosmetic: run_witness_suite.js's
+// spawnSync uses Node's default 1MB stdout maxBuffer, and looping several buildings' worth of that
+// per-element chatter (Hospital alone: 64k elements_meta rows) produces 7MB+, which gets the child
+// process SIGTERM'd mid-run (spawnSync reports status:null, read by the runner as RED) even though
+// the script itself exits 0 when run directly. None of that diagnostic output is asserted on here.
 'use strict';
 const fs = require('fs');
 const path = require('path');
@@ -25,18 +36,29 @@ const { Schedule4DTaskRow } = require('../../witness_kit/schemas/schedule_4d');
 const { datesOrdered, noPre1970Dates, criticalFloatZero } = require('../../witness_kit/invariants/schedule');
 const { generateRealTasksTable } = require('../../witness_kit/generators/schedule_4d');
 
-const BUILDINGS_DIR = path.join(__dirname, '..', '..', 'buildings');
+const BLD_DIR = process.env.BLD_DIR || path.join(require('os').homedir(), 'bim-ootb', 'buildings');
 const BUILDINGS = ['Duplex', 'Hospital', 'Clinic', 'JKR', 'HHS_Office_Federated'];
 const SKIPPED = { Terminal: 'split meta/geo DB, no tasks/schedules tables in either half', LTU_AHouse: 'same split-DB gap as Terminal' };
 
+async function generateQuietly(dbPath) {
+  // schedule_author.js's own diagnostics split across BOTH streams — §AUTHOR_*/§PHASE_* on
+  // console.log, §CLASS_UNMATCHED (the bulk of it, one line per unmatched element) on
+  // console.warn/stderr. Muting only console.log left stderr alone still overflowing
+  // spawnSync's 1MB maxBuffer (measured: 1MB+ of stderr from Hospital's 64k elements alone).
+  const realLog = console.log, realWarn = console.warn, realError = console.error;
+  console.log = console.warn = console.error = () => {};
+  try { return await generateRealTasksTable(dbPath); }
+  finally { console.log = realLog; console.warn = realWarn; console.error = realError; }
+}
+
 async function runOne(name) {
-  const dbPath = path.join(BUILDINGS_DIR, `${name}_extracted.db`);
+  const dbPath = path.join(BLD_DIR, `${name}_extracted.db`);
   if (!fs.existsSync(dbPath)) {
     console.log(`  SKIP ${name} — fixture missing: ${dbPath}`);
     return { name, skipped: true };
   }
   console.log(`-- ${name} --`);
-  const rows = await generateRealTasksTable(dbPath);
+  const rows = await generateQuietly(dbPath);
   const result = Witness(`tm_schedule_output_of_truth_${name}`)
     .population(() => rows)
     .schema(Schedule4DTaskRow)

--- a/viewer/tests/witness_tm_schedule_output_of_truth_all_buildings.js
+++ b/viewer/tests/witness_tm_schedule_output_of_truth_all_buildings.js
@@ -1,0 +1,60 @@
+#!/usr/bin/env node
+// WITNESS — tm_schedule_output_of_truth_all_buildings: black-box, reusable, fleet-wide version of
+// witness_tm_schedule_output_of_truth.js — same real generation + witness_kit contract, run per
+// building instead of hand-verified on Duplex alone. Built on user request (2026-08-25): "test this
+// on a HHS Office DB... a black box separate test script that we can reuse later" — checked first
+// whether an equivalent already existed: witness_support_invariant_all_buildings.js is the one real
+// precedent for a multi-building loop in this codebase, but it checks a DIFFERENT thing (an ephemeral
+// ScheduleGate.computeSchedule() support invariant, never persisted) — nothing already exercises the
+// real materializeDefault→scheduleContiguous→computeCpm path, persisted to `tasks`, across more than
+// one building. This fills that gap; it does not replace the existing precedent.
+//
+// BUILDINGS — mirrors witness_support_invariant_all_buildings.js's own list and its explicit ruling
+// (2026-08-04: "DX too small for our engine" — Duplex is a different, small/residential regime) MINUS
+// Terminal and LTU_AHouse, which don't fit this specific job: both ship split meta/geo DBs with no
+// `tasks`/`schedules`/`task_elements` tables in either half (verified 2026-08-25) — wiring that up is
+// real extra scope, named below as SKIPPED, not silently dropped and not attempted here.
+// Duplex is INCLUDED here (unlike the support-invariant witness) because output-of-truth persistence
+// is not an engine-scale claim — it's whether small buildings persist correctly too, and Duplex is
+// this witness_kit's own original worked case (WITNESS_INTERFACE_FRAMEWORK.md §3).
+'use strict';
+const fs = require('fs');
+const path = require('path');
+const { Witness } = require('../../witness_kit/contract');
+const { Schedule4DTaskRow } = require('../../witness_kit/schemas/schedule_4d');
+const { datesOrdered, noPre1970Dates, criticalFloatZero } = require('../../witness_kit/invariants/schedule');
+const { generateRealTasksTable } = require('../../witness_kit/generators/schedule_4d');
+
+const BUILDINGS_DIR = path.join(__dirname, '..', '..', 'buildings');
+const BUILDINGS = ['Duplex', 'Hospital', 'Clinic', 'JKR', 'HHS_Office_Federated'];
+const SKIPPED = { Terminal: 'split meta/geo DB, no tasks/schedules tables in either half', LTU_AHouse: 'same split-DB gap as Terminal' };
+
+async function runOne(name) {
+  const dbPath = path.join(BUILDINGS_DIR, `${name}_extracted.db`);
+  if (!fs.existsSync(dbPath)) {
+    console.log(`  SKIP ${name} — fixture missing: ${dbPath}`);
+    return { name, skipped: true };
+  }
+  console.log(`-- ${name} --`);
+  const rows = await generateRealTasksTable(dbPath);
+  const result = Witness(`tm_schedule_output_of_truth_${name}`)
+    .population(() => rows)
+    .schema(Schedule4DTaskRow)
+    .invariant('dates-ordered', rs => rs.every(datesOrdered))
+    .invariant('no-1970-dates', rs => rs.every(noPre1970Dates))
+    .invariant('critical-float-zero', criticalFloatZero)
+    .redControl(rs => { const c = rs.map(r => Object.assign({}, r)); if (c[0]) c[0].schedule_start = '1970-01-05'; return c; })
+    .run();
+  return Object.assign({ name }, result);
+}
+
+(async () => {
+  const results = [];
+  for (const name of BUILDINGS) results.push(await runOne(name));
+  for (const name in SKIPPED) console.log(`  SKIP ${name} — ${SKIPPED[name]}`);
+
+  const totalFail = results.reduce((n, r) => n + (r.fail || 0), 0);
+  const summary = results.map(r => `${r.name}:${r.fail === 0 ? 'green' : 'RED(' + r.fail + ')'}`).join(' ');
+  console.log(`§WITNESS_TM_SCHEDULE_OUTPUT_OF_TRUTH_ALL_BUILDINGS ran=${results.length} skipped=${Object.keys(SKIPPED).length} fail=${totalFail} — ${summary}`);
+  if (totalFail > 0) process.exitCode = 1;
+})();

--- a/witness_kit/generators/schedule_4d.js
+++ b/witness_kit/generators/schedule_4d.js
@@ -1,0 +1,55 @@
+// witness_kit/generators/schedule_4d.js — real schedule generation, factored out of
+// witness_tm_schedule_output_of_truth.js so a second, multi-building black-box script
+// (witness_tm_schedule_output_of_truth_all_buildings.js) can reuse it byte-for-byte instead of
+// hand-copying it — the exact drift witness_kit exists to prevent (WITNESS_CONTRACT_AUDIT.md's
+// #1 rot source: a predicate/procedure re-mirrored per file instead of imported once).
+//
+// WHY THIS EXISTS AT ALL, not a static fixture read: no shipped building DB has a populated `tasks`
+// table on disk (verified across all 21 buildings/*.db + modeller/*_meta.db, 2026-08-25) — the real
+// table only exists at runtime via the generative fallback. So this drives the actual production
+// generator — schedule_author.js's materializeDefault() + scheduleContiguous() + computeCpm(), the
+// same calls time_machine.js makes — against the building's real elements_meta and rates.js's real
+// SEQUENCE_RULES/LABOR_RATES (loaded via vm.createContext, since rates.js is a browser-global script
+// with no module boundary — the same pattern witness_gantt_bars_in_rect.js already uses).
+'use strict';
+const fs = require('fs');
+const vm = require('vm');
+const path = require('path');
+const initSqlJs = require('sql.js');
+
+const SA = require(path.join(__dirname, '..', '..', 'viewer', 'schedule_author.js'));
+const RATES_PATH = path.join(__dirname, '..', '..', 'viewer', 'rates.js');
+
+function rowsFromResult(r) {
+  if (!r.length) return [];
+  return r[0].values.map(v => { const o = {}; r[0].columns.forEach((c, i) => o[c] = v[i]); return o; });
+}
+
+function loadRealRates() {
+  const sandbox = { console, window: undefined };
+  vm.createContext(sandbox);
+  vm.runInContext(fs.readFileSync(RATES_PATH, 'utf8'), sandbox);
+  return { rules: sandbox.SEQUENCE_RULES, labor: sandbox.LABOR_RATES, dflt: sandbox.SEQUENCE_DEFAULT };
+}
+
+// generateRealTasksTable(dbPath, opts) -> Promise<row[]>
+// opts.scheduleId defaults to 'SCH_AUTHORED' (materializeDefault's own default); opts.start
+// defaults to '2026-01-01' (scheduleContiguous's own default) — both left overridable, never
+// hidden, so a caller can name a real reason to diverge instead of the default silently drifting.
+async function generateRealTasksTable(dbPath, opts) {
+  opts = opts || {};
+  const scheduleId = opts.scheduleId || 'SCH_AUTHORED';
+  const start = opts.start || '2026-01-01';
+
+  const SQL = await initSqlJs();
+  const db = new SQL.Database(new Uint8Array(fs.readFileSync(dbPath)));
+  const { rules, labor, dflt } = loadRealRates();
+  SA.materializeDefault(db, rules, { laborRates: labor, rates: {}, defaultRule: dflt, scheduleId });
+  SA.scheduleContiguous(db, scheduleId, { start });
+  SA.computeCpm(db, scheduleId, {});
+  const rows = rowsFromResult(db.exec('SELECT * FROM tasks'));
+  db.close();
+  return rows;
+}
+
+module.exports = { generateRealTasksTable };


### PR DESCRIPTION
## Summary
- Factors the real generation call (`materializeDefault`→`scheduleContiguous`→`computeCpm`) out of `witness_tm_schedule_output_of_truth.js` into `witness_kit/generators/schedule_4d.js`, so it has one source instead of a hand-copy (the #1 rot source `WITNESS_CONTRACT_AUDIT.md` found across ~340 witnesses).
- Adds `viewer/tests/witness_tm_schedule_output_of_truth_all_buildings.js` — a separate, reusable, black-box script that runs the same witness_kit contract across **Duplex, Hospital, Clinic, JKR, HHS_Office_Federated**. User request (2026-08-25): test on a real HHS Office DB, as a script reusable later, not a one-off.
- `Terminal`/`LTU_AHouse` are named-SKIPPED (both ship split meta/geo DBs with no `tasks`/`schedules` tables in either half) — real follow-on scope, not silently dropped.
- Checked first whether an equivalent already existed: `witness_support_invariant_all_buildings.js` is the one real multi-building precedent in this codebase, but it checks a different, ephemeral thing (`ScheduleGate.computeSchedule`'s support invariant, never persisted) — nothing already swept the real *persisted* `tasks` table across more than one building.
- Both witness files now use the house `BLD_DIR` env convention (`witness_door_window_host_wall.js` etc.) instead of a hardcoded path.

## Real bug found and fixed during build
`run_witness_suite.js`'s `spawnSync` uses Node's default 1MB stdout+stderr `maxBuffer`. Looping 5 buildings' worth of `schedule_author.js`'s own diagnostic logging (`§CLASS_UNMATCHED` alone is one `console.warn` line per unmatched element — Hospital's 64k `elements_meta` rows produced 1MB+ on stderr by itself) silently overflowed it: the runner SIGTERM'd the child (`status: null`, reported as RED) even though the script exits 0 cleanly standalone. Fixed by muting `console.log`/`warn`/`error` locally around each building's generation call (not the shared generator, not the runner) — none of that diagnostic chatter is asserted on by the witness anyway.

## Test plan
- [x] `node viewer/tests/witness_tm_schedule_output_of_truth_all_buildings.js` (standalone) — green, all 5 buildings `pass=6 fail=0` each, HHS Office: `ran=6` real generated tasks with real 2026 CPM dates
- [x] `node tests/run_witness_suite.js --filter tm_schedule_output_of_truth` — both witnesses PASS (reproduced the RED/maxBuffer bug first, then confirmed the fix through the real runner, not just standalone)
- [x] Confirmed single-building witness (`witness_tm_schedule_output_of_truth.js`) still green after the `BLD_DIR` refactor

🤖 Generated with [Claude Code](https://claude.com/claude-code)