### PR TITLE
fix(tm): Alt+C bake never generates a building's first-ever 4D schedule

### DIFF
--- a/tests/run_witness_suite.js
+++ b/tests/run_witness_suite.js
@@ -97,7 +97,13 @@ const KNOWN_RED = {
   // Reproducible reds whose cause has NOT been established. Labelled honestly rather than guessed:
   // an earlier pass called these "browser/server not up", which was wrong — both are headless.
   'witness_tm_stream_index_defer.js':        'C — reproducible red, cause NOT yet established',
-  'witness_xray_cache_memo.js':              'C — reproducible red, cause NOT yet established'
+  'witness_xray_cache_memo.js':              'C — reproducible red, cause NOT yet established',
+  // D — environment/data, NOT a code defect: ~/bim-ootb/buildings/Duplex_meta.db is 0 bytes
+  // (found 2026-08-25, both were green earlier the same day — pass=49/bad=0 — so this is a live
+  // regression in the SHARED checkout's data, not stale). Fix = redownload/regenerate that one file
+  // (see deploy/OCI_UPLOAD.md); nothing to change in either witness or in schedule_gate.js/S50.
+  'witness_midair_zero.js':                  'D — Duplex_meta.db is 0 bytes in the shared checkout, not a code defect',
+  'witness_s50_cell_engine.js':              'D — same root cause: Duplex_meta.db is 0 bytes in the shared checkout'
 };
 
 // The 21 browser witnesses are deliberately NOT listed here. They are report-only (see the header):

