### PR TITLE
feat(4d): the core programme template JSON — the artifact asked for months ago that never existed

### DIFF
--- a/viewer/rates/programme_template.json
+++ b/viewer/rates/programme_template.json
@@ -1,0 +1,87 @@
+{
+  "meta": {
+    "id": "programme_template",
+    "name": "Core Construction Programme Template",
+    "version": "1.0.0",
+    "what": "THE core Gantt programme every building instance copies from. This is the artifact that did not exist before 2026-08-25: a checked-in, reviewable, witnessed programme SKELETON — phases, per-level activities, and the dependency logic between them — authored once here instead of emerging at runtime from a geometry solve and being discarded on reload.",
+    "not_this_file": "sequence_rules.json is a CLASSIFICATION table (ifc_class -> phase/sequence/trade + labour productivity). It answers 'which phase does this element belong to'. It cannot answer 'what is the programme', and 4D_SCHEDULE_PERFECTION.md line 1751's claim that it IS the template is wrong. The two files are used together: this one is the shape, that one is the lookup.",
+    "instantiation": "A building instance copies this file, replicates every activity marked replicate_per_level once per real storey (bottom-up), drops any activity whose element population is empty for that building, and resolves durations by the duration_rule below. Nothing here is per-building; nothing per-building belongs here.",
+    "provenance": "phases[].id/name/sequence and phases[].trades are EXTRACTED from viewer/rates/sequence_rules.json's own SEQUENCE_RULES (min/max sequence per phase, the union of resources that phase's classes name) — not typed by hand, and they must not drift from it. witness_programme_template.js gates that.",
+    "editable": "Registered like every other project JSON: id = programme_template, file = rates/programme_template.json, storageKey = json_programme_template."
+  },
+
+  "calendar": {
+    "_what": "The working calendar the programme is authored against. Named here because it was previously implicit: rates.js SHIFT_HOURS alone carried it, and nothing stated the week.",
+    "hours_per_shift": 24,
+    "days_per_week": 7,
+    "_hours_per_shift_why": "24 is the STANDING USER RULING recorded at rates.js SHIFT_HOURS (2026-08-13): 'our default, import and JSON setting can import as we align to standard model'. Carried forward verbatim, NOT changed here — this file only makes it visible and editable. A standard-model import sets 8.",
+    "_days_per_week_why": "7 matches what the engine actually does today (schedule_gate.js applies no week calendar; §CREW_DAY logs '24/7 calendar unchanged'). Stated so a 5-day working week becomes an edit rather than a rewrite.",
+    "holidays": []
+  },
+
+  "duration_rule": {
+    "_what": "How an activity's duration is derived. THIS IS THE ANCHOR the chain was missing: before this, a task's length came from however long the geometry placement solve happened to span, which is why one HHS run logged 185.2 crew-days of work content inside a 42-day programme — a 4.4x self-contradiction in a single log.",
+    "basis": "work_content",
+    "formula": "days = ceil( sum(element.installSecs) / (hours_per_shift * 3600 * crews) ), crews = sum of max_crews over the trades the activity's own elements actually use",
+    "min_days": 1,
+    "_installSecs_source": "ScheduleAuthor._installSecs, from sequence_rules.json LABOR_RATES productivity. Same function the engine uses — never a second copy.",
+    "_not_this": "NOT the elapsed span of the placement solve. The solve orders elements; it does not price the work."
+  },
+
+  "phases": [
+    {
+      "id": "substructure", "name": "Substructure", "sequence": 1,
+      "trades": ["CONCRETE_GANG"],
+      "replicate_per_level": false,
+      "_scope": "Ground-bearing work below the frame. Single occurrence per building — it does not repeat per storey.",
+      "_empty_ok": true,
+      "_empty_ok_why": "A federated or partial model legitimately ships no foundations. HHS_Office_Federated is one: its programme logs phases [Superstructure, Architecture, MEP Rough-in, MEP Final, Finishes] with no Substructure at all. Absent must be REPORTED as absent, never silently skipped."
+    },
+    {
+      "id": "superstructure", "name": "Superstructure", "sequence": 2,
+      "trades": ["CONCRETE_GANG", "STEEL_ERECTOR"],
+      "replicate_per_level": true,
+      "_scope": "Frame and floor plates for one level."
+    },
+    {
+      "id": "architecture", "name": "Architecture", "sequence": 5,
+      "trades": ["CARPENTER", "CONCRETE_GANG", "MASON", "ROOFER"],
+      "replicate_per_level": true,
+      "_scope": "Envelope and internal fabric for one level: walls, doors, windows, curtain walling, roof."
+    },
+    {
+      "id": "mep_rough_in", "name": "MEP Rough-in", "sequence": 7,
+      "trades": ["ELECTRICIAN", "HVAC_TECH", "PLUMBER"],
+      "replicate_per_level": true,
+      "_scope": "First-fix services for one level, after that level is weather-tight."
+    },
+    {
+      "id": "mep_final", "name": "MEP Final", "sequence": 9,
+      "trades": ["ELECTRICIAN", "HVAC_TECH", "PLUMBER"],
+      "replicate_per_level": true,
+      "_scope": "Second-fix services and terminals for one level."
+    },
+    {
+      "id": "finishes", "name": "Finishes", "sequence": 10,
+      "trades": ["FINISHER"],
+      "replicate_per_level": true,
+      "_scope": "Coverings, furniture and final finishes for one level."
+    }
+  ],
+
+  "dependencies": {
+    "_what": "Construction LOGIC, authored here, independent of any date. This is the second half of the anchor: today's task_sequences rows are computed FROM the dates they are meant to validate (schedule_author.js: 'succ.start = pred.finish + lag EXACTLY'), so every edge is tight by construction, float is zero everywhere, and CPM reports 17 of 17 tasks critical. An edge that comes from the answer cannot contradict the answer. These do.",
+    "within_level": [
+      { "pred": "substructure",   "succ": "superstructure", "type": "FS", "lag_days": 0, "_why": "Frame bears on the foundations." },
+      { "pred": "superstructure", "succ": "architecture",   "type": "FS", "lag_days": 0, "_why": "Envelope and partitions need the frame and slab of their own level." },
+      { "pred": "architecture",   "succ": "mep_rough_in",   "type": "FS", "lag_days": 0, "_why": "First fix follows weather-tight. This is the same precedence the 2026-08-25 IfcRoof 8->6 ruling encoded at class level; stated here as programme logic rather than a sequence number." },
+      { "pred": "mep_rough_in",   "succ": "mep_final",      "type": "FS", "lag_days": 0, "_why": "Second fix follows first fix." },
+      { "pred": "mep_final",      "succ": "finishes",       "type": "FS", "lag_days": 0, "_why": "Finishes close up completed services." }
+    ],
+    "across_levels": [
+      { "pred": "superstructure", "succ": "superstructure", "type": "FS", "lag_days": 0, "level_offset": 1,
+        "_why": "A level's frame cannot start before the level below it is framed. This is the ONLY hard vertical constraint; everything else follows from it plus the within-level chain." }
+    ],
+    "_overlap": "Every lag is 0 and every type is FS in v1.0.0 — a deliberately conservative, strictly serial start. Real programmes overlap trades (SS with lag, FS with negative lead). Those belong here as edits, each with its own _why, so an overlap is a reviewed decision and not an artifact of a solver."
+  }
+}

