### PR TITLE
fix(4d): §ZONE_WINDOW_COVERS_WORK — a zone's window must fit its own members' work (5/135 → 0/135)

### DIFF
--- a/tests/run_witness_suite.js
+++ b/tests/run_witness_suite.js
@@ -84,6 +84,13 @@ const KNOWN_RED = {
   //   witness_zone_display_authoring.js — W-ZDA-4a re-locked to per-building baselines in
   //     baselines/midair.json (Duplex 22->37, HHS 894->1839). The inequality it replaced was
   //     permanently false, i.e. it gated nothing.
+  // DRAINED 2026-08-25 (§S65 STAGE 3, same PR that added it): witness_gantt_bar_is_its_task.js —
+  //   arrived red on window-covers-work-content and is green here. The red was real and was FIXED,
+  //   not tuned: §ZONE_WINDOW_COVERS_WORK now floors a zone's window at its own members' crew-days
+  //   (5 over-committed windows across 4 buildings -> 0/135). The 6th apparent case, JKR "MEP
+  //   Rough-in — 03 Water Tank Floor Level", was a WITNESS defect — the generator re-derived the
+  //   trade from SEQUENCE_RULES[cls], ignoring NAME_OVERRIDES, and so disagreed with the engine
+  //   about crew count; it now reads the element's own installSecs/resource.
   // DRAINED 2026-08-25 (§S65 template lock PR): witness_sequence_template_lock.js arrived red on 3
   //   of 7 gates and is green in this same PR — the template itself was fixed, not the witness
   //   relaxed. 7/65 rows were on _installSecs' silent 120s floor; now 0/63 schedulable rows.
@@ -105,20 +112,6 @@ const KNOWN_RED = {
                                               '(->14,267). Newly wired in 2026-08-24 (was git-orphaned at repo root since fc58210, ' +
                                               'per §S66 — suite never ran it, so this went undetected). Cause: 4D_SCHEDULE_PERFECTION.md ' +
                                               '"REGRESSION FOUND" section.',
-  'witness_gantt_bar_is_its_task.js':        'C — 1 of 7 gates (no-hairline-bars-3px). NOT the layer this witness is ' +
-                                              'about, and deliberately NOT tuned away. Its own subject — an authored bar ' +
-                                              'is drawn at its task window — is GREEN on 135 bars across Duplex/Clinic/' +
-                                              'JKR/HHS_Office_Federated: worst window error 0.000 days, spanFromOps=0. ' +
-                                              'The red is an UPSTREAM authoring defect this witness makes visible: Clinic ' +
-                                              'ships 6+ zone tasks with exactly 1.00-day windows on a 156-day axis ' +
-                                              '(2.2px), including "MEP Rough-in - Roof - Mech" with 139 elements and ' +
-                                              '"Substructure - TOF Footing" with 58. Cause: schedule_author.js:517 floors ' +
-                                              'a zone whose SOLVED span rounds below a day at exactly one day ' +
-                                              '(eDays <= sDays -> sDays + 1), so a zone window comes from the element ' +
-                                              'solve span and never from its work content — the already-named ' +
-                                              '§CPM_GENERATOR_UPSTREAM_SPEC / "window derivation from work content" item ' +
-                                              'in 4D_SCHEDULE_PERFECTION.md, open before this PR and untouched by it. ' +
-                                              'Lowering the 3px threshold would hide a real number; the gate stays.',
   // Reproducible reds whose cause has NOT been established. Labelled honestly rather than guessed:
   // an earlier pass called these "browser/server not up", which was wrong — both are headless.
   'witness_tm_stream_index_defer.js':        'C — reproducible red, cause NOT yet established',

--- a/viewer/schedule_author.js
+++ b/viewer/schedule_author.js
@@ -498,6 +498,14 @@
 
     var stmtTk = db.prepare('INSERT INTO tasks (task_id,schedule_id,wbs_parent,name,predefined_type,is_summary,schedule_start,schedule_finish,schedule_duration,resource,status) VALUES (?,?,?,?,?,?,?,?,?,?,?)');
     var stmtTe = db.prepare('INSERT OR IGNORE INTO task_elements VALUES (?,?)');
+    // §ZONE_WINDOW_COVERS_WORK — lookup + shift length for the per-zone work-content floor below.
+    // opts.shiftHours mirrors computeSchedule's own default (8) when a caller omits it, so probes
+    // and legacy callers stay byte-identical.
+    var _elByGuid = {};
+    for (var _ei = 0; _ei < elements.length; _ei++) _elByGuid[elements[_ei].guid] = elements[_ei];
+    var _shiftMs = (opts.shiftHours > 0 ? opts.shiftHours : 8) * 3600 * 1000;
+    var _workWidened = 0, _workWidenedDays = 0;
+
     var zoneTaskId = {}, zoneDays = {};
     rolled.zones.forEach(function (z) {
       var tid = 'TASK_' + _slug(z.phase) + '_' + _slug(z.storey);
@@ -516,6 +524,44 @@
         eDays = Math.round((z.end - minStart) / 86400000);
       }
       if (eDays <= sDays) eDays = sDays + 1;
+      // §ZONE_WINDOW_COVERS_WORK (2026-08-25, bim-compiler prompts/4D_SCHEDULE_PERFECTION.md §S65
+      // STAGE 3 follow-up — Witness: witness_gantt_bar_is_its_task.js G-BAR-WORK).
+      // The rounding above derives a window from the SOLVE'S SPAN alone, so a zone whose elements
+      // happen to be solved into a tight cluster gets a window shorter than its own members' work
+      // — and the Gantt then draws a bar that cannot physically contain what it represents.
+      // MEASURED across Duplex/Clinic/JKR/HHS_Office_Federated (135 zone tasks): 5 were
+      // over-committed, worst JKR "MEP Final — 02 1st Floor Level" at 1.744 crew-days inside a
+      // 1.00-day window (74% over), then Clinic "Finishes — Level 1" 1.333 (33%), JKR "MEP Rough-in
+      // — 03 Water Tank Floor Level" 3.405 in 3.00 (14%), Clinic "Substructure — TOF Footing" 1.074
+      // (7%), HHS "MEP Rough-in — Level 2" 9.508 in 9.00 (6%).
+      //
+      // NOT a blanket widening, and NOT a new duration model: crew-days come from the elements'
+      // OWN already-computed installSecs (set by _installSecs in _buildScheduleElements) over the
+      // same per-trade max_crews the solve itself used. A zone whose window already covers its work
+      // is untouched — 130 of the 135 above. Nothing is invented; this only refuses to author a
+      // window that its own contents cannot fit in.
+      //
+      // Deliberately a FLOOR, not a re-derivation: the solve's span still sets the window whenever
+      // it is the larger of the two, so dead-air/gap behaviour and every zone that was already
+      // honest stay byte-identical. Replacing the span rule outright is the separate, larger
+      // §CPM_GENERATOR_UPSTREAM_SPEC item.
+      var _wSecs = 0, _wTrades = {};
+      for (var _gi = 0; _gi < z.guids.length; _gi++) {
+        var _we = _elByGuid[z.guids[_gi]];
+        if (!_we) continue;
+        _wSecs += _we.installSecs || 0;
+        if (_we.resource && _we.resource !== '_DEFAULT') _wTrades[_we.resource] = 1;
+      }
+      var _wCrews = 0;
+      for (var _wt in _wTrades) _wCrews += (laborRates[_wt] && laborRates[_wt].max_crews) || 1;
+      if (!_wCrews) _wCrews = 1;
+      var _crewDays = (_wSecs * 1000) / (_shiftMs * _wCrews);
+      var _needDays = Math.ceil(_crewDays);
+      if (eDays - sDays < _needDays) {
+        _workWidened++;
+        _workWidenedDays += _needDays - (eDays - sDays);
+        eDays = sDays + _needDays;
+      }
       // §ZONE_EDGE_LEAD: remember the ROUNDED day numbers actually written. The edge lags below are
       // derived from these, not re-rounded independently from raw ms — rounding dates and lags
       // separately let the two disagree by a day, which showed up as 53 self-violated edges on
@@ -526,6 +572,9 @@
       z.guids.forEach(function (g) { stmtTe.run([tid, g]); });
     });
     stmtTk.free(); stmtTe.free();
+    console.log('§ZONE_WINDOW_COVERS_WORK zones=' + rolled.zones.length + ' widened=' + _workWidened +
+      ' addedDays=' + _workWidenedDays + ' (a widened zone had a window shorter than its own ' +
+      'members\' crew-days; 0 = every zone window already covered its work)');
 
     var stmtSeq = db.prepare('INSERT OR IGNORE INTO task_sequences VALUES (?,?,?,?)');
     var edgeN = 0;

--- a/viewer/sw.js
+++ b/viewer/sw.js
@@ -17,8 +17,12 @@
 // an authored Gantt bar is now drawn at its TASK'S window instead of a Tukey fence over its member
 // elements. Both files are in PRECACHE_ASSETS. v1087 shipped the STAGE 2 template fix (#1527); this is
 // a separate change and needs its own bump, per the twice-missed rule (§CRISIS LESSON 4).
+// v1089 (2026-08-25) §ZONE_WINDOW_COVERS_WORK: schedule_author.js changed — a zone task's window is
+// now floored at its own members' crew-days (5 over-committed windows across 4 buildings -> 0/135).
+// schedule_author.js is in PRECACHE_ASSETS; v1088 shipped the STAGE 3 drawer change (#1528), so this
+// separate change needs its own bump (§CRISIS LESSON 4).
 // DEPLOY: bump CACHE_VERSION on every OCI upload. Old caches are purged on activate.
-const CACHE_VERSION = 'v1088';   // bump on each deploy; per-change detail is the git commit message.
+const CACHE_VERSION = 'v1089';   // bump on each deploy; per-change detail is the git commit message.
 // v1084 (2026-08-25) §CPE_BUILDUP_REQUIRE_TM_FIRST (CINEMA_PATH_EDITOR.md, user ruling "no auto
 // JSON outside TM"): Alt+C's bake no longer generates a building's first-ever 4D schedule.
 // window.tmHasExistingSchedule() (time_machine.js) — read-only, no DB writes, never generates —

--- a/viewer/tests/witness_gantt_bar_is_its_task.js
+++ b/viewer/tests/witness_gantt_bar_is_its_task.js
@@ -35,7 +35,7 @@ const path = require('path');
 const { Witness } = require('../../witness_kit/contract');
 const { GanttBarRow } = require('../../witness_kit/schemas/gantt_bars');
 const {
-  barsMatchTaskWindow, authoredBarsUseTaskSpan, noHairlineBars, barsOrdered, MIN_PX
+  barsMatchTaskWindow, authoredBarsUseTaskSpan, windowCoversWorkContent, barsOrdered, WORK_TOLERANCE
 } = require('../../witness_kit/invariants/gantt_bars');
 const { generateRealGanttBars } = require('../../witness_kit/generators/gantt_bars');
 
@@ -73,12 +73,23 @@ const FIXTURES = ['Duplex', 'Clinic', 'JKR', REQUIRED];
     ' worstWindowErrorDays=' + (worst ? (worst.d / 86400000).toFixed(3) : 'n/a') +
     (worst && worst.d > 1000 ? ' at=' + JSON.stringify(worst.r.name) : ''));
 
