### PR TITLE
fix(4d): 4D_template v1.1.0 + the crew cap must bind the FINAL times (§S67)

### DIFF
--- a/viewer/rates/4D_template.json
+++ b/viewer/rates/4D_template.json
@@ -1,12 +1,13 @@
 {
   "meta": {
     "id": "4d_template",
-    "name": "Core Construction Programme Template",
-    "version": "1.0.0",
-    "what": "THE core Gantt programme every building instance copies from. This is the artifact that did not exist before 2026-08-25: a checked-in, reviewable, witnessed programme SKELETON — phases, per-level activities, and the dependency logic between them — authored once here instead of emerging at runtime from a geometry solve and being discarded on reload.",
-    "not_this_file": "sequence_rules.json is a CLASSIFICATION table (ifc_class -> phase/sequence/trade + labour productivity). It answers 'which phase does this element belong to'. It cannot answer 'what is the programme', and 4D_SCHEDULE_PERFECTION.md line 1751's claim that it IS the template is wrong. The two files are used together: this one is the shape, that one is the lookup.",
-    "instantiation": "A building instance copies this file, replicates every activity marked replicate_per_level once per real storey (bottom-up), drops any activity whose element population is empty for that building, and resolves durations by the duration_rule below. Nothing here is per-building; nothing per-building belongs here.",
-    "provenance": "phases[].id/name/sequence and phases[].trades are EXTRACTED from viewer/rates/sequence_rules.json's own SEQUENCE_RULES (min/max sequence per phase, the union of resources that phase's classes name) — not typed by hand, and they must not drift from it. witness_4d_template.js gates that.",
+    "name": "Core 4D Programme Template",
+    "version": "1.1.0",
+    "what": "THE core Gantt programme every building instance copies from: a checked-in, reviewable, witnessed programme SKELETON — phases, per-level activities, the dependency logic between them, and the two physical rules (work content, crew capacity) that bound any schedule derived from it. Authored once here instead of emerging at runtime from a geometry solve and being discarded on reload.",
+    "not_this_file": "sequence_rules.json is a CLASSIFICATION table (ifc_class -> phase/sequence/trade + labour productivity). It answers 'which phase does this element belong to'. It cannot answer 'what is the programme'. The two files are used together: this one is the shape, that one is the lookup.",
+    "what_this_file_authors": "EXACTLY three things: calendar, duration_rule, capacity_rule + dependencies. Everything else in this file (the phase set, each phase's sequence, each phase's trades) is EXTRACTED from sequence_rules.json and gated against drift. v1.0.0's header claimed this file was 'the only place a fact is authored' — that overclaimed, and its own provenance line contradicted it. Stated as the three, it is exact.",
+    "instantiation": "A building instance copies this file, replicates every activity marked replicate_per_level once per real storey (bottom-up), REPORTS (never silently drops) any activity whose element population is empty for that building, and resolves durations by duration_rule subject to capacity_rule. Nothing here is per-building; nothing per-building belongs here.",
+    "provenance": "phases[].id/name/sequence and phases[].trades are EXTRACTED from viewer/rates/sequence_rules.json's own SEQUENCE_RULES (min sequence per phase, the union of resources that phase's classes name) — not typed by hand, and they must not drift from it. witness_4d_template.js gates that.",
     "editable": "Registered like every other project JSON: id = 4d_template, file = rates/4D_template.json, storageKey = json_4d_template."
   },
 
@@ -20,12 +21,24 @@
   },
 
   "duration_rule": {
-    "_what": "How an activity's duration is derived. THIS IS THE ANCHOR the chain was missing: before this, a task's length came from however long the geometry placement solve happened to span, which is why one HHS run logged 185.2 crew-days of work content inside a 42-day programme — a 4.4x self-contradiction in a single log.",
+    "_what": "How an activity's duration is derived. THIS IS THE ANCHOR the chain was missing: before this, a task's length came from however long the geometry placement solve happened to span. The solve ORDERS elements; it does not PRICE the work.",
     "basis": "work_content",
-    "formula": "days = ceil( sum(element.installSecs) / (hours_per_shift * 3600 * crews) ), crews = sum of max_crews over the trades the activity's own elements actually use",
+    "divisor_scope": "per_trade",
+    "formula": "days = ceil( MAX over trades t of ( sum(installSecs of this activity's elements worked by t) / (hours_per_shift * 3600 * max_crews[t]) ) )",
     "min_days": 1,
     "_installSecs_source": "ScheduleAuthor._installSecs, from sequence_rules.json LABOR_RATES productivity. Same function the engine uses — never a second copy.",
-    "_not_this": "NOT the elapsed span of the placement solve. The solve orders elements; it does not price the work."
+    "_max_crews_source": "sequence_rules.json LABOR_RATES[trade].max_crews. Present on all 10 trades.",
+    "_why_max_and_not_sum": "v1.0.0 wrote 'crews = sum of max_crews over the trades the activity's own elements actually use' and divided the activity's TOTAL seconds by it. That treats trades as FUNGIBLE — an electrician's seconds worked off by a plumber's crew. Work content is per trade: an activity is as long as its slowest trade, never the pooled average. MEASURED on HHS_Office_Federated (6839 elements, 24h shift, 2026-08-25): whole-programme sum-of-crews = 40.1 days, correct per-trade = 69.8 days — the sum form understates by 1.74x overall, and up to 3.00x on a single phase (MEP Rough-in / MEP Final: 3 trades, Sum(max_crews)=6, but no one trade has more than 2 crews). The file exists to end a duration contradiction; the sum form would have replaced it with a new one.",
+    "_same_bug_shipped_elsewhere": "schedule_author.js materializeZones' §ZONE_WINDOW_COVERS_WORK floor computes _wCrews as the SAME sum. Any fix here is not complete until that site divides per trade too.",
+    "_not_this": "NOT the elapsed span of the placement solve."
+  },
+
+  "capacity_rule": {
+    "_what": "The hard physical bound on ANY schedule derived from this template. Distinct from duration_rule: duration_rule prices one activity, capacity_rule constrains the whole programme at every instant.",
+    "rule": "at no instant may more than max_crews[t] elements of trade t be in progress, for every trade t",
+    "applies_to": "the FINAL emitted times, not only the times at first placement",
+    "_why_final_and_not_first": "MEASURED on HHS_Office_Federated (2026-08-25, A/B with the repair loop disabled): schedule_gate.js enforces the cap correctly inside claimCrew at placement — every trade sits exactly at or under its cap. The §DEQ_REPAIR sweep then moves elements forward to satisfy geometry gates by writing o.start/o.end DIRECTLY, without re-claiming a crew slot. Result: CARPENTER peaks at 8 simultaneous crews against max_crews=2, a 4.0x breach, while all 7 other trades stay legal. Disabling the repair loop returns CARPENTER to 2. The span is 46.9 days either way — the breach does not shorten the programme, it just makes it unbuildable.",
+    "_witness": "witness_4d_capacity_honoured.js — sweeps the emitted start/end times per trade and asserts peak concurrency <= max_crews."
   },
 
   "phases": [
@@ -33,44 +46,58 @@
       "id": "substructure", "name": "Substructure", "sequence": 1,
       "trades": ["CONCRETE_GANG"],
       "replicate_per_level": false,
+      "scope": "building",
       "_scope": "Ground-bearing work below the frame. Single occurrence per building — it does not repeat per storey.",
       "_empty_ok": true,
-      "_empty_ok_why": "A federated or partial model legitimately ships no foundations. HHS_Office_Federated is one: its programme logs phases [Superstructure, Architecture, MEP Rough-in, MEP Final, Finishes] with no Substructure at all. Absent must be REPORTED as absent, never silently skipped."
+      "_empty_ok_why": "A federated or partial model legitimately ships no foundations. HHS_Office_Federated is one: MEASURED 2026-08-25, 0 of its 6839 elements classify Substructure, so the generated programme has no Substructure row at all. Absent must be REPORTED as absent, never silently skipped."
     },
     {
       "id": "superstructure", "name": "Superstructure", "sequence": 2,
       "trades": ["CONCRETE_GANG", "STEEL_ERECTOR"],
       "replicate_per_level": true,
+      "scope": "level",
       "_scope": "Frame and floor plates for one level."
     },
     {
       "id": "architecture", "name": "Architecture", "sequence": 5,
       "trades": ["CARPENTER", "CONCRETE_GANG", "MASON", "ROOFER"],
       "replicate_per_level": true,
+      "scope": "level",
       "_scope": "Envelope and internal fabric for one level: walls, doors, windows, curtain walling, roof."
     },
     {
       "id": "mep_rough_in", "name": "MEP Rough-in", "sequence": 7,
       "trades": ["ELECTRICIAN", "HVAC_TECH", "PLUMBER"],
       "replicate_per_level": true,
+      "scope": "level",
       "_scope": "First-fix services for one level, after that level is weather-tight."
     },
     {
       "id": "mep_final", "name": "MEP Final", "sequence": 9,
       "trades": ["ELECTRICIAN", "HVAC_TECH", "PLUMBER"],
       "replicate_per_level": true,
+      "scope": "level",
       "_scope": "Second-fix services and terminals for one level."
     },
     {
       "id": "finishes", "name": "Finishes", "sequence": 10,
       "trades": ["FINISHER"],
       "replicate_per_level": true,
+      "scope": "level",
       "_scope": "Coverings, furniture and final finishes for one level."
     }
   ],
 
