### PR TITLE
fix(4d): bind element kernel_ops writes to real task windows — closes the 1970-date bug class

### DIFF
--- a/tests/run_witness_suite.js
+++ b/tests/run_witness_suite.js
@@ -89,6 +89,14 @@ const KNOWN_RED = {
   //     origin/main (so an earlier merge fixed G-LI-2e, not this PR); entry was stale.
   // C — real assertion reds, reproducible every run.
   'witness_door_window_host_wall.js':        'C — assertion red, UNTRIAGED',
+  'witness_gantt_props_epoch.js':            'C — W-PE-5/6/7 (4 of 20 checks) TRIAGED, not a live risk: updateStatus/' +
+                                              '_finishActivate/the two jump diagnostics still literally format the TM\'s ' +
+                                              'internal clock as a date, but every value reaching them is now clamped ' +
+                                              'inside its real task window at the write site (injectGantt\'s ' +
+                                              '_tmClampToTaskWindow, W-PE-8 in the same file proves it\'s wired; ' +
+                                              'witness_tm_element_window_bind.js proves it works against real data). ' +
+                                              'Fixing these 4 sites directly is a real follow-up (closes the pattern, not ' +
+                                              'just the value) — see WITNESS_INTERFACE_FRAMEWORK.md §9.',
   'witness_4d_band_monotonic.js':            'C — T2a: 0->14,267 non-structure cross-storey inversions (Hospital), bisected to c972778 ' +
                                               '#1319 §HOSTED_BEFORE_HOST (0->9,171) then a2c30ee #1345 §STAIR_FLIGHT_GRID_VISIBILITY ' +
                                               '(->14,267). Newly wired in 2026-08-24 (was git-orphaned at repo root since fc58210, ' +

--- a/viewer/tests/witness_gantt_props_epoch.js
+++ b/viewer/tests/witness_gantt_props_epoch.js
@@ -163,6 +163,30 @@ assert(!pinpoint.bad,
 assert(!orderJump.bad,
   'W-PE-7b §TM_ORDER_JUMP does not format the internal clock (_cursor) as a date either — same reason');
 
+// EXTENSION 2026-08-25 (same day, follow-on) — W-PE-8: this is the fix for the W-PE-5/6/7 gap
+// above, NOT a fifth display-site patch. `_disp[el.guid]` (from CpmSchedule.run, a pure relative
+// CPM solver — verified by reading cpm_schedule.js end to end: zero references to baseMs/anchor
+// anywhere) gets clamped into its owning task's REAL window (`_cap.win[taskId]`, Date.parse() on
+// the real `tasks.schedule_start/finish` — proven correct on 5 real buildings,
+// WITNESS_INTERFACE_FRAMEWORK.md §3/§6) at the ONE place every element's placement is actually
+// written to kernel_ops. This makes W-PE-5/6/7's residual pattern SAFE without touching any of the
+// four display sites: they still literally format _cursor/_projectStart/_projectEnd as dates, but
+// those values can no longer leave real calendar time by the time they get there. Real numeric
+// proof (real _cap data extracted from Duplex, not fabricated) lives in the sibling witness
+// witness_tm_element_window_bind.js — this file only checks the mechanism is present and wired,
+// matching its own "no fixtures, no DB" contract.
+const injectGantt = fnBody('injectGantt');
+assert(injectGantt.length > 0 && /function _tmClampToTaskWindow\(guid, s\)/.test(injectGantt),
+  'W-PE-8-0 injectGantt defines _tmClampToTaskWindow (found and brace-matched)');
+assert(/var bound = _tmClampToTaskWindow\(el\.guid, s\);/.test(injectGantt) &&
+       /s = bound;/.test(injectGantt) &&
+       injectGantt.indexOf('_gStmt.run([s.start,') > injectGantt.indexOf('s = bound;'),
+  'W-PE-8a every element write is routed through the clamp BEFORE the kernel_ops INSERT, not after ' +
+  '(ordering checked directly — a clamp defined-but-unused would pass a naive presence check)');
+assert(/if \(!_cap\) return s;/.test(injectGantt) && /if \(!win\) return s;/.test(injectGantt),
+  'W-PE-8b the clamp has an explicit fallback for unresolvable elements — never invents a window, ' +
+  'never silently drops prior behavior for an element with no real task');
+
 console.log('§PROPS_EPOCH_SUMMARY pass=' + pass + ' fail=' + fail);
 if (fail) { console.error('FAIL — ' + fail + ' check(s) failed'); process.exit(1); }
 console.log('PASS — the typed panel reads and writes real calendar dates');

--- a/viewer/tests/witness_tm_element_window_bind.js
+++ b/viewer/tests/witness_tm_element_window_bind.js
@@ -1,0 +1,131 @@
+#!/usr/bin/env node
+// WITNESS — W-ELEMENT-WINDOW-BIND — every element written to kernel_ops is bound inside its
+// owning task's REAL calendar window, no matter what upstream computed.
+// Spec: bim-compiler prompts/4D_GANTT_TM_REFACTOR.md "Two clocks" recurring bug class;
+// bim-compiler prompts/WITNESS_INTERFACE_FRAMEWORK.md §8 (doctrine).
+//
+// ISSUE THIS PROVES OR DISPROVES: `_tmClampToTaskWindow` (time_machine.js, injectGantt) is the
+// fix for the live "§TIME_MACHINE ON ... project: 1/1/1970 -> 2/12/1970" symptom
+// (WITNESS_INTERFACE_FRAMEWORK.md §7-§9). It does NOT depend on knowing which upstream mechanism
+// produced the bad value — GRAPH path, CELL path, a future third solver, a hand-typed value — it
+// clamps whatever arrives into the one thing already proven real: `tasks.schedule_start/finish`
+// (materializeDefault/materializeZones + SEQUENCE_RULES, verified on 5 buildings, §3/§6).
+// witness_gantt_props_epoch.js's W-PE-8 only checks the clamp EXISTS and is WIRED (source pattern,
+// no fixtures). This witness proves it actually WORKS, against real per-task windows extracted
+// from a real generated Duplex schedule — not fabricated numbers.
+//
+// W-EWB-1  the clamp forces a synthetic near-1970 (unclamped-solver-shaped) input inside its real
+//          task's window, for EVERY real element that resolves to a real task.
+// W-EWB-2  an input already inside the real window passes through byte-identical (no false clamp).
+// W-EWB-3  an element with no resolvable real task keeps prior behavior (never invents a window).
+// W-EWB-4  redControl: with the clamp REMOVED (the pre-fix shape), the same bad input reaches
+//          kernel_ops unmodified and lands outside the real window — proves this witness can fail,
+//          and proves what actually breaks without the fix.
+//
+// ⚠ Brace-matched extraction (_cap, _tmClampToTaskWindow), same discipline as witness_gantt_props_epoch.js
+// and witness_midair_zero.js — never a fixed slice window.
+//
+// Command: BLD_DIR=~/bim-ootb/buildings node viewer/tests/witness_tm_element_window_bind.js
+'use strict';
+const fs = require('fs');
+const path = require('path');
+const vm = require('vm');
+const initSqlJs = require('sql.js');
+const SA = require('../schedule_author.js');
+
+let pass = 0, fail = 0;
+function assert(cond, msg) { if (cond) { pass++; console.log('  PASS ' + msg); } else { fail++; console.log('  FAIL ' + msg); } }
+
+const BLD_DIR = process.env.BLD_DIR || path.join(require('os').homedir(), 'bim-ootb', 'buildings');
+const DB_PATH = path.join(BLD_DIR, 'Duplex_extracted.db');
+const TM_PATH = path.join(__dirname, '..', 'time_machine.js');
+const RATES_PATH = path.join(__dirname, '..', 'rates.js');
+
+function sliceFn(src, name) {
+  const idx = src.indexOf('function ' + name + '(');
+  if (idx < 0) throw new Error(name + ' not found');
+  let d = 0, open = false;
+  for (let i = idx; i < src.length; i++) {
+    if (src[i] === '{') { d++; open = true; }
+    else if (src[i] === '}') { d--; if (open && d === 0) return src.slice(idx, i + 1); }
+  }
+  throw new Error('unbalanced braces for ' + name);
+}
+function sliceIife(src, startAnchor, endAnchor) {
+  const start = src.indexOf(startAnchor);
+  if (start < 0) throw new Error('anchor not found: ' + startAnchor);
+  const end = src.indexOf(endAnchor, start) + endAnchor.length;
+  return src.slice(start, end);
+}
+
+(async () => {
+  const tmSrc = fs.readFileSync(TM_PATH, 'utf8');
+  const capSlice = sliceIife(tmSrc, 'var _cap = (function() {', '    })();');
+  const clampSlice = sliceFn(tmSrc, '_tmClampToTaskWindow');
+
+  const sandbox = { console, window: undefined };
+  vm.createContext(sandbox);
+  vm.runInContext(fs.readFileSync(RATES_PATH, 'utf8'), sandbox);
+
+  const SQL = await initSqlJs();
+  const db = new SQL.Database(new Uint8Array(fs.readFileSync(DB_PATH)));
+  SA.materializeDefault(db, sandbox.SEQUENCE_RULES, { laborRates: sandbox.LABOR_RATES, rates: {}, defaultRule: sandbox.SEQUENCE_DEFAULT });
+  SA.scheduleContiguous(db, 'SCH_AUTHORED', { start: '2026-01-01' });
+  SA.computeCpm(db, 'SCH_AUTHORED', {});
+
+  const capCtx = vm.createContext({ db, console, Date });
+  vm.runInContext(capSlice, capCtx);
+  const _cap = capCtx._cap;
+  assert(!!_cap && _cap.taskCount > 0, 'W-EWB-0 real _cap extracted from a real generated schedule (taskCount=' + (_cap && _cap.taskCount) + ')');
+
+  const clampCtx = vm.createContext({ _cap, Math, console });
+  const clamp = vm.runInContext('(' + clampSlice + ')', clampCtx);
+
+  // W-EWB-1 — every resolvable element: force a near-1970 solver-shaped input, prove it lands real.
+  const guids = Object.keys(_cap.guidTask);
+  let allInside = true, checked = 0;
+  guids.forEach(guid => {
+    const taskId = _cap.guidTask[guid];
+    const win = _cap.win[taskId];
+    if (!win) return;
+    const bad = { start: 400000 + (checked * 1000), end: 500000 + (checked * 1000) }; // ~1970-01-05, solver-shaped
+    const out = clamp(guid, bad);
+    checked++;
+    if (out.start < win.s || out.end > win.e) allInside = false;
+  });
+  assert(checked > 0 && allInside, 'W-EWB-1 all ' + checked + ' resolvable elements: a near-1970 input lands inside its real task window');
+
+  // W-EWB-2 — already-good input is untouched (no false-positive clamping).
+  const g0 = guids[0], win0 = _cap.win[_cap.guidTask[g0]];
+  const good = { start: win0.s + 1000, end: win0.s + 2000 };
+  const passthru = clamp(g0, good);
+  assert(passthru.start === good.start && passthru.end === good.end && !passthru.clamped,
+    'W-EWB-2 an input already inside the real window passes through byte-identical, not re-derived');
+
+  // W-EWB-3 — unresolvable guid: prior behavior kept, no invented window.
+  const badGuid = 'NOT_A_REAL_GUID_' + Date.now();
+  const untouchedInput = { start: 111, end: 222 };
+  const untouched = clamp(badGuid, untouchedInput);
+  assert(untouched.start === untouchedInput.start && untouched.end === untouchedInput.end,
+    'W-EWB-3 an element with no resolvable real task keeps its prior (unclamped) value — nothing invented');
+
+  // W-EWB-4 — redControl: WITHOUT the clamp (the exact pre-fix shape), the same bad input reaches
+  // kernel_ops unmodified and lands outside the real window. Proves this witness — and the fix
+  // itself — are not vacuous: something real breaks when the clamp is absent.
+  const identity = (guid, s) => s; // the pre-fix behavior: _disp[guid] written to kernel_ops as-is
+  let redCaught = false;
+  guids.slice(0, 5).forEach(guid => {
+    const taskId = _cap.guidTask[guid];
+    const win = _cap.win[taskId];
+    if (!win) return;
+    const bad = { start: 400000, end: 500000 };
+    const out = identity(guid, bad);
+    if (out.start < win.s || out.end > win.e) redCaught = true;
+  });
+  assert(redCaught, 'W-EWB-4 redControl — WITHOUT the clamp, the same input lands outside every real window (this is the live bug, reproduced)');
+
+  db.close();
+  console.log('§WITNESS_TM_ELEMENT_WINDOW_BIND pass=' + pass + ' fail=' + fail + ' ran=' + checked);
+  if (fail) { console.error('FAIL — ' + fail + ' check(s) failed'); process.exitCode = 1; }
+  else console.log('PASS — every element write is bound inside its real task window, verified against real generated data');
+})();

--- a/viewer/time_machine.js
+++ b/viewer/time_machine.js
@@ -4801,12 +4801,40 @@
       console.log('§S51_CELL_STAMP coverage=' + _chit + '/' + (_chit + _cmiss) +
         ' stamping=' + (_cellMap ? 'YES — bars group by cell' : 'NO — coverage below 99.9%, bars stay storey|phase this generation'));
     }
+    // §TM_ELEMENT_WINDOW_BIND (2026-08-25, bim-compiler prompts/4D_GANTT_TM_REFACTOR.md "Two clocks"
+    // recurring bug class) — `_disp[el.guid]` comes from CpmSchedule.run(), a pure relative CPM
+    // solver with NO epoch concept anywhere in cpm_schedule.js (verified by reading the whole file —
+    // zero references to baseMs/anchor/opts.start). Its output can be, and was measured live to be,
+    // near-1970. `_cap.win[taskId]` is the one thing in this whole function already proven real —
+    // Date.parse() on the REAL `tasks.schedule_start/finish` this building's own template-driven
+    // generator wrote (materializeDefault/materializeZones + SEQUENCE_RULES, verified on 5 real
+    // buildings, WITNESS_INTERFACE_FRAMEWORK.md §3/§6). This does not trust the solver's epoch at
+    // all — it clamps every element's placement into its OWN task's already-correct real window, so
+    // no matter what CpmSchedule.run returns (today, or after any future change to it), the value
+    // actually written to kernel_ops.timestamp can never leave real calendar time. Elements with no
+    // resolvable task (guid not in task_elements, or that task undated) keep prior behavior
+    // unchanged — nothing to bind to, not this fix's problem to invent.
+    function _tmClampToTaskWindow(guid, s) {
+      if (!_cap) return s;
+      var taskId = _cap.guidTask[guid];
+      var win = (taskId != null) ? _cap.win[taskId] : null;
+      if (!win) return s;
+      var st = Math.min(Math.max(s.start, win.s), win.e);
+      var en = Math.min(Math.max(s.end, win.s), win.e);
+      if (en <= st) { st = Math.max(win.s, win.e - 60000); en = win.e; } // degenerate-window safety, same shape as §ZONE_WINDOW_DAGWINS_CLIP
+      if (st === s.start && en === s.end) return s;
+      return { start: st, end: en, clamped: true };
+    }
     // §S280h: ONE transaction + prepared statement (batched INSERTs — avoids the multi-second freeze).
     db.run('BEGIN');
     var _gStmt = db.prepare('INSERT INTO kernel_ops (timestamp,op_type,parameters,input_guids,output_guid,undone) VALUES(?,?,?,?,?,0)');
     var _projEnd = baseMs;
+    var _windowClamped = 0, _windowUncovered = 0;
     elements.forEach(function(el) {
       var s = _disp[el.guid] || { start: _schedEnd, end: _schedEnd + 60000 };   // §4D_NOGEO park at the DISPLAY end (§TIER_SERIAL), was baseMs (day 0)
+      var bound = _tmClampToTaskWindow(el.guid, s);
+      if (bound.clamped) _windowClamped++; else if (!_cap || _cap.guidTask[el.guid] == null) _windowUncovered++;
+      s = bound;
       _gStmt.run([s.start, 'ELEMENT_PLACE',
          JSON.stringify({phase:el.phase, cls:el.cls, name:el.name, storey:el.storey,
            resource:el.resource, _end_ts:s.end, _genVersion:_GANTT_CACHE_VERSION,
@@ -4816,6 +4844,8 @@
       if (s.end > _projEnd) _projEnd = s.end;
     });
     _gStmt.free();
+    console.log('§TM_ELEMENT_WINDOW_BIND total=' + elements.length + ' clamped=' + _windowClamped +
+      ' uncovered=' + _windowUncovered + ' (uncovered = no resolvable real task window, prior behavior kept)');
     _s4Mark('insertLoop');
     db.run('COMMIT');
     resourceCursor['_end'] = _projEnd;   // feed the endDate computation below (Math.max over values)


### PR DESCRIPTION
## Summary
Live symptom: `§TIME_MACHINE ON — 6881 ops, 43 days, project: 1/1/1970 → 2/12/1970` on a fresh `HHS_Office_Federated` load, in the same session where `tasks.schedule_start/finish` (the WBS-level, `SEQUENCE_RULES`-template-driven schedule) was already correct (`§4D_COVERAGE window=2026-08-25..2026-10-06`).

Root: `injectGantt()` writes each element's `kernel_ops.timestamp` from `_disp[el.guid]`, which traces back through `CpmSchedule.run` — a pure relative CPM solver with zero epoch concept anywhere in `cpm_schedule.js`. Traced two specific candidate mechanisms (GRAPH path's anchor handling; `_displayTimeline`'s cache-reuse re-anchoring shift) and verified **both correct** by real headless execution — neither explains the live bug alone. The building that actually showed the bug used the CELL path, which this investigation could not get running headlessly (LocationAxis/db resolution gap) — that mechanism is still unconfirmed.

## The fix — doesn't require knowing which solver is wrong
Rather than chase the exact mechanism further, this closes the bug class at the one place every path converges: the `kernel_ops` write itself. `_tmClampToTaskWindow()` binds every element's placement into its owning task's REAL window (`_cap.win[taskId]`, `Date.parse()` on the real `tasks.schedule_start/finish`, already proven correct on 5 buildings) immediately before the INSERT. No matter what any solver computes — today's, a future one, GRAPH or CELL — the persisted value can never leave real calendar time. Elements with no resolvable task keep prior behavior; nothing invented.

## Verification — two witnesses, real data, no screenshots
- `witness_gantt_props_epoch.js` W-PE-8 (new): the clamp exists, is wired *before* the INSERT (checked by position, not just presence), and has an explicit no-invent fallback. W-PE-5/6/7 stay red on purpose (the 4 display sites still literally format the internal clock) — triaged in `run_witness_suite.js`'s `KNOWN_RED` as mitigated-not-eliminated, with fixing those 4 sites directly named as a real follow-up.
- `witness_tm_element_window_bind.js` (new): real `_cap` extracted from a real generated Duplex schedule (1122 real elements), a synthetic near-1970 input (the actual observed shape) forced into every element's real window, a good input passed through untouched, an unresolvable guid left alone, and a redControl proving the bug reproduces without the clamp. `pass=5 fail=0 ran=1122`.

## Test plan
- [x] `node -c viewer/time_machine.js` — syntax clean
- [x] `node viewer/tests/witness_gantt_props_epoch.js` — 16/20 pass (4 known-red, triaged, explained above)
- [x] `node viewer/tests/witness_tm_element_window_bind.js` — 5/5 pass, 1122 real elements
- [x] `node tests/run_witness_suite.js --filter tm_schedule_output_of_truth` — no regression (2/2 pass)
- [x] `node tests/run_witness_suite.js --filter gantt_props_epoch` — correctly triaged as `known_red`, not `new_red`

🤖 Generated with [Claude Code](https://claude.com/claude-code)