--- a/viewer/tests/witness_programme_template.js
+++ b/viewer/tests/witness_programme_template.js
@@ -1,0 +1,100 @@
+#!/usr/bin/env node
+// WITNESS — programme_template: the core Gantt programme skeleton every building instance copies
+// from. Spec: bim-compiler prompts/4D_SCHEDULE_PERFECTION.md §S66.
+//
+// WHICH LAYER THIS PROVES (WITNESS_INTERFACE_FRAMEWORK.md §CRISIS LESSON 1):
+//   the TEMPLATE layer only — the authored programme skeleton as a file. It says nothing about any
+//   building's instantiated tasks, nothing about kernel_ops, nothing about drawn bars.
+//
+// ISSUE THIS PROVES OR DISPROVES: the user asked for a core programme-template JSON months before
+// 2026-08-25 and was repeatedly told it existed. It did not. A repo-wide scan of all 96 JSON files
+// found zero containing tasks, durations or dependencies, and 4D_SCHEDULE_PERFECTION.md:1751 states
+// "sequence_rules.json IS that template and it does work" — which is false: that file is an
+// ifc_class -> phase/sequence/trade lookup and cannot express a programme. This witness exists so
+// the new file cannot rot into the same claim: it gates that the template stays DERIVED from
+// sequence_rules.json where it should be, and INDEPENDENT of dates where it must be.
+//
+// Command: node viewer/tests/witness_programme_template.js
+'use strict';
+const fs = require('fs');
+const vm = require('vm');
+const path = require('path');
+const { Witness } = require('../../witness_kit/contract');
+const { ProgrammePhaseRow } = require('../../witness_kit/schemas/programme_template');
+const {
+  phasesMatchClassificationOrder, tradesMatchClassification, edgesReferenceRealPhases,
+  withinLevelChainCoversAllPhases, edgesAreDateIndependent, calendarMatchesEngine,
+  durationRuleIsWorkContent
+} = require('../../witness_kit/invariants/programme_template');
+
+const VIEWER_DIR = process.env.VIEWER_DIR || path.join(__dirname, '..');
+const T = JSON.parse(fs.readFileSync(path.join(VIEWER_DIR, 'rates', 'programme_template.json'), 'utf8'));
+const C = JSON.parse(fs.readFileSync(path.join(VIEWER_DIR, 'rates', 'sequence_rules.json'), 'utf8'));
+
+// The EXECUTED clock, not the mirror — same reasoning as witness_sequence_template_lock.js:
+// viewer.html never calls loadSequenceRules(), so rates.js's literal is what the browser runs.
+function executedShiftHours() {
+  const sandbox = { console: { log() {}, warn() {}, error() {} } };
+  vm.createContext(sandbox);
+  vm.runInContext(fs.readFileSync(path.join(VIEWER_DIR, 'rates.js'), 'utf8'), sandbox);
+  return sandbox.SHIFT_HOURS;
+}
+const SHIFT = executedShiftHours();
+
+// One row per phase, carrying what the template declares AND what the classification table says,
+// so an invariant compares the two instead of trusting either.
+const classPhases = {};
+Object.keys(C.SEQUENCE_RULES).forEach(cls => {
+  const r = C.SEQUENCE_RULES[cls];
+  if (!r.phase || r.sequence == null) return;
+  const p = classPhases[r.phase] || (classPhases[r.phase] = { min: Infinity, trades: {} });
+  if (r.sequence < p.min) p.min = r.sequence;
+  if (r.resource) p.trades[r.resource] = 1;
+});
+
+const rows = T.phases.map((p, i) => ({
+  id: p.id,
+  name: p.name,
+  sequence: p.sequence,
+  trades: (p.trades || []).slice().sort(),
+  replicate_per_level: !!p.replicate_per_level,
+  index: i,
+  classMinSequence: classPhases[p.name] ? classPhases[p.name].min : null,
+  classTrades: classPhases[p.name] ? Object.keys(classPhases[p.name].trades).sort() : null
+}));
+
+console.log('§PT_SOURCE template=rates/programme_template.json v=' + T.meta.version +
+  ' phases=' + rows.length + ' withinLevelEdges=' + T.dependencies.within_level.length +
+  ' acrossLevelEdges=' + T.dependencies.across_levels.length);
+console.log('§PT_PHASES ' + rows.map(r => r.name + '(' + r.sequence + ')' +
+  (r.replicate_per_level ? '/level' : '/building')).join(' -> '));
+console.log('§PT_CALENDAR hoursPerShift=' + T.calendar.hours_per_shift + ' engineSHIFT_HOURS=' + SHIFT +
+  ' daysPerWeek=' + T.calendar.days_per_week + ' durationBasis=' + T.duration_rule.basis);
+
+Witness('programme_template')
+  .population(() => rows)
+  .schema(ProgrammePhaseRow)
+  // Phase set and order are EXTRACTED from the classification table, never typed twice.
+  .invariant('phases-match-classification-order', phasesMatchClassificationOrder)
+  .invariant('trades-match-classification', tradesMatchClassification)
+  // The dependency graph must be well-formed and must cover every phase, so no phase can be
+  // silently unsequenced the way Substructure currently vanishes from HHS's generated programme.
+  .invariant('edges-reference-real-phases', () => edgesReferenceRealPhases(T))
+  .invariant('within-level-chain-covers-all-phases', () => withinLevelChainCoversAllPhases(T))
+  // THE POINT OF THE FILE: no edge may carry a date, a start, or an absolute day number. Today's
+  // task_sequences rows are computed from the dates they are supposed to validate, which is why
+  // CPM reports 17/17 critical and float 0..0. An edge that comes from the answer proves nothing.
+  .invariant('edges-are-date-independent', () => edgesAreDateIndependent(T))
+  // One clock: the template's calendar must equal the engine's own SHIFT_HOURS.
+  .invariant('calendar-matches-engine', () => calendarMatchesEngine(T, SHIFT))
+  // Duration comes from work content, not from the placement solve's elapsed span.
+  .invariant('duration-rule-is-work-content', () => durationRuleIsWorkContent(T))
+  // RED CONTROL — reproduce the real defect this file exists to prevent: give an edge an absolute
+  // date, which is exactly the shape schedule_author.js's derived lags have.
+  .redControl(rs => {
+    T.dependencies.within_level[0].schedule_start = '2026-08-25';
+    return rs;
+  })
+  .run();
+
+delete T.dependencies.within_level[0].schedule_start;

