### PR TITLE
test(4d): re-lock W-ZDA-4a's HHS floating pair — cause isolated by A/B, not assumed

### DIFF
--- a/viewer/tests/baselines/midair.json
+++ b/viewer/tests/baselines/midair.json
@@ -3,23 +3,45 @@
   "_relocked": "2026-08-21 — §S50 cell-grain schedule (bim-ootb #1442), carried unchanged through §S51 (#1444). float_after_cpm ONLY re-locked 2026-08-22 (§S64): HHS 889->884, LTU_AHouse 5023->4998, JKR 1222->1212 — auditFloating shed false positives when its tPool was made to mirror hangGate's elPool and its wall pool given wallCarries' carry-at-top bound. NO schedule time changed (both fixes are inside auditFloating, which no gate reads); midair and orphans are byte-identical on all 7, which is the proof this was the audit and not the engine.",
   "float_after_cpm": {
     "_what": "W-MZ-8 — ScheduleGate.auditFloating AFTER _displayTimeline. The measured TRADE: a dependent may start before its support FINISHES. Deliberate and named, never silent.",
-    "Terminal": 554, "Hospital": 935, "Duplex": 44, "HHS_Office_Federated": 884,
-    "Clinic": 324, "LTU_AHouse": 4998, "JKR": 1212
+    "Terminal": 554,
+    "Hospital": 935,
+    "Duplex": 44,
+    "HHS_Office_Federated": 884,
+    "Clinic": 324,
+    "LTU_AHouse": 4998,
+    "JKR": 1212
   },
   "midair": {
     "_what": "W-MZ-2 — this witness's own census(): elements appearing before the first thing they touch. Non-zero ONLY on the CELL-path buildings (the §S26.11 leg-4 exception surface); GRAPH-path buildings stay at 0. W-MZ-7 is the proof this judge can go red.",
-    "Terminal": 684, "Hospital": 218, "Duplex": 0, "HHS_Office_Federated": 0,
-    "Clinic": 422, "LTU_AHouse": 0, "JKR": 0
+    "Terminal": 684,
+    "Hospital": 218,
+    "Duplex": 0,
+    "HHS_Office_Federated": 0,
+    "Clinic": 422,
+    "LTU_AHouse": 0,
+    "JKR": 0
   },
   "zda_display_float": {
     "_what": "W-ZDA-4a — the floating census under DISPLAY-AUTHORED windows vs the raw-authored baseline, from witness_zone_display_authoring.js. The display path IS measurably worse and always has been; this locks the exact pair so a CHANGE reddens, replacing an inequality assert that shipped permanently red. base = raw-authored windows + shipped rescale/sweep/parity; display = display-authored windows, rescale + parity, no sweep. Deliberately NOT a % threshold — that judge transfer was tried and retracted.",
-    "_measured": "2026-08-22 on origin/main 6ec0dcc (§S63)",
-    "Duplex_extracted":               { "base": 22,  "display": 37 },
-    "HHS_Office_Federated_extracted": { "base": 894, "display": 1839 }
+    "_measured": "2026-08-22 on origin/main 6ec0dcc (§S63); HHS_Office_Federated RE-LOCKED 2026-08-25 (§S65) — see _relocked_2026_08_25 below",
+    "Duplex_extracted": {
+      "base": 22,
+      "display": 37
+    },
+    "HHS_Office_Federated_extracted": {
+      "base": 977,
+      "display": 1727
+    },
+    "_relocked_2026_08_25": "HHS_Office_Federated 894->1839 becomes 977->1727. CAUSE ISOLATED BY A/B, not assumed. PR #1527 (§S65 STAGE 2) changed two things that feed the solve: element DURATIONS (1217 elements were on _installSecs' silent 120s floor, now on real productivity math) and two SEQUENCE moves (IfcRoof 8->6, glazed_curtainwall_facade 7->6, the user's weather-tight-before-rough-in ruling). Ran the template with the duration fixes but the sequences reverted: 891->1815. So the durations cost NOTHING in raw floating (894->891, three better) and improved the display side by 24; the entire +88 raw regression is the SEQUENCE moves, and they leave the display timeline byte-unchanged at 1815 — the movie is unaffected, only the raw generative audit moves. Accepted as the measured price of a deliberate ruling. PR #1529 (§ZONE_WINDOW_COVERS_WORK) then took the display side 1815->1727 by flooring each zone's window at its own members' crew-days. Net vs the old lock: raw +83, display -112."
   },
   "orphans": {
     "_what": "W-MZ-4 — elements touching nothing in the model. Purely geometric (never reads .s/.e), so independent of which display-authoring path produced the times. An extraction limit, reported never gated.",
-    "Terminal": 25, "Hospital": 35, "Duplex": 1, "HHS_Office_Federated": 36,
-    "Clinic": 27, "LTU_AHouse": 865, "JKR": 1
+    "Terminal": 25,
+    "Hospital": 35,
+    "Duplex": 1,
+    "HHS_Office_Federated": 36,
+    "Clinic": 27,
+    "LTU_AHouse": 865,
+    "JKR": 1
   }
 }


### PR DESCRIPTION
## Owning a miss first

**PR #1527 (§S65 STAGE 2) broke this locked baseline and I shipped it without running this witness.** Recorded plainly, because that is the exact discipline failure this lane exists to end. `--filter gantt` and `--filter tm_` both passed; `witness_zone_display_authoring` matches neither filter, and I did not run the full suite before merging.

## Bisected, then A/B'd — not guessed

Green 18/18 at `bf62a7b` (before #1527), red from #1527 onward. #1527 changed **two** things that feed the solve — element durations and two sequence moves — so I ran the template with the duration fixes but the sequences reverted rather than attributing it:

| variant | HHS raw → display |
|---|---|
| before #1527 (the old lock) | 894 → 1839 |
| **duration fixes only, sequences reverted** | **891 → 1815** (raw **3 better**, display 24 better) |
| full #1527 | **979** → 1815 |
| + #1529 zone-window floor | 977 → **1727** |

**The duration fixes cost nothing** — they actually improved both sides. **The entire +88 raw regression is the sequence moves** (`IfcRoof` 8→6, `glazed_curtainwall_facade` 7→6 — the weather-tight-before-rough-in ruling), and they leave the **display timeline byte-unchanged at 1815**: the movie is unaffected, only the raw generative audit moves.

Accepted as the measured price of a deliberate ruling, named in the baseline file itself so the next reader does not re-derive it.

**Net vs the old lock: raw +83, display −112.**

## Re-lock

`HHS_Office_Federated_extracted` → `{ base: 977, display: 1727 }`, per `baselines/midair.json`'s own standing discipline: *"a re-lock is a data edit in baselines/midair.json with a named cause"*. `W-ZDA-4a` now **18/18**.

Test data only — no precached asset touched, so no `CACHE_VERSION` bump applies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)