### PR TITLE
fix(4d): the preset template itself — 1217 of 6839 elements were 2-minute zero-width slivers (§S65 STAGE 2)

### DIFF
--- a/tests/run_witness_suite.js
+++ b/tests/run_witness_suite.js
@@ -84,6 +84,9 @@ const KNOWN_RED = {
   //   witness_zone_display_authoring.js — W-ZDA-4a re-locked to per-building baselines in
   //     baselines/midair.json (Duplex 22->37, HHS 894->1839). The inequality it replaced was
   //     permanently false, i.e. it gated nothing.
+  // DRAINED 2026-08-25 (§S65 template lock PR): witness_sequence_template_lock.js arrived red on 3
+  //   of 7 gates and is green in this same PR — the template itself was fixed, not the witness
+  //   relaxed. 7/65 rows were on _installSecs' silent 120s floor; now 0/63 schedulable rows.
   // DRAINED 2026-08-24 (§TM_P6_FOLD PR):
   //   witness_gantt_lock_integrity.js — 20/20 green, verified twice AND against pristine
   //     origin/main (so an earlier merge fixed G-LI-2e, not this PR); entry was stale.
@@ -102,22 +105,6 @@ const KNOWN_RED = {
                                               '(->14,267). Newly wired in 2026-08-24 (was git-orphaned at repo root since fc58210, ' +
                                               'per §S66 — suite never ran it, so this went undetected). Cause: 4D_SCHEDULE_PERFECTION.md ' +
                                               '"REGRESSION FOUND" section.',
-  'witness_sequence_template_lock.js':       'C — RED BY DESIGN ON ARRIVAL, 3 of 7 checks. This witness is NEW (2026-08-25) ' +
-                                              'and it is the FIRST check of any kind on the preset 4D template itself; it ' +
-                                              'arrives red because the template is genuinely wrong, not because the witness ' +
-                                              'is unfinished. no-zero-minute-rows + every-resource-resolves: 7/65 rows land ' +
-                                              'on ScheduleAuthor._installSecs\' silent 120s floor (IfcSpace, ' +
-                                              'IfcBuildingElementProxy and SEQUENCE_DEFAULT all ship resource:null; the ' +
-                                              'glazed_curtainwall_facade override moves IfcPlate/IfcMember to CARPENTER and ' +
-                                              'furniture_generic_bucket moves IfcBuildingElementPart to FINISHER, neither of ' +
-                                              'which carries productivity for those classes) — a 120s element is a ' +
-                                              'zero-width bar that stacks with every other one, the user-reported "zero ' +
-                                              'minute stacking". phase-bands-disjoint: Architecture spans seq 5-8 while MEP ' +
-                                              'Rough-in sits at 7, so IfcRoof (Architecture, seq 8) sequences AFTER all MEP ' +
-                                              'rough-in. TWO of the six defects are BLOCKED on a fact that exists nowhere in ' +
-                                              'the rate table (what trade + daily productivity a generic/unclassified ' +
-                                              'element carries) — filling it in would be invention, so it is a user ' +
-                                              'question, not a code task. Cause + full table: 4D_SCHEDULE_PERFECTION.md §S65.',
   // Reproducible reds whose cause has NOT been established. Labelled honestly rather than guessed:
   // an earlier pass called these "browser/server not up", which was wrong — both are headless.
   'witness_tm_stream_index_defer.js':        'C — reproducible red, cause NOT yet established',

--- a/viewer/rates.js
+++ b/viewer/rates.js
@@ -140,11 +140,24 @@ var LABOR_RATES = {
   },
   MASON: {
     rate_per_day: 155, crew_size: 3, max_crews: 2, trade: 'Mason (Skilled) + Laborers',
-    productivity: {IfcWall:12,IfcWallStandardCase:12,IfcOpeningElement:20,IfcBuildingElementPart:15}
+    // §TPL_ZERO_MINUTE (2026-08-25, bim-compiler prompts/4D_SCHEDULE_PERFECTION.md §S65, user ruling):
+    // IfcBuildingElementProxy carried resource:null and therefore _installSecs' silent 120s floor —
+    // a zero-width Gantt bar, stacked with every other floored element. Value COPIED from its own
+    // sibling IfcBuildingElementPart (15), same generic-Architecture/seq-5 rule, already shipped and
+    // measured here — not a new invented figure. default_productivity serves SEQUENCE_DEFAULT: the
+    // class-key lookup below is a SUBSTRING match, so an unmatched class can never resolve any key
+    // and would floor no matter which resource it named.
+    default_productivity: 15,
+    productivity: {IfcWall:12,IfcWallStandardCase:12,IfcOpeningElement:20,IfcBuildingElementPart:15,IfcBuildingElementProxy:15}
   },
   CARPENTER: {
     rate_per_day: 165, crew_size: 2, max_crews: 2, trade: 'Carpenter (Skilled)',
-    productivity: {IfcDoor:6,IfcWindow:6,IfcStair:2,IfcStairFlight:3,IfcRailing:15,IfcCurtainWall:8}
+    // §TPL_ZERO_MINUTE (§S65 defect 4): the glazed_curtainwall_facade NAME_OVERRIDE reassigns
+    // IfcPlate/IfcMember to CARPENTER, which carried no productivity for either — so the override
+    // fixed those elements' PHASE and silently destroyed their DURATION (Hospital 2211 IfcPlate +
+    // 7122 IfcMember, HHS 438 IfcPlate, all 120s). Values COPIED verbatim from STEEL_ERECTOR, the
+    // class's own canonical trade above (IfcPlate:12, IfcMember:10) — extracted, not invented.
+    productivity: {IfcDoor:6,IfcWindow:6,IfcStair:2,IfcStairFlight:3,IfcRailing:15,IfcCurtainWall:8,IfcPlate:12,IfcMember:10}
   },
   ROOFER: {
     rate_per_day: 175, crew_size: 3, max_crews: 1, trade: 'Roofer (Skilled)',
@@ -152,7 +165,10 @@ var LABOR_RATES = {
   },
   FINISHER: {
     rate_per_day: 135, crew_size: 2, max_crews: 2, trade: 'Finisher (Skilled)',
-    productivity: {IfcCovering:20,IfcFurniture:8,IfcFurnishingElement:8}
+    // §TPL_ZERO_MINUTE (§S65 defect 5): furniture_generic_bucket reassigns IfcBuildingElementProxy/
+    // IfcBuildingElementPart to FINISHER, which carried neither — same silent duration loss as the
+    // curtain-wall override above. Values COPIED from MASON, those classes' own canonical trade (15).
+    productivity: {IfcCovering:20,IfcFurniture:8,IfcFurnishingElement:8,IfcBuildingElementPart:15,IfcBuildingElementProxy:15}
   },
   LABORER: {
     rate_per_day: 95, crew_size: 1, max_crews: 1, trade: 'General Laborer',
@@ -244,8 +260,8 @@ var SEQUENCE_RULES = {
   IfcRailing:{phase:'Architecture',sequence:6,resource:'CARPENTER'},
   IfcRamp:{phase:'Architecture',sequence:6,resource:'CONCRETE_GANG'},
   IfcRampFlight:{phase:'Architecture',sequence:6,resource:'CONCRETE_GANG'},
-  IfcRoof:{phase:'Architecture',sequence:8,resource:'ROOFER'},
-  IfcBuildingElementProxy:{phase:'Architecture',sequence:5,resource:null},
+  IfcRoof:{phase:'Architecture',sequence:6,resource:'ROOFER'},   // §S65 defect 7 (user ruling): was 8, which sequenced the roof AFTER all MEP Rough-in (seq 7) — MEP installed before the roof existed, and it made the Architecture band [5-8] overlap MEP Rough-in [7]. Weather-tight first.
+  IfcBuildingElementProxy:{phase:'Architecture',sequence:5,resource:'MASON'},   // §S65: was resource:null -> 120s floor
   IfcCurtainWall:{phase:'Architecture',sequence:6,resource:'CARPENTER'},
   // MEP Final
   IfcLightFixture:{phase:'MEP Final',sequence:9,resource:'ELECTRICIAN'},
@@ -257,7 +273,7 @@ var SEQUENCE_RULES = {
   IfcFurniture:{phase:'Finishes',sequence:11,resource:'FINISHER'},
   IfcFurnishingElement:{phase:'Finishes',sequence:11,resource:'FINISHER'},
 };
-var SEQUENCE_DEFAULT = {phase:'Architecture',sequence:6,resource:null};
+var SEQUENCE_DEFAULT = {phase:'Architecture',sequence:6,resource:'MASON'};   // §S65: was resource:null -> every unmatched class floored at 120s
 // §4D_FACADE_ORDER: name-based reclass ahead of the class lookup above — ifc_class alone cannot
 // tell curtain-wall glazing/framing (IfcPlate/IfcMember) from genuinely structural plates/members
 // (e.g. Terminal's 33,324 Metal Deck IfcPlate, JKR/LTU_AHouse structural steel/timber, which must
@@ -272,7 +288,12 @@ var SEQUENCE_NAME_OVERRIDES = [
     pattern: 'glaz|glass|verglas|vitrage|vidrio|curtain|mullion',
     flags: 'i',
     phase: 'Architecture',
-    sequence: 7,
+    // §S65 defect 7 (2026-08-25): was 7, which tied this override with MEP Rough-in (seq 7) and kept
+    // the Architecture band [5-7] overlapping it. 6 is IfcCurtainWall's OWN class rule (line ~265) —
+    // these are the glazing panels and mullions OF that same curtain-wall system, so 7 was also
+    // internally inconsistent with the class it belongs to. Aligned, not invented; and it applies the
+    // user's own IfcRoof ruling (weather-tight envelope before MEP rough-in) to the other envelope.
+    sequence: 6,
     resource: 'CARPENTER'
   },
   // §PILE_SLAB_RECLASS (2026-08-11, bim-compiler prompts/4D_SCHEDULE_PERFECTION.md big-element

--- a/viewer/rates/sequence_rules.json
+++ b/viewer/rates/sequence_rules.json
@@ -2,7 +2,7 @@
   "meta": {
     "name": "Default Sequence + Labour Rules",
     "version": "2024.2",
-    "note": "Timeline default steps (ifc_class -> phase/sequence/resource + labour productivity). Values copied verbatim from rates.js (schedule_generator.py / boq_export.py origins). READ THIS BEFORE CITING A NUMBER FROM THIS FILE (corrected 2026-08-13, §RULES_TABLE_SOURCE): this file is NOT what Time Machine injectGantt runs on. viewer.html never calls loadSequenceRules() — only mep_report.html and boq_charts.html do — so rates.js's hardcoded SEQUENCE_RULES/LABOR_RATES/SEQUENCE_DEFAULT/SEQUENCE_NAME_OVERRIDES are what the viewer, Time Machine and the Author wizard actually execute, and this file is their MIRROR plus the Settings-JSON-editor override surface. The previous wording here claimed the opposite and is why every Node probe and viewer/tests/witness_*.js measured this file instead of ship: they had drifted (LABOR_RATES.ELECTRICIAN.productivity held 8 class keys here against rates.js's 15 — IfcSwitchingDevice/IfcSensor/IfcActuator/IfcFlowInstrument/IfcDistributionControlElement/IfcProtectiveDeviceTrippingUnit/IfcUnitaryControlElement were missing), worth 1889.4d vs 1926.4d of Hospital programme. Re-synced 2026-08-13. When you edit rates.js, edit this file in the same commit."
+    "note": "Timeline default steps (ifc_class -> phase/sequence/resource + labour productivity). Values copied verbatim from rates.js (schedule_generator.py / boq_export.py origins). READ THIS BEFORE CITING A NUMBER FROM THIS FILE (corrected 2026-08-13, §RULES_TABLE_SOURCE): this file is NOT what Time Machine injectGantt runs on. viewer.html never calls loadSequenceRules() — only mep_report.html and boq_charts.html do — so rates.js's hardcoded SEQUENCE_RULES/LABOR_RATES/SEQUENCE_DEFAULT/SEQUENCE_NAME_OVERRIDES are what the viewer, Time Machine and the Author wizard actually execute, and this file is their MIRROR plus the Settings-JSON-editor override surface. The previous wording here claimed the opposite and is why every Node probe and viewer/tests/witness_*.js measured this file instead of ship: they had drifted (LABOR_RATES.ELECTRICIAN.productivity held 8 class keys here against rates.js's 15 — IfcSwitchingDevice/IfcSensor/IfcActuator/IfcFlowInstrument/IfcDistributionControlElement/IfcProtectiveDeviceTrippingUnit/IfcUnitaryControlElement were missing), worth 1889.4d vs 1926.4d of Hospital programme. Re-synced 2026-08-13. When you edit rates.js, edit this file in the same commit. | 2026-08-25 §S65 (bim-compiler prompts/4D_SCHEDULE_PERFECTION.md): six §TPL_ZERO_MINUTE fixes — IfcBuildingElementProxy and SEQUENCE_DEFAULT no longer carry resource:null (both -> MASON, productivity copied from the sibling IfcBuildingElementPart:15); MASON.default_productivity added because the productivity lookup is a SUBSTRING match an unmatched class can never satisfy; CARPENTER gained IfcPlate:12/IfcMember:10 (copied from STEEL_ERECTOR) and FINISHER gained IfcBuildingElementPart/Proxy:15 (copied from MASON) so the glazed_curtainwall_facade and furniture_generic_bucket NAME_OVERRIDES stop silently destroying the duration of the elements they reassign; IfcRoof sequence 8 -> 6 (user ruling) so the roof precedes MEP Rough-in and the Architecture band stops overlapping it. Locked by viewer/tests/witness_sequence_template_lock.js."
   },
   "NAME_OVERRIDES": [
     {
@@ -14,7 +14,7 @@
       "pattern": "glaz|glass|verglas|vitrage|vidrio|curtain|mullion",
       "flags": "i",
       "phase": "Architecture",
-      "sequence": 7,
+      "sequence": 6,
       "resource": "CARPENTER",
       "reason": "ifc_class alone cannot separate curtain-wall glazing/framing from structural steel plates/members — a Revit curtain-wall panel is IfcPlate and its mullions are IfcMember, same classes as genuinely structural plates/members (e.g. Terminal's 33,324 Metal Deck IfcPlate, JKR's CHS/RHS steel framing, LTU_AHouse's timber beams, which must all stay at their structural seq). Name is the only extracted signal that discriminates them. Matched, measured against 8 shipped buildings: Hospital 'System Panel:Glazed' (2211/2211 IfcPlate) + 'Curtain Wall:...Framing'/'Curtain System' (7122/7127 IfcMember), Clinic 'Rectangular/Circular Mullion' (522/534 IfcMember), HHS 'Systemelement:Verglasung' (438/629 IfcPlate, German) — zero false positives on Terminal/JKR/LTU_AHouse/TermRooms. See bim-compiler prompts/RESUME_4D_TRUTH_AND_BE_HERE_WHEN.md §STAGE A A.3/A.4 and prompts/GANTT_ACCURACY.md §4D_HOST_BEFORE_HOSTED. Elements not matching this pattern keep their class-default seq (measured, never guessed) — known remaining blind spot: HHS 'Rechteckiger Pfosten' (German curtain-wall posts, 1450 IfcMember) not matched, deliberately not covered by a generic 'post' pattern (too ambiguous vs real structural posts) — reported, not silently dropped."
     },
@@ -299,13 +299,13 @@
     },
     "IfcRoof": {
       "phase": "Architecture",
-      "sequence": 8,
+      "sequence": 6,
       "resource": "ROOFER"
     },
     "IfcBuildingElementProxy": {
       "phase": "Architecture",
       "sequence": 5,
-      "resource": null
+      "resource": "MASON"
     },
     "IfcCurtainWall": {
       "phase": "Architecture",
@@ -351,7 +351,7 @@
   "SEQUENCE_DEFAULT": {
     "phase": "Architecture",
     "sequence": 6,
-    "resource": null
+    "resource": "MASON"
   },
   "LABOR_RATES": {
     "HVAC_TECH": {
@@ -445,8 +445,10 @@
         "IfcWall": 12,
         "IfcWallStandardCase": 12,
         "IfcOpeningElement": 20,
-        "IfcBuildingElementPart": 15
-      }
+        "IfcBuildingElementPart": 15,
+        "IfcBuildingElementProxy": 15
+      },
+      "default_productivity": 15
     },
     "CARPENTER": {
       "rate_per_day": 165,
@@ -459,7 +461,9 @@
         "IfcStair": 2,
         "IfcStairFlight": 3,
         "IfcRailing": 15,
-        "IfcCurtainWall": 8
+        "IfcCurtainWall": 8,
+        "IfcPlate": 12,
+        "IfcMember": 10
       }
     },
     "ROOFER": {
@@ -479,7 +483,9 @@
       "productivity": {
         "IfcCovering": 20,
         "IfcFurniture": 8,
-        "IfcFurnishingElement": 8
+        "IfcFurnishingElement": 8,
+        "IfcBuildingElementPart": 15,
+        "IfcBuildingElementProxy": 15
       }
     },
     "LABORER": {

--- a/viewer/schedule_author.js
+++ b/viewer/schedule_author.js
@@ -59,15 +59,35 @@
   // by its class's real average length. A flat per-unit rate assumes every element is "typical
   // sized" (e.g. a 5.7m beam); this element's own real size scales the flat rate instead, so a 60m
   // beam and a 0.9m beam charge differently even though both are counted as "1 IfcBeam".
+  // §TPL_ZERO_MINUTE (2026-08-25, bim-compiler prompts/4D_SCHEDULE_PERFECTION.md §S65) — the 120s
+  // returns below are a FLOOR, not a real duration: on a 45-day axis a 120-second element draws a
+  // zero-width Gantt bar, and every floored element starts at the same instant, so they stack. That
+  // is the user-reported "zero minute stacking", and it survived weeks of downstream fixes because
+  // this function reached the floor SILENTLY — no §-log, at any of its sites, ever.
+  // Now reported, but AGGREGATED PER CLASS and once only: §CLASS_UNMATCHED already warns once per
+  // ELEMENT and that alone overflowed run_witness_suite.js's 1MB spawnSync maxBuffer on Hospital
+  // (WITNESS_INTERFACE_FRAMEWORK.md §6). A per-element line here would be strictly worse.
+  var _floorSeen = {};
+  function _reportFloor(cls, resource, why) {
+    var k = cls + '|' + resource + '|' + why;
+    if (_floorSeen[k]) return;
+    _floorSeen[k] = 1;
+    console.warn('§TPL_ZERO_MINUTE cls=' + cls + ' resource=' + resource + ' reason=' + why +
+      ' — 120s floor, this class draws a zero-width bar (first occurrence only)');
+  }
   function _installSecs(cls, rule, laborRates, realQty, lengthRatio) {
     var resource = rule && rule.resource;
-    if (!resource || !laborRates[resource]) return 120;
+    if (!resource || !laborRates[resource]) { _reportFloor(cls, resource, 'no-resource'); return 120; }
     var labor = laborRates[resource], bestPk = null, bestLen = 0;
     for (var pk in labor.productivity) {
       if (cls.indexOf(pk) >= 0 && pk.length > bestLen) { bestPk = pk; bestLen = pk.length; }
     }
-    var prod = bestPk ? labor.productivity[bestPk] : 0;
-    if (prod <= 0) return 120;
+    // §S65: the class-key lookup above is a SUBSTRING match, so a class the table does not name can
+    // never resolve ANY key — which is why SEQUENCE_DEFAULT floored no matter which resource it
+    // pointed at. default_productivity is the resource's own declared figure for that case; absent,
+    // this is 0 and the floor still applies exactly as before (backward-compatible).
+    var prod = bestPk ? labor.productivity[bestPk] : (labor.default_productivity || 0);
+    if (prod <= 0) { _reportFloor(cls, resource, bestPk ? 'productivity<=0' : 'no-productivity-key'); return 120; }
     var secsPerUnit = 28800 / prod;
     if (realQty != null) return Math.round(secsPerUnit * realQty);
     if (lengthRatio != null) return Math.round(secsPerUnit * lengthRatio);

--- a/viewer/sw.js
+++ b/viewer/sw.js
@@ -7,8 +7,14 @@
 // Network-first for .html/.js (always fresh on deploy).
 // Cache-first for heavy assets (.wasm, images). DB files skip SW (IndexedDB handles them).
 //
+// v1087 (2026-08-25) §S65 §TPL_ZERO_MINUTE: rates.js + rates/sequence_rules.json + schedule_author.js
+// + time_machine.js all changed (preset 4D template fixes — see witness_sequence_template_lock.js).
+// All four are in PRECACHE_ASSETS, so without this bump an installed service worker keeps serving the
+// old table and the fix never reaches an existing user. That exact miss happened twice in 90 minutes
+// on 2026-08-25 (#1521 for #1520, then #1524 for #1523) — WITNESS_INTERFACE_FRAMEWORK.md §CRISIS
+// LESSON 4. Bumped in the SAME PR as the change, deliberately.
 // DEPLOY: bump CACHE_VERSION on every OCI upload. Old caches are purged on activate.
-const CACHE_VERSION = 'v1086';   // bump on each deploy; per-change detail is the git commit message.
+const CACHE_VERSION = 'v1087';   // bump on each deploy; per-change detail is the git commit message.
 // v1084 (2026-08-25) §CPE_BUILDUP_REQUIRE_TM_FIRST (CINEMA_PATH_EDITOR.md, user ruling "no auto
 // JSON outside TM"): Alt+C's bake no longer generates a building's first-ever 4D schedule.
 // window.tmHasExistingSchedule() (time_machine.js) — read-only, no DB writes, never generates —

--- a/viewer/tests/witness_sequence_template_lock.js
+++ b/viewer/tests/witness_sequence_template_lock.js
@@ -36,7 +36,8 @@ const path = require('path');
 const { Witness } = require('../../witness_kit/contract');
 const { TemplateRuleRow } = require('../../witness_kit/schemas/template');
 const {
-  noZeroMinuteRows, everyResourceResolves, phaseBandsDisjoint, phaseBandReport, FALLBACK_SECS
+  noZeroMinuteRows, everyResourceResolves, phaseBandsDisjoint, phaseBandReport, FALLBACK_SECS,
+  isSchedulable, NON_PHYSICAL
 } = require('../../witness_kit/invariants/template');
 
 const VIEWER_DIR = process.env.VIEWER_DIR || path.join(__dirname, '..');
@@ -106,11 +107,14 @@ function buildRows() {
 const rows = buildRows();
 
 // §-log proof lines: the shape of what was checked, readable without re-running.
-const zero = rows.filter(r => r.installSecs === FALLBACK_SECS);
+const zero = rows.filter(isSchedulable).filter(r => r.installSecs === FALLBACK_SECS);
+const skipped = rows.filter(r => !isSchedulable(r));
 console.log('§TPL_SOURCE executed=viewer/rates.js rules=' + Object.keys(T.rules).length +
   ' labor=' + Object.keys(T.labor).length + ' overrides=' + T.overrides.length + ' rows=' + rows.length);
 console.log('§TPL_BANDS ' + phaseBandReport(rows));
-console.log('§TPL_ZERO_MINUTE n=' + zero.length + '/' + rows.length +
+console.log('§TPL_NON_PHYSICAL excluded=' + skipped.length + ' [' + NON_PHYSICAL.join(',') +
+  '] — not schedulable, cannot reach _installSecs (schedule_author.js:307, time_machine.js:3673/4476/9165)');
+console.log('§TPL_ZERO_MINUTE n=' + zero.length + '/' + rows.filter(isSchedulable).length +
   (zero.length ? ' [' + zero.map(r => r.key + '(res=' + r.resource + ')').join(' ') + ']' : ''));
 
 /**
@@ -123,11 +127,21 @@ function mirrorMatchesExecuted() {
   const strip = o => {
     const c = Object.assign({}, o); delete c.reason; return c;
   };
-  if (JSON.stringify(T.rules) !== JSON.stringify(M.SEQUENCE_RULES)) return false;
-  if (JSON.stringify(T.labor) !== JSON.stringify(M.LABOR_RATES)) return false;
-  if (JSON.stringify(T.dflt) !== JSON.stringify(M.SEQUENCE_DEFAULT)) return false;
+  // Canonical (key-sorted) serialisation, NOT plain JSON.stringify. A first cut used stringify
+  // directly and reported drift the moment `default_productivity` was added before `productivity` in
+  // one file and after it in the other — the two tables were identical in every value. Key ORDER in a
+  // config object is not drift, and a gate that fires on it teaches people to ignore it.
+  const canon = v => {
+    if (Array.isArray(v)) return '[' + v.map(canon).join(',') + ']';
+    if (v && typeof v === 'object')
+      return '{' + Object.keys(v).sort().map(k => JSON.stringify(k) + ':' + canon(v[k])).join(',') + '}';
+    return JSON.stringify(v);
+  };
+  if (canon(T.rules) !== canon(M.SEQUENCE_RULES)) return false;
+  if (canon(T.labor) !== canon(M.LABOR_RATES)) return false;
+  if (canon(T.dflt) !== canon(M.SEQUENCE_DEFAULT)) return false;
   const a = (T.overrides || []).map(strip), b = (M.NAME_OVERRIDES || []).map(strip);
-  return JSON.stringify(a) === JSON.stringify(b);
+  return canon(a) === canon(b);
 }
 
 Witness('sequence_template_lock')

--- a/viewer/time_machine.js
+++ b/viewer/time_machine.js
@@ -4459,7 +4459,9 @@
       for (var pk in labor.productivity) {
         if (cls.indexOf(pk) >= 0 && pk.length > bestLen) { bestPk = pk; bestLen = pk.length; }
       }
-      var prod = bestPk ? labor.productivity[bestPk] : 0;
+      // §TPL_ZERO_MINUTE (§S65) — keep this fallback in step with ScheduleAuthor._installSecs'
+      // default_productivity, or the two copies disagree the moment ScheduleAuthor fails to load.
+      var prod = bestPk ? labor.productivity[bestPk] : (labor.default_productivity || 0);
       return prod > 0 ? Math.round(28800 / prod) : 120;
     }
 

--- a/witness_kit/invariants/template.js
+++ b/witness_kit/invariants/template.js
@@ -19,6 +19,24 @@
 // real function's own behaviour, and the point of the gate is that NOTHING should reach it.
 const FALLBACK_SECS = 120;
 
+// NON-PHYSICAL classes, excluded from scheduling before a rule is ever consulted. NOT a judgement
+// call here — this list mirrors the actual SQL predicate the element builders use, verbatim:
+//   schedule_author.js:307   WHERE m.ifc_class != 'IfcOpeningElement' AND m.ifc_class != 'IfcSpace'
+//   time_machine.js:3673, :4476, :9165  — the same predicate, all three element-query sites.
+// A rule for one of these can never reach _installSecs, so holding it to the duration gates would be
+// a FALSE POSITIVE. It was one, on this witness's first run: IfcSpace ships resource:null and got
+// reported as a live zero-minute source when it is unreachable dead config (§S65 correction).
+// IfcOpeningElement is listed for completeness — it currently has a real MASON rule and would pass
+// anyway; the point is that the exclusion set is read from the product, not curated by hand here.
+const NON_PHYSICAL = ['IfcOpeningElement', 'IfcSpace'];
+
+/**
+ * Is this row's class actually schedulable — i.e. can it ever reach _installSecs at runtime?
+ * @param {{cls:string}} row
+ * @returns {boolean}
+ */
+const isSchedulable = row => NON_PHYSICAL.indexOf(row.cls) < 0;
+
 /**
  * A row lands on the silent 120s floor — i.e. it will draw a zero-width bar.
  * @param {{installSecs:number}} row
@@ -32,7 +50,7 @@ const isZeroMinute = row => row.installSecs === FALLBACK_SECS;
  * @param {object[]} rows
  * @returns {boolean}
  */
-const noZeroMinuteRows = rows => rows.every(r => !isZeroMinute(r));
+const noZeroMinuteRows = rows => rows.filter(isSchedulable).every(r => !isZeroMinute(r));
 
 /**
  * G-TPL-RES — every resource a row names must exist in the labour table.
@@ -42,7 +60,7 @@ const noZeroMinuteRows = rows => rows.every(r => !isZeroMinute(r));
  * @returns {boolean}
  */
 const everyResourceResolves = (rows, laborRates) =>
-  rows.every(r => r.resource != null && !!laborRates[r.resource]);
+  rows.filter(isSchedulable).every(r => r.resource != null && !!laborRates[r.resource]);
 
 /**
  * G-TPL-BANDS — phase sequence bands must not interleave.
@@ -89,6 +107,6 @@ function phaseBandReport(rows) {
 }
 
 module.exports = {
-  FALLBACK_SECS, isZeroMinute, noZeroMinuteRows, everyResourceResolves,
-  phaseBandsDisjoint, phaseBandReport
+  FALLBACK_SECS, NON_PHYSICAL, isSchedulable, isZeroMinute, noZeroMinuteRows,
+  everyResourceResolves, phaseBandsDisjoint, phaseBandReport
 };


### PR DESCRIPTION
## Measured, same building, same code, only the template changed

`HHS_Office_Federated`, 6839 elements:

| metric | before | after |
|---|---|---|
| elements at/below `_installSecs`' silent 120s floor | **1217 (17.8%)** | **114 (1.7%)** |
| distinct start instants | 6011/6839 | 6296/6839 |
| project span | 47.52 d | 46.92 d |

**1,103 elements — 16% of the building — were two-minute zero-width bars purely because the preset table routed them to a silent fallback.** The remaining 114 are genuinely short elements from real productivity math (min 14s), a separate and much smaller question.

This is the fix half of #1526, which merged the witness only (a squash + a late push orphaned this commit — the `PR #138` failure mode `CLAUDE.md` names). Re-landed off fresh `origin/main`. With it, `witness_sequence_template_lock.js` goes `pass=7 fail=0` and its `KNOWN_RED` entry is drained here.

## Zero-minute: six routes to the floor, all closed with copied values, none invented

`_installSecs` returns a bare `120` when the rule's resource is missing or the class has no productivity entry.

- `IfcBuildingElementProxy`: `resource: null` → MASON, productivity **15 copied from its sibling `IfcBuildingElementPart`** (same generic Architecture/seq-5 rule). User ruling.
- `SEQUENCE_DEFAULT`: `resource: null` → MASON. The productivity lookup is a **substring match**, so an unmatched class could never resolve any key whatever resource it named — hence `MASON.default_productivity: 15`, honoured by `_installSecs` and by `time_machine.js`'s fallback copy. Absent field = 0 = the old floor, so every other trade is byte-unchanged.
- `glazed_curtainwall_facade` reassigns `IfcPlate`/`IfcMember` to CARPENTER, which carried neither — the override fixed those elements' PHASE and silently destroyed their DURATION (Hospital 2211 IfcPlate + 7122 IfcMember, HHS 438 IfcPlate). CARPENTER gains `IfcPlate:12`, `IfcMember:10`, **copied verbatim from STEEL_ERECTOR**, those classes' own canonical trade.
- `furniture_generic_bucket` reassigns `IfcBuildingElementPart`/`Proxy` to FINISHER, same shape. FINISHER gains both at 15, **copied from MASON**.

## Order: weather-tight before rough-in (user ruling)

`IfcRoof` sequence **8 → 6**. At 8 the roof sequenced *after* all MEP Rough-in (seq 7) — MEP installed before the roof existed — and it made the Architecture band `[5-8]` overlap MEP Rough-in `[7]`. The `glazed_curtainwall_facade` override moves **7 → 6** for the same reason plus an inconsistency of its own: it covers the glazing and mullions *of* `IfcCurtainWall`, whose own class rule is already 6.

Bands are now disjoint: `Substructure[1] Superstructure[2-4] Architecture[5-6] MEP Rough-in[7] MEP Final[9] Finishes[10-11]`.

## The floor is no longer silent

`§TPL_ZERO_MINUTE` is logged at each site — **aggregated per class, once only**. `§CLASS_UNMATCHED` already warns per *element* and that alone overflowed `run_witness_suite.js`'s 1MB `spawnSync` maxBuffer on Hospital, so a per-element line here would be strictly worse.

## Witness correction, found by reading the product rather than trusting the first run

`IfcSpace` was reported as a live zero-minute source and is not one — it is excluded from scheduling before any rule is consulted (`schedule_author.js:307`, `time_machine.js:3673/4476/9165`). The gates now skip non-physical classes, with the exclusion set quoted from that SQL predicate rather than curated by hand. The mirror invariant also used plain `JSON.stringify` and reported drift purely from key *order*; it now compares canonically.

## Deploy

Both files edited in the same commit per `rates.js:116`'s own standing rule. `CACHE_VERSION` **v1086 → v1087**: `rates.js`, `rates/sequence_rules.json`, `schedule_author.js` and `time_machine.js` are all in `PRECACHE_ASSETS`, so without the bump an installed service worker keeps serving the old table — the exact miss that happened twice in 90 minutes on 2026-08-25 (#1521, #1524).

🤖 Generated with [Claude Code](https://claude.com/claude-code)