+  // §GBT_WORK — a thin bar is only a defect if its window is shorter than its own members' work.
+  // Reported for every bar, gated by windowCoversWorkContent. Pixel width stays in the log as
+  // information, deliberately NOT as a gate: 7 of Clinic's 9 one-day windows are honest work.
+  const over = rows.filter(r => r.taskId && r.crewDays > r.windowDays * WORK_TOLERANCE)
+    .sort((a, b) => (b.crewDays / b.windowDays) - (a.crewDays / a.windowDays));
+  console.log('§GBT_WORK overCommittedWindows=' + over.length + '/' + authored.length +
+    ' tolerance=' + ((WORK_TOLERANCE - 1) * 100).toFixed(0) + '%');
+  over.slice(0, 8).forEach(r => console.log('   ' + r.building + ' ' + JSON.stringify(r.name) +
+    ' windowDays=' + r.windowDays.toFixed(2) + ' crewDays=' + r.crewDays.toFixed(3) +
+    ' members=' + r.members + ' (' + ((r.crewDays / r.windowDays - 1) * 100).toFixed(0) + '% over)'));
+
   Witness('gantt_bar_is_its_task')
     .population(() => rows)
     .schema(GanttBarRow)
     .invariant('bars-match-task-window', barsMatchTaskWindow)
     .invariant('authored-bars-use-task-span', authoredBarsUseTaskSpan)
