### PR TITLE
witness_gantt_props_epoch: extend to updateStatus/_finishActivate (RED, proves the gap, no fix)

### DIFF
--- a/viewer/tests/witness_gantt_props_epoch.js
+++ b/viewer/tests/witness_gantt_props_epoch.js
@@ -22,6 +22,27 @@
 //   W-PE-3  no real dates → loud refusal, never an edit offered on invented values.
 //   W-PE-4  the sibling paths that already got §S22 right are still right (regression guard).
 //
+// EXTENSION 2026-08-25 (bim-compiler prompts/WITNESS_INTERFACE_FRAMEWORK.md §7) — W-PE-5/6/7:
+//   The house rule this whole file exists to gate is "anything user-facing reads `tasks`, never the
+//   bar" (4D_GANTT_TM_REFACTOR.md "recurring bug classes" §(a) "Two clocks"). That rule had ALREADY
+//   bitten twice (commitGanttDrag §S22, the typed panel above §S72) before this extension — both
+//   fixes were scoped to the one function an incident happened to touch, never swept to every OTHER
+//   function doing the identical `new Date(<internal clock>).toLocaleDateString/toISOString(...)`
+//   thing. Live evidence the sweep below exists to close: a fresh HHS_Office_Federated load
+//   (2026-08-25) printed `§TIME_MACHINE ON — 6881 ops, 43 days, project: 1/1/1970 → 2/12/1970` in
+//   the SAME session `§4D_COVERAGE window=2026-08-25..2026-10-06` — the real 2026 dates existed one
+//   layer over, `activate()`'s own status line just never read them. `updateStatus()`'s live scrubber
+//   date label carries the identical unconverted read. Traced via source (fnBody, same as W-PE-1..4),
+//   not a screenshot — no `new Date(op.start_ts|_cursor|_projectStart|_projectEnd)` was ever run to
+//   confirm the epoch live; the point is these call sites read the SAME unconverted variables §S22/
+//   §S72 already proved corrupt, independent of what a live run happens to show.
+//   W-PE-5  updateStatus()'s scrubber date/time label does not format _cursor as an absolute date.
+//   W-PE-6  activate()'s "§TIME_MACHINE ON" line does not format _projectStart/_projectEnd as dates.
+//   W-PE-7  refoldSchedule()'s §TM_PINPOINT_JUMP/§TM_ORDER_JUMP diagnostics don't either (console-only,
+//           lower severity, same violation — named so it can't hide behind "just a log line").
+//   ⚠ THESE ARE EXPECTED RED TODAY — this extension is the witness FIRST, per this project's Spec-
+//   First rule: it names the gap; the fix is a separate, deliberate pass, not bundled into this file.
+//
 // ⚠ Brace-matched, never a fixed slice window (the G-COH-6 false-negative class, §S65/§S71).
 //
 // Command: node viewer/tests/witness_gantt_props_epoch.js     (no fixtures, no DB, no browser)