--- a/witness_kit/invariants/programme_template.js
+++ b/witness_kit/invariants/programme_template.js
@@ -1,0 +1,112 @@
+// witness_kit/invariants/programme_template.js — reusable predicates for the core programme
+// template. Spec: bim-compiler prompts/4D_SCHEDULE_PERFECTION.md §S66.
+//
+// The template and the classification table (sequence_rules.json) are TWO FILES describing ONE set
+// of construction phases. That is the exact "two clocks" shape WITNESS_INTERFACE_FRAMEWORK.md §8
+// names — two independent computations claiming to represent the same real-world fact, each locally
+// correct while the PAIR is wrong, because nothing checks the relationship. These predicates check
+// the relationship.
+'use strict';
+
+/**
+ * G-PT-ORDER — the template's phase set and order must be the classification table's own, derived
+ * from SEQUENCE_RULES' minimum sequence per phase. Not "similar to": identical, in order.
+ * Prevents the drift that already bit this project three times — gantt_model.js's own header
+ * records _VAR_ORDER as a THIRD stale copy of the phase order that PR #1165 missed, still reading
+ * MEP rough-in BEFORE the envelope.
+ * @param {object[]} rows
+ * @returns {boolean}
+ */
+function phasesMatchClassificationOrder(rows) {
+  if (rows.some(r => r.classMinSequence == null)) return false;   // a phase the table doesn't know
+  for (const r of rows) if (r.sequence !== r.classMinSequence) return false;
+  for (let i = 1; i < rows.length; i++) if (rows[i].sequence <= rows[i - 1].sequence) return false;
+  return true;
+}
+
+/**
+ * G-PT-TRADES — a phase's declared trades must be exactly the union of resources its own classes
+ * name in the classification table. A trade listed here but absent there means the template invents
+ * work; a trade there but missing here means the programme cannot price it.
+ * @param {object[]} rows
+ * @returns {boolean}
+ */
+const tradesMatchClassification = rows => rows.every(r =>
+  r.classTrades != null && JSON.stringify(r.trades) === JSON.stringify(r.classTrades));
+
+/**
+ * G-PT-EDGES — every dependency endpoint must be a real phase id declared in this file.
+ * @param {object} T - the parsed template
+ * @returns {boolean}
+ */
+function edgesReferenceRealPhases(T) {
+  const ids = new Set(T.phases.map(p => p.id));
+  const all = T.dependencies.within_level.concat(T.dependencies.across_levels);
+  return all.every(e => ids.has(e.pred) && ids.has(e.succ));
+}
+
+/**
+ * G-PT-COVER — the within-level chain must reach EVERY phase: one unbroken path from the first
+ * phase to the last, no phase orphaned. This is the gate for the defect visible in HHS's live log
+ * today, where the generated programme simply has no Substructure row at all — an unsequenced phase
+ * does not appear, and nothing notices.
+ * @param {object} T
+ * @returns {boolean}
+ */
+function withinLevelChainCoversAllPhases(T) {
+  const ids = T.phases.map(p => p.id);
+  const succOf = {};
+  T.dependencies.within_level.forEach(e => { succOf[e.pred] = e.succ; });
+  let node = ids[0], seen = new Set([node]);
+  while (succOf[node]) {
+    node = succOf[node];
+    if (seen.has(node)) return false;   // cycle
+    seen.add(node);
+  }
+  return seen.size === ids.length && node === ids[ids.length - 1];
+}
+
+/**
+ * G-PT-NODATES — THE POINT OF THIS FILE. No edge may carry a date, an absolute day number, or a
+ * start/finish. Construction logic must be independent of the schedule it constrains.
+ *
+ * Today's persisted task_sequences rows are the opposite: schedule_author.js derives each lag from
+ * the dates it is meant to validate ("succ.start = pred.finish + lag EXACTLY"), so every edge is
+ * tight by construction, float is zero everywhere, and §GANTT_CPM_ANNOTATE reports 17 of 17 tasks
+ * critical with float 0..0 on a real building. An edge computed from the answer cannot contradict
+ * the answer, which makes the whole CPM tautological.
+ * @param {object} T
+ * @returns {boolean}
+ */
+function edgesAreDateIndependent(T) {
+  const BANNED = ['schedule_start', 'schedule_finish', 'start', 'finish', 'date', 'day_number', 'ts'];
+  const all = T.dependencies.within_level.concat(T.dependencies.across_levels);
+  return all.every(e => Object.keys(e).every(k => !BANNED.includes(k)));
+}
+
+/**
+ * G-PT-ONECLOCK — the template's calendar must equal the engine's own SHIFT_HOURS. Two files
+ * declaring the working day is precisely how §GANTT_SHIFT_HOURS_DESYNC happened before: bars were
+ * authored at 8h while the canvas played at 24h, so elements appeared before their own bar started.
+ * @param {object} T
+ * @param {number} engineShiftHours
+ * @returns {boolean}
+ */
+const calendarMatchesEngine = (T, engineShiftHours) =>
+  Number(T.calendar.hours_per_shift) === Number(engineShiftHours);
+
+/**
+ * G-PT-WORK — duration must be declared as derived from work content.
+ * The alternative — the elapsed span of the geometry placement solve — is what produced HHS's
+ * 185.2 crew-days of work content inside a 42-day programme, a 4.4x contradiction inside one log.
+ * @param {object} T
+ * @returns {boolean}
+ */
+const durationRuleIsWorkContent = T =>
+  T.duration_rule && T.duration_rule.basis === 'work_content' && Number(T.duration_rule.min_days) >= 1;
+
+module.exports = {
+  phasesMatchClassificationOrder, tradesMatchClassification, edgesReferenceRealPhases,
+  withinLevelChainCoversAllPhases, edgesAreDateIndependent, calendarMatchesEngine,
+  durationRuleIsWorkContent
+};

