### PR TITLE
witness_kit: day0-fanout invariant — first-minute stack-hell smell test

### DIFF
--- a/viewer/tests/witness_tm_schedule_output_of_truth.js
+++ b/viewer/tests/witness_tm_schedule_output_of_truth.js
@@ -15,12 +15,17 @@
 // witness_tm_schedule_output_of_truth_all_buildings.js — a separate, reusable script, not folded
 // into this one, so a single-building failure and a fleet-wide sweep stay independently readable.
 //
+// day0-fanout (2026-08-25, user request): "Day 0, Hour 0, Minute 1 — if multiple bars, clearly
+// stack hell." A fast, cheap, first-minute smell test — see witness_kit/invariants/schedule.js
+// §DAY0_FANOUT for the real baseline this was measured against (1 leaf task at min start, every
+// building, no exceptions found).
+//
 // Command: node viewer/tests/witness_tm_schedule_output_of_truth.js
 'use strict';
 const path = require('path');
 const { Witness } = require('../../witness_kit/contract');
 const { Schedule4DTaskRow } = require('../../witness_kit/schemas/schedule_4d');
-const { datesOrdered, noPre1970Dates, criticalFloatZero } = require('../../witness_kit/invariants/schedule');
+const { datesOrdered, noPre1970Dates, criticalFloatZero, day0FanoutOk } = require('../../witness_kit/invariants/schedule');
 const { generateRealTasksTable } = require('../../witness_kit/generators/schedule_4d');
 
 // BLD_DIR — same house convention witness_door_window_host_wall.js etc use, and what
@@ -37,6 +42,14 @@ const DB_PATH = path.join(BLD_DIR, 'Duplex_extracted.db');
     .invariant('dates-ordered', rs => rs.every(datesOrdered))
     .invariant('no-1970-dates', rs => rs.every(noPre1970Dates))
     .invariant('critical-float-zero', criticalFloatZero)
-    .redControl(rs => { const c = rs.map(r => Object.assign({}, r)); if (c[0]) c[0].schedule_start = '1970-01-05'; return c; })
+    .invariant('day0-fanout', day0FanoutOk)
+    .redControl(rs => {
+      const c = rs.map(r => Object.assign({}, r));
+      if (c[0]) c[0].schedule_start = '1970-01-05'; // trips no-1970-dates
+      // trips day0-fanout too — pile every leaf task onto the same start, the "stack hell" shape
+      const minStart = c.reduce((m, r) => (!r.is_summary && (m == null || r.schedule_start < m)) ? r.schedule_start : m, null);
+      c.forEach(r => { if (!r.is_summary) r.schedule_start = minStart; });
+      return c;
+    })
     .run();
 })();

--- a/viewer/tests/witness_tm_schedule_output_of_truth_all_buildings.js
+++ b/viewer/tests/witness_tm_schedule_output_of_truth_all_buildings.js
@@ -33,7 +33,7 @@ const fs = require('fs');
 const path = require('path');
 const { Witness } = require('../../witness_kit/contract');
 const { Schedule4DTaskRow } = require('../../witness_kit/schemas/schedule_4d');
-const { datesOrdered, noPre1970Dates, criticalFloatZero } = require('../../witness_kit/invariants/schedule');
+const { datesOrdered, noPre1970Dates, criticalFloatZero, day0FanoutOk } = require('../../witness_kit/invariants/schedule');
 const { generateRealTasksTable } = require('../../witness_kit/generators/schedule_4d');
 
 const BLD_DIR = process.env.BLD_DIR || path.join(require('os').homedir(), 'bim-ootb', 'buildings');
@@ -65,7 +65,14 @@ async function runOne(name) {
     .invariant('dates-ordered', rs => rs.every(datesOrdered))
     .invariant('no-1970-dates', rs => rs.every(noPre1970Dates))
     .invariant('critical-float-zero', criticalFloatZero)
-    .redControl(rs => { const c = rs.map(r => Object.assign({}, r)); if (c[0]) c[0].schedule_start = '1970-01-05'; return c; })
+    .invariant('day0-fanout', day0FanoutOk)
+    .redControl(rs => {
+      const c = rs.map(r => Object.assign({}, r));
+      if (c[0]) c[0].schedule_start = '1970-01-05';
+      const minStart = c.reduce((m, r) => (!r.is_summary && (m == null || r.schedule_start < m)) ? r.schedule_start : m, null);
+      c.forEach(r => { if (!r.is_summary) r.schedule_start = minStart; });
+      return c;
+    })
     .run();
   return Object.assign({ name }, result);
 }