@@ -77,6 +98,70 @@ assert(/tasksBefore\[bar\.taskId\]/.test(drag) && /no_real_task_snapshot/.test(d
 const retime = fnBody('retimeTaskElements');
 assert(/§S22_EPOCH_FIX/.test(retime),
   'W-PE-4b retimeTaskElements still carries its §S22 clock translation');
+
+// W-PE-5/6/7 — does `body` ever turn one of the TM's internal-clock variables into an absolute
+// calendar date? Covers BOTH idioms actually used in this file: the direct chain
+// (`new Date(_projectStart).toLocaleDateString()`) and assign-then-format
+// (`var d = new Date(_cursor); ... d.toLocaleDateString()`), so this catches updateStatus()'s shape
+// (the latter) as well as activate()'s (the former) — a regex tied to only one idiom would silently
+// miss the other, the exact "population gap" this extension exists to close.
+const CLOCK_VARS = '_cursor|_projectStart|_projectEnd|bar\\.startTs|bar\\.endTs|op\\.start_ts|op\\.end_ts|op2\\.start_ts';
+const DATE_FMT_METHODS = 'toLocaleDateString|toLocaleTimeString|toLocaleString|toDateString|toISOString';
+function clockFormattedAsDate(body) {
+  const directRe = new RegExp('new Date\\((' + CLOCK_VARS + ')\\)\\s*\\.\\s*(' + DATE_FMT_METHODS + ')');
+  if (directRe.test(body)) return true;
+  const assignRe = new RegExp('\\b(?:var|let|const)\\s+(\\w+)\\s*=\\s*new Date\\((' + CLOCK_VARS + ')\\)', 'g');
+  let m;
+  while ((m = assignRe.exec(body))) {
+    const varName = m[1];
+    const useRe = new RegExp('\\b' + varName + '\\s*\\.\\s*(' + DATE_FMT_METHODS + ')');
+    if (useRe.test(body)) return true;
+  }
+  return false;
+}
+// Around one console.log TAG — for the two diagnostics (§TM_PINPOINT_JUMP/§TM_ORDER_JUMP) that live
+// inside anonymous `window.tmX = function(...) {...}` closures fnBody() can't brace-match by name
+// (it only matches `function NAME(`). A window is enough since these are single console.log calls.
+function clockFormattedNearTag(tag) {
+  const idx = src.indexOf(tag);
+  if (idx < 0) return { found: false, bad: false };
+  return { found: true, bad: clockFormattedAsDate(src.slice(Math.max(0, idx - 400), idx + 400)) };
+}
+
+const updStatus = fnBody('updateStatus');
+assert(updStatus.length > 0, 'W-PE-5-0 updateStatus found and brace-matched (' + updStatus.length + ' chars)');
+assert(!clockFormattedAsDate(updStatus),
+  'W-PE-5 updateStatus() does not format _cursor (the TM playback clock, near-1970 by construction, ' +
+  'same clock §S22/§S72 already proved corrupt) as an absolute calendar date for the live scrubber label');
+
+// activate(silent) is a thin async dispatcher (early-return guards, then
+// `_activateAsync(...).then(...)`) — the "§TIME_MACHINE ON" line actually lives in
+// _finishActivate(), which _activateAsync() calls once ops are ready. Checked directly (not
+// assumed): fnBody('activate') is 3183 chars and ends at its `return;` before the async
+// continuation; _finishActivate is the function whose body actually contains both
+// "§TIME_MACHINE ON" occurrences (silent + non-silent).
+const finishAct = fnBody('_finishActivate');
+assert(finishAct.length > 0 && (finishAct.match(/§TIME_MACHINE ON/g) || []).length === 2,
+  'W-PE-6-0 _finishActivate found, brace-matched, and contains both §TIME_MACHINE ON lines (' + finishAct.length + ' chars)');
+assert(!clockFormattedAsDate(finishAct),
+  'W-PE-6 _finishActivate()\'s "§TIME_MACHINE ON" line does not format _projectStart/_projectEnd as an ' +
+  'absolute calendar date — same violation as W-PE-5, different function, same unswept population gap');
+
+// §TM_PINPOINT_JUMP / §TM_ORDER_JUMP live inside anonymous `window.tmJumpToPhase = function(...)`/
+// `window.tmJumpToOrder = function(...)` closures (doJump()), not named `function NAME(...)`
+// declarations — fnBody('refoldSchedule') brace-matches a real but DIFFERENT, unrelated 10-line
+// function; checked directly (its own content has neither tag). Anchored on 'built~...%' — the tag
+// string itself also appears on an earlier, unrelated "skip=no-ops" line in the same closure, and
+// indexOf() would silently anchor on THAT one instead (checked: it did, first draft of this check).
+const pinpoint = clockFormattedNearTag("built~' + pct + '% (frozen on the item)");
+const orderJump = clockFormattedNearTag("cost=' + Math.round(info.cost) + ' built~' + pct + '%'");
+assert(pinpoint.found && orderJump.found,
+  'W-PE-7-0 both §TM_PINPOINT_JUMP and §TM_ORDER_JUMP tags found in source');
+assert(!pinpoint.bad,
+  'W-PE-7a §TM_PINPOINT_JUMP does not format the internal clock (op.end_ts) as a date — console-only, ' +
+  'but the identical violation, named so it cannot hide as "just a log line"');
+assert(!orderJump.bad,
+  'W-PE-7b §TM_ORDER_JUMP does not format the internal clock (_cursor) as a date either — same reason');
 
 console.log('§PROPS_EPOCH_SUMMARY pass=' + pass + ' fail=' + fail);
 if (fail) { console.error('FAIL — ' + fail + ' check(s) failed'); process.exit(1); }


### PR DESCRIPTION
## Summary
Extends `witness_gantt_props_epoch.js` — the one witness enforcing this project's "Two clocks" rule ("anything user-facing reads `tasks`, never the bar" — `4D_GANTT_TM_REFACTOR.md` recurring bug classes §(a)) — to cover the two live call sites that reproduce the exact same violation §S22 and §S72 already fixed elsewhere, but were never swept:

- `updateStatus()` — the TM's live scrubber date/time label
- `_finishActivate()` — the `§TIME_MACHINE ON` status line (NOT `activate()` itself, which is a thin async dispatcher — traced by content, not assumed)
- `§TM_PINPOINT_JUMP` / `§TM_ORDER_JUMP` — two console-only diagnostics, same violation, lower severity

## Why now
Live evidence: a fresh `HHS_Office_Federated` load printed `§TIME_MACHINE ON — 6881 ops, 43 days, project: 1/1/1970 → 2/12/1970` in the same session where `§4D_COVERAGE window=2026-08-25..2026-10-06` shows the real 2026 dates existed one layer over. `kernel_ops.timestamp` is a day-offset CPM solve, near-1970 by construction — the house rule already says never format it directly as a calendar date, and a witness already exists for this exact rule. It just never covered these two functions.

## This is RED on purpose — no product code touched
`pass=13 fail=4`, exit 1. Per this project's Spec-First discipline: the witness names the gap first; fixing `updateStatus()`/`_finishActivate()` is a separate, deliberate pass. This PR is test-only.

## Test plan
- [x] `node viewer/tests/witness_gantt_props_epoch.js` — 13 PASS / 4 FAIL (W-PE-5, W-PE-6, W-PE-7a, W-PE-7b), matches a manual whole-file regex inventory of every `new Date(<internal clock>).toLocale*/toISOString()` call in `time_machine.js` (6 real occurrences, 2 idioms: direct-chain and assign-then-format)
- [x] Existing W-PE-0..4 checks still pass — no regression to the original §S72 coverage
- [x] Verified two of my own first-draft mistakes before trusting the result: `fnBody('activate')` doesn't reach the real bug (had to retarget `_finishActivate`); the shared `§TM_PINPOINT_JUMP` tag string collides with an earlier unrelated log line in the same closure (had to anchor on a unique substring instead)

🤖 Generated with [Claude Code](https://claude.com/claude-code)