--- a/viewer/cinema_maxq.js
+++ b/viewer/cinema_maxq.js
@@ -1191,6 +1191,15 @@
         if (typeof window.tmOrderByCameraPath !== 'function' || typeof window.tmActivateForBake !== 'function') {
           console.warn('§CPE_BUILDUP_SKIP reason=time_machine.js not loaded — baking without the buildup');
           _buildup = false;
+        } else if (typeof window.tmHasExistingSchedule === 'function' && !(await window.tmHasExistingSchedule())) {
+          // §CPE_BUILDUP_REQUIRE_TM_FIRST — never let the movie button generate a building's FIRST
+          // schedule; that's Time Machine's job, once, so the user actually sees the buildup before
+          // it's baked. A visible status (not just a console warning) since this is a one-time thing
+          // the user needs to go DO, not a background detail.
+          console.warn('§CPE_BUILDUP_SKIP reason=no schedule generated yet — open Time Machine first');
+          _status('🎬 Open Time Machine first to build the construction schedule — baking without it this time');
+          await _sleep(2000);
+          _buildup = false;
         } else if (!(await window.tmActivateForBake())) {
           console.warn('§CPE_BUILDUP_SKIP reason=no derived build order (Time Machine has no ops for this building)');
           _buildup = false;

--- a/viewer/sw.js
+++ b/viewer/sw.js
@@ -8,7 +8,16 @@
 // Cache-first for heavy assets (.wasm, images). DB files skip SW (IndexedDB handles them).
 //
 // DEPLOY: bump CACHE_VERSION on every OCI upload. Old caches are purged on activate.
-const CACHE_VERSION = 'v1083';   // bump on each deploy; per-change detail is the git commit message.
+const CACHE_VERSION = 'v1084';   // bump on each deploy; per-change detail is the git commit message.
+// v1084 (2026-08-25) §CPE_BUILDUP_REQUIRE_TM_FIRST (CINEMA_PATH_EDITOR.md, user ruling "no auto
+// JSON outside TM"): Alt+C's bake no longer generates a building's first-ever 4D schedule.
+// window.tmHasExistingSchedule() (time_machine.js) — read-only, no DB writes, never generates —
+// checks active ops / IDB gantt cache / kernel_ops before cinema_maxq.js ever calls
+// tmActivateForBake(). No schedule yet -> visible status "Open Time Machine first to build the
+// construction schedule — baking without it this time", bake continues as a plain flythrough with
+// no buildup. Once a schedule exists (from either source) every later bake reads it silently, same
+// as before — this is a one-time gate, not a per-bake check. Witness:
+// witness_cpe_buildup_require_tm_first.js.
 // v1083 (2026-08-25) §CPE_BUILDUP_ACTIVATE_POPS_PANEL (CINEMA_PATH_EDITOR.md): Alt+C's bake
 // (tmActivateForBake) no longer calls the real, panel-popping activate() — a new `silent` param
 // threaded through activate()->_activateAsync()->_finishActivate() loads the same schedule data

--- a/viewer/tests/witness_cpe_buildup_activate_silent.js
+++ b/viewer/tests/witness_cpe_buildup_activate_silent.js
@@ -17,11 +17,12 @@
 //   drawDashboard/_loadTwin must be ZERO on a silent activation and UNCHANGED (>0, same as a
 //   plain call) on a real one.
 //
-// HOW IT FALSIFIES: Gate A runs against both `origin/main` (shipped, no `silent` param — must
-// FAIL, panel calls fire regardless of the flag) and the working tree (must PASS, panel calls
-// fire only when NOT silent). A run where shipped also passes is not evidence — it means the RED
-// case stopped reproducing and the witness is blind. Gate B (deactivate ownership) only exists in
-// the working tree; shipped has no tmDeactivateIfBakeOwned to test at all.
+// HOW IT FALSIFIES: Gate A runs against the CURRENT working tree — re-deriving the panel-call
+// contract from real source every run is what makes this falsifiable, not a permanent RED control.
+// It also runs the same gates against `origin/main` and logs the comparison, but that comparison is
+// informational only, NOT a verdict gate: this fix (bim-ootb #1510) is itself part of origin/main
+// from the day it merged, so "shipped still reproduces the bug" becomes permanently unsatisfiable —
+// that's the fix being live, not the witness going blind. The verdict is `fixed`'s gates alone.
 //
 // Run (from the repo root): node witness_cpe_buildup_activate_silent.js
 // Read the log, not the exit code.
@@ -212,16 +213,20 @@ async function gateB2() {
   const b1 = await gateB();
   const b2 = await gateB2();
 
-  // RED control: shipped has no `silent` concept, so calling activate(true) on it must still pop
-  // the panel exactly like a real Play — i.e. shipped's "silent" gate must FAIL.
-  const redReproduces = shipped.realPlay === true && shipped.silent === false;
-  console.log('\n§ACTIVATE_SILENT_RESULT red=' + (redReproduces
-    ? 'shipped ignores the flag, panel still pops on a "silent" call (the bug reproduces)'
-    : 'WITNESS IS BLIND — shipped source unexpectedly passed the silent gate'));
+  // RED control vs origin/main: informational only, NOT a verdict gate. This fix (bim-ootb #1510)
+  // is now itself part of origin/main, so "shipped still reproduces the bug" is permanently
+  // unsatisfiable from the day this merged — that's the fix being live, not the witness going
+  // blind. Same phenomenon already documented for the sibling witness_cpe_buildup_arm_gate.js in
+  // bim-compiler prompts/CINEMA_PATH_EDITOR.md. The real, permanent regression test is `fixed`
+  // below, which re-derives the panel-call contract from the CURRENT source every run regardless
+  // of what origin/main contains.
+  const redReproducedHistorically = shipped.realPlay === true && shipped.silent === false;
+  console.log('\n§ACTIVATE_SILENT_RESULT vs-origin-main=' + (redReproducedHistorically
+    ? 'origin/main still lacks the fix (unexpected post-merge — worth a look)'
+    : 'origin/main already carries this fix (expected once #1510 merged — not a witness failure)'));
   const green = fixed.realPlay && fixed.silent && b1 && b2;
   console.log('§ACTIVATE_SILENT_RESULT green=' + (green ? 'all gates pass on the fix' : 'FIX INCOMPLETE') +
     ' (realPlay=' + fixed.realPlay + ' silent=' + fixed.silent + ' ownershipOn=' + b1 + ' ownershipAlreadyOn=' + b2 + ')');
-  const verdict = redReproduces && green;
-  console.log('§ACTIVATE_SILENT_VERDICT ' + (verdict ? 'GREEN — falsifiable and fixed' : 'RED — see gates above'));
-  process.exit(verdict ? 0 : 1);
+  console.log('§ACTIVATE_SILENT_VERDICT ' + (green ? 'GREEN — contract holds on the working tree' : 'RED — see gates above'));
+  process.exit(green ? 0 : 1);
 })();