+  "phase_bands": {
+    "_what": "A phase owns a CONTIGUOUS, NON-OVERLAPPING band of sequence_rules.json sequence numbers. Declared as a rule, not as a list, because the numbers themselves live in the lookup.",
+    "rule": "max(sequence of every class in phase[i]) < min(sequence of every class in phase[i+1])",
+    "_why": "v1.0.0 gated only that each phase's MINIMUM sequence increases. That cannot see a band INTERLEAVE — the exact defect §S65 #7 found and PR #1527 fixed (IfcRoof sat at sequence 8, inside Architecture, therefore after ALL of MEP Rough-in at 7). Under a min-only gate Architecture's min stays 5, the mins still increase, and the witness stays green while a roof is built after the ductwork it is supposed to cover. Bands MEASURED clean 2026-08-25: Substructure 1-1, Superstructure 2-4, Architecture 5-6, MEP Rough-in 7-7, MEP Final 9-9, Finishes 10-11."
+  },
+
   "dependencies": {
-    "_what": "Construction LOGIC, authored here, independent of any date. This is the second half of the anchor: today's task_sequences rows are computed FROM the dates they are meant to validate (schedule_author.js: 'succ.start = pred.finish + lag EXACTLY'), so every edge is tight by construction, float is zero everywhere, and CPM reports 17 of 17 tasks critical. An edge that comes from the answer cannot contradict the answer. These do.",
+    "_what": "Construction LOGIC, authored here, independent of any date. Today's task_sequences rows are computed FROM the dates they are meant to validate (schedule_author.js: 'succ.start = pred.finish + lag EXACTLY'), so every edge is tight by construction, float is zero everywhere, and CPM reports every task critical. MEASURED on HHS_Office_Federated 2026-08-25: 25 of 25 derived zone edges have a lag exactly equal to the observed gap between the two zones' own dates — 100% restatement, 0% logic. An edge that comes from the answer cannot contradict the answer. These do.",
+    "_edge_scope_rule": "An edge whose predecessor is a building-scope phase and whose successor is a level-scope phase attaches to the LOWEST level only; every level above takes its predecessor from the across_levels chain instead. An edge between two level-scope phases instantiates once per level. Without this rule an instantiator has to guess which level a single Substructure activity precedes.",
+    "_empty_phase_rule": "When a phase is dropped for empty population, its within-level edge is BRIDGED (pred of the dropped phase -> succ of the dropped phase), never left dangling, and the drop is REPORTED. Verified need: HHS_Office_Federated drops Substructure, which is the head of the chain — an unbridged drop leaves Superstructure with no predecessor.",
     "within_level": [
       { "pred": "substructure",   "succ": "superstructure", "type": "FS", "lag_days": 0, "_why": "Frame bears on the foundations." },
       { "pred": "superstructure", "succ": "architecture",   "type": "FS", "lag_days": 0, "_why": "Envelope and partitions need the frame and slab of their own level." },
@@ -82,6 +109,6 @@
       { "pred": "superstructure", "succ": "superstructure", "type": "FS", "lag_days": 0, "level_offset": 1,
         "_why": "A level's frame cannot start before the level below it is framed. This is the ONLY hard vertical constraint; everything else follows from it plus the within-level chain." }
     ],
-    "_overlap": "Every lag is 0 and every type is FS in v1.0.0 — a deliberately conservative, strictly serial start. Real programmes overlap trades (SS with lag, FS with negative lead). Those belong here as edits, each with its own _why, so an overlap is a reviewed decision and not an artifact of a solver."
+    "_overlap": "Every lag is 0 and every type is FS in v1.x — a deliberately conservative, strictly serial start. Real programmes overlap trades (SS with lag, FS with negative lead). Those belong here as edits, each with its own _why, so an overlap is a reviewed decision and not an artifact of a solver. NOTE, MEASURED: the engine today already overlaps phases heavily — HHS spans 46.9 days against this chain's 69.8 days of serial per-trade work content. That gap is the template's logic disagreeing with what runs, and it is the thing instantiation has to reconcile."
   }
 }

--- a/viewer/schedule_author.js
+++ b/viewer/schedule_author.js
@@ -550,12 +550,31 @@
         var _we = _elByGuid[z.guids[_gi]];
         if (!_we) continue;
         _wSecs += _we.installSecs || 0;
-        if (_we.resource && _we.resource !== '_DEFAULT') _wTrades[_we.resource] = 1;
+        // per-trade seconds, not a presence marker — the divisor is per trade now (see below).
+        if (_we.resource && _we.resource !== '_DEFAULT')
+          _wTrades[_we.resource] = (_wTrades[_we.resource] || 0) + (_we.installSecs || 0);
       }
-      var _wCrews = 0;
-      for (var _wt in _wTrades) _wCrews += (laborRates[_wt] && laborRates[_wt].max_crews) || 1;
-      if (!_wCrews) _wCrews = 1;
-      var _crewDays = (_wSecs * 1000) / (_shiftMs * _wCrews);
+      // §CREW_DIVISOR_PER_TRADE (2026-08-25, bim-compiler prompts/4D_SCHEDULE_PERFECTION.md §S67 —
+      // viewer/rates/4D_template.json duration_rule.divisor_scope, gated by
+      // witness_4d_template.js `duration-divisor-is-per-trade`).
+      // This used to divide the zone's TOTAL seconds by the SUM of its trades' max_crews, which
+      // treats trades as FUNGIBLE — an electrician's seconds worked off by a plumber's crew. A zone
+      // is as long as its SLOWEST TRADE. MEASURED on HHS_Office_Federated (2026-08-25, 24h shift):
+      // whole-programme sum-of-crews 40.1d vs correct per-trade 69.8d (1.74x), and 3.00x on MEP
+      // Rough-in alone (3 trades, Sum(max_crews)=6, no single trade above 2). The sum form let a
+      // window pass this floor while still being shorter than the work one trade actually has to do
+      // in it. Still a FLOOR and still per-trade only over the trades this zone's OWN elements use.
+      var _crewDays = 0, _wAnyTrade = 0;
+      for (var _wt in _wTrades) {
+        _wAnyTrade = 1;
+        var _wCap = (laborRates[_wt] && laborRates[_wt].max_crews) || 1;
+        var _wd = (_wTrades[_wt] * 1000) / (_shiftMs * _wCap);
+        if (_wd > _crewDays) _crewDays = _wd;
+      }
+      // A zone whose elements are ALL '_DEFAULT' (no named trade) names no crew to divide by. The
+      // sum form fell back to _wCrews=1 there; keep that exact behaviour rather than silently
+      // dropping the floor to zero for those zones.
+      if (!_wAnyTrade) _crewDays = (_wSecs * 1000) / _shiftMs;
       var _needDays = Math.ceil(_crewDays);
       if (eDays - sDays < _needDays) {
         _workWidened++;

--- a/viewer/schedule_gate.js
+++ b/viewer/schedule_gate.js
@@ -958,7 +958,7 @@
     // start order so support chains settle in few sweeps, measured 8 residual at cap=4 on Hospital
     // from a wall-on-roof chain deeper than the cap). Crew slots are NOT re-solved for shifted
     // elements — counted and logged, accepted v1 tradeoff (4D_SCHEDULE_PERFECTION.md §DEQ_V1_IMPL #4).
-    var _rIter = 0, _rMovedTot = 0;
+    var _rIter = 0, _rMovedTot = 0, _crewPackMovedTot = 0;
     for (; _rIter < 16; _rIter++) {
       var _moved = 0;
       // §CURTAIN_WALL_OPENING tally reset — cwGrid/wallGrid are complete by now, so the LAST sweep's
@@ -981,11 +981,59 @@
           _moved++;
         }
       });
