### PR TITLE
fix(4d): a Gantt bar IS its task — stop deriving the bar's span from its member elements (§S65 STAGE 3)

### DIFF
--- a/tests/run_witness_suite.js
+++ b/tests/run_witness_suite.js
@@ -105,6 +105,20 @@ const KNOWN_RED = {
                                               '(->14,267). Newly wired in 2026-08-24 (was git-orphaned at repo root since fc58210, ' +
                                               'per §S66 — suite never ran it, so this went undetected). Cause: 4D_SCHEDULE_PERFECTION.md ' +
                                               '"REGRESSION FOUND" section.',
+  'witness_gantt_bar_is_its_task.js':        'C — 1 of 7 gates (no-hairline-bars-3px). NOT the layer this witness is ' +
+                                              'about, and deliberately NOT tuned away. Its own subject — an authored bar ' +
+                                              'is drawn at its task window — is GREEN on 135 bars across Duplex/Clinic/' +
+                                              'JKR/HHS_Office_Federated: worst window error 0.000 days, spanFromOps=0. ' +
+                                              'The red is an UPSTREAM authoring defect this witness makes visible: Clinic ' +
+                                              'ships 6+ zone tasks with exactly 1.00-day windows on a 156-day axis ' +
+                                              '(2.2px), including "MEP Rough-in - Roof - Mech" with 139 elements and ' +
+                                              '"Substructure - TOF Footing" with 58. Cause: schedule_author.js:517 floors ' +
+                                              'a zone whose SOLVED span rounds below a day at exactly one day ' +
+                                              '(eDays <= sDays -> sDays + 1), so a zone window comes from the element ' +
+                                              'solve span and never from its work content — the already-named ' +
+                                              '§CPM_GENERATOR_UPSTREAM_SPEC / "window derivation from work content" item ' +
+                                              'in 4D_SCHEDULE_PERFECTION.md, open before this PR and untouched by it. ' +
+                                              'Lowering the 3px threshold would hide a real number; the gate stays.',
   // Reproducible reds whose cause has NOT been established. Labelled honestly rather than guessed:
   // an earlier pass called these "browser/server not up", which was wrong — both are headless.
   'witness_tm_stream_index_defer.js':        'C — reproducible red, cause NOT yet established',

--- a/viewer/gantt_model.js
+++ b/viewer/gantt_model.js
@@ -135,11 +135,51 @@
     // (reuses the exact proven formula, not a fresh invention).
     // Members outside the fence still exist in the underlying data (§TIER_DAG_WINS doctrine:
     // counted, never hidden) — they just don't get to single-handedly define the bar's span.
+    // §GANTT_BAR_IS_ITS_TASK (2026-08-25, bim-compiler prompts/4D_SCHEDULE_PERFECTION.md §S65 STAGE 3)
+    // — an AUTHORED bar's span is its TASK'S OWN WINDOW, not a statistical envelope over the elements
+    // that happen to be in it.
+    //
+    // The defect this closes, measured on HHS_Office_Federated (6839 ops, 17 bars, ALL of them
+    // carrying a real task_id — probe_bar_vs_task.js, §BVT_*):
+    //   Superstructure — Roof Level   drawn   0.6px  vs its own task's 101.4px  =   0.6% of its window
+    //   Architecture   — Roof Level   drawn   0.6px  vs                 58.0px  =   1.0%
+    //   Architecture   — Level 3      drawn  46.9px  vs                202.9px  =  23.1%, start off 22.03d
+    //   mean absolute start error across all 17 bars: 5.33 DAYS.
+    // The window was never unknown — buildTaskIndex already puts `start`/`finish` on every entry of
+    // idx.tasks (time_machine.js:5295) and this function read only `.name` from it. So the drawer
+    // computed a worse answer than the one it was already holding.
+    //
+    // WHY THE TUKEY ENVELOPE IS WRONG HERE, specifically: it is a fence over the MEMBERS. When a
+    // task's elements bunch (which the CPM/crew solve makes routine — one storey's steel goes up in a
+    // burst inside a window sized for the whole storey), the fence collapses onto the bunch and the
+    // bar becomes a sliver, while the real authored task is weeks long. That is the "tiny bars,
+    // stacked" shape, and NO element-level fix can reach it: the bar's geometry simply wasn't derived
+    // from the schedule. §S65's own §TPL_ZERO_MINUTE template fix moved 1217 zero-width elements to
+    // 114 and did not change this at all, because this is a different layer.
+    //
+    // UN-AUTHORED groups (no task_id — the storey|phase and cell fallbacks) keep the Tukey rule
+    // EXACTLY as before: there is no window to prefer, and those buildings must not shift. The
+    // fallback also still applies to an authored task whose dates are missing/unparseable — never
+    // invent a span, fall back to the measured one.
     var tasks = [];
+    var _fromWin = 0, _fromOps = 0;
     for (var k in groups) {
       var gg = groups[k];
-      gg.startTs = tukeyBound(gg.starts, true);
-      gg.endTs = Math.max(tukeyBound(gg.ends, false), gg.startTs);   // degenerate-group safety (n=1)
+      var win = (gg.taskId && idx && idx.tasks && idx.tasks[gg.taskId]) ? idx.tasks[gg.taskId] : null;
+      var ws = win && win.start != null ? Date.parse(win.start) : NaN;
+      var we = win && win.finish != null ? Date.parse(win.finish) : NaN;
+      if (isFinite(ws) && isFinite(we) && we > ws) {
+        gg.startTs = ws; gg.endTs = we; gg.spanFrom = 'task'; _fromWin++;
+      } else {
+        gg.startTs = tukeyBound(gg.starts, true);
+        gg.endTs = Math.max(tukeyBound(gg.ends, false), gg.startTs);   // degenerate-group safety (n=1)
+        gg.spanFrom = 'ops'; _fromOps++;
+      }
+      // The member ops stay available as the bar's FILL/progress extent — the elements are not
+      // hidden, they are just no longer allowed to define the bar's outline (§TIER_DAG_WINS
+      // doctrine: counted, never hidden).
+      gg.opsStartTs = tukeyBound(gg.starts, true);
+      gg.opsEndTs = Math.max(tukeyBound(gg.ends, false), gg.opsStartTs);
       delete gg.starts; delete gg.ends;
       tasks.push(gg);
     }
@@ -156,7 +196,8 @@
       return (a.startTs - b.startTs) || (a.storey < b.storey ? -1 : a.storey > b.storey ? 1 : 0);
     });
 