--- a/viewer/tests/witness_cpe_buildup_require_tm_first.js
+++ b/viewer/tests/witness_cpe_buildup_require_tm_first.js
@@ -1,0 +1,130 @@
+#!/usr/bin/env node
+// witness_cpe_buildup_require_tm_first.js — W-REQUIRE-TM-FIRST
+// Implementing bim-compiler prompts/CINEMA_PATH_EDITOR.md §CPE_BUILDUP_REQUIRE_TM_FIRST
+//
+// THE ISSUE THIS WITNESS PROVES OR DISPROVES:
+//   Before this fix, Alt+C's bake (tmActivateForBake -> activate(true) -> _activateAsync) would
+//   silently GENERATE the building's first-ever 4D schedule if none existed yet — the user's own
+//   ruling was "no auto JSON outside TM": the first schedule for a building must come from a real
+//   Time Machine open, where the user can actually see the buildup, never manufactured on the fly
+//   by the movie button. window.tmHasExistingSchedule() is the read-only gate cinema_maxq now
+//   checks BEFORE ever calling tmActivateForBake — it must say NO when nothing has been generated
+//   yet (cache empty, kernel_ops has no ELEMENT_PLACE rows) and YES once a real schedule exists,
+//   from either source, without EVER calling activate()/generating anything itself.
+//
+//   A witness that only checks "returns a boolean" would PASS on a version that always returns
+//   true (or always false) — the assertion here is that the SAME function returns different
+//   answers for 5 real states, and never touches activate/cacheDel/cachePut/db.run (proving it is
+//   truly read-only, not a disguised generate-and-check).
+//
+// HOW IT FALSIFIES: runs against `origin/main` (shipped — has tmActivateForBake but no
+// tmHasExistingSchedule at all, so `typeof` must read 'undefined' — the RED control) and the
+// working tree (must exist and answer all 5 gates correctly).
+//
+// Run (from the repo root): node witness_cpe_buildup_require_tm_first.js
+// Read the log, not the exit code.
+'use strict';
+const fs = require('fs');
+const path = require('path');
+const vm = require('vm');
+const cp = require('child_process');
+
+const TM = path.join(__dirname, '..', 'time_machine.js');
+const workingSrc = fs.readFileSync(TM, 'utf8');
+const shippedSrc = cp.execFileSync('git', ['show', 'origin/main:viewer/time_machine.js'],
+  { cwd: __dirname, maxBuffer: 1 << 28 }).toString();
+
+function slice(src, marker, optional) {
+  const idx = src.indexOf(marker);
+  if (idx < 0) {
+    if (optional) return '';
+    throw new Error('marker not found: ' + marker);
+  }
+  let depth = 0, seen = false, i = idx;
+  for (; i < src.length; i++) {
+    if (src[i] === '{') { depth++; seen = true; }
+    else if (src[i] === '}') { depth--; if (seen && depth === 0) break; }
+  }
+  return src.slice(idx, i + 1) + ';';
+}
+
+const PLACE = (guid, t) => ({ output_guid: guid, input_guids: [], start_ts: t, end_ts: t + 86400000, op_type: 'ELEMENT_PLACE' });
+const NON_PLACE = { output_guid: null, input_guids: [], start_ts: 0, end_ts: 0, op_type: 'BUILDING_OPEN' };
+
+function makeHarness(src, state) {
+  const calls = { activate: 0, cacheDel: 0, cachePut: 0, dbRun: 0 };
+  const ctx = {
+    _ops: state.active ? state.activeOps : [],
+    _active: !!state.active,
+    console: { log: () => {}, warn: () => {} },
+    activate: () => { calls.activate++; },
+    cacheDel: () => { calls.cacheDel++; },
+    cachePut: () => { calls.cachePut++; },
+    cacheGet: (k) => Promise.resolve(state.cachedOps === undefined ? null : state.cachedOps),
+    A: () => ({
+      db: state.dbOps === undefined ? null : {
+        exec: () => [{ values: state.dbOps.map(o => [1, o.start_ts, o.op_type,
+          JSON.stringify({ _end_ts: o.end_ts }), JSON.stringify(o.input_guids), o.output_guid]) }],
+        run: () => { calls.dbRun++; },
+      },
+    }),
+  };
+  ctx.window = ctx;
+  vm.createContext(ctx);
+  vm.runInContext([
+    slice(src, 'function loadOps()'),
+    slice(src, 'window.tmHasExistingSchedule = function', true),
+  ].join('\n'), ctx);
+  return { ctx, calls };
+}
+
+async function runGates(src, label) {
+  const probe = makeHarness(src, { active: false, cachedOps: null, dbOps: [] });
+  const presentType = typeof probe.ctx.window.tmHasExistingSchedule;
+  const out = { label, present: presentType === 'function' };
+  console.log('§REQUIRE_TM_FIRST G-0 ' + label + ' tmHasExistingSchedule typeof=' + presentType +
+    ' → ' + (out.present ? 'EXISTS (testable)' : 'MISSING'));
+  if (!out.present) { out.g1 = out.g2 = out.g3 = out.g4 = out.g5 = false; return out; }
+
+  const cases = [
+    { name: 'G-1 nothing generated yet',        state: { active: false, cachedOps: null, dbOps: [] },                 want: false },
+    { name: 'G-2 cache has a real schedule',     state: { active: false, cachedOps: [PLACE('g1', 1.7e12)], dbOps: [] }, want: true },
+    { name: 'G-3 kernel_ops has a real schedule (cache empty)', state: { active: false, cachedOps: null, dbOps: [PLACE('g1', 1.7e12)] }, want: true },
+    { name: 'G-4 only bookkeeping ops (no ELEMENT_PLACE) anywhere', state: { active: false, cachedOps: [NON_PLACE], dbOps: [NON_PLACE] }, want: false },
+    { name: 'G-5 TM already active with real ops loaded', state: { active: true, activeOps: [PLACE('g1', 1.7e12)], cachedOps: null, dbOps: [] }, want: true },
+  ];
+  let idx = 1;
+  for (const c of cases) {
+    const h = makeHarness(src, c.state);
+    let got = null, threw = null;
+    try { got = await h.ctx.window.tmHasExistingSchedule(); } catch (e) { threw = e.message; }
+    const pass = threw === null && got === c.want && h.calls.activate === 0 && h.calls.cacheDel === 0 &&
+      h.calls.cachePut === 0 && h.calls.dbRun === 0;
+    out['g' + idx] = pass;
+    console.log('§REQUIRE_TM_FIRST ' + c.name + ' ' + label + ' got=' + got + ' want=' + c.want +
+      ' sideEffects(activate=' + h.calls.activate + ' cacheDel=' + h.calls.cacheDel +
+      ' cachePut=' + h.calls.cachePut + ' dbRun=' + h.calls.dbRun + ')' +
+      (threw ? ' THREW=' + threw : '') + ' → ' + (pass ? 'PASS' : 'FAIL'));
+    idx++;
+  }
+  return out;
+}
+
+(async function () {
+  console.log('§REQUIRE_TM_FIRST W-REQUIRE-TM-FIRST — §CPE_BUILDUP_REQUIRE_TM_FIRST, two sources, one harness\n');
+  const shipped = await runGates(shippedSrc, 'SHIPPED(origin/main)');
+  console.log('');
+  const fixed = await runGates(workingSrc, 'FIXED(working-tree)');
+
+  const redReproduces = shipped.present === false;
+  console.log('\n§REQUIRE_TM_FIRST_RESULT red=' + (redReproduces
+    ? 'shipped has no tmHasExistingSchedule at all — a bake there cannot refuse before generating (the gap reproduces)'
+    : 'WITNESS IS BLIND — shipped source unexpectedly already has this gate'));
+  const green = fixed.present && fixed.g1 && fixed.g2 && fixed.g3 && fixed.g4 && fixed.g5;
+  console.log('§REQUIRE_TM_FIRST_RESULT green=' + (green ? 'all gates pass on the fix' : 'FIX INCOMPLETE') +
+    ' (present=' + fixed.present + ' g1=' + fixed.g1 + ' g2=' + fixed.g2 + ' g3=' + fixed.g3 +
+    ' g4=' + fixed.g4 + ' g5=' + fixed.g5 + ')');
+  const verdict = redReproduces && green;
+  console.log('§REQUIRE_TM_FIRST_VERDICT ' + (verdict ? 'GREEN — falsifiable and fixed' : 'RED — see gates above'));
+  process.exit(verdict ? 0 : 1);
+})();