--- a/witness_kit/schemas/programme_template.js
+++ b/witness_kit/schemas/programme_template.js
@@ -1,0 +1,26 @@
+// witness_kit/schemas/programme_template.js — the contract for ONE phase of the core programme
+// template. Spec: bim-compiler prompts/4D_SCHEDULE_PERFECTION.md §S66.
+//
+// classMinSequence / classTrades are ['...','null'] because a phase MAY legitimately name no
+// classes in sequence_rules.json — but whether that is allowed is an invariant question
+// (phasesMatchClassificationOrder), not a shape one. Keeping it out of the schema stops a real
+// drift from being triaged as malformed data.
+'use strict';
+
+const ProgrammePhaseRow = {
+  type: 'object',
+  required: ['id', 'name', 'sequence', 'trades', 'replicate_per_level', 'index'],
+  properties: {
+    id:                  { type: 'string', minLength: 1, pattern: '^[a-z0-9_]+$' },
+    name:                { type: 'string', minLength: 1 },
+    sequence:            { type: 'integer', minimum: 1 },
+    trades:              { type: 'array', minItems: 1, items: { type: 'string', minLength: 1 } },
+    replicate_per_level: { type: 'boolean' },
+    index:               { type: 'integer', minimum: 0 },
+    classMinSequence:    { type: ['integer', 'null'] },
+    classTrades:         { type: ['array', 'null'], items: { type: 'string' } }
+  },
+  additionalProperties: true
+};
+
+module.exports = { ProgrammePhaseRow };


