### PR TITLE
fix(deploy): bump sw.js CACHE_VERSION — PR #1520's fix never reached existing users

### DIFF
--- a/viewer/sw.js
+++ b/viewer/sw.js
@@ -8,7 +8,7 @@
 // Cache-first for heavy assets (.wasm, images). DB files skip SW (IndexedDB handles them).
 //
 // DEPLOY: bump CACHE_VERSION on every OCI upload. Old caches are purged on activate.
-const CACHE_VERSION = 'v1084';   // bump on each deploy; per-change detail is the git commit message.
+const CACHE_VERSION = 'v1085';   // bump on each deploy; per-change detail is the git commit message.
 // v1084 (2026-08-25) §CPE_BUILDUP_REQUIRE_TM_FIRST (CINEMA_PATH_EDITOR.md, user ruling "no auto
 // JSON outside TM"): Alt+C's bake no longer generates a building's first-ever 4D schedule.
 // window.tmHasExistingSchedule() (time_machine.js) — read-only, no DB writes, never generates —


### PR DESCRIPTION
## Summary
`#1520` (element-window-clamp, the "1970 dates" fix) changed `viewer/time_machine.js` — which is in `PRECACHE_ASSETS` — without bumping `CACHE_VERSION` in the same PR. Caught by a live re-test after merge: the browser still showed `§TIME_MACHINE ON ... project: 1/1/1970 → 2/12/1970` even though a direct fetch of the deployed `time_machine.js` confirmed the fix WAS on the server. Any browser with an already-installed service worker was serving the stale precached file regardless.

`v1084 -> v1085` forces the SW to purge the old precache and refetch on next activate.

## Test plan
- [x] `node -c viewer/sw.js` — syntax clean
- [x] Confirmed `time_machine.js` is in `PRECACHE_ASSETS`
- [ ] Live re-test after this deploys — should show real 2026 dates on a fresh HHS_Office_Federated load (not verified here; needs the actual deploy + a hard reload)

🤖 Generated with [Claude Code](https://claude.com/claude-code)