+      // ══ §CREW_CAP_FINAL (2026-08-25, bim-compiler prompts/4D_SCHEDULE_PERFECTION.md §S67) ═══
+      // THE CREW CAP HAS TO BIND THE FINAL TIMES, NOT ONLY PLACEMENT.
+      //
+      // claimCrew above enforces LABOR_RATES[trade].max_crews correctly — but only at the moment an
+      // element is first placed. The geometry sweep immediately above then writes o.start/o.end
+      // DIRECTLY, so every shifted element lands wherever its gate demands with no regard for
+      // whether that trade has a free crew there. hostGate is the biggest shifter and its whole
+      // population is hosted openings (IfcDoor/IfcWindow = CARPENTER), so they pile onto the same
+      // instants: MEASURED 2026-08-25, final emitted times, 24h shift —
+      //   Terminal CARPENTER peak 20 vs cap 2 (10.0x) · HHS 8 vs 2 (4.0x) · Duplex 3 vs 2 (1.5x),
+      // every other trade legal on every building. A/B with this loop disabled returns all three to
+      // their caps, which isolates the sweep as the cause. The breach never shortened the programme
+      // (HHS span 46.9d either way) — it just authored work no crew exists to do.
+      //
+      // The fix re-packs crews over the CURRENT times, inside the SAME convergence loop, so the two
+      // constraints settle together instead of one undoing the other: geometry may only push an
+      // element later, and so may the re-pack, so the loop is monotone and terminates. A re-pack
+      // move counts as _moved, which is what makes the next geometry sweep re-check what it broke.
+      // Duration is carried in PRODUCTIVE ms exactly as the geometry sweep does it (§ARCH_START_TEMPO
+      // / M1) — a shift across a different number of idle windows must not invent or destroy hours.
+      var _packSlots = {};
+      function _packClaim(resource, notBefore) {
+        var cap = crewCapFor(resource);
+        var slots = _packSlots[resource] || (_packSlots[resource] = new Array(cap).fill(baseMs));
+        var idx = 0;
+        for (var pi = 1; pi < slots.length; pi++) if (slots[pi] < slots[idx]) idx = pi;
+        return { start: Math.max(notBefore, slots[idx]), commit: function (e) { slots[idx] = e; } };
+      }
+      var _packMoved = 0;
+      elements.slice().filter(function (e) { return out[e.guid]; })
+        .sort(function (a, b) { return (out[a.guid].start - out[b.guid].start) || (a.seq - b.seq); })
+        .forEach(function (el) {
+          var o = out[el.guid];
+          var dur = prodAt(o.end) - prodAt(o.start);
+          var cl = _packClaim(el.resource, o.start);
+          var end = wallAt(prodAt(cl.start) + dur);
+          cl.commit(end);
+          if (cl.start > o.start) {
+            o.start = cl.start; o.end = end;
+            var prl = recsByGuid[el.guid];
+            if (prl) for (var pq = 0; pq < prl.length; pq++) prl[pq].end = o.end;
+            _moved++; _packMoved++;
+          }
+        });
+      _crewPackMovedTot += _packMoved;
       _rMovedTot += _moved;
       if (!_moved) break;
     }
     if (typeof console !== 'undefined' && console.log)
       console.log('§DEQ_REPAIR sweeps=' + _rIter + ' shifted=' + _rMovedTot + ' (0=order already dependency-consistent)');
+    if (typeof console !== 'undefined' && console.log)
+      console.log('§CREW_CAP_FINAL crewRepacked=' + _crewPackMovedTot +
+        ' (elements pushed later because their trade had no free crew at the time a geometry gate wanted them; 0=every gate landing already had a crew)');
     // §CURTAIN_WALL_OPENING — the coverage number, so the pool is auditable rather than trusted.
     // cwGated = openings with NO IfcWall* host that the curtain-wall pool caught; stillUngated =
     // openings bracketed by neither pool (a genuinely wall-less opening — reported, never invented