### PR DESCRIPTION
## It never existed

A repo-wide scan of **all 96 JSON files** found zero containing tasks, durations or dependencies. `4D_SCHEDULE_PERFECTION.md:1751` states *"sequence_rules.json IS that template and it does work"* — false. That file is an `ifc_class → phase/sequence/trade` lookup: it answers *which phase does this element belong to*, never *what is the programme*. That claim is why every session since could report the template as done.

`viewer/rates/programme_template.json` is the missing artifact — 6 phases, per-level replication, and the dependency logic between them, authored once instead of emerging at runtime from a geometry solve and being discarded on reload.

## Two properties nothing in this chain had

**1. `duration_rule.basis = "work_content"`** — a task's length is `sum(installSecs) / (shift × crews)`, not the elapsed span of the placement solve. That span is what produced HHS's **185.2 crew-days of work inside a 42-day programme** — a 4.4× self-contradiction in a single log.

**2. Dependencies are construction logic, independent of any date.** Today's `task_sequences` rows are derived *from* the dates they are meant to validate (`schedule_author.js`: `succ.start = pred.finish + lag EXACTLY`), so every edge is tight by construction, float is zero everywhere, and `§GANTT_CPM_ANNOTATE` reports **17 of 17 tasks critical, float 0..0** on a real building. An edge computed from the answer cannot contradict the answer. These can.

## Not invented where it must not be

`phases[].id/name/sequence` and `phases[].trades` are **extracted** from `sequence_rules.json`'s own `SEQUENCE_RULES` — min sequence per phase, union of that phase's resources. The calendar carries `rates.js SHIFT_HOURS = 24` verbatim (the standing 2026-08-13 ruling); this file makes it visible and editable, it does not change it.

## Witness — `pass=10 fail=0`

Gates the **relationship** between the two files, the "two clocks" shape `WITNESS_INTERFACE_FRAMEWORK.md §8` names:

| gate | what it prevents |
|---|---|
| `phases-match-classification-order` | phase order drifting into a second copy — `gantt_model.js`'s own header already records `_VAR_ORDER` as a **third** stale copy that PR #1165 missed |
| `trades-match-classification` | the template inventing work, or being unable to price it |
| `within-level-chain-covers-all-phases` | an unsequenced phase vanishing — HHS's generated programme today has **no Substructure row at all** |
| `edges-are-date-independent` | the tautological CPM above |
| `calendar-matches-engine` | `§GANTT_SHIFT_HOURS_DESYNC`, which was exactly two files disagreeing about the working day |
| `duration-rule-is-work-content` | the 186-vs-42 contradiction |

Red control gives an edge a date and proves the gate fires.

## Scope

**No loader wired.** This ships the artifact and its gate only. Instantiation is deliberately separate — it changes every number on every building and needs baselines re-derived, not re-locked. `audit_sw_precache.js` exit 0; no runtime file changed, so no `CACHE_VERSION` bump applies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)