--- a/viewer/time_machine.js
+++ b/viewer/time_machine.js
@@ -8879,6 +8879,22 @@
   // them. window.tmDeactivateIfBakeOwned() (below) is the paired cleanup cinema_maxq calls on every
   // bake exit path (normal end, cancel, throw) — same contract as tmRestoreDerivedOrder/_ghostGroundRestore.
   var _bakeOwnsActivation = false;
+  // §CPE_BUILDUP_REQUIRE_TM_FIRST (2026-08-25, bim-compiler prompts/CINEMA_PATH_EDITOR.md — user
+  // ruling "no auto JSON outside TM"): a plain existence check, read-only, no DB writes, never
+  // generates anything. cinema_maxq calls this BEFORE tmActivateForBake so it can refuse with a
+  // clear reason instead of silently falling through activate()'s cold-generate path — the FIRST
+  // schedule for a building must be born from a real Time Machine open (the one place generation is
+  // allowed to run), so the user actually sees the buildup before it gets baked into a movie. Once a
+  // schedule exists (cache OR kernel_ops), every later bake reads it silently — a one-time gate, not
+  // a per-bake nag (user: "it is only 1 time and good practice").
+  window.tmHasExistingSchedule = function() {
+    function hasPlace(ops) { return !!ops && ops.some(function(o) { return o.op_type === 'ELEMENT_PLACE'; }); }
+    if (_active && hasPlace(_ops)) return Promise.resolve(true);
+    return cacheGet('gantt').then(function(cachedOps) {
+      if (hasPlace(cachedOps)) return true;
+      return hasPlace(loadOps());
+    }).catch(function() { return hasPlace(loadOps()); });
+  };
   window.tmActivateForBake = function() {
     return new Promise(function(resolve) {
       if (_active && _bakeTimelineReady()) return resolve(true);

--- a/viewer/viewer.html
+++ b/viewer/viewer.html
@@ -828,7 +828,7 @@ html.bim-embedded, html.bim-embedded body { background: #0b0b0b; }
 <script src="cinema_path_editor.js?v=15" onerror="console.warn('§LOAD_FAIL cinema_path_editor.js — Alt+C path editing disabled')"></script>
 <script src="cpe_walk.js?v=6" onerror="console.warn('§LOAD_FAIL cpe_walk.js — CPE walk-mode disabled')"></script>
 <script src="cpe_xr.js?v=1" onerror="console.warn('§LOAD_FAIL cpe_xr.js — VR entry disabled')"></script>
-<script src="cinema_maxq.js?v=6" onerror="console.warn('§LOAD_FAIL cinema_maxq.js — Alt+M MaxQ export disabled')"></script>
+<script src="cinema_maxq.js?v=7" onerror="console.warn('§LOAD_FAIL cinema_maxq.js — Alt+M MaxQ export disabled')"></script>
 <script src="input_registry.js?v=1" onerror="console.warn('§LOAD_FAIL input_registry.js')"></script>
 <script src="../common/pill_builder.js?v=1" onerror="console.warn('§LOAD_FAIL pill_builder.js')"></script>
 <script src="list_builder.js?v=1" onerror="console.warn('§LOAD_FAIL list_builder.js')"></script>
@@ -950,7 +950,7 @@ html.bim-embedded, html.bim-embedded body { background: #0b0b0b; }
      Must load BEFORE time_machine.js — its _zoneIndexBuild wrapper calls it. -->
 <script src="zone_index.js?v=1" onerror="console.warn('§LOAD_FAIL zone_index.js — storey banding unavailable (zone inference falls back to declared storey)')"></script>
 <script src="support_sweep.js?v=1" onerror="console.warn('§LOAD_FAIL support_sweep.js — support-order physics unavailable (schedule repair, judge parity, lock-gate midair audit)')"></script>
-<script src="time_machine.js?v=76" onerror="console.warn('§LOAD_FAIL time_machine.js')"></script>
+<script src="time_machine.js?v=77" onerror="console.warn('§LOAD_FAIL time_machine.js')"></script>
 <script src="dlod_nav.js?v=2" onerror="console.warn('§LOAD_FAIL dlod_nav.js')"></script>
 <script src="schedule_author.js?v=14" onerror="console.warn('§LOAD_FAIL schedule_author.js')"></script>
 <script src="schedule_sync.js?v=3" onerror="console.warn('§LOAD_FAIL schedule_sync.js')"></script>


### PR DESCRIPTION
## Summary
- User ruling: **"no auto JSON outside TM"** — Alt+C's bake could previously fall into the same cold-generate path as a real Time Machine open, silently manufacturing a building's first-ever 4D schedule on a movie button. Given the live hell #1 "Gantt overstacked" regression, baking a never-reviewed schedule blind is exactly the failure mode worth closing.
- New `window.tmHasExistingSchedule()` (`time_machine.js`) — read-only, no DB writes, never generates. `cinema_maxq.js` calls it BEFORE `tmActivateForBake()`; if nothing exists yet, the bake shows a visible status ("Open Time Machine first to build the construction schedule — baking without it this time") and falls back to a plain flythrough, same shape as the block's other `_buildup=false` reasons. Once a schedule exists (from either source) every later bake reads it silently — a one-time gate, not a per-bake nag.
- Fixed `witness_cpe_buildup_activate_silent.js`'s verdict logic — it compared against `origin/main` as a live RED control, which went permanently stale once its own fix (#1510) merged. Verdict is now the working-tree gates alone.
- Registered `witness_midair_zero.js` / `witness_s50_cell_engine.js` in `KNOWN_RED` — both broke today (pre-existing, unrelated): `~/bim-ootb/buildings/Duplex_meta.db` is 0 bytes in the shared checkout.

Ref: `prompts/CINEMA_PATH_EDITOR.md` §CPE_BUILDUP_REQUIRE_TM_FIRST (bim-compiler repo).

## Test plan
- [x] `node -c` on all 3 changed `.js` runtime files — clean
- [x] `npx eslint` on all changed files — 0 errors, 0 warnings
- [x] New witness `witness_cpe_buildup_require_tm_first.js` — 5 gates (no schedule anywhere / cache-only / kernel_ops-only / bookkeeping-ops-only / TM-already-active), each asserting zero side effects. `§REQUIRE_TM_FIRST_VERDICT GREEN`.
- [x] Full suite `node tests/run_witness_suite.js`: `green=54 new_red=0 known_red=6` (4 pre-existing + 2 newly-registered Duplex-DB ones, neither caused by this change)
- [x] `viewer.html` script versions bumped (`time_machine.js?v=77`, `cinema_maxq.js?v=7`) + `sw.js CACHE_VERSION v1084`, same PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)