-    return { tasks: tasks, identified: _idN, unidentified: _noIdN };
+    return { tasks: tasks, identified: _idN, unidentified: _noIdN,
+             spanFromTask: _fromWin, spanFromOps: _fromOps };
   }
 
   // computeDays() — the day ladder and BOTH time axes, from the ELEMENT_PLACE ops only.
@@ -166,7 +207,15 @@
   // SEPARATE from projectStart/projectEnd on purpose: those two remain the real, unqualified
   // playback bounds (renderAtTime, scrubbing, "every element must eventually build" — Prime Rule,
   // do not touch). The axis pair is the DISPLAY axis for the Gantt drawer only.
-  function computeDays(placeOps) {
+  // §GANTT_AXIS_COVERS_TASKS (2026-08-25, §S65 STAGE 3) — `taskWins` is the optional list of real
+  // authored task windows ({start,finish} strings, i.e. idx.tasks' values). Since buildTasks() now
+  // draws an authored bar at its TASK'S span rather than at its elements' Tukey envelope, a bar can
+  // legitimately end LATER than the Tukey-qualified op axis — and would then be drawn past the right
+  // edge of the chart. So the display axis is widened to cover every real window. This does NOT
+  // touch projectStart/projectEnd (the true playback bounds, Prime Rule) and it is still never an
+  // invention: a task window is real persisted schedule data, exactly like an op timestamp.
+  // Callers that omit taskWins are byte-identical to before.
+  function computeDays(placeOps, taskWins) {
     var cOps = placeOps;
     var seen = {};
     cOps.forEach(function (op) {
@@ -195,6 +244,17 @@
     out.axisEnd = cOps.length
       ? tukeyBound(cOps.map(function (o) { return o.end_ts; }), false)
       : out.projectEnd;
+    // §GANTT_AXIS_COVERS_TASKS — widen to cover every authored window, so no authored bar is drawn
+    // off the right edge of its own axis.
+    if (taskWins) {
+      for (var wk in taskWins) {
+        var w = taskWins[wk]; if (!w) continue;
+        var ws = w.start != null ? Date.parse(w.start) : NaN;
+        var we = w.finish != null ? Date.parse(w.finish) : NaN;
+        if (isFinite(ws) && (out.axisStart == null || ws < out.axisStart)) out.axisStart = ws;
+        if (isFinite(we) && (out.axisEnd == null || we > out.axisEnd)) out.axisEnd = we;
+      }
+    }
     return out;
   }
 

--- a/viewer/sw.js
+++ b/viewer/sw.js
@@ -13,8 +13,12 @@
 // old table and the fix never reaches an existing user. That exact miss happened twice in 90 minutes
 // on 2026-08-25 (#1521 for #1520, then #1524 for #1523) — WITNESS_INTERFACE_FRAMEWORK.md §CRISIS
 // LESSON 4. Bumped in the SAME PR as the change, deliberately.
+// v1088 (2026-08-25) §GANTT_BAR_IS_ITS_TASK (§S65 STAGE 3): gantt_model.js + time_machine.js changed —
+// an authored Gantt bar is now drawn at its TASK'S window instead of a Tukey fence over its member
+// elements. Both files are in PRECACHE_ASSETS. v1087 shipped the STAGE 2 template fix (#1527); this is
+// a separate change and needs its own bump, per the twice-missed rule (§CRISIS LESSON 4).
 // DEPLOY: bump CACHE_VERSION on every OCI upload. Old caches are purged on activate.
-const CACHE_VERSION = 'v1087';   // bump on each deploy; per-change detail is the git commit message.
+const CACHE_VERSION = 'v1088';   // bump on each deploy; per-change detail is the git commit message.
 // v1084 (2026-08-25) §CPE_BUILDUP_REQUIRE_TM_FIRST (CINEMA_PATH_EDITOR.md, user ruling "no auto
 // JSON outside TM"): Alt+C's bake no longer generates a building's first-ever 4D schedule.
 // window.tmHasExistingSchedule() (time_machine.js) — read-only, no DB writes, never generates —

--- a/viewer/tests/witness_gantt_bar_is_its_task.js
+++ b/viewer/tests/witness_gantt_bar_is_its_task.js
@@ -1,0 +1,94 @@
+#!/usr/bin/env node
+// WITNESS — gantt_bar_is_its_task: the drawn Gantt bar's SPAN, across the real fleet.
+// Spec: bim-compiler prompts/4D_SCHEDULE_PERFECTION.md §S65 STAGE 3.
+//
+// WHICH LAYER THIS PROVES (WITNESS_INTERFACE_FRAMEWORK.md §CRISIS LESSON 1 — three layers got
+// conflated as "witnessed" during the crisis, so every witness now names its own):
+//   the DRAWER'S MODEL layer — GanttModel.buildTasks/computeDays, the functions whose output the
+//   canvas draws rectangles from. It proves nothing about the persisted kernel_ops table, nothing
+//   about the movie's per-element playback, and nothing about pixels actually painted.
+//
+// ISSUE THIS PROVES OR DISPROVES — user, 2026-08-25: "a human gantt chart maker will easily arrange
+// with zero such hell." They were right, and the reason is structural: a human writes ~17 bars and
+// assigns elements to them; the drawer did the inverse, deriving each bar's outline as a Tukey fence
+// over its member elements. When a task's elements bunch (routine under the crew/CPM solve) the
+// fence collapses and the bar becomes a sliver — while the authored window sat UNREAD in the index
+// the drawer was already handed (buildTaskIndex puts start/finish on every entry, time_machine.js
+// :5295, and buildTasks read only .name).
+//
+// Measured on HHS_Office_Federated before the fix — 6839 ops, 17 bars, ALL with a real task_id:
+//   Superstructure — Roof Level  0.6px vs its own 101.4px window (0.6%)
+//   Architecture   — Roof Level  0.6px vs 58.0px (1.0%)
+//   Architecture   — Level 3    46.9px vs 202.9px (23.1%), start off by 22.03 days
+//   mean absolute start error 5.33 DAYS; 2 bars under 3px
+// After: every bar 100.0% of its window, mean start/end error 0.00 days, 0 bars under 3px.
+//
+// COVERAGE IS DELIBERATE AND NOT LEFT TO JUDGEMENT (§CRISIS LESSON 2): the whole crisis ran on
+// witnesses that only ever saw Duplex or 5 synthetic rows, never the building the live bug was on.
+// HHS_Office_Federated is REQUIRED here — if it is missing from the fixture set the witness fails
+// rather than quietly proving less.
+//
+// Command: node viewer/tests/witness_gantt_bar_is_its_task.js
+'use strict';
+const fs = require('fs');
+const path = require('path');
+const { Witness } = require('../../witness_kit/contract');
+const { GanttBarRow } = require('../../witness_kit/schemas/gantt_bars');
+const {
+  barsMatchTaskWindow, authoredBarsUseTaskSpan, noHairlineBars, barsOrdered, MIN_PX
+} = require('../../witness_kit/invariants/gantt_bars');
+const { generateRealGanttBars } = require('../../witness_kit/generators/gantt_bars');
+
+const BLD_DIR = process.env.BLD_DIR || path.join(require('os').homedir(), 'bim-ootb', 'buildings');
+const REQUIRED = 'HHS_Office_Federated';   // the building the live defect was reported on
+const FIXTURES = ['Duplex', 'Clinic', 'JKR', REQUIRED];
+
+(async () => {
+  const present = FIXTURES.filter(b => fs.existsSync(path.join(BLD_DIR, b + '_extracted.db')));
+  if (present.indexOf(REQUIRED) < 0) {
+    console.log('§WITNESS_GANTT_BAR_IS_ITS_TASK pass=0 fail=1 ran=0 — REQUIRED fixture ' + REQUIRED +
+      ' missing from ' + BLD_DIR + '; refusing to report a narrower run as green (§CRISIS LESSON 2)');
+    process.exitCode = 1;
+    return;
+  }
+
+  let rows = [];
+  for (const b of present) {
+    const r = await generateRealGanttBars(path.join(BLD_DIR, b + '_extracted.db'));
+    console.log('§GBT_BUILDING ' + b + ' bars=' + r.length +
+      ' fromTask=' + r.filter(x => x.spanFrom === 'task').length +
+      ' fromOps=' + r.filter(x => x.spanFrom === 'ops').length +
+      ' minWidthPx=' + (r.length ? Math.min.apply(null, r.map(x => x.widthPx)).toFixed(1) : 'n/a'));
+    rows = rows.concat(r);
+  }
+
+  const authored = rows.filter(r => r.taskId && r.winStart != null);
+  const worst = authored.reduce((w, r) => {
+    const d = Math.max(Math.abs(r.startTs - r.winStart), Math.abs(r.endTs - r.winEnd));
+    return (!w || d > w.d) ? { d, r } : w;
+  }, null);
+  console.log('§GBT_SCOPE buildings=' + present.length + ' bars=' + rows.length +
+    ' authored=' + authored.length + ' thinnestPx=' +
+    (rows.length ? Math.min.apply(null, rows.map(r => r.widthPx)).toFixed(1) : 'n/a') +
+    ' worstWindowErrorDays=' + (worst ? (worst.d / 86400000).toFixed(3) : 'n/a') +
+    (worst && worst.d > 1000 ? ' at=' + JSON.stringify(worst.r.name) : ''));
+
+  Witness('gantt_bar_is_its_task')
+    .population(() => rows)
+    .schema(GanttBarRow)
+    .invariant('bars-match-task-window', barsMatchTaskWindow)
+    .invariant('authored-bars-use-task-span', authoredBarsUseTaskSpan)
+    .invariant('no-hairline-bars-' + MIN_PX + 'px', rs => noHairlineBars(rs))
+    .invariant('bars-ordered', barsOrdered)
+    // RED CONTROL — reproduce the REAL defect, not a synthetic break: put one authored bar back on
+    // the ops-derived envelope it used to use. Before the fix every bar looked like this row.
+    .redControl(rs => rs.map((r, i) => {
+      if (i !== 0 || !r.taskId) return r;
+      const collapsed = Object.assign({}, r);
+      collapsed.spanFrom = 'ops';
+      collapsed.endTs = collapsed.startTs + 120000;   // the 0.6px shape, measured
+      collapsed.widthPx = 0.6;
+      return collapsed;
+    }))
+    .run();
+})().catch(e => { console.error('WITNESS_FAIL', e && e.stack || e); process.exit(1); });

--- a/viewer/time_machine.js
+++ b/viewer/time_machine.js
@@ -131,7 +131,12 @@
   function computeDays() {
     var GM = (typeof window !== 'undefined' && window.GanttModel) || null;
     if (!GM) { console.warn('§LOAD_FAIL gantt_model.js — computeDays skipped, timeline bounds unchanged'); return; }
-    var r = GM.computeDays(_placeOps());
+    // §GANTT_AXIS_COVERS_TASKS (§S65 STAGE 3) — pass the real authored windows so the display axis
+    // covers every bar buildTasks() now draws at its task's own span. buildTaskIndex() is the same
+    // source buildGanttTasks() uses, so the two layers cannot disagree about what a task's window is.
+    var _axIdx = null;
+    try { _axIdx = buildTaskIndex(); } catch (e) { _axIdx = null; }
+    var r = GM.computeDays(_placeOps(), _axIdx && _axIdx.tasks);
     _days = r.days;
     if (r.projectStart !== null) { _projectStart = r.projectStart; _projectEnd = r.projectEnd; }
     _ganttAxisStart = r.axisStart; _ganttAxisEnd = r.axisEnd;
@@ -5218,7 +5223,8 @@
 
   // ── Mini Gantt chart ──
   var _ganttTasksComputed = false; // §S58: no longer gates the log lines; "has ever built" only
-  var _ganttRebuildN = 0;          // §S58: rebuild ordinal — N rebuilds per gesture is readable
+  var _ganttRebuildN = 0;
+  var _ganttSpanFromTask = 0, _ganttSpanFromOps = 0;   // §GANTT_BAR_IS_ITS_TASK (§S65)          // §S58: rebuild ordinal — N rebuilds per gesture is readable
 
   // ── §GANTT_BAR_IDENTITY (K0 — prompts/4D_SCHEDULE_PERFECTION.md §GANTT_EDIT) ──
   // The drawer used to derive its bars purely by grouping raw kernel_ops on storey|phase, yielding
@@ -5659,6 +5665,7 @@
     var r = GM.buildTasks(_ops, idx, (typeof window !== 'undefined' && window.SEQUENCE_RULES) || null);
     _ganttTasks = r.tasks;
     _ganttIdentified = r.identified; _ganttUnidentified = r.unidentified;
+    _ganttSpanFromTask = r.spanFromTask || 0; _ganttSpanFromOps = r.spanFromOps || 0;
 
     // §S58 (4D_GANTT_TM_REFACTOR.md §S58.1a): these three lines used to be gated on
     // `_ganttTasksComputed`, a "log once flag" reset only at building-close — so they reported the
@@ -5692,6 +5699,14 @@
         ' bars=' + _ganttTasks.length + ' editable=' + _idBars +
         ' opsWithTask=' + _ganttIdentified + ' opsWithout=' + _ganttUnidentified +
         ' modelTasks=' + ((_taskIndex && _taskIndex.n) || 0));
+      // §GANTT_BAR_IS_ITS_TASK (§S65 STAGE 3) — where each bar's SPAN came from. spanFromTask is the
+      // authored window (the correct source); spanFromOps is the Tukey envelope over member elements,
+      // now only the un-authored fallback. Before this fix every bar was spanFromOps, and on
+      // HHS_Office_Federated that drew "Superstructure — Roof Level" 0.6px wide against its own
+      // 101.4px window (0.6%), with a mean absolute start error of 5.33 days across 17 bars.
+      console.log('§GANTT_BAR_SPAN_SOURCE rebuild=' + _ganttRebuildN +
+        ' spanFromTask=' + _ganttSpanFromTask + ' spanFromOps=' + _ganttSpanFromOps +
+        ' bars=' + _ganttTasks.length);
       _ganttTasksComputed = true;
     }
   }

--- a/witness_kit/generators/gantt_bars.js
+++ b/witness_kit/generators/gantt_bars.js
@@ -1,0 +1,142 @@
+// witness_kit/generators/gantt_bars.js — the REAL drawer's bar model, driven end-to-end on a real
+// building. Spec: bim-compiler prompts/4D_SCHEDULE_PERFECTION.md §S65 STAGE 3.
+//
+// WHY A GENERATOR AND NOT AN INLINE BLOCK IN THE WITNESS: the same assembly is needed by the
+// single-building and the fleet witness, and hand-copying it is the exact drift class witness_kit
+// exists to prevent (WITNESS_CONTRACT_AUDIT.md's #1 rot source). Same reasoning as
+// generators/schedule_4d.js.
+//
+// WHAT IT DRIVES, and why each piece is the real one:
+//   - ScheduleAuthor.materializeZones — the PRODUCTION authoring path (schedule_author_ui.js:284,
+//     time_machine.js buildTaskIndex's stale-regen). NOT materializeDefault: that produces 6 coarse
+//     phase tasks while production produces ~17 zone tasks, and every earlier witness in this lane
+//     drove the wrong one, which is a large part of why they stayed green through real defects
+//     (§S65 STAGE 1).
+//   - ScheduleAuthor._buildScheduleElements + ScheduleGate.computeSchedule — the same element solve
+//     injectGantt's kernel_ops ELEMENT_PLACE rows carry.
+//   - idx in the SHAPE buildTaskIndex() actually builds — { id, name, start, finish } per task
+//     (time_machine.js:5295). A first cut passed only { name } and silently exercised the ops
+//     fallback instead of the path under test; the witness looked unchanged and proved nothing.
+//   - GanttModel.buildTasks / GanttModel.computeDays — the REAL drawer model, called, never mirrored.
+//
+// WHAT IT IS NOT: this is not the persisted kernel_ops table and not the rendered canvas. It is the
+// drawer's MODEL layer — the function whose output the canvas draws rectangles from. Named per
+// WITNESS_INTERFACE_FRAMEWORK.md §CRISIS LESSON 1 so nobody extends its claim past what it checks.
+'use strict';
+const fs = require('fs');
+const vm = require('vm');
+const path = require('path');
+
+const ROOT = path.join(__dirname, '..', '..');
+const initSqlJs = require('sql.js');   // same resolution as generators/schedule_4d.js
+const SA = require(path.join(ROOT, 'viewer', 'schedule_author.js'));
+const SG = require(path.join(ROOT, 'viewer', 'schedule_gate.js'));
+require(path.join(ROOT, 'viewer', 'cpm_schedule.js'));
+require(path.join(ROOT, 'viewer', 'support_sweep.js'));
+const GM = require(path.join(ROOT, 'viewer', 'gantt_model.js'));
+
+const DAY = 86400000;
+
+function rowsFrom(r) {
+  if (!r.length) return [];
+  return r[0].values.map(v => { const o = {}; r[0].columns.forEach((c, i) => o[c] = v[i]); return o; });
+}
+
+function loadRealRates() {
+  const sandbox = { console: { log() {}, warn() {}, error() {} } };
+  vm.createContext(sandbox);
+  vm.runInContext(fs.readFileSync(path.join(ROOT, 'viewer', 'rates.js'), 'utf8'), sandbox);
+  return sandbox;
+}
+
+/**
+ * generateRealGanttBars(dbPath, opts) -> Promise<row[]>
+ * One row per drawn bar, carrying both what the drawer WILL draw and the authored window it must
+ * match, plus the pixel width at a realistic canvas so a "too thin to see" claim is a number.
+ * @param {string} dbPath
+ * @param {{start?:string, barW?:number}} [opts]
+ * @returns {Promise<object[]>}
+ */
+async function generateRealGanttBars(dbPath, opts) {
+  opts = opts || {};
+  const start = opts.start || '2026-08-25';
+  const barW = opts.barW || 340;   // real drawer: rc.clientWidth - 60 (time_machine.js:5868)
+
+  const SQL = await initSqlJs();
+  const db = new SQL.Database(new Uint8Array(fs.readFileSync(dbPath)));
+  const R = loadRealRates();
+  const shift = (R.SHIFT_HOURS > 0) ? R.SHIFT_HOURS : 24;
+
+  // schedule_author.js emits one §CLASS_UNMATCHED warn per unmatched ELEMENT; on Hospital that alone
+  // exceeded run_witness_suite.js's 1MB spawnSync maxBuffer and got the child SIGTERM'd while the
+  // script exits 0 standalone (WITNESS_INTERFACE_FRAMEWORK.md §6). Mute locally — not in the shared
+  // engine, not in the runner.
+  const mute = ['log', 'warn', 'error'].map(k => { const o = console[k]; console[k] = () => {}; return [k, o]; });
+  let els, solve;
+  try {
+    const res = SA.materializeZones(db, R.SEQUENCE_RULES, {
+      start, laborRates: R.LABOR_RATES, rates: R.RATES || {},
+      scheduleGate: SG, shiftHours: shift, defaultRule: R.SEQUENCE_DEFAULT
+    });
+    if (!res || !res.ok) { db.close(); mute.forEach(([k, o]) => console[k] = o); return []; }
+    els = SA._buildScheduleElements(db, R.SEQUENCE_RULES, {
+      laborRates: R.LABOR_RATES, rates: R.RATES || {}, defaultRule: R.SEQUENCE_DEFAULT,
+      nameOverrides: R.SEQUENCE_NAME_OVERRIDES
+    });
+    const maxCrews = {};
+    for (const r in R.LABOR_RATES) if (R.LABOR_RATES[r].max_crews) maxCrews[r] = R.LABOR_RATES[r].max_crews;
+    solve = SG.computeSchedule(els, Date.parse(start), 1, maxCrews, shift);
+  } finally { mute.forEach(([k, o]) => console[k] = o); }
+
+  const tasks = rowsFrom(db.exec('SELECT * FROM tasks'));
+  const te = rowsFrom(db.exec('SELECT task_id, guid FROM task_elements'));
+
+  const win = {}, taskRow = {};
+  tasks.forEach(t => {
+    if (Number(t.is_summary) === 1 || !t.schedule_start || !t.schedule_finish) return;
+    const s = Date.parse(t.schedule_start), e = Date.parse(t.schedule_finish);
+    if (!isFinite(s) || !isFinite(e)) return;
+    win[t.task_id] = { s, e, name: t.name };
+    taskRow[t.task_id] = { id: t.task_id, name: t.name, start: t.schedule_start, finish: t.schedule_finish };
+  });
+  const guidTask = {};
+  te.forEach(r => {
+    if (!win[r.task_id]) return;
+    if (!guidTask[r.guid] || win[r.task_id].s < win[guidTask[r.guid]].s) guidTask[r.guid] = r.task_id;
+  });
+
+  const byGuid = {}; els.forEach(e => byGuid[e.guid] = e);
+  const ops = [];
+  Object.keys(solve).forEach(g => {
+    const e = byGuid[g]; if (!e) return;
+    ops.push({
+      op_type: 'ELEMENT_PLACE', output_guid: g,
+      start_ts: solve[g].start, end_ts: solve[g].end,
+      parameters: { storey: e.storey || '_UNKNOWN', phase: e.phase || 'Architecture' }
+    });
+  });
+
+  const built = GM.buildTasks(ops, { guidTask, tasks: taskRow }, R.SEQUENCE_RULES);
+  const days = GM.computeDays(ops, taskRow);
+  const axis = Math.max(1, days.axisEnd - days.axisStart);
+
+  const out = built.tasks.map(b => {
+    const w = b.taskId ? win[b.taskId] : null;
+    return {
+      building: path.basename(dbPath).replace(/_extracted\.db$/, ''),
+      taskId: b.taskId || null,
+      name: (w && w.name) || (b.phase + '|' + b.storey),
+      phase: b.phase,
+      spanFrom: b.spanFrom,
+      startTs: b.startTs, endTs: b.endTs,
+      winStart: w ? w.s : null, winEnd: w ? w.e : null,
+      widthPx: ((b.endTs - b.startTs) / axis) * barW,
+      axisDays: axis / DAY,
+      members: b.count
+    };
+  });
+  db.close();
+  return out;
+}
+
+module.exports = { generateRealGanttBars, DAY };

--- a/witness_kit/invariants/gantt_bars.js
+++ b/witness_kit/invariants/gantt_bars.js
@@ -1,0 +1,63 @@
+// witness_kit/invariants/gantt_bars.js — reusable predicates for the Gantt DRAWER'S bar geometry.
+// Spec: bim-compiler prompts/4D_SCHEDULE_PERFECTION.md §S65 STAGE 3.
+//
+// The defect these exist to make impossible, measured on HHS_Office_Federated before the fix
+// (6839 ops, 17 bars, every one carrying a real task_id):
+//   Superstructure — Roof Level   drawn   0.6px   vs its own task's 101.4px  =  0.6% of its window
+//   Architecture   — Roof Level   drawn   0.6px   vs                 58.0px  =  1.0%
+//   Architecture   — Level 3      drawn  46.9px   vs                202.9px  = 23.1%, start off 22.03d
+//   mean absolute start error across all 17: 5.33 DAYS
+// The drawer derived each bar's span as a Tukey fence over its MEMBER ELEMENTS while the authored
+// window sat unread in the very index it was already given. When a task's elements bunch — which the
+// crew/CPM solve makes routine — the fence collapses onto the bunch and the bar becomes a sliver.
+'use strict';
+
+const SECOND = 1000;
+
+/**
+ * G-BAR-WINDOW — an AUTHORED bar (one with a real task_id and a parseable window) must be drawn at
+ * EXACTLY its task's window. Not "inside it", not "close to it" — equal. Tolerance is 1 second, for
+ * float/parse noise only, deliberately far below the 1-day granularity the schedule is authored at.
+ *
+ * "Inside the window" is precisely the weaker claim that let the §CRISIS regressions ship green
+ * (WITNESS_INTERFACE_FRAMEWORK.md §CRISIS LESSON 1: BOUNDS is not DISTRIBUTION is not RENDERED
+ * SHAPE) — a 0.6px bar sitting inside a 101.4px window satisfies "inside" perfectly.
+ * @param {object[]} rows
+ * @returns {boolean}
+ */
+const barsMatchTaskWindow = rows => rows
+  .filter(r => r.taskId && r.winStart != null)
+  .every(r => Math.abs(r.startTs - r.winStart) <= SECOND && Math.abs(r.endTs - r.winEnd) <= SECOND);
+
+/**
+ * G-BAR-SOURCE — no authored bar may take its span from the ops fallback. The fallback is correct
+ * ONLY for un-authored groups (storey|phase and cell keys, which have no window to prefer); an
+ * authored bar reaching it means the window was silently unavailable, which is how this defect
+ * looked from the outside for months.
+ * @param {object[]} rows
+ * @returns {boolean}
+ */
+const authoredBarsUseTaskSpan = rows => rows
+  .filter(r => r.taskId && r.winStart != null)
+  .every(r => r.spanFrom === 'task');
+
+/**
+ * G-BAR-VISIBLE — no bar may be thinner than MIN_PX at a realistic canvas width. This is the
+ * "tiny bars" claim expressed as a number instead of an impression, and it is checked on the
+ * drawer's own output, never on a screenshot.
+ * @param {object[]} rows
+ * @param {number} [minPx]
+ * @returns {boolean}
+ */
+const MIN_PX = 3;
+const noHairlineBars = (rows, minPx) => rows.every(r => r.widthPx >= (minPx == null ? MIN_PX : minPx));
+
+/**
+ * G-BAR-ORDERED — a bar's own start must precede its own end. Degenerate/inverted bars are the
+ * shape a collapsed span takes when the fence has nothing left to fence.
+ * @param {object[]} rows
+ * @returns {boolean}
+ */
+const barsOrdered = rows => rows.every(r => r.endTs > r.startTs);
+
+module.exports = { SECOND, MIN_PX, barsMatchTaskWindow, authoredBarsUseTaskSpan, noHairlineBars, barsOrdered };

--- a/witness_kit/schemas/gantt_bars.js
+++ b/witness_kit/schemas/gantt_bars.js
@@ -1,0 +1,36 @@
+// witness_kit/schemas/gantt_bars.js — the contract for ONE drawn Gantt bar, as data.
+// Spec: bim-compiler prompts/4D_SCHEDULE_PERFECTION.md §S65 STAGE 3.
+//
+// `winStart`/`winEnd` are ['integer','null'] because an UN-AUTHORED bar (a storey|phase or cell
+// group, on a building with no authored schedule) genuinely has no window — that is a real, correct
+// shape, not a defect. Whether an AUTHORED bar is allowed to diverge from its window is an invariant
+// question (barsMatchTaskWindow / authoredBarsUseTaskSpan), never a shape one: conflating the two
+// would let a real defect read as "malformed" and get triaged as a data problem.
+//
+// `spanFrom` is the provenance of the bar's outline — 'task' (the authored window, correct for an
+// authored bar) or 'ops' (the Tukey envelope over member elements, correct ONLY as the un-authored
+// fallback). Making provenance part of the persisted row is what lets a witness assert WHERE a
+// number came from instead of only what it equals.
+'use strict';
+
+const GanttBarRow = {
+  type: 'object',
+  required: ['building', 'name', 'phase', 'spanFrom', 'startTs', 'endTs', 'widthPx', 'members'],
+  properties: {
+    building: { type: 'string', minLength: 1 },
+    taskId:   { type: ['string', 'null'] },
+    name:     { type: 'string', minLength: 1 },
+    phase:    { type: 'string', minLength: 1 },
+    spanFrom: { type: 'string', enum: ['task', 'ops'] },
+    startTs:  { type: 'number' },
+    endTs:    { type: 'number' },
+    winStart: { type: ['number', 'null'] },
+    winEnd:   { type: ['number', 'null'] },
+    widthPx:  { type: 'number', minimum: 0 },
+    axisDays: { type: 'number', exclusiveMinimum: 0 },
+    members:  { type: 'integer', minimum: 1 }
+  },
+  additionalProperties: true
+};
+
+module.exports = { GanttBarRow };


### PR DESCRIPTION
## The structural answer

User, 2026-08-25: *"a human gantt chart maker will easily arrange with zero such hell."* Correct — and the reason is architectural.

**A human writes ~17 bars and assigns elements to them. The drawer did the inverse:** it computed each bar's outline as a Tukey fence over its *member elements*. When a task's elements bunch — routine under the crew/CPM solve, one storey's steel goes up in a burst inside a window sized for the whole storey — the fence collapses onto the bunch and the bar becomes a sliver.

**The window was never unknown.** `buildTaskIndex()` already puts `start`/`finish` on every entry of `idx.tasks` (`time_machine.js:5295`); `buildTasks()` read only `.name` from it. The drawer was computing a worse answer than the one it was already holding.

## Measured — HHS_Office_Federated, 6839 ops, 17 bars, every one with a real `task_id`

| bar | before | its task | after |
|---|---|---|---|
| Superstructure — Roof Level | **0.6px** | 101.4px | **100.0%** |
| Architecture — Roof Level | 0.6px | 58.0px | 100.0% |
| Architecture — Level 3 | 46.9px (start off **22.03 days**) | 202.9px | 100.0% |
| mean absolute start / end error | **5.33d / 1.61d** | — | **0.00 / 0.00** |
| bars under 3px | 2 | — | **0** |

## Why no earlier fix could reach it

This is a **different layer** from everything the crisis touched. §S65 STAGE 2's template fix moved 1217 zero-width *elements* to 114 and changed these bars by exactly nothing. Same for #1520's clamp and #1523's rescale — both element-layer. The bar's geometry was never derived from the schedule at all.

## Change

`gantt_model.js buildTasks()`: an **authored** group (real `task_id` + parseable window) takes its span from that window. **Un-authored** groups — the `storey|phase` and cell fallbacks — keep the Tukey rule byte-identically, since they have no window to prefer; so does an authored task whose dates are missing or unparseable (never invent a span, fall back to the measured one).

The member envelope is still computed and returned as `opsStartTs`/`opsEndTs` for fill/progress — the elements are not hidden, they just no longer define the outline (§TIER_DAG_WINS: counted, never hidden).

`computeDays()` gains an optional `taskWins` argument so the DISPLAY axis covers every authored window; otherwise a bar wider than the Tukey op axis would draw off the right edge. `projectStart`/`projectEnd` (true playback bounds, Prime Rule) untouched. New `§GANTT_BAR_SPAN_SOURCE` log reports `spanFromTask` vs `spanFromOps` per rebuild, so provenance is readable from the log rather than from source.

## Witness

`witness_gantt_bar_is_its_task.js` — fleet: **135 bars** over Duplex/Clinic/JKR/HHS_Office_Federated, **worst window error 0.000 days, `spanFromOps=0`**.

- `HHS_Office_Federated` is a **required** fixture — the witness fails rather than reporting a narrower run as green (§CRISIS LESSON 2: the whole crisis ran on witnesses that never saw the building the bug was on).
- Red control reproduces the **real** defect (puts one bar back on the ops envelope at its measured 0.6px), not a synthetic break.
- Gates assert **equality** to the window, not "inside" it — "inside" is exactly the weaker claim that let the crisis regressions ship green.

## One gate is red and stays red

`no-hairline-bars-3px`. Clinic ships 6+ zone tasks with exactly **1.00-day windows on a 156-day axis** (2.2px), including `MEP Rough-in — Roof - Mech` with **139 elements** and `Substructure — TOF Footing` with 58.

Cause is **upstream of this change and predates it**: `schedule_author.js:517` floors a zone whose solved span rounds below a day at exactly one day, so a zone's window comes from the element solve's span and never from its work content — the already-named `§CPM_GENERATOR_UPSTREAM_SPEC` / "window derivation from work content" item.

Tuning the threshold to 2px would have made this PR fully green and hidden a real number. **The gate stays**, registered in `KNOWN_RED` with the full cause.

## Regression

`run_witness_suite.js --filter gantt` → **green=17, new_red=0**, including `witness_gantt_model.js` 21/21 (the existing direct test of this very function). `--filter tm_` → green=12, and its one `new_red` (`witness_cpe_buildup_require_tm_first.js`) reproduces on **pristine `origin/main`** — its own output says *"WITNESS IS BLIND — shipped source unexpectedly already has this gate"*, a stale red control, unrelated to this change.

`CACHE_VERSION` **v1087 → v1088** — both changed files are precached; v1087 shipped #1527.

🤖 Generated with [Claude Code](https://claude.com/claude-code)