--- a/witness_kit/invariants/schedule.js
+++ b/witness_kit/invariants/schedule.js
@@ -12,4 +12,22 @@ const noPre1970Dates = row => new Date(row.schedule_start).getFullYear() > 1971;
 const criticalFloatZero = rows =>
   rows.filter(r => r.is_critical === 1).every(r => Math.abs(Number(r.total_float || 0)) < 1e-6);
 
-module.exports = { datesOrdered, noPre1970Dates, criticalFloatZero };
+// §DAY0_FANOUT — user request (2026-08-25): "Day 0, Hour 0, Minute 1, what is the building events?
+// If multiple bars, clearly stack hell." Real construction starts ONE thing (a phase/task), not a
+// pile-up of unrelated bars — a fast, cheap, first-minute smell test, complementary to the deep
+// per-function checks: this doesn't prove any ONE call site is right, it proves the SHAPE of the
+// schedule is sane at its own origin. Grounded, not guessed: measured on all 5 real generated
+// buildings (Duplex/Hospital/Clinic/JKR/HHS_Office_Federated, 2026-08-25) — every one shows exactly
+// 1 leaf task at the project's minimum schedule_start. maxAtMin defaults to 1 (the observed real
+// baseline everywhere); pass a higher value only with a NAMED reason (e.g. two genuinely independent
+// building wings breaking ground together), never to silence a real fan-out.
+function day0FanoutOk(rows, maxAtMin) {
+  maxAtMin = maxAtMin == null ? 1 : maxAtMin;
+  const leaves = rows.filter(r => !r.is_summary);
+  if (!leaves.length) return true; // nothing to fan out — §W-EMPTY-POP is a separate, earlier check
+  const minStart = leaves.reduce((m, r) => (m == null || r.schedule_start < m) ? r.schedule_start : m, null);
+  const atMin = leaves.filter(r => r.schedule_start === minStart);
+  return atMin.length <= maxAtMin;
+}
+
+module.exports = { datesOrdered, noPre1970Dates, criticalFloatZero, day0FanoutOk };


### PR DESCRIPTION
## Summary
Adds `day0FanoutOk` to `witness_kit/invariants/schedule.js` — a fast, cheap, first-instant sanity check per user request: "Day 0, Hour 0, Minute 1, what is the building events? If multiple bars, clearly stack hell." Real construction sequencing starts ONE thing at the project's earliest date, not a pile-up. Complementary to `witness_gantt_props_epoch.js`'s deep per-function checks — this doesn't prove any one call site is right, it proves the schedule's overall SHAPE is sane at its own origin.

Wired into both `witness_tm_schedule_output_of_truth.js` and its all-buildings sibling. `redControl` extended to also collapse every leaf task onto the same start date (the actual "stack hell" shape) so this specific invariant is proven to fail, not just riding along on the existing 1970-date mutation.

## Grounded, not guessed
Measured against all 5 real generated buildings before writing the threshold: Duplex, Hospital, Clinic, JKR, HHS_Office_Federated all show exactly 1 leaf task at the project's minimum `schedule_start`, no exceptions. `maxAtMin` defaults to 1 and is overridable with a named reason, never to silence a real fan-out.

## Test plan
- [x] `node viewer/tests/witness_tm_schedule_output_of_truth.js` — 7/7 pass incl. day0-fanout
- [x] `node tests/run_witness_suite.js --filter tm_schedule_output_of_truth` — both green through the real runner
- [x] Standalone all-buildings run: 5/5 green, `day0-fanout` PASS on every building incl. HHS Office
- [x] Confirmed the invariant itself rejects a stacked case directly (3 leaf tasks forced to the same start → `false`) before wiring it in

🤖 Generated with [Claude Code](https://claude.com/claude-code)