--- a/viewer/tests/probe_4d_motion.js
+++ b/viewer/tests/probe_4d_motion.js
@@ -1,0 +1,174 @@
+#!/usr/bin/env node
+// PROBE — walk HHS_Office_Federated through the 4D motion hop by hop and report, at each hop,
+// what the 4D_template DECLARES vs what the engine PRODUCES. Not a witness: a measurement.
+'use strict';
+const fs = require('fs'), path = require('path');
+const initSqlJs = require('/home/red1/bim-ootb/node_modules/sql.js');
+const SQLJS_DIST = '/home/red1/bim-ootb/node_modules/sql.js/dist';
+const ScheduleAuthor = require(path.join(__dirname, '..', 'schedule_author.js'));
+const ScheduleGate  = require(path.join(__dirname, '..', 'schedule_gate.js'));
+global.ScheduleGate = ScheduleGate;
+
+function loadRules() {
+  // Run rates.js WHOLE in a sandbox — the EXECUTED table, not a hand-sliced subset. Slicing from
+  // 'var RATES = {' silently dropped SEQUENCE_NAME_OVERRIDES and SHIFT_HOURS.
+  const vm = require('vm');
+  const sandbox = { console: { log() {}, warn() {}, error() {} }, window: undefined };
+  vm.createContext(sandbox);
+  vm.runInContext(fs.readFileSync(path.join(__dirname, '..', 'rates.js'), 'utf8'), sandbox);
+  return { SEQUENCE_RULES: sandbox.SEQUENCE_RULES, SEQUENCE_DEFAULT: sandbox.SEQUENCE_DEFAULT,
+           LABOR_RATES: sandbox.LABOR_RATES, RATES: sandbox.RATES,
+           SEQUENCE_NAME_OVERRIDES: sandbox.SEQUENCE_NAME_OVERRIDES || [], SHIFT_HOURS: sandbox.SHIFT_HOURS };
+}
+const T = JSON.parse(fs.readFileSync(path.join(__dirname, '..', 'rates', '4D_template.json'), 'utf8'));
+const BUILDING = process.argv[2] || 'HHS_Office_Federated';
+const BLD = process.env.BLD || path.join(require('os').homedir(), 'bim-ootb', 'buildings', BUILDING + '_extracted.db');
+
+(async () => {
+  const SQL = await initSqlJs({ locateFile: f => path.join(SQLJS_DIST, f) });
+  const db = new SQL.Database(new Uint8Array(fs.readFileSync(BLD)));
+  const R = loadRules();
+  const SHIFT = T.calendar.hours_per_shift;              // ONE CLOCK — from the template
+  const shiftSecs = SHIFT * 3600;
+
+  // ── HOP 0 — elements ────────────────────────────────────────────────────────────────────────
+  const _log = console.log, _warn = console.warn;
+  let floors = [];
+  const unmatched = {};
+  console.warn = (...a) => { const s = a.join(' ');
+    if (s.indexOf('§TPL_ZERO_MINUTE') === 0) floors.push(s);
+    const m = s.match(/§CLASS_UNMATCHED cls=(\S+)/); if (m) unmatched[m[1]] = (unmatched[m[1]] || 0) + 1; };
+  console.log = () => {};
+  const els = ScheduleAuthor._buildScheduleElements
+    ? ScheduleAuthor._buildScheduleElements(db, R.SEQUENCE_RULES, { laborRates: R.LABOR_RATES, rates: R.RATES, nameOverrides: R.SEQUENCE_NAME_OVERRIDES, defaultRule: R.SEQUENCE_DEFAULT })
+    : null;
+  console.log = _log; console.warn = _warn;
+  if (!els) { console.log('HOP0 FAIL: _buildScheduleElements not exported'); process.exit(2); }
+
+  console.log('§HOP0_ELEMENTS n=' + els.length + ' zeroMinuteClasses=' + floors.length +
+    ' unmatchedClasses=' + Object.keys(unmatched).length);
+  floors.forEach(f => console.log('   ' + f.replace(/ — .*$/, '')));
+  Object.keys(unmatched).forEach(c => console.log('   §CLASS_UNMATCHED ' + c + ' x' + unmatched[c] + ' -> default ' + R.SEQUENCE_DEFAULT.phase));
+
+  // real storeys
+  const storeys = {}; els.forEach(e => { storeys[ScheduleGate.collapsePhase(e.storey)] = 1; });
+  const storeyList = Object.keys(storeys).sort();
+  // per-phase / per-trade work content
+  const byPhase = {};
+  els.forEach(e => {
+    const p = e.phase || '_UNPHASED';
+    const b = byPhase[p] || (byPhase[p] = { secs: 0, n: 0, trades: {} });
+    b.secs += e.installSecs || 0; b.n++;
+    const t = e.resource || '_NONE';
+    b.trades[t] = (b.trades[t] || 0) + (e.installSecs || 0);
+  });
+  console.log('§HOP0_STOREYS n=' + storeyList.length + ' [' + storeyList.join(', ') + ']');
+
+  // ── HOP 1 — what the TEMPLATE declares ──────────────────────────────────────────────────────
+  console.log('\n§HOP1_TEMPLATE_SAYS phases=' + T.phases.length + ' shift=' + SHIFT + 'h');
+  const mc = t => (R.LABOR_RATES[t] && R.LABOR_RATES[t].max_crews) || 1;
+  let tplSerial = 0, tplSumCrew = 0, tplPerTrade = 0;
+  const hdr = ['phase', 'declared?', 'present?', 'els', 'crewSecs', 'days:Σcrews', 'days:perTrade', 'bottleneck'];
+  const rows = [];
+  T.phases.forEach(p => {
+    const b = byPhase[p.name];
+    if (!b) { rows.push([p.name, 'yes', 'ABSENT', 0, 0, '-', '-', '-']); return; }
+    const sumCrews = Object.keys(b.trades).filter(t => t !== '_NONE').reduce((a, t) => a + mc(t), 0) || 1;
+    const dSum = b.secs / (shiftSecs * sumCrews);
+    let dMax = 0, bott = '-';
+    Object.keys(b.trades).forEach(t => {
+      const d = b.trades[t] / (shiftSecs * (t === '_NONE' ? 1 : mc(t)));
+      if (d > dMax) { dMax = d; bott = t + '(' + mc(t) + ' crews)'; }
+    });
+    tplSerial += b.secs / shiftSecs; tplSumCrew += dSum; tplPerTrade += dMax;
+    rows.push([p.name, 'yes', 'yes', b.n, Math.round(b.secs), dSum.toFixed(2), dMax.toFixed(2), bott]);
+  });
+  Object.keys(byPhase).filter(p => !T.phases.some(x => x.name === p)).forEach(p => {
+    rows.push([p, 'NO — UNDECLARED', 'yes', byPhase[p].n, Math.round(byPhase[p].secs), '-', '-', '-']);
+  });
+  const w = hdr.map((h, i) => Math.max(h.length, ...rows.map(r => String(r[i]).length)));
+  console.log('  ' + hdr.map((h, i) => h.padEnd(w[i])).join('  '));
+  rows.forEach(r => console.log('  ' + r.map((c, i) => String(c).padEnd(w[i])).join('  ')));
+  console.log('§HOP1_DURATION serialDays=' + tplSerial.toFixed(1) +
+    ' sumCrewsDays=' + tplSumCrew.toFixed(1) + ' perTradeDays=' + tplPerTrade.toFixed(1) +
+    '  (serial = 1 crew does everything; sumCrews = the SHIPPED formula; perTrade = correct lower bound)');
+
+  // ── HOP 2 — the solve ───────────────────────────────────────────────────────────────────────
+  const maxCrews = {}; for (const k in R.LABOR_RATES) if (R.LABOR_RATES[k].max_crews) maxCrews[k] = R.LABOR_RATES[k].max_crews;
+  console.log = () => {};
+  const sched = ScheduleGate.computeSchedule(els, 0, 1, maxCrews, SHIFT);
+  console.log = _log;
+  let sMin = Infinity, sMax = -Infinity, nSched = 0;
+  for (const g in sched) { nSched++; if (sched[g].start < sMin) sMin = sched[g].start; if (sched[g].end > sMax) sMax = sched[g].end; }
+  const spanDays = (sMax - sMin) / 86400000;
+  console.log('\n§HOP2_SOLVE scheduled=' + nSched + '/' + els.length + ' spanDays=' + spanDays.toFixed(1) +
+    ' vs template perTradeDays=' + tplPerTrade.toFixed(1) + ' (ratio=' + (spanDays / tplPerTrade).toFixed(2) + 'x)');
+
+  // ── HOP 2b — THE HARD FLOOR: no trade can beat its own crew cap, whatever the overlap ───────
+  // Building-wide, phase-agnostic. Overlap between phases is a legitimate design choice; exceeding
+  // a trade's max_crews is not — it is physically impossible work.
+  const tradeSecs = {}, conc = {};
+  els.forEach(e => { const t = e.resource || '_NONE'; tradeSecs[t] = (tradeSecs[t] || 0) + (e.installSecs || 0); });
+  // observed peak concurrency per trade, swept from the solve's own start/end times
+  const ev = {};
+  els.forEach(e => { const st = sched[e.guid]; if (!st) return; const t = e.resource || '_NONE';
+    (ev[t] = ev[t] || []).push([st.start, 1], [st.end, -1]); });
+  Object.keys(ev).forEach(t => {
+    ev[t].sort((a, b) => a[0] - b[0] || a[1] - b[1]);
+    let cur = 0, pk = 0; ev[t].forEach(x => { cur += x[1]; if (cur > pk) pk = cur; }); conc[t] = pk;
+  });
+  console.log('\n§HOP2B_TRADE_FLOOR spanDays=' + spanDays.toFixed(1) + '  (a trade needing MORE days than the span is impossible work)');
+  const th = ['trade', 'crewSecs', 'max_crews', 'needDays', 'fitsInSpan?', 'peakConcurrent', 'capBreached?'];
+  const tr = Object.keys(tradeSecs).sort((a, b) => tradeSecs[b] - tradeSecs[a]).map(t => {
+    const cap = t === '_NONE' ? 1 : mc(t);
+    const need = tradeSecs[t] / (shiftSecs * cap);
+    return [t, Math.round(tradeSecs[t]), cap, need.toFixed(2), need <= spanDays ? 'yes' : 'NO — IMPOSSIBLE',
+            conc[t] || 0, (conc[t] || 0) > cap ? 'YES x' + ((conc[t] / cap).toFixed(1)) : 'no'];
+  });
+  const tw = th.map((h, i) => Math.max(h.length, ...tr.map(r => String(r[i]).length)));
+  console.log('  ' + th.map((h, i) => h.padEnd(tw[i])).join('  '));
+  tr.forEach(r => console.log('  ' + r.map((c, i) => String(c).padEnd(tw[i])).join('  ')));
+
+  // ── HOP 3 — zones ───────────────────────────────────────────────────────────────────────────
+  console.log = () => {};
+  const rolled = ScheduleGate.deriveZones(els, sched, null);
+  console.log = _log;
+  const expectTasks = T.phases.reduce((a, p) => a + (byPhase[p.name] ? (p.replicate_per_level ? storeyList.length : 1) : 0), 0);
+  console.log('§HOP3_ZONES actual=' + rolled.zones.length + ' templateExpects=' + expectTasks +
+    ' edges=' + rolled.edges.length);
+  const zByPhase = {}; rolled.zones.forEach(z => { (zByPhase[z.phase] = zByPhase[z.phase] || []).push(z); });
+  T.phases.forEach(p => {
+    if (!byPhase[p.name]) return;
+    const want = p.replicate_per_level ? storeyList.length : 1;
+    const got = (zByPhase[p.name] || []).length;
+    if (got !== want) console.log('   DEVIATION ' + p.name + ': template wants ' + want + ' task(s) (' +
+      (p.replicate_per_level ? 'per-level x' + storeyList.length : 'per-building') + '), engine produced ' + got);
+  });
+
+  // ── HOP 4 — zone windows vs their own work ──────────────────────────────────────────────────
+  const elByGuid = {}; els.forEach(e => { elByGuid[e.guid] = e; });
+  let over = 0, worst = null;
+  rolled.zones.forEach(z => {
+    let secs = 0; const tr = {};
+    z.guids.forEach(g => { const e = elByGuid[g]; if (!e) return; secs += e.installSecs || 0; if (e.resource) tr[e.resource] = (tr[e.resource] || 0) + (e.installSecs || 0); });
+    const winD = (z.end - z.start) / 86400000;
+    const sumC = Object.keys(tr).reduce((a, t) => a + mc(t), 0) || 1;
+    const dSum = secs / (shiftSecs * sumC);
+    let dMax = 0; Object.keys(tr).forEach(t => { const d = tr[t] / (shiftSecs * mc(t)); if (d > dMax) dMax = d; });
+    if (dMax > winD) { over++; const r = dMax / Math.max(winD, 1e-9); if (!worst || r > worst.r) worst = { id: z.id, r, winD, dMax, dSum }; }
+  });
+  console.log('§HOP4_WINDOWS zonesOverCommitted(perTrade)=' + over + '/' + rolled.zones.length +
+    (worst ? ' worst=' + worst.id + ' window=' + worst.winD.toFixed(2) + 'd needs(perTrade)=' + worst.dMax.toFixed(2) + 'd needs(Σcrews)=' + worst.dSum.toFixed(2) + 'd' : ''));
+
+  // ── HOP 5 — edges: are they logic or restatements of the dates? ─────────────────────────────
+  let restated = 0;
+  rolled.edges.forEach(e => {
+    const p = rolled.zones.find(z => z.id === e.predId), s = rolled.zones.find(z => z.id === e.succId);
+    if (!p || !s) return;
+    if (Math.abs((s.start - p.end) - e.lagMs) < 1) restated++;    // lag IS the observed gap
+  });
+  console.log('§HOP5_EDGES n=' + rolled.edges.length + ' lagEqualsObservedGap=' + restated +
+    ' (' + (100 * restated / Math.max(1, rolled.edges.length)).toFixed(0) + '%) — template declares ' +
+    (T.dependencies.within_level.length + T.dependencies.across_levels.length) + ' LOGIC edges with no date');
+  db.close();
+})();