-    .invariant('no-hairline-bars-' + MIN_PX + 'px', rs => noHairlineBars(rs))
+    .invariant('window-covers-work-content', windowCoversWorkContent)
     .invariant('bars-ordered', barsOrdered)
     // RED CONTROL — reproduce the REAL defect, not a synthetic break: put one authored bar back on
     // the ops-derived envelope it used to use. Before the fix every bar looked like this row.
@@ -88,6 +99,7 @@ const FIXTURES = ['Duplex', 'Clinic', 'JKR', REQUIRED];
       collapsed.spanFrom = 'ops';
       collapsed.endTs = collapsed.startTs + 120000;   // the 0.6px shape, measured
       collapsed.widthPx = 0.6;
+      collapsed.windowDays = 120000 / 86400000;        // and the window no longer covers its own work
       return collapsed;
     }))
     .run();

--- a/witness_kit/generators/gantt_bars.js
+++ b/witness_kit/generators/gantt_bars.js
@@ -106,6 +106,35 @@ async function generateRealGanttBars(dbPath, opts) {
   });
 
   const byGuid = {}; els.forEach(e => byGuid[e.guid] = e);
+
+  // §BAR_WORK_CONTENT (2026-08-25, §S65 STAGE 3 follow-up) — the real crew-days each task's own
+  // members represent, from the SAME ScheduleAuthor._installSecs the generator uses. Measured, not
+  // assumed: this is what distinguishes an honest short bar from an under-sized window. Clinic's
+  // "MEP Rough-in - Roof - Mech" looks alarming at 139 elements in a 1.00-day window and is in fact
+  // 0.817 crew-days at 24h x 4 crews — genuinely a one-day task. Its neighbours
+  // "Finishes - Level 1" (1.333 crew-days) and "Substructure - TOF Footing" (1.074) are NOT.
+  const SHIFT_MS = shift * 3600 * 1000;
+  const workOf = {};
+  // Read the element's OWN already-computed installSecs/resource — the exact values
+  // _buildScheduleElements assigned (schedule_author.js:372-373) and the engine itself uses.
+  // A first cut re-derived them from SEQUENCE_RULES[e.cls], which IGNORES NAME_OVERRIDES, so the
+  // witness and the engine disagreed about which trade an overridden element belongs to and
+  // therefore about the crew count. That produced a phantom red on JKR "MEP Rough-in — 03 Water
+  // Tank Floor Level" — a mirrored predicate diverging from the real one, i.e. precisely the drift
+  // class witness_kit exists to prevent, caught here on its first real run.
+  te.forEach(r => {
+    const e = byGuid[r.guid]; if (!e || !win[r.task_id]) return;
+    const w = workOf[r.task_id] || (workOf[r.task_id] = { secs: 0, trades: {} });
+    w.secs += e.installSecs || 0;
+    if (e.resource && e.resource !== '_DEFAULT') w.trades[e.resource] = 1;
+  });
+  function crewDaysOf(tid) {
+    const w = workOf[tid]; if (!w) return 0;
+    var crews = 0;
+    for (var t in w.trades) crews += (R.LABOR_RATES[t] && R.LABOR_RATES[t].max_crews) || 1;
+    if (!crews) crews = 1;
+    return (w.secs * 1000) / (SHIFT_MS * crews);
+  }
   const ops = [];
   Object.keys(solve).forEach(g => {
     const e = byGuid[g]; if (!e) return;
@@ -131,6 +160,8 @@ async function generateRealGanttBars(dbPath, opts) {
       startTs: b.startTs, endTs: b.endTs,
       winStart: w ? w.s : null, winEnd: w ? w.e : null,
       widthPx: ((b.endTs - b.startTs) / axis) * barW,
+      crewDays: b.taskId ? crewDaysOf(b.taskId) : 0,
+      windowDays: (b.endTs - b.startTs) / DAY,
       axisDays: axis / DAY,
       members: b.count
     };

--- a/witness_kit/invariants/gantt_bars.js
+++ b/witness_kit/invariants/gantt_bars.js
@@ -42,15 +42,28 @@ const authoredBarsUseTaskSpan = rows => rows
   .every(r => r.spanFrom === 'task');
 
 /**
- * G-BAR-VISIBLE — no bar may be thinner than MIN_PX at a realistic canvas width. This is the
- * "tiny bars" claim expressed as a number instead of an impression, and it is checked on the
- * drawer's own output, never on a screenshot.
+ * G-BAR-WORK — a task's window must be long enough for its OWN members' work.
+ *
+ * This REPLACED a `no-hairline-bars-3px` pixel gate, and the replacement is strictly stronger, not a
+ * relaxation — measured on Clinic (156-day axis, 9 tasks with exactly 1.00-day windows):
+ *   MEP Rough-in - Roof - Mech   139 members  0.817 crew-days  -> HONEST, the pixel gate failed it
+ *   Architecture - Roof - Main    25 members  0.207 crew-days  -> HONEST, the pixel gate failed it
+ *   Finishes - Level 1            64 members  1.333 crew-days  -> REAL DEFECT (33% over its window)
+ *   Substructure - TOF Footing    58 members  1.074 crew-days  -> REAL DEFECT (7% over)
+ * 7 of the 9 were honest. A genuine one-day task on a 156-day chart SHOULD be thin — P6 draws it
+ * thin — so a pixel threshold flags real work as a defect and, worse, would be silenced by nudging
+ * the threshold. Crew-days is the thing that is actually true or false about a window.
+ *
+ * TOLERANCE: 5%, the project's own standing error-margin ruling (4D_SCHEDULE_PERFECTION.md
+ * §WORKING_STYLE: "5% error margin is acceptable — do not chase exactness past the point of
+ * usefulness"). Not a number invented for this gate.
  * @param {object[]} rows
- * @param {number} [minPx]
  * @returns {boolean}
  */
-const MIN_PX = 3;
-const noHairlineBars = (rows, minPx) => rows.every(r => r.widthPx >= (minPx == null ? MIN_PX : minPx));
+const WORK_TOLERANCE = 1.05;
+const windowCoversWorkContent = rows => rows
+  .filter(r => r.taskId && r.crewDays > 0)
+  .every(r => r.crewDays <= r.windowDays * WORK_TOLERANCE);
 
 /**
  * G-BAR-ORDERED — a bar's own start must precede its own end. Degenerate/inverted bars are the
@@ -60,4 +73,5 @@ const noHairlineBars = (rows, minPx) => rows.every(r => r.widthPx >= (minPx == n
  */
 const barsOrdered = rows => rows.every(r => r.endTs > r.startTs);
 
-module.exports = { SECOND, MIN_PX, barsMatchTaskWindow, authoredBarsUseTaskSpan, noHairlineBars, barsOrdered };
+module.exports = { SECOND, WORK_TOLERANCE, barsMatchTaskWindow, authoredBarsUseTaskSpan,
+                   windowCoversWorkContent, barsOrdered };


### PR DESCRIPTION
## Found by the previous fix, not despite it

Once bars were drawn at their real task windows (#1528), the witness could ask a question nobody could ask before: **is the window itself long enough for the work it contains?**

Measured across Duplex / Clinic / JKR / HHS_Office_Federated — 135 zone tasks, **5 windows shorter than their own members' crew-days**:

| task | crew-days | window | over | elements |
|---|---|---|---|---|
| JKR — MEP Final — 02 1st Floor Level | 1.744 | 1.00d | **74%** | 126 |
| Clinic — Finishes — Level 1 | 1.333 | 1.00d | 33% | 64 |
| JKR — MEP Rough-in — 03 Water Tank Floor | 3.405 | 3.00d | 14% | 404 |
| Clinic — Substructure — TOF Footing | 1.074 | 1.00d | 7% | 58 |
| HHS — MEP Rough-in — Level 2 | 9.508 | 9.00d | 6% | 976 |

**Now 0/135**, every building's worst crew-day ratio below 1.0.

## Cause and shape of the fix

`schedule_author.js` derived a zone's window from the **solve's span alone**, so a zone whose elements happened to be solved into a tight cluster got a window shorter than its own contents — a bar that cannot physically contain what it represents.

The fix is a **floor, not a re-derivation**: the solve's span still sets the window whenever it is larger, so dead-air/gap behaviour and the 130 zones that were already honest stay byte-identical. Replacing the span rule outright remains the separate, larger `§CPM_GENERATOR_UPSTREAM_SPEC` item.

**Nothing invented** — crew-days come from the elements' own already-computed `installSecs` (set by `_installSecs` in `_buildScheduleElements`) over the same per-trade `max_crews` the solve itself used. New `§ZONE_WINDOW_COVERS_WORK` log reports zones widened and days added per generation.

## The gate was replaced, and it is strictly stronger — not a relaxation

The first cut gated on **pixels** (`no-hairline-bars-3px`) and was measuring the wrong thing. Of Clinic's 9 one-day windows, **7 were honest work**: `MEP Rough-in — Roof - Mech` packs 139 elements into **0.817 crew-days** at 24h × 4 crews. A genuine one-day task on a 156-day chart *should* be thin — P6 draws it thin.

A pixel threshold flags real work as a defect, and worse, can be silenced by nudging the number. **Crew-days is the thing that is actually true or false about a window.** Tolerance is 5% — the project's own standing error-margin ruling, not a number invented for this gate.

## A witness defect, found and fixed in the same pass

The generator re-derived each element's trade from `SEQUENCE_RULES[cls]`, which **ignores NAME_OVERRIDES**, so it disagreed with the engine about crew count and produced a phantom 6th red on JKR's water-tank zone. It now reads the element's own `installSecs`/`resource` — the exact values the engine uses.

That is the mirrored-predicate drift class `witness_kit` exists to prevent, caught on this witness's first real run.

## Verification

- `witness_gantt_bar_is_its_task.js`: **pass=7 fail=0**, 135 bars, worst window error 0.000 days, `spanFromOps=0`, `overCommittedWindows=0/135`.
- `KNOWN_RED` entry drained in the same PR that added it — the runner independently reported `§SUITE_FIXED` for it.
- Regression: `--filter gantt` → **green=17, new_red=0**. Full headless suite running.
- `CACHE_VERSION` **v1088 → v1089** (`schedule_author.js` is precached; v1088 shipped #1528).

🤖 Generated with [Claude Code](https://claude.com/claude-code)