### PR TITLE
test(4d): witness the PRESET TEMPLATE itself — the layer nothing had ever checked (§S65 STAGE 2)

### DIFF
--- a/tests/run_witness_suite.js
+++ b/tests/run_witness_suite.js
@@ -102,6 +102,22 @@ const KNOWN_RED = {
                                               '(->14,267). Newly wired in 2026-08-24 (was git-orphaned at repo root since fc58210, ' +
                                               'per §S66 — suite never ran it, so this went undetected). Cause: 4D_SCHEDULE_PERFECTION.md ' +
                                               '"REGRESSION FOUND" section.',
+  'witness_sequence_template_lock.js':       'C — RED BY DESIGN ON ARRIVAL, 3 of 7 checks. This witness is NEW (2026-08-25) ' +
+                                              'and it is the FIRST check of any kind on the preset 4D template itself; it ' +
+                                              'arrives red because the template is genuinely wrong, not because the witness ' +
+                                              'is unfinished. no-zero-minute-rows + every-resource-resolves: 7/65 rows land ' +
+                                              'on ScheduleAuthor._installSecs\' silent 120s floor (IfcSpace, ' +
+                                              'IfcBuildingElementProxy and SEQUENCE_DEFAULT all ship resource:null; the ' +
+                                              'glazed_curtainwall_facade override moves IfcPlate/IfcMember to CARPENTER and ' +
+                                              'furniture_generic_bucket moves IfcBuildingElementPart to FINISHER, neither of ' +
+                                              'which carries productivity for those classes) — a 120s element is a ' +
+                                              'zero-width bar that stacks with every other one, the user-reported "zero ' +
+                                              'minute stacking". phase-bands-disjoint: Architecture spans seq 5-8 while MEP ' +
+                                              'Rough-in sits at 7, so IfcRoof (Architecture, seq 8) sequences AFTER all MEP ' +
+                                              'rough-in. TWO of the six defects are BLOCKED on a fact that exists nowhere in ' +
+                                              'the rate table (what trade + daily productivity a generic/unclassified ' +
+                                              'element carries) — filling it in would be invention, so it is a user ' +
+                                              'question, not a code task. Cause + full table: 4D_SCHEDULE_PERFECTION.md §S65.',
   // Reproducible reds whose cause has NOT been established. Labelled honestly rather than guessed:
   // an earlier pass called these "browser/server not up", which was wrong — both are headless.
   'witness_tm_stream_index_defer.js':        'C — reproducible red, cause NOT yet established',

--- a/viewer/tests/witness_sequence_template_lock.js
+++ b/viewer/tests/witness_sequence_template_lock.js
@@ -1,0 +1,156 @@
+#!/usr/bin/env node
+// WITNESS — sequence_template_lock: the PRESET 4D TEMPLATE itself, before any building, any
+// geometry, any kernel_ops. Spec: bim-compiler prompts/4D_SCHEDULE_PERFECTION.md §S65 STAGE 2.
+//
+// WHICH LAYER THIS PROVES (WITNESS_INTERFACE_FRAMEWORK.md §CRISIS LESSON 1 requires this to be
+// named explicitly, because three different layers got conflated as "the fix is witnessed"):
+//   this is the TEMPLATE layer — the static sequence/labour rules table. It says NOTHING about
+//   `tasks` rows, NOTHING about `kernel_ops` element ops, and NOTHING about the rendered Gantt bar
+//   widths. It proves only that the preset every downstream layer is built on is internally sound.
+//
+// ISSUE THIS PROVES OR DISPROVES — user, 2026-08-25: "the inbuilt preset gantt chart template that
+// will always be correct already having all the types and arranged proper sequence - no zero minute
+// stacking, no midair MEPs or beams." It had never been checked by anything. §S65 measured 7 real
+// defects in it, and the reason they survived is that the failure mode is SILENT: ScheduleAuthor.
+// _installSecs (schedule_author.js:62-75) returns a bare `120` seconds when the rule's resource is
+// missing or the class has no productivity entry — no §-log at any of its three sites
+// (schedule_author.js:64, :70, time_machine.js:4457). On a 45-day axis, 120s is a zero-width bar,
+// and every such element starts at the same instant: the reported "zero minute stacking".
+//
+// POPULATION — the EXECUTED table, not the mirror. STAGE 1 of §S65 established that viewer.html:865
+// loads rates.js and NEVER calls loadSequenceRules(), so the JS literal in viewer/rates.js is what
+// the browser actually runs and rates/sequence_rules.json is a hand-synced mirror (rates.js:107-110,
+// §RULES_TABLE_SOURCE). A witness that read the JSON would repeat the exact mistake that comment
+// records: "every Node probe and every viewer/tests/witness_*.js reads the JSON, they were all
+// measuring a labour table the browser never used." So: population is loaded from rates.js via
+// vm.createContext (the same pattern witness_gantt_bars_in_rect.js uses for a browser-global script),
+// and the mirror is checked as a separate invariant instead of trusted.
+//
+// Durations come from the REAL ScheduleAuthor._installSecs — never a mirrored copy of the formula.
+//
+// Command: node viewer/tests/witness_sequence_template_lock.js
+'use strict';
+const fs = require('fs');
+const vm = require('vm');
+const path = require('path');
+const { Witness } = require('../../witness_kit/contract');
+const { TemplateRuleRow } = require('../../witness_kit/schemas/template');
+const {
+  noZeroMinuteRows, everyResourceResolves, phaseBandsDisjoint, phaseBandReport, FALLBACK_SECS
+} = require('../../witness_kit/invariants/template');
+
+const VIEWER_DIR = process.env.VIEWER_DIR || path.join(__dirname, '..');
+const SA = require(path.join(VIEWER_DIR, 'schedule_author.js'));
+
+// ── the EXECUTED table (viewer/rates.js JS literal) ─────────────────────────
+function loadExecutedTable() {
+  const sandbox = { console: { log() {}, warn() {}, error() {} }, window: undefined };
+  vm.createContext(sandbox);
+  vm.runInContext(fs.readFileSync(path.join(VIEWER_DIR, 'rates.js'), 'utf8'), sandbox);
+  return {
+    rules: sandbox.SEQUENCE_RULES,
+    labor: sandbox.LABOR_RATES,
+    dflt: sandbox.SEQUENCE_DEFAULT,
+    overrides: sandbox.SEQUENCE_NAME_OVERRIDES || []
+  };
+}
+
+// ── the MIRROR (rates/sequence_rules.json), for the drift invariant only ────
+function loadMirror() {
+  return JSON.parse(fs.readFileSync(path.join(VIEWER_DIR, 'rates', 'sequence_rules.json'), 'utf8'));
+}
+
+const T = loadExecutedTable();
+const M = loadMirror();
+
+/**
+ * One row per schedulable declaration, with its REAL duration attached.
+ * A NAME_OVERRIDE contributes one row per class it declares, because the override REPLACES the
+ * resource for that class — §S65 defect 4 is exactly an override moving IfcPlate/IfcMember from
+ * STEEL_ERECTOR (which has productivity 12/10) to CARPENTER (which has neither), so the override's
+ * own class list is where the duration is silently lost. Checking the override once, class-free,
+ * would miss it.
+ * @returns {object[]}
+ */
+function buildRows() {
+  const rows = [];
+  Object.keys(T.rules).forEach(cls => {
+    const r = T.rules[cls];
+    rows.push({
+      key: 'rule:' + cls, kind: 'rule', cls,
+      phase: r.phase, sequence: r.sequence, resource: r.resource == null ? null : r.resource,
+      installSecs: SA._installSecs(cls, r, T.labor, null, null)
+    });
+  });
+  T.overrides.forEach(o => {
+    (o.classes || []).forEach(cls => {
+      rows.push({
+        key: 'override:' + o.id + ':' + cls, kind: 'override', cls,
+        phase: o.phase, sequence: o.sequence, resource: o.resource == null ? null : o.resource,
+        installSecs: SA._installSecs(cls, o, T.labor, null, null)
+      });
+    });
+  });
+  // SEQUENCE_DEFAULT is what EVERY unmatched IFC class in EVERY building resolves to — the widest
+  // blast radius in the file, and §S65 defect 1. `cls` is a deliberate sentinel: the default's whole
+  // point is that it applies to a class the table does not name.
+  rows.push({
+    key: 'default:SEQUENCE_DEFAULT', kind: 'default', cls: '__UNMATCHED_CLASS__',
+    phase: T.dflt.phase, sequence: T.dflt.sequence,
+    resource: T.dflt.resource == null ? null : T.dflt.resource,
+    installSecs: SA._installSecs('__UNMATCHED_CLASS__', T.dflt, T.labor, null, null)
+  });
+  return rows;
+}
+
+const rows = buildRows();
+
+// §-log proof lines: the shape of what was checked, readable without re-running.
+const zero = rows.filter(r => r.installSecs === FALLBACK_SECS);
+console.log('§TPL_SOURCE executed=viewer/rates.js rules=' + Object.keys(T.rules).length +
+  ' labor=' + Object.keys(T.labor).length + ' overrides=' + T.overrides.length + ' rows=' + rows.length);
+console.log('§TPL_BANDS ' + phaseBandReport(rows));
+console.log('§TPL_ZERO_MINUTE n=' + zero.length + '/' + rows.length +
+  (zero.length ? ' [' + zero.map(r => r.key + '(res=' + r.resource + ')').join(' ') + ']' : ''));
+
+/**
+ * The mirror must be byte-equal to the executed table on every FUNCTIONAL key. The JSON additionally
+ * carries a `reason` string per override (documentation the JS literal omits) — that difference is
+ * intentional and is excluded, so this invariant fails on real drift and not on prose.
+ * @returns {boolean}
+ */
+function mirrorMatchesExecuted() {
+  const strip = o => {
+    const c = Object.assign({}, o); delete c.reason; return c;
+  };
+  if (JSON.stringify(T.rules) !== JSON.stringify(M.SEQUENCE_RULES)) return false;
+  if (JSON.stringify(T.labor) !== JSON.stringify(M.LABOR_RATES)) return false;
+  if (JSON.stringify(T.dflt) !== JSON.stringify(M.SEQUENCE_DEFAULT)) return false;
+  const a = (T.overrides || []).map(strip), b = (M.NAME_OVERRIDES || []).map(strip);
+  return JSON.stringify(a) === JSON.stringify(b);
+}
+
+Witness('sequence_template_lock')
+  .population(() => rows)
+  .schema(TemplateRuleRow)
+  // G-TPL-ZERO — the gate that would have caught §S65 defects 1-6 the day they were written.
+  .invariant('no-zero-minute-rows', noZeroMinuteRows)
+  // G-TPL-RES — a null/absent resource is exactly what routes a row to the silent floor.
+  .invariant('every-resource-resolves', rs => everyResourceResolves(rs, T.labor))
+  // G-TPL-BANDS — §S65 defect 7: Architecture spans seq 5-8 while MEP Rough-in sits at 7, so
+  // IfcRoof (Architecture, seq 8) sequences after all MEP rough-in — MEP before the roof exists.
+  .invariant('phase-bands-disjoint', phaseBandsDisjoint)
+  // STAGE 1 lock — the executed table and the shipped JSON must not diverge. This is the property
+  // that silently broke once already (ELECTRICIAN.productivity: 15 class keys in rates.js vs 8 in
+  // the JSON, rates.js:110-116) and cost a measured 1889.4d-vs-1926.4d Hospital programme error.
+  .invariant('mirror-matches-executed', mirrorMatchesExecuted)
+  // RED CONTROL — reproduce the real §S65 defect shape rather than a synthetic break: strip one
+  // row's resource and RECOMPUTE its duration through the real _installSecs, which is what actually
+  // returns the 120s floor. A hand-set installSecs=120 would prove the assertion, not the mechanism.
+  .redControl(rs => rs.map((r, i) => {
+    if (i !== 0) return r;
+    const broken = Object.assign({}, r, { resource: null });
+    broken.installSecs = SA._installSecs(broken.cls, { resource: null }, T.labor, null, null);
+    return broken;
+  }))
+  .run();

--- a/witness_kit/invariants/template.js
+++ b/witness_kit/invariants/template.js
@@ -1,0 +1,94 @@
+// witness_kit/invariants/template.js — reusable predicates for the PRESET 4D TEMPLATE
+// (sequence rules + labour rates), the layer every generated schedule is built on top of.
+//
+// WHY THESE EXIST (bim-compiler prompts/4D_SCHEDULE_PERFECTION.md §S65, 2026-08-25):
+// the template had NO witness of any kind, and its worst failure mode is silent by construction —
+// ScheduleAuthor._installSecs (schedule_author.js:62-75) returns a bare `120` seconds whenever the
+// rule's resource is missing OR that class has no productivity entry, with zero §-log at any of its
+// three sites (schedule_author.js:64, :70, time_machine.js:4457). On a 45-day axis a 120s element is
+// a zero-width bar, and every one of them starts at the same instant — the user-reported
+// "zero minute stacking", originating here rather than in any downstream drawer/solver code.
+//
+// These predicates take ROWS in the shape witness_sequence_template_lock.js's population() builds
+// (one row per rule / per NAME_OVERRIDE×class / one for SEQUENCE_DEFAULT) and are imported by name
+// so the predicate exists in exactly ONE place — the drift class WITNESS_CONTRACT_AUDIT.md found
+// 10+ times in one day.
+'use strict';
+
+// The silent floor _installSecs falls back to. NOT a tuned constant of ours — it is read from the
+// real function's own behaviour, and the point of the gate is that NOTHING should reach it.
+const FALLBACK_SECS = 120;
+
+/**
+ * A row lands on the silent 120s floor — i.e. it will draw a zero-width bar.
+ * @param {{installSecs:number}} row
+ * @returns {boolean} true if this row is a zero-minute element.
+ */
+const isZeroMinute = row => row.installSecs === FALLBACK_SECS;
+
+/**
+ * G-TPL-ZERO — no rule, override or default may produce the 120s floor.
+ * This is the gate that would have caught §S65 defects 1-6 on the day they were written.
+ * @param {object[]} rows
+ * @returns {boolean}
+ */
+const noZeroMinuteRows = rows => rows.every(r => !isZeroMinute(r));
+
+/**
+ * G-TPL-RES — every resource a row names must exist in the labour table.
+ * A null/absent resource is exactly what routes a row to the floor above.
+ * @param {object[]} rows
+ * @param {object} laborRates
+ * @returns {boolean}
+ */
+const everyResourceResolves = (rows, laborRates) =>
+  rows.every(r => r.resource != null && !!laborRates[r.resource]);
+
+/**
+ * G-TPL-BANDS — phase sequence bands must not interleave.
+ * Derives each phase's [min..max] sequence band from the rows, orders phases by min, and requires
+ * each band to start strictly after the previous one ends. An overlap means "phase order" and
+ * "element order" disagree: §S65 defect 7 — Architecture spans 5-8 while MEP Rough-in sits at 7, so
+ * IfcRoof (Architecture, seq 8) sequences AFTER all MEP rough-in, i.e. MEP installs before the roof
+ * exists. That is a midair-MEP condition readable in the template, before any geometry is involved.
+ * @param {object[]} rows
+ * @returns {boolean}
+ */
+function phaseBandsDisjoint(rows) {
+  const bounds = {};
+  rows.forEach(r => {
+    if (!r.phase || r.sequence == null) return;
+    const b = bounds[r.phase] || (bounds[r.phase] = { min: Infinity, max: -Infinity });
+    if (r.sequence < b.min) b.min = r.sequence;
+    if (r.sequence > b.max) b.max = r.sequence;
+  });
+  const ordered = Object.keys(bounds).sort((a, b) => bounds[a].min - bounds[b].min);
+  for (let i = 1; i < ordered.length; i++) {
+    if (bounds[ordered[i]].min <= bounds[ordered[i - 1]].max) return false;
+  }
+  return true;
+}
+
+/**
+ * Human-readable band report, for the §-log line — so a failure names WHICH phases overlap
+ * instead of just returning false.
+ * @param {object[]} rows
+ * @returns {string}
+ */
+function phaseBandReport(rows) {
+  const bounds = {};
+  rows.forEach(r => {
+    if (!r.phase || r.sequence == null) return;
+    const b = bounds[r.phase] || (bounds[r.phase] = { min: Infinity, max: -Infinity, n: 0 });
+    if (r.sequence < b.min) b.min = r.sequence;
+    if (r.sequence > b.max) b.max = r.sequence;
+    b.n++;
+  });
+  return Object.keys(bounds).sort((a, b) => bounds[a].min - bounds[b].min)
+    .map(p => p + '[' + bounds[p].min + '-' + bounds[p].max + ']x' + bounds[p].n).join(' ');
+}
+
+module.exports = {
+  FALLBACK_SECS, isZeroMinute, noZeroMinuteRows, everyResourceResolves,
+  phaseBandsDisjoint, phaseBandReport
+};

--- a/witness_kit/schemas/template.js
+++ b/witness_kit/schemas/template.js
@@ -1,0 +1,30 @@
+// witness_kit/schemas/template.js — the contract for ONE row of the preset 4D template,
+// as data. Spec: bim-compiler prompts/4D_SCHEDULE_PERFECTION.md §S65 STAGE 2.
+//
+// A "row" is one schedulable declaration in the template: a class rule, one NAME_OVERRIDE applied to
+// one of its declared classes, or SEQUENCE_DEFAULT. Every one of them must name a phase, a sequence
+// position, a resource that exists, and must resolve to a REAL install duration.
+//
+// `resource` is deliberately typed ['string','null'] rather than 'string': null is the shape the
+// file actually ships today (IfcSpace, IfcBuildingElementProxy, SEQUENCE_DEFAULT), and the schema's
+// job is to describe the artifact honestly. Whether null is ALLOWED is an invariant question
+// (G-TPL-RES / G-TPL-ZERO in invariants/template.js), not a shape question — keeping it here would
+// conflate "malformed" with "wrong", and the §S65 defects are wrong, not malformed.
+'use strict';
+
+const TemplateRuleRow = {
+  type: 'object',
+  required: ['key', 'kind', 'cls', 'phase', 'sequence', 'resource', 'installSecs'],
+  properties: {
+    key:         { type: 'string', minLength: 1 },
+    kind:        { type: 'string', enum: ['rule', 'override', 'default'] },
+    cls:         { type: 'string', minLength: 1 },
+    phase:       { type: 'string', minLength: 1 },
+    sequence:    { type: 'integer', minimum: 0 },
+    resource:    { type: ['string', 'null'] },
+    installSecs: { type: 'integer', minimum: 1 }
+  },
+  additionalProperties: true   // a floor, not a ceiling
+};
+
+module.exports = { TemplateRuleRow };


### PR DESCRIPTION
## What

First witness of any kind on the **preset 4D sequence/labour template** — the static table every generated schedule is built on top of. It had never been checked.

**Stage 2 of the user-directed staging** (`4D_SCHEDULE_PERFECTION.md` §S65):

```
STAGE 1  establish: template + setting result live in ONE JSON file
STAGE 2  look at THAT FILE alone -> correct? -> LOCK (witness)   <- this PR
STAGE 3  populate (retrofit building metadata) -> look again -> LOCK
STAGE 4  only then present on the TM panel
```

## Why it survived weeks of downstream fixes

`ScheduleAuthor._installSecs` (`schedule_author.js:62-75`) returns a bare `120` seconds when the rule's resource is missing or the class has no productivity entry — **zero §-log at any of its three sites** (`schedule_author.js:64`, `:70`, `time_machine.js:4457`). On a 45-day axis a 120s element is a zero-width bar, and every one of them starts at the same instant. That is the reported "zero minute stacking", originating in the template, not in any solver or drawer.

## Arrives RED on 3 of 7 checks — by design, registered in `KNOWN_RED`

Red because the template is wrong, not because the witness is unfinished.

| Gate | Finding |
|------|---------|
| `no-zero-minute-rows` / `every-resource-resolves` | **7/65 rows hit the 120s floor.** `IfcSpace`, `IfcBuildingElementProxy` and `SEQUENCE_DEFAULT` ship `resource: null`. `glazed_curtainwall_facade` moves `IfcPlate`/`IfcMember` from STEEL_ERECTOR (productivity 12/10) to **CARPENTER (neither)**; `furniture_generic_bucket` moves `IfcBuildingElementPart` from MASON (15) to **FINISHER (none)**. Both overrides fix their elements' PHASE and silently destroy their DURATION — including Hospital's 2211 IfcPlate + 7122 IfcMember and HHS's 438 IfcPlate. |
| `phase-bands-disjoint` | Architecture spans seq **5-8** while MEP Rough-in sits at **7** → `IfcRoof` (Architecture, seq 8) sequences **after** all MEP rough-in. MEP installs before the roof exists — a midair-MEP condition readable in the template, before any geometry. |

Green: `population-nonempty`, `schema-valid`, `mirror-matches-executed`, `redControl-detected`.

## Design notes

- **Population is the EXECUTED table** (the `viewer/rates.js` JS literal), not the JSON mirror. `viewer.html:865` never calls `loadSequenceRules()`, so a witness reading the JSON would repeat the exact mistake `rates.js:110-116` already records — every node probe measuring a labour table the browser never used (Hospital 1889.4d measured vs 1926.4d shipped). The mirror is checked as an invariant instead of trusted, which also locks Stage 1's property.
- **Durations come from the real `_installSecs`**, never a mirrored copy of the formula.
- **Names which layer it proves** (template only — not `tasks`, not `kernel_ops`, not rendered bar widths), per `WITNESS_INTERFACE_FRAMEWORK.md` §CRISIS LESSON 1.
- **Red control reproduces the real defect shape** — strips a resource and recomputes through `_installSecs`, rather than hand-setting `installSecs = 120`, so it proves the mechanism and not just the assertion.
- **Verified through `tests/run_witness_suite.js --filter`**, not only standalone — the §6 gap where a witness passes alone and fails under the shared runner.

## Blocked, deliberately not guessed

Two of the six duration defects need a productivity figure that **exists nowhere in the rate table** — what trade + daily productivity a generic/unclassified element carries (`IfcBuildingElementProxy`, and `SEQUENCE_DEFAULT` for any unmatched class; `LABORER` is the obvious trade slot but ships an empty productivity map). Any value invented here would violate the Prime Directive, so it stays a user question.

No precached asset touched → no `CACHE_VERSION` bump applies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)