--- a/viewer/tests/witness_4d_capacity_honoured.js
+++ b/viewer/tests/witness_4d_capacity_honoured.js
@@ -1,0 +1,103 @@
+#!/usr/bin/env node
+// WITNESS — 4D capacity: the crew cap must bind the FINAL emitted times, not only the times at
+// first placement. Spec: viewer/rates/4D_template.json `capacity_rule`;
+// bim-compiler prompts/4D_SCHEDULE_PERFECTION.md §S67.
+//
+// WHICH LAYER THIS PROVES (WITNESS_INTERFACE_FRAMEWORK.md §CRISIS LESSON 1):
+//   the SOLVE layer only — ScheduleGate.computeSchedule's emitted {start,end} per element. It says
+//   nothing about zones, tasks, persisted dates or drawn bars.
+//
+// ISSUE THIS PROVES OR DISPROVES: schedule_gate.js enforces LABOR_RATES[trade].max_crews inside
+// claimCrew, which runs at placement. The §DEQ_REPAIR sweep afterwards moves elements forward to
+// satisfy geometry gates by writing o.start/o.end DIRECTLY, never re-claiming a crew slot. If that
+// is a real breach, some trade's peak concurrency in the FINAL output exceeds its cap.
+//
+// MEASURED BEFORE THE FIX (2026-08-25, HHS_Office_Federated, 24h shift): CARPENTER cap=2, peak=8
+// (4.0x). All 7 other trades legal. With the repair loop disabled, CARPENTER returns to 2 — so the
+// repair sweep is the cause, isolated by A/B. Span 46.9d either way: the breach does not shorten
+// the programme, it makes it unbuildable.
+//
+// Command: node viewer/tests/witness_4d_capacity_honoured.js [Building ...]
+'use strict';
+const fs = require('fs');
+const path = require('path');
+const vm = require('vm');
+const initSqlJs = require(path.join(require('os').homedir(), 'bim-ootb', 'node_modules', 'sql.js'));
+const SQLJS_DIST = path.join(require('os').homedir(), 'bim-ootb', 'node_modules', 'sql.js', 'dist');
+const VIEWER_DIR = process.env.VIEWER_DIR || path.join(__dirname, '..');
+const ScheduleGate = require(path.join(VIEWER_DIR, 'schedule_gate.js'));
+global.ScheduleGate = ScheduleGate;
+const ScheduleAuthor = require(path.join(VIEWER_DIR, 'schedule_author.js'));
+
+const BLD_DIR = process.env.BLD_DIR || path.join(require('os').homedir(), 'bim-ootb', 'buildings');
+const BUILDINGS = process.argv.slice(2).length ? process.argv.slice(2)
+  : ['HHS_Office_Federated', 'Duplex', 'Terminal'];
+
+// The EXECUTED table, not the JSON mirror: viewer.html never calls loadSequenceRules(), so rates.js's
+// own literal is what the browser runs (§RULES_TABLE_SOURCE, rates.js:107-110). Run the WHOLE file —
+// slicing it from `var RATES = {` silently drops SEQUENCE_NAME_OVERRIDES and SHIFT_HOURS.
+function executedRules() {
+  const sb = { console: { log() {}, warn() {}, error() {} } };
+  vm.createContext(sb);
+  vm.runInContext(fs.readFileSync(path.join(VIEWER_DIR, 'rates.js'), 'utf8'), sb);
+  return sb;
+}
+// ONE CLOCK: the shift comes from the template, which is gated equal to rates.js SHIFT_HOURS by
+// witness_4d_template.js's calendar-matches-engine. Never a hand-typed third copy.
+const T = JSON.parse(fs.readFileSync(path.join(VIEWER_DIR, 'rates', '4D_template.json'), 'utf8'));
+const SHIFT = T.calendar.hours_per_shift;
+
+let pass = 0, fail = 0;
+function assert(cond, msg) { if (cond) { pass++; console.log('  PASS ' + msg); } else { fail++; console.log('  FAIL ' + msg); } }
+
+(async () => {
+  const SQL = await initSqlJs({ locateFile: f => path.join(SQLJS_DIST, f) });
+  const R = executedRules();
+  const maxCrews = {};
+  for (const k in R.LABOR_RATES) if (R.LABOR_RATES[k].max_crews) maxCrews[k] = R.LABOR_RATES[k].max_crews;
+
+  let anyRan = 0;
+  for (const bld of BUILDINGS) {
+    const file = path.join(BLD_DIR, bld + '_extracted.db');
+    if (!fs.existsSync(file)) { console.log('§4DCAP_SKIP ' + bld + ' (no ' + path.basename(file) + ')'); continue; }
+    anyRan++;
+    const db = new SQL.Database(new Uint8Array(fs.readFileSync(file)));
+    const _l = console.log, _w = console.warn;
+    console.log = () => {}; console.warn = () => {};
+    const els = ScheduleAuthor._buildScheduleElements(db, R.SEQUENCE_RULES, {
+      laborRates: R.LABOR_RATES, rates: R.RATES,
+      nameOverrides: R.SEQUENCE_NAME_OVERRIDES, defaultRule: R.SEQUENCE_DEFAULT
+    });
+    const sched = ScheduleGate.computeSchedule(els, 0, 1, maxCrews, SHIFT);
+    console.log = _l; console.warn = _w;
+
+    // Peak concurrency per trade, swept from the FINAL emitted times. An end-event is processed
+    // before a start-event at the same instant (sort by [t, delta]) so a hand-off is not counted
+    // as an overlap.
+    const ev = {}, cap = {};
+    els.forEach(e => {
+      const st = sched[e.guid]; if (!st) return;
+      const t = e.resource || '_DEFAULT';
+      cap[t] = maxCrews[t] || 0;
+      (ev[t] = ev[t] || []).push([st.start, 1], [st.end, -1]);
+    });
+    const breaches = [];
+    let spanMin = Infinity, spanMax = -Infinity;
+    for (const g in sched) { if (sched[g].start < spanMin) spanMin = sched[g].start; if (sched[g].end > spanMax) spanMax = sched[g].end; }
+    Object.keys(ev).forEach(t => {
+      if (!cap[t]) return;                       // a trade with no declared cap is not gated here
+      ev[t].sort((a, b) => a[0] - b[0] || a[1] - b[1]);
+      let cur = 0, pk = 0;
+      ev[t].forEach(x => { cur += x[1]; if (cur > pk) pk = cur; });
+      if (pk > cap[t]) breaches.push(t + ' peak=' + pk + ' cap=' + cap[t] + ' (' + (pk / cap[t]).toFixed(1) + 'x)');
+    });
+    console.log('§4DCAP ' + bld + ' n=' + els.length + ' spanD=' + ((spanMax - spanMin) / 86400000).toFixed(1) +
+      ' trades=' + Object.keys(ev).length + ' breaches=' + breaches.length +
+      (breaches.length ? ' [' + breaches.join('; ') + ']' : ''));
+    assert(breaches.length === 0, bld + ': every trade within max_crews in the FINAL emitted times');
+    db.close();
+  }
+  assert(anyRan > 0, 'at least one building available to test');
+  console.log('§WITNESS_4D_CAPACITY pass=' + pass + ' fail=' + fail);
+  process.exit(fail ? 1 : 0);
+})();

