### PR TITLE
chore(4d): rename programme_template -> 4D_template (user directive)

### DIFF
--- a/viewer/rates/4D_template.json
+++ b/viewer/rates/4D_template.json
@@ -1,13 +1,13 @@
 {
   "meta": {
-    "id": "programme_template",
+    "id": "4d_template",
     "name": "Core Construction Programme Template",
     "version": "1.0.0",
     "what": "THE core Gantt programme every building instance copies from. This is the artifact that did not exist before 2026-08-25: a checked-in, reviewable, witnessed programme SKELETON — phases, per-level activities, and the dependency logic between them — authored once here instead of emerging at runtime from a geometry solve and being discarded on reload.",
     "not_this_file": "sequence_rules.json is a CLASSIFICATION table (ifc_class -> phase/sequence/trade + labour productivity). It answers 'which phase does this element belong to'. It cannot answer 'what is the programme', and 4D_SCHEDULE_PERFECTION.md line 1751's claim that it IS the template is wrong. The two files are used together: this one is the shape, that one is the lookup.",
     "instantiation": "A building instance copies this file, replicates every activity marked replicate_per_level once per real storey (bottom-up), drops any activity whose element population is empty for that building, and resolves durations by the duration_rule below. Nothing here is per-building; nothing per-building belongs here.",
-    "provenance": "phases[].id/name/sequence and phases[].trades are EXTRACTED from viewer/rates/sequence_rules.json's own SEQUENCE_RULES (min/max sequence per phase, the union of resources that phase's classes name) — not typed by hand, and they must not drift from it. witness_programme_template.js gates that.",
-    "editable": "Registered like every other project JSON: id = programme_template, file = rates/programme_template.json, storageKey = json_programme_template."
+    "provenance": "phases[].id/name/sequence and phases[].trades are EXTRACTED from viewer/rates/sequence_rules.json's own SEQUENCE_RULES (min/max sequence per phase, the union of resources that phase's classes name) — not typed by hand, and they must not drift from it. witness_4d_template.js gates that.",
+    "editable": "Registered like every other project JSON: id = 4d_template, file = rates/4D_template.json, storageKey = json_4d_template."
   },
 
   "calendar": {

--- a/viewer/tests/witness_4d_template.js
+++ b/viewer/tests/witness_4d_template.js
@@ -1,12 +1,12 @@
 #!/usr/bin/env node
-// WITNESS — programme_template: the core Gantt programme skeleton every building instance copies
+// WITNESS — 4d_template: the core Gantt programme skeleton every building instance copies
 // from. Spec: bim-compiler prompts/4D_SCHEDULE_PERFECTION.md §S66.
 //
 // WHICH LAYER THIS PROVES (WITNESS_INTERFACE_FRAMEWORK.md §CRISIS LESSON 1):
 //   the TEMPLATE layer only — the authored programme skeleton as a file. It says nothing about any
 //   building's instantiated tasks, nothing about kernel_ops, nothing about drawn bars.
 //
-// ISSUE THIS PROVES OR DISPROVES: the user asked for a core programme-template JSON months before
+// ISSUE THIS PROVES OR DISPROVES: the user asked for a core 4D template JSON months before
 // 2026-08-25 and was repeatedly told it existed. It did not. A repo-wide scan of all 96 JSON files
 // found zero containing tasks, durations or dependencies, and 4D_SCHEDULE_PERFECTION.md:1751 states
 // "sequence_rules.json IS that template and it does work" — which is false: that file is an
@@ -14,21 +14,21 @@
 // the new file cannot rot into the same claim: it gates that the template stays DERIVED from
 // sequence_rules.json where it should be, and INDEPENDENT of dates where it must be.
 //
-// Command: node viewer/tests/witness_programme_template.js
+// Command: node viewer/tests/witness_4d_template.js
 'use strict';
 const fs = require('fs');
 const vm = require('vm');
 const path = require('path');
 const { Witness } = require('../../witness_kit/contract');
-const { ProgrammePhaseRow } = require('../../witness_kit/schemas/programme_template');
+const { PhaseRow4D } = require('../../witness_kit/schemas/4d_template');
 const {
   phasesMatchClassificationOrder, tradesMatchClassification, edgesReferenceRealPhases,
   withinLevelChainCoversAllPhases, edgesAreDateIndependent, calendarMatchesEngine,
   durationRuleIsWorkContent
-} = require('../../witness_kit/invariants/programme_template');
+} = require('../../witness_kit/invariants/4d_template');
 
 const VIEWER_DIR = process.env.VIEWER_DIR || path.join(__dirname, '..');
-const T = JSON.parse(fs.readFileSync(path.join(VIEWER_DIR, 'rates', 'programme_template.json'), 'utf8'));
+const T = JSON.parse(fs.readFileSync(path.join(VIEWER_DIR, 'rates', '4D_template.json'), 'utf8'));
 const C = JSON.parse(fs.readFileSync(path.join(VIEWER_DIR, 'rates', 'sequence_rules.json'), 'utf8'));
 
 // The EXECUTED clock, not the mirror — same reasoning as witness_sequence_template_lock.js:
@@ -63,17 +63,17 @@ const rows = T.phases.map((p, i) => ({
   classTrades: classPhases[p.name] ? Object.keys(classPhases[p.name].trades).sort() : null
 }));
 
-console.log('§PT_SOURCE template=rates/programme_template.json v=' + T.meta.version +
+console.log('§4DT_SOURCE template=rates/4D_template.json v=' + T.meta.version +
   ' phases=' + rows.length + ' withinLevelEdges=' + T.dependencies.within_level.length +
   ' acrossLevelEdges=' + T.dependencies.across_levels.length);
-console.log('§PT_PHASES ' + rows.map(r => r.name + '(' + r.sequence + ')' +
+console.log('§4DT_PHASES ' + rows.map(r => r.name + '(' + r.sequence + ')' +
   (r.replicate_per_level ? '/level' : '/building')).join(' -> '));
-console.log('§PT_CALENDAR hoursPerShift=' + T.calendar.hours_per_shift + ' engineSHIFT_HOURS=' + SHIFT +
+console.log('§4DT_CALENDAR hoursPerShift=' + T.calendar.hours_per_shift + ' engineSHIFT_HOURS=' + SHIFT +
   ' daysPerWeek=' + T.calendar.days_per_week + ' durationBasis=' + T.duration_rule.basis);
 
-Witness('programme_template')
+Witness('4d_template')
   .population(() => rows)
-  .schema(ProgrammePhaseRow)
+  .schema(PhaseRow4D)
   // Phase set and order are EXTRACTED from the classification table, never typed twice.
   .invariant('phases-match-classification-order', phasesMatchClassificationOrder)
   .invariant('trades-match-classification', tradesMatchClassification)

--- a/witness_kit/invariants/4d_template.js
+++ b/witness_kit/invariants/4d_template.js
@@ -1,4 +1,4 @@
-// witness_kit/invariants/programme_template.js — reusable predicates for the core programme
+// witness_kit/invariants/4d_template.js — reusable predicates for the core programme
 // template. Spec: bim-compiler prompts/4D_SCHEDULE_PERFECTION.md §S66.
 //
 // The template and the classification table (sequence_rules.json) are TWO FILES describing ONE set

--- a/witness_kit/schemas/4d_template.js
+++ b/witness_kit/schemas/4d_template.js
@@ -1,4 +1,4 @@
-// witness_kit/schemas/programme_template.js — the contract for ONE phase of the core programme
+// witness_kit/schemas/4d_template.js — the contract for ONE phase of the core programme
 // template. Spec: bim-compiler prompts/4D_SCHEDULE_PERFECTION.md §S66.
 //
 // classMinSequence / classTrades are ['...','null'] because a phase MAY legitimately name no
@@ -7,7 +7,7 @@
 // drift from being triaged as malformed data.
 'use strict';
 
-const ProgrammePhaseRow = {
+const PhaseRow4D = {
   type: 'object',
   required: ['id', 'name', 'sequence', 'trades', 'replicate_per_level', 'index'],
   properties: {
@@ -23,4 +23,4 @@ const ProgrammePhaseRow = {
   additionalProperties: true
 };
 
-module.exports = { ProgrammePhaseRow };
+module.exports = { PhaseRow4D };


### PR DESCRIPTION
Rename only. No content, invariant or gate changed.

The name "programme_template" collided in conversation with `sequence_rules.json` (also called "the template" — see 4D_SCHEDULE_PERFECTION.md §S65) and with `gantt_model.js`'s stale phase-order copy. User directive: one unambiguous name.

| before | after |
|---|---|
| `viewer/rates/programme_template.json` | `viewer/rates/4D_template.json` |
| `viewer/tests/witness_programme_template.js` | `viewer/tests/witness_4d_template.js` |
| `witness_kit/invariants/programme_template.js` | `witness_kit/invariants/4d_template.js` |
| `witness_kit/schemas/programme_template.js` | `witness_kit/schemas/4d_template.js` |

Also: `meta.id` `programme_template` → `4d_template`; storageKey `json_programme_template` → `json_4d_template`; log tag `§PT_` → `§4DT_`; export `ProgrammePhaseRow` → `PhaseRow4D`.

Nothing else in the repo referenced the old name (`grep -rn programme_template` → 0 hits after).

## Witness
```
§4DT_SOURCE template=rates/4D_template.json v=1.0.0 phases=6 withinLevelEdges=5 acrossLevelEdges=1
§4DT_PHASES Substructure(1)/building -> Superstructure(2)/level -> Architecture(5)/level -> MEP Rough-in(7)/level -> MEP Final(9)/level -> Finishes(10)/level
§4DT_CALENDAR hoursPerShift=24 engineSHIFT_HOURS=24 daysPerWeek=7 durationBasis=work_content
§WITNESS_4D_TEMPLATE pass=10 fail=0 ran=6
```
Suite discovery: `node tests/run_witness_suite.js --filter 4d_template` → `green=1 new_red=0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)