--- a/viewer/tests/witness_4d_template.js
+++ b/viewer/tests/witness_4d_template.js
@@ -22,9 +22,10 @@ const path = require('path');
 const { Witness } = require('../../witness_kit/contract');
 const { PhaseRow4D } = require('../../witness_kit/schemas/4d_template');
 const {
-  phasesMatchClassificationOrder, tradesMatchClassification, edgesReferenceRealPhases,
-  withinLevelChainCoversAllPhases, edgesAreDateIndependent, calendarMatchesEngine,
-  durationRuleIsWorkContent
+  phasesMatchClassificationOrder, phaseBandsDoNotOverlap, tradesMatchClassification,
+  edgesReferenceRealPhases, withinLevelChainCoversAllPhases, edgesAreDateIndependent,
+  calendarMatchesEngine, durationRuleIsWorkContent, durationDivisorIsPerTrade,
+  capacityRuleIsHard, phasesDeclareScope, dependencyScopeRulesDeclared
 } = require('../../witness_kit/invariants/4d_template');
 
 const VIEWER_DIR = process.env.VIEWER_DIR || path.join(__dirname, '..');
@@ -47,8 +48,9 @@ const classPhases = {};
 Object.keys(C.SEQUENCE_RULES).forEach(cls => {
   const r = C.SEQUENCE_RULES[cls];
   if (!r.phase || r.sequence == null) return;
-  const p = classPhases[r.phase] || (classPhases[r.phase] = { min: Infinity, trades: {} });
+  const p = classPhases[r.phase] || (classPhases[r.phase] = { min: Infinity, max: -Infinity, trades: {} });
   if (r.sequence < p.min) p.min = r.sequence;
+  if (r.sequence > p.max) p.max = r.sequence;
   if (r.resource) p.trades[r.resource] = 1;
 });
 
@@ -58,25 +60,32 @@ const rows = T.phases.map((p, i) => ({
   sequence: p.sequence,
   trades: (p.trades || []).slice().sort(),
   replicate_per_level: !!p.replicate_per_level,
+  scope: p.scope,
   index: i,
   classMinSequence: classPhases[p.name] ? classPhases[p.name].min : null,
+  classMaxSequence: classPhases[p.name] ? classPhases[p.name].max : null,
   classTrades: classPhases[p.name] ? Object.keys(classPhases[p.name].trades).sort() : null
 }));
 
 console.log('§4DT_SOURCE template=rates/4D_template.json v=' + T.meta.version +
   ' phases=' + rows.length + ' withinLevelEdges=' + T.dependencies.within_level.length +
   ' acrossLevelEdges=' + T.dependencies.across_levels.length);
-console.log('§4DT_PHASES ' + rows.map(r => r.name + '(' + r.sequence + ')' +
-  (r.replicate_per_level ? '/level' : '/building')).join(' -> '));
+console.log('§4DT_PHASES ' + rows.map(r => r.name + '[' + r.classMinSequence + '-' + r.classMaxSequence + ']' +
+  '/' + r.scope).join(' -> '));
 console.log('§4DT_CALENDAR hoursPerShift=' + T.calendar.hours_per_shift + ' engineSHIFT_HOURS=' + SHIFT +
-  ' daysPerWeek=' + T.calendar.days_per_week + ' durationBasis=' + T.duration_rule.basis);
+  ' daysPerWeek=' + T.calendar.days_per_week + ' durationBasis=' + T.duration_rule.basis +
+  ' divisorScope=' + T.duration_rule.divisor_scope);
+console.log('§4DT_CAPACITY rule="' + T.capacity_rule.rule + '" appliesTo=' + T.capacity_rule.applies_to);
 
 Witness('4d_template')
   .population(() => rows)
   .schema(PhaseRow4D)
   // Phase set and order are EXTRACTED from the classification table, never typed twice.
   .invariant('phases-match-classification-order', phasesMatchClassificationOrder)
+  // MIN-only ordering cannot see a band INTERLEAVE — the §S65 #7 roof defect passed that shape.
+  .invariant('phase-bands-do-not-overlap', phaseBandsDoNotOverlap)
   .invariant('trades-match-classification', tradesMatchClassification)
+  .invariant('phases-declare-scope', phasesDeclareScope)
   // The dependency graph must be well-formed and must cover every phase, so no phase can be
   // silently unsequenced the way Substructure currently vanishes from HHS's generated programme.
   .invariant('edges-reference-real-phases', () => edgesReferenceRealPhases(T))
@@ -89,6 +98,13 @@ Witness('4d_template')
   .invariant('calendar-matches-engine', () => calendarMatchesEngine(T, SHIFT))
   // Duration comes from work content, not from the placement solve's elapsed span.
   .invariant('duration-rule-is-work-content', () => durationRuleIsWorkContent(T))
+  // An activity is as long as its SLOWEST TRADE. Dividing total seconds by the SUM of the trades'
+  // crews treats trades as fungible and understated HHS by 1.74x overall, 3.00x on one phase.
+  .invariant('duration-divisor-is-per-trade', () => durationDivisorIsPerTrade(T))
+  // Crew caps bind the FINAL times, not just placement — §DEQ_REPAIR breaches them 4.0x on HHS.
+  .invariant('capacity-rule-is-hard', () => capacityRuleIsHard(T))
+  // The two instantiation rules v1.0.0 left undefined, both of which HHS actually needs.
+  .invariant('dependency-scope-rules-declared', () => dependencyScopeRulesDeclared(T))
   // RED CONTROL — reproduce the real defect this file exists to prevent: give an edge an absolute
   // date, which is exactly the shape schedule_author.js's derived lags have.
   .redControl(rs => {

--- a/witness_kit/generators/gantt_bars.js
+++ b/witness_kit/generators/gantt_bars.js
@@ -74,9 +74,17 @@ async function generateRealGanttBars(dbPath, opts) {
   const mute = ['log', 'warn', 'error'].map(k => { const o = console[k]; console[k] = () => {}; return [k, o]; });
   let els, solve;
   try {
+    // nameOverrides MUST be passed here, not only to _buildScheduleElements below. In the browser
+    // materializeZones picks them up off window.SEQUENCE_NAME_OVERRIDES (rates.js sets it), so the
+    // production path is fine; under node `global.SEQUENCE_NAME_OVERRIDES` is undefined and it
+    // silently authored task windows from UNOVERRIDDEN classification while this generator measured
+    // them against OVERRIDDEN elements. Two classifications, one comparison — the exact drift the
+    // NAME_OVERRIDES note further down records, reappearing at a second call site. MEASURED: it
+    // manufactured one phantom over-commit (Clinic "Superstructure — Roof - Main", 11%).
     const res = SA.materializeZones(db, R.SEQUENCE_RULES, {
       start, laborRates: R.LABOR_RATES, rates: R.RATES || {},
-      scheduleGate: SG, shiftHours: shift, defaultRule: R.SEQUENCE_DEFAULT
+      scheduleGate: SG, shiftHours: shift, defaultRule: R.SEQUENCE_DEFAULT,
+      nameOverrides: R.SEQUENCE_NAME_OVERRIDES
     });
     if (!res || !res.ok) { db.close(); mute.forEach(([k, o]) => console[k] = o); return []; }
     els = SA._buildScheduleElements(db, R.SEQUENCE_RULES, {
@@ -126,14 +134,27 @@ async function generateRealGanttBars(dbPath, opts) {
     const e = byGuid[r.guid]; if (!e || !win[r.task_id]) return;
     const w = workOf[r.task_id] || (workOf[r.task_id] = { secs: 0, trades: {} });
     w.secs += e.installSecs || 0;
-    if (e.resource && e.resource !== '_DEFAULT') w.trades[e.resource] = 1;
+    // §CREW_DIVISOR_PER_TRADE — per-trade SECONDS, not a presence marker. See crewDaysOf below.
+    if (e.resource && e.resource !== '_DEFAULT')
+      w.trades[e.resource] = (w.trades[e.resource] || 0) + (e.installSecs || 0);
   });
+  // §CREW_DIVISOR_PER_TRADE (2026-08-25, viewer/rates/4D_template.json duration_rule.divisor_scope).
+  // A task is as long as its SLOWEST TRADE, never total-seconds over pooled crews: summing max_crews
+  // across trades treats them as fungible (an electrician's seconds worked off by a plumber's crew)
+  // and understated HHS_Office_Federated by 1.74x overall, 3.00x on MEP Rough-in alone. This mirrors
+  // schedule_author.js's §ZONE_WINDOW_COVERS_WORK divisor exactly — the two must not drift, which is
+  // the same lesson the NAME_OVERRIDES note directly above records.
   function crewDaysOf(tid) {
     const w = workOf[tid]; if (!w) return 0;
-    var crews = 0;
-    for (var t in w.trades) crews += (R.LABOR_RATES[t] && R.LABOR_RATES[t].max_crews) || 1;
-    if (!crews) crews = 1;
-    return (w.secs * 1000) / (SHIFT_MS * crews);
+    var d = 0, any = 0;
+    for (var t in w.trades) {
+      any = 1;
+      var cap = (R.LABOR_RATES[t] && R.LABOR_RATES[t].max_crews) || 1;
+      var td = (w.trades[t] * 1000) / (SHIFT_MS * cap);
+      if (td > d) d = td;
+    }
+    if (!any) d = (w.secs * 1000) / SHIFT_MS;   // all '_DEFAULT': one crew, as before
+    return d;
   }
   const ops = [];
   Object.keys(solve).forEach(g => {

--- a/witness_kit/invariants/4d_template.js
+++ b/witness_kit/invariants/4d_template.js
@@ -25,6 +25,25 @@ function phasesMatchClassificationOrder(rows) {
 }
 
 /**
+ * G-PT-BANDS — a phase owns a CONTIGUOUS, NON-OVERLAPPING band of sequence numbers:
+ * max(sequence in phase[i]) < min(sequence in phase[i+1]).
+ *
+ * phasesMatchClassificationOrder above compares MINIMA only, and a min-only gate CANNOT SEE A BAND
+ * INTERLEAVE. That is not hypothetical: §S65 defect #7 was exactly this shape — IfcRoof carried
+ * sequence 8 while sitting in Architecture (min 5), so the roof sequenced after ALL of MEP Rough-in
+ * (7). Architecture's min stayed 5, the minima still increased, and a min-only witness would have
+ * stayed green through it. PR #1527 fixed the data; this invariant is what stops it coming back.
+ * @param {object[]} rows
+ * @returns {boolean}
+ */
+function phaseBandsDoNotOverlap(rows) {
+  if (rows.some(r => r.classMinSequence == null || r.classMaxSequence == null)) return false;
+  for (let i = 1; i < rows.length; i++)
+    if (rows[i].classMinSequence <= rows[i - 1].classMaxSequence) return false;
+  return true;
+}
+
+/**
  * G-PT-TRADES — a phase's declared trades must be exactly the union of resources its own classes
  * name in the classification table. A trade listed here but absent there means the template invents
  * work; a trade there but missing here means the programme cannot price it.
@@ -103,10 +122,70 @@ const calendarMatchesEngine = (T, engineShiftHours) =>
  * @returns {boolean}
  */
 const durationRuleIsWorkContent = T =>
-  T.duration_rule && T.duration_rule.basis === 'work_content' && Number(T.duration_rule.min_days) >= 1;
+  !!T.duration_rule && T.duration_rule.basis === 'work_content' && Number(T.duration_rule.min_days) >= 1;
+
+/**
+ * G-PT-PERTRADE — the duration divisor must be PER TRADE, never a sum across trades.
+ *
+ * v1.0.0 divided an activity's TOTAL seconds by the SUM of its trades' max_crews, which treats
+ * trades as fungible — an electrician's seconds worked off by a plumber's crew. An activity is as
+ * long as its slowest trade. MEASURED on HHS_Office_Federated (2026-08-25, 24h shift): whole
+ * programme sum-of-crews 40.1d vs correct per-trade 69.8d (1.74x), and up to 3.00x on one phase
+ * (MEP Rough-in: 3 trades, Sum(max_crews)=6, no single trade above 2).
+ *
+ * Gated on BOTH the declared scope and the formula text, so the two cannot drift apart: a formula
+ * quietly re-edited back to a sum while divisor_scope still says per_trade is the failure this
+ * catches.
+ * @param {object} T
+ * @returns {boolean}
+ */
+const durationDivisorIsPerTrade = T => !!T.duration_rule &&
+  T.duration_rule.divisor_scope === 'per_trade' &&
+  /MAX over trades/.test(T.duration_rule.formula || '') &&
+  !/sum of max_crews/i.test(T.duration_rule.formula || '');
+
+/**
+ * G-PT-CAPACITY — the template must declare crew capacity as a HARD bound on the FINAL emitted
+ * times, not merely on the times at first placement.
+ *
+ * MEASURED on HHS_Office_Federated (2026-08-25, A/B with schedule_gate.js's repair loop disabled):
+ * claimCrew enforces the cap correctly at placement — all 8 trades legal. §DEQ_REPAIR then shifts
+ * 33 elements forward by writing o.start/o.end directly, without re-claiming a crew, and CARPENTER
+ * ends at 8 simultaneous crews against max_crews=2 (4.0x). Repair off returns it to 2. The span is
+ * 46.9d either way: the breach does not shorten the programme, it makes it unbuildable.
+ * @param {object} T
+ * @returns {boolean}
+ */
+const capacityRuleIsHard = T => !!T.capacity_rule &&
+  /max_crews/.test(T.capacity_rule.rule || '') &&
+  /at no instant/i.test(T.capacity_rule.rule || '') &&
+  /FINAL emitted times/.test(T.capacity_rule.applies_to || '');
+
+/**
+ * G-PT-SCOPE — every phase must declare its instantiation scope explicitly, and it must agree with
+ * replicate_per_level. Without this, an instantiator has to infer scope from a boolean's name.
+ * @param {object[]} rows
+ * @returns {boolean}
+ */
+const phasesDeclareScope = rows => rows.every(r =>
+  (r.scope === 'level' && r.replicate_per_level === true) ||
+  (r.scope === 'building' && r.replicate_per_level === false));
+
+/**
+ * G-PT-EDGESCOPE — the two instantiation rules that v1.0.0 left undefined must be stated in the
+ * file: which level a building-scope predecessor attaches to, and what happens to the chain when a
+ * phase is dropped for empty population. HHS_Office_Federated needs BOTH — it drops Substructure,
+ * which is both building-scope and the head of the within-level chain.
+ * @param {object} T
+ * @returns {boolean}
+ */
+const dependencyScopeRulesDeclared = T => !!T.dependencies &&
+  /LOWEST level/.test(T.dependencies._edge_scope_rule || '') &&
+  /BRIDGED/.test(T.dependencies._empty_phase_rule || '');
 
 module.exports = {
-  phasesMatchClassificationOrder, tradesMatchClassification, edgesReferenceRealPhases,
-  withinLevelChainCoversAllPhases, edgesAreDateIndependent, calendarMatchesEngine,
-  durationRuleIsWorkContent
+  phasesMatchClassificationOrder, phaseBandsDoNotOverlap, tradesMatchClassification,
+  edgesReferenceRealPhases, withinLevelChainCoversAllPhases, edgesAreDateIndependent,
+  calendarMatchesEngine, durationRuleIsWorkContent, durationDivisorIsPerTrade,
+  capacityRuleIsHard, phasesDeclareScope, dependencyScopeRulesDeclared
 };

--- a/witness_kit/schemas/4d_template.js
+++ b/witness_kit/schemas/4d_template.js
@@ -9,15 +9,17 @@
 
 const PhaseRow4D = {
   type: 'object',
-  required: ['id', 'name', 'sequence', 'trades', 'replicate_per_level', 'index'],
+  required: ['id', 'name', 'sequence', 'trades', 'replicate_per_level', 'scope', 'index'],
   properties: {
     id:                  { type: 'string', minLength: 1, pattern: '^[a-z0-9_]+$' },
     name:                { type: 'string', minLength: 1 },
     sequence:            { type: 'integer', minimum: 1 },
     trades:              { type: 'array', minItems: 1, items: { type: 'string', minLength: 1 } },
     replicate_per_level: { type: 'boolean' },
+    scope:               { type: 'string', enum: ['building', 'level'] },
     index:               { type: 'integer', minimum: 0 },
     classMinSequence:    { type: ['integer', 'null'] },
+    classMaxSequence:    { type: ['integer', 'null'] },
     classTrades:         { type: ['array', 'null'], items: { type: 'string' } }
   },
   additionalProperties: true


### PR DESCRIPTION
Walked HHS_Office_Federated hop by hop against the template (viewer/tests/probe_4d_motion.js)
and fixed what deviated. Three defects in the template itself, one live defect in the engine.

TEMPLATE v1.1.0 (viewer/rates/4D_template.json), witness 10 -> 15 gates, all with red controls:

1. duration_rule divisor is PER TRADE, not a sum. v1.0.0 divided an activity's total seconds
   by the SUM of its trades' max_crews, which treats trades as fungible — an electrician's
   seconds worked off by a plumber's crew. MEASURED on HHS (6839 els, 24h): sum form 40.1d vs
   correct per-trade 69.8d (1.74x), and 3.00x on MEP Rough-in alone (3 trades, Sum=6 crews, no
   single trade above 2). New gate `duration-divisor-is-per-trade`.

2. phase_bands: max(seq of phase[i]) < min(seq of phase[i+1]). The old gate compared MINIMA
   only and could not see a band INTERLEAVE — the §S65 #7 roof defect (IfcRoof at seq 8 inside
   Architecture, therefore after all MEP Rough-in at 7) passes a min-only gate. New gate
   `phase-bands-do-not-overlap`; red control reproduces the roof shape.

3. instantiation scope was undefined where a building-scope phase meets a level-scope one, and
   when a phase is dropped for empty population. HHS needs both — it drops Substructure, which
   is BOTH building-scope AND the head of the within-level chain. Declared `scope` per phase +
   `_edge_scope_rule` + `_empty_phase_rule`. New gates `phases-declare-scope`,
   `dependency-scope-rules-declared`.

   Also corrected the v1.0.0 header's overclaim: this file authors exactly three things —
   calendar, duration_rule/capacity_rule, dependencies. Phases/trades are EXTRACTED from
   sequence_rules.json, as its own provenance field always said.

ENGINE — §CREW_CAP_FINAL (viewer/schedule_gate.js), a live defect found by the walk:

   claimCrew enforces max_crews at PLACEMENT. The §DEQ_REPAIR sweep then moves elements forward
   to satisfy geometry gates by writing o.start/o.end directly, never re-claiming a crew. Its
   biggest population is hosted openings (IfcDoor/IfcWindow = CARPENTER), which pile onto the
   same instants. MEASURED on the FINAL emitted times, 24h shift:

       Terminal  CARPENTER peak 20 vs cap 2  (10.0x)
       HHS       CARPENTER peak  8 vs cap 2  ( 4.0x)
       Duplex    CARPENTER peak  3 vs cap 2  ( 1.5x)

   Every other trade legal on every building. A/B with the repair loop disabled returns all
   three to their caps, isolating the sweep as the cause. Fix re-packs crews over the current
   times inside the SAME convergence loop (both constraints only ever push later, so it is
   monotone and terminates). Spans are UNCHANGED — 131.6 / 46.9 / 9.9 days before and after:
   the breach never shortened the programme, it authored work no crew exists to do.
   New witness: viewer/tests/witness_4d_capacity_honoured.js (RED before, green after).

SAME per-trade bug, two more shipped sites, both fixed:
 - schedule_author.js §ZONE_WINDOW_COVERS_WORK computed _wCrews as the same sum.
 - witness_kit/generators/gantt_bars.js crewDaysOf did too, so witness_gantt_bar_is_its_task
   was measuring the lenient rule. Under the strict rule it went 0/135 -> 1/135, and that one
   (Clinic "Superstructure — Roof - Main", 11%) turned out to be a HARNESS bug: the generator
   never passed nameOverrides to materializeZones, so windows were authored from unoverridden
   classification and measured against overridden elements. Browser is unaffected (window.
   SEQUENCE_NAME_OVERRIDES supplies it); node was not. Fixed -> 0/136 under the strict rule.

WITNESSES
  witness_4d_template.js            §WITNESS_4D_TEMPLATE pass=15 fail=0 ran=6
  witness_4d_capacity_honoured.js   §WITNESS_4D_CAPACITY pass=4 fail=0 (HHS/Duplex/Terminal)
  witness_gantt_bar_is_its_task.js  overCommittedWindows=0/136 under the STRICT per-trade rule
  tests/run_witness_suite.js        green=57 new_red=1 known_red=7 total=65

  The one new_red (witness_cpe_buildup_require_tm_first.js) is byte-identically red with and
  without this change — baselined by stashing the diff and re-running. Pre-existing, unrelated
  (its own output says "WITNESS IS BLIND — shipped source unexpectedly already has this gate").

🤖 Generated with [Claude Code](https://claude.com/claude-code)