### PR TITLE
feat(4d): template v1.2.0 — packed+sequential, full band-monotonic ladder, per-gate red controls

### DIFF
--- a/viewer/rates/4D_template.json
+++ b/viewer/rates/4D_template.json
@@ -2,7 +2,7 @@
   "meta": {
     "id": "4d_template",
     "name": "Core 4D Programme Template",
-    "version": "1.1.0",
+    "version": "1.2.0",
     "what": "THE core Gantt programme every building instance copies from: a checked-in, reviewable, witnessed programme SKELETON — phases, per-level activities, the dependency logic between them, and the two physical rules (work content, crew capacity) that bound any schedule derived from it. Authored once here instead of emerging at runtime from a geometry solve and being discarded on reload.",
     "not_this_file": "sequence_rules.json is a CLASSIFICATION table (ifc_class -> phase/sequence/trade + labour productivity). It answers 'which phase does this element belong to'. It cannot answer 'what is the programme'. The two files are used together: this one is the shape, that one is the lookup.",
     "what_this_file_authors": "EXACTLY three things: calendar, duration_rule, capacity_rule + dependencies. Everything else in this file (the phase set, each phase's sequence, each phase's trades) is EXTRACTED from sequence_rules.json and gated against drift. v1.0.0's header claimed this file was 'the only place a fact is authored' — that overclaimed, and its own provenance line contradicted it. Stated as the three, it is exact.",
@@ -105,10 +105,19 @@
       { "pred": "mep_rough_in",   "succ": "mep_final",      "type": "FS", "lag_days": 0, "_why": "Second fix follows first fix." },
       { "pred": "mep_final",      "succ": "finishes",       "type": "FS", "lag_days": 0, "_why": "Finishes close up completed services." }
     ],
+    "_ladder_rule": "EVERY level-scope phase chains to ITSELF on the level below (FS+0, level_offset 1). This is the project's own §4D_BAND_MONOTONIC ruling — 'a trade may not run ahead of ITSELF on the floor below' — declared here as programme logic instead of living only inside the solver's gates. v1.1.0 declared the ladder for superstructure ALONE, and MEASURED on HHS_Office_Federated (2026-08-25, probe_4d_motion.js) that is NOT crew-legal: with levels otherwise free to run in parallel, MEP Rough-in on Levels 1/2/3 overlaps and PLUMBER peaks at 3.67 crews against a cap of 2 (1.84x), HVAC_TECH at 3.48 (1.74x). With the full ladder: ZERO breaches on every trade, and the programme costs 49 days against 41 — the 8 days that buy physical legality. Different trades still overlap ACROSS floors, which is what a trade train is; only a trade overtaking itself is forbidden.",
     "across_levels": [
       { "pred": "superstructure", "succ": "superstructure", "type": "FS", "lag_days": 0, "level_offset": 1,
-        "_why": "A level's frame cannot start before the level below it is framed. This is the ONLY hard vertical constraint; everything else follows from it plus the within-level chain." }
+        "_why": "A level's frame cannot start before the level below it is framed. The one constraint that is structural as well as logistical." },
+      { "pred": "architecture",   "succ": "architecture",   "type": "FS", "lag_days": 0, "level_offset": 1,
+        "_why": "§4D_BAND_MONOTONIC: the envelope/fabric trades may not run ahead of themselves. The user's own report that produced that ruling was 'upper floors gets walled first'." },
+      { "pred": "mep_rough_in",   "succ": "mep_rough_in",   "type": "FS", "lag_days": 0, "level_offset": 1,
+        "_why": "§4D_BAND_MONOTONIC, and the measured binding case: without it PLUMBER runs 1.84x over cap across three simultaneous levels." },
+      { "pred": "mep_final",      "succ": "mep_final",      "type": "FS", "lag_days": 0, "level_offset": 1,
+        "_why": "§4D_BAND_MONOTONIC. Same trades as rough-in, same crew pool, same failure mode." },
+      { "pred": "finishes",       "succ": "finishes",       "type": "FS", "lag_days": 0, "level_offset": 1,
+        "_why": "§4D_BAND_MONOTONIC. One FINISHER pool for the building." }
     ],
-    "_overlap": "Every lag is 0 and every type is FS in v1.x — a deliberately conservative, strictly serial start. Real programmes overlap trades (SS with lag, FS with negative lead). Those belong here as edits, each with its own _why, so an overlap is a reviewed decision and not an artifact of a solver. NOTE, MEASURED: the engine today already overlaps phases heavily — HHS spans 46.9 days against this chain's 69.8 days of serial per-trade work content. That gap is the template's logic disagreeing with what runs, and it is the thing instantiation has to reconcile."
+    "_overlap": "USER RULING 2026-08-25: 'wont it be safer to avoid the hell — we make phases packed but sequential? User can then just drag them overlap if they want. As long it is editable.' Adopted. Every lag is 0 and every type is FS: phases are PACKED (no dead air, min_days 1) and STRICTLY SEQUENTIAL within a level, with the ladder above across levels. An overlap is then a deliberate EDIT a human drags in on the TM Gantt, never something a solver produced and nobody authorised.\n\nThis is not the expensive choice, which is why it is the safe one. MEASURED on HHS_Office_Federated (2026-08-25): the packed-sequential programme is 49 days against the current overlapping engine's 46.9 — +4%, two days, and it is crew-legal on every trade where the engine needed a repair pass to become so. The old fear that serialising costs a much longer film is not supported by the numbers on this building."
   }
 }

--- a/viewer/tests/probe_4d_motion.js
+++ b/viewer/tests/probe_4d_motion.js
@@ -64,6 +64,43 @@ const BLD = process.env.BLD || path.join(require('os').homedir(), 'bim-ootb', 'b
   });
   console.log('§HOP0_STOREYS n=' + storeyList.length + ' [' + storeyList.join(', ') + ']');
 
+  // ── HOP 0b — CONTAMINATION + THE DAY-0 STACK ────────────────────────────────────────────────
+  // User report 2026-08-25: "i noticed MEP appearing or that HR 0 truly stacked. Also they can be
+  // contaminated with MEP elements in there."
+  // (1) CONTAMINATION = an element whose FINAL phase differs from the phase its own ifc_class
+  //     declares in SEQUENCE_RULES. Something moved it: a NAME_OVERRIDE, or a reclass pass.
+  // (2) DAY-0 STACK = elements whose solved start is the very first instant. A structural phase
+  //     legitimately starts there; anything else starting at hour 0 is the reported symptom.
+  const classPhaseOf = {};
+  Object.keys(R.SEQUENCE_RULES).forEach(k => { classPhaseOf[k] = R.SEQUENCE_RULES[k].phase; });
+  const declaredPhase = cls => {
+    let best = null, bl = 0;
+    for (const k in classPhaseOf) if (cls.indexOf(k) >= 0 && k.length > bl) { best = k; bl = k.length; }
+    return best ? classPhaseOf[best] : R.SEQUENCE_DEFAULT.phase;
+  };
+  const MEP = ph => ph === 'MEP Rough-in' || ph === 'MEP Final';
+  const contam = {}, moved = {};
+  els.forEach(e => {
+    const want = declaredPhase(e.cls), got = e.phase;
+    if (want === got) return;
+    const k = e.cls + ': ' + want + ' -> ' + got;
+    moved[k] = (moved[k] || 0) + 1;
+    if (MEP(want) && !MEP(got)) contam[k] = (contam[k] || 0) + 1;   // an MEP element sitting in a structural/arch phase
+  });
+  console.log('\n§HOP0B_CONTAMINATION reclassified=' + Object.values(moved).reduce((a, b) => a + b, 0) +
+    ' ofWhichMEPintoNonMEP=' + Object.values(contam).reduce((a, b) => a + b, 0));
+  Object.keys(moved).sort((a, b) => moved[b] - moved[a]).slice(0, 8)
+    .forEach(k => console.log('   ' + (contam[k] ? 'MEP-CONTAM ' : 'reclass    ') + k + ' x' + moved[k]));
+  // what classes actually sit in each structural phase
+  ['Substructure', 'Superstructure'].forEach(ph => {
+    const cc = {};
+    els.forEach(e => { if (e.phase === ph) cc[e.cls] = (cc[e.cls] || 0) + 1; });
+    const keys = Object.keys(cc).sort((a, b) => cc[b] - cc[a]);
+    const bad = keys.filter(c => MEP(declaredPhase(c)));
+    console.log('   ' + ph.padEnd(15) + (keys.length ? keys.map(c => c + '=' + cc[c]).join(' ') : '(empty)') +
+      (bad.length ? '   ⛔ MEP classes present: ' + bad.join(',') : ''));
+  });
+
   // ── HOP 1 — what the TEMPLATE declares ──────────────────────────────────────────────────────
   console.log('\n§HOP1_TEMPLATE_SAYS phases=' + T.phases.length + ' shift=' + SHIFT + 'h');
   const mc = t => (R.LABOR_RATES[t] && R.LABOR_RATES[t].max_crews) || 1;
@@ -103,6 +140,16 @@ const BLD = process.env.BLD || path.join(require('os').homedir(), 'bim-ootb', 'b
   const spanDays = (sMax - sMin) / 86400000;
   console.log('\n§HOP2_SOLVE scheduled=' + nSched + '/' + els.length + ' spanDays=' + spanDays.toFixed(1) +
     ' vs template perTradeDays=' + tplPerTrade.toFixed(1) + ' (ratio=' + (spanDays / tplPerTrade).toFixed(2) + 'x)');
+
+  // day-0 stack: what starts at the very first instant, by phase
+  const zeroBy = {};
+  let zeroN = 0;
+  els.forEach(e => { const st = sched[e.guid]; if (!st || st.start !== sMin) return; zeroN++;
+    zeroBy[e.phase || '_UNPHASED'] = (zeroBy[e.phase || '_UNPHASED'] || 0) + 1; });
+  const structFirst = Object.keys(zeroBy).every(ph => ph === 'Substructure' || ph === 'Superstructure');
+  console.log('§HOP2C_DAY0_STACK atFirstInstant=' + zeroN + '/' + els.length + ' byPhase=' +
+    JSON.stringify(zeroBy) + ' structuralOnly=' + structFirst +
+    (structFirst ? '' : '   ⛔ a non-structural phase starts at hour 0'));
 
   // ── HOP 2b — THE HARD FLOOR: no trade can beat its own crew cap, whatever the overlap ───────
   // Building-wide, phase-agnostic. Overlap between phases is a legitimate design choice; exceeding
@@ -145,6 +192,32 @@ const BLD = process.env.BLD || path.join(require('os').homedir(), 'bim-ootb', 'b
       (p.replicate_per_level ? 'per-level x' + storeyList.length : 'per-building') + '), engine produced ' + got);
   });
 
+  // ── HOP 3b — HOW MUCH DO PHASES ACTUALLY STACK? ─────────────────────────────────────────────
+  // User 2026-08-25: "it is strange why all this while we cannot rein in phases stacking."
+  // The template says phases are FS+0 within a level: zero overlap. Measure the real overlap.
+  const zByLevel = {};
+  rolled.zones.forEach(z => { (zByLevel[z.storey] = zByLevel[z.storey] || []).push(z); });
+  const order = {}; T.phases.forEach((p, i) => { order[p.name] = i; });
+  let pairs = 0, overlapping = 0, worstPair = null, invertedPairs = 0;
+  Object.keys(zByLevel).forEach(lv => {
+    const list = zByLevel[lv].filter(z => order[z.phase] != null).sort((a, b) => order[a.phase] - order[b.phase]);
+    for (let i = 0; i < list.length; i++) for (let j = i + 1; j < list.length; j++) {
+      const a = list[i], b = list[j]; pairs++;
+      const ov = Math.min(a.end, b.end) - Math.max(a.start, b.start);
+      if (ov > 0) {
+        overlapping++;
+        const frac = ov / Math.max(1, Math.min(a.end - a.start, b.end - b.start));
+        if (!worstPair || frac > worstPair.frac) worstPair = { frac, lv, a: a.phase, b: b.phase, days: ov / 86400000 };
+      }
+      if (b.start < a.start) invertedPairs++;    // a LATER phase starts before an EARLIER one
+    }
+  });
+  console.log('§HOP3B_PHASE_STACK samLevelPhasePairs=' + pairs + ' overlapping=' + overlapping +
+    ' (' + (100 * overlapping / Math.max(1, pairs)).toFixed(0) + '%) startOrderInverted=' + invertedPairs +
+    (worstPair ? '  worst=' + worstPair.lv + ' ' + worstPair.a + ' vs ' + worstPair.b + ' ' +
+      worstPair.days.toFixed(1) + 'd (' + (worstPair.frac * 100).toFixed(0) + '% of the shorter bar)' : '') +
+    '   — template declares FS+0: 0% overlap, 0 inversions');
+
   // ── HOP 4 — zone windows vs their own work ──────────────────────────────────────────────────
   const elByGuid = {}; els.forEach(e => { elByGuid[e.guid] = e; });
   let over = 0, worst = null;
@@ -159,6 +232,86 @@ const BLD = process.env.BLD || path.join(require('os').homedir(), 'bim-ootb', 'b
   });
   console.log('§HOP4_WINDOWS zonesOverCommitted(perTrade)=' + over + '/' + rolled.zones.length +
     (worst ? ' worst=' + worst.id + ' window=' + worst.winD.toFixed(2) + 'd needs(perTrade)=' + worst.dMax.toFixed(2) + 'd needs(Σcrews)=' + worst.dSum.toFixed(2) + 'd' : ''));
+
+  // ── HOP 6 — WHAT WOULD THE TEMPLATE'S OWN SERIAL CHAIN COST? ────────────────────────────────
+  // The question this answers: if the engine STOPPED overlapping and instantiated the template
+  // literally — phases packed but strictly sequential per level, levels tied only by the
+  // superstructure ladder — how much longer is the programme? Nothing here changes any engine
+  // behaviour; it prices the option.
+  const ranks = ScheduleGate.deriveBandRanks(els, null).bandRank;
+  const levelsUp = storeyList.slice().sort((a, b) => (ranks[a] == null ? 1e9 : ranks[a]) - (ranks[b] == null ? 1e9 : ranks[b]));
+  // per (phase, level) work content, per-trade
+  const cell = {};
+  els.forEach(e => {
+    const ph = e.phase || '_UNPHASED', st = ScheduleGate.collapsePhase(e.storey);
+    const k = ph + '||' + st;
+    const c = cell[k] || (cell[k] = {});
+    const t = e.resource || '_NONE';
+    c[t] = (c[t] || 0) + (e.installSecs || 0);
+  });
+  const cellDays = k => {
+    const c = cell[k]; if (!c) return 0;
+    let d = 0;
+    Object.keys(c).forEach(t => { const v = c[t] / (shiftSecs * (t === '_NONE' ? 1 : mc(t))); if (v > d) d = v; });
+    return Math.max(d > 0 ? 1 : 0, Math.ceil(d));   // duration_rule.min_days = 1
+  };
+  const ladderPhases = new Set(T.dependencies.across_levels
+    .filter(e => e.pred === e.succ && e.level_offset === 1)
+    .filter(e => !process.env.LADDER_ONLY || process.env.LADDER_ONLY.split(',').indexOf(e.pred) >= 0)
+    .map(e => e.pred));
+  const present = T.phases.filter(p => byPhase[p.name]);          // _empty_phase_rule: dropped, chain BRIDGED
+  const finish = {}, finishSpan = {};                             // key -> finish day / {s,e}
+  let programme = 0;
+  levelsUp.forEach((lv, li) => {
+    let t = 0;
+    present.forEach(p => {
+      const isBuilding = p.scope === 'building';
+      if (isBuilding && li > 0) return;                            // _edge_scope_rule: LOWEST level only
+      const k = p.name + '||' + lv;
+      const d = cellDays(k);
+      if (!d) return;                                              // no elements of this phase on this level
+      let start = t;
+      // across_levels ladder, READ FROM THE TEMPLATE — never a second hand-typed list. LADDER_ONLY
+      // is a what-if knob for pricing a narrower ladder (it is how the v1.1.0 superstructure-only
+      // ladder was measured at PLUMBER 1.84x over cap before v1.2.0 widened it).
+      if (ladderPhases.has(p.id) && li > 0) {
+        const below = finish[p.name + '||' + levelsUp[li - 1]];   // keyed by NAME, same as finish[k]
+        if (below != null && below > start) start = below;
+      }
+      const end = start + d;
+      finish[k] = end; finishSpan[k] = { s: start, e: end }; t = end;
+      if (process.env.HOP6_DEBUG) console.log('     dbg ' + k + ' start=' + start + ' d=' + d + ' end=' + end);
+      if (end > programme) programme = end;
+    });
+  });
+  // HOP 6b — is the serial plan CREW-LEGAL? Levels run in parallel (only the superstructure ladder
+  // ties them), so the same trade can be demanded on two levels at once. Average crew demand per
+  // task per trade = secs_t / (shift * durationDays); summed across every task live on a given day.
+  const dayDemand = {};                                            // trade -> day -> crews
+  Object.keys(finishSpan).forEach(k => {
+    const sp = finishSpan[k], c = cell[k] || {};
+    Object.keys(c).forEach(t => {
+      if (t === '_NONE') return;
+      const crews = c[t] / (shiftSecs * Math.max(1, sp.e - sp.s));
+      const dd = dayDemand[t] || (dayDemand[t] = {});
+      for (let d = sp.s; d < sp.e; d++) dd[d] = (dd[d] || 0) + crews;
+    });
+  });
+  const serialBreach = [];
+  Object.keys(dayDemand).forEach(t => {
+    let pk = 0; Object.keys(dayDemand[t]).forEach(d => { if (dayDemand[t][d] > pk) pk = dayDemand[t][d]; });
+    if (pk > mc(t) + 1e-9) serialBreach.push(t + ' peak=' + pk.toFixed(2) + ' cap=' + mc(t) + ' (' + (pk / mc(t)).toFixed(2) + 'x)');
+  });
+
+  console.log('\n§HOP6_SERIAL_COST ladder=[' + Array.from(ladderPhases).join(',') + '] templateSerialProgramme=' + programme + 'd vs engineSpan=' +
+    spanDays.toFixed(1) + 'd  (ratio=' + (programme / spanDays).toFixed(2) + 'x) — phases packed, strictly sequential per level, levels tied only by the superstructure ladder');
+  levelsUp.forEach(lv => {
+    const parts = present.map(p => { const d = cellDays(p.name + '||' + lv); return d ? p.name + '=' + d + 'd' : null; }).filter(Boolean);
+    if (parts.length) console.log('   ' + lv.padEnd(14) + parts.join('  '));
+  });
+  console.log('§HOP6B_SERIAL_CREWLEGAL breaches=' + serialBreach.length +
+    (serialBreach.length ? ' [' + serialBreach.join('; ') + ']' : ' — every trade within max_crews across the level-parallel plan') +
+    '  (levels run in parallel under the one declared vertical edge, so a trade CAN be demanded on two levels at once)');
 
   // ── HOP 5 — edges: are they logic or restatements of the dates? ─────────────────────────────
   let restated = 0;

--- a/viewer/tests/witness_4d_template.js
+++ b/viewer/tests/witness_4d_template.js
@@ -25,7 +25,8 @@ const {
   phasesMatchClassificationOrder, phaseBandsDoNotOverlap, tradesMatchClassification,
   edgesReferenceRealPhases, withinLevelChainCoversAllPhases, edgesAreDateIndependent,
   calendarMatchesEngine, durationRuleIsWorkContent, durationDivisorIsPerTrade,
-  capacityRuleIsHard, phasesDeclareScope, dependencyScopeRulesDeclared
+  capacityRuleIsHard, phasesDeclareScope, dependencyScopeRulesDeclared,
+  ladderCoversEveryLevelPhase, allEdgesAreSerialFS
 } = require('../../witness_kit/invariants/4d_template');
 
 const VIEWER_DIR = process.env.VIEWER_DIR || path.join(__dirname, '..');
@@ -69,13 +70,18 @@ const rows = T.phases.map((p, i) => ({
 
 console.log('§4DT_SOURCE template=rates/4D_template.json v=' + T.meta.version +
   ' phases=' + rows.length + ' withinLevelEdges=' + T.dependencies.within_level.length +
-  ' acrossLevelEdges=' + T.dependencies.across_levels.length);
+  ' acrossLevelEdges=' + T.dependencies.across_levels.length +
+  ' allFSzeroLag=' + allEdgesAreSerialFS(T));
 console.log('§4DT_PHASES ' + rows.map(r => r.name + '[' + r.classMinSequence + '-' + r.classMaxSequence + ']' +
   '/' + r.scope).join(' -> '));
 console.log('§4DT_CALENDAR hoursPerShift=' + T.calendar.hours_per_shift + ' engineSHIFT_HOURS=' + SHIFT +
   ' daysPerWeek=' + T.calendar.days_per_week + ' durationBasis=' + T.duration_rule.basis +
   ' divisorScope=' + T.duration_rule.divisor_scope);
 console.log('§4DT_CAPACITY rule="' + T.capacity_rule.rule + '" appliesTo=' + T.capacity_rule.applies_to);
+
+// Deep copy + mutate, so a red control can inject a defect without touching the real T every
+// later gate reads. structuredClone is node>=17; JSON round-trip is enough for a plain JSON doc.
+const mut = f => { const c = JSON.parse(JSON.stringify(T)); f(c); return c; };
 
 Witness('4d_template')
   .population(() => rows)
@@ -105,6 +111,46 @@ Witness('4d_template')
   .invariant('capacity-rule-is-hard', () => capacityRuleIsHard(T))
   // The two instantiation rules v1.0.0 left undefined, both of which HHS actually needs.
   .invariant('dependency-scope-rules-declared', () => dependencyScopeRulesDeclared(T))
+  // §4D_BAND_MONOTONIC as logic: a trade may not overtake itself up the building. Without the full
+  // ladder the packed-sequential plan is NOT crew-legal (PLUMBER 1.84x over cap on HHS).
+  .invariant('ladder-covers-every-level-phase', () => ladderCoversEveryLevelPhase(T))
+  // User ruling 2026-08-25: packed and strictly sequential; an overlap is a human's drag, not a
+  // solver artifact.
+  .invariant('all-edges-are-serial-fs', () => allEdgesAreSerialFS(T))
+  .invariant('redctl:ladder rejects a superstructure-only ladder', () => ladderCoversEveryLevelPhase(
+    mut(c => { c.dependencies.across_levels = c.dependencies.across_levels.filter(e => e.pred === 'superstructure'); })) === false)
+  .invariant('redctl:serial rejects a hand-authored overlap', () => allEdgesAreSerialFS(
+    mut(c => { c.dependencies.within_level[0].lag_days = -3; })) === false)
+  // ── PER-GATE RED CONTROLS ────────────────────────────────────────────────────────────────
+  // The contract allows ONE .redControl(), which proves the witness as a whole can fail. It does
+  // NOT prove that each individual gate can. That distinction is not academic here: every gate
+  // below this line was added in one sitting, and a gate whose predicate is quietly always-true
+  // reads exactly like a gate that passes. Each check injects that gate's OWN real defect into a
+  // deep copy and asserts the gate rejects it, every run, in the committed witness — not in a
+  // throwaway console session that nobody can re-run.
+  .invariant('redctl:bands reject an interleave', () => phaseBandsDoNotOverlap(
+    // the §S65 #7 shape: a class at sequence 8 inside Architecture, i.e. after all MEP Rough-in (7)
+    [{ classMinSequence: 1, classMaxSequence: 1 }, { classMinSequence: 5, classMaxSequence: 8 },
+     { classMinSequence: 7, classMaxSequence: 7 }]) === false)
+  .invariant('redctl:bands accept clean bands', () => phaseBandsDoNotOverlap(
+    [{ classMinSequence: 1, classMaxSequence: 1 }, { classMinSequence: 5, classMaxSequence: 6 },
+     { classMinSequence: 7, classMaxSequence: 7 }]) === true)
+  .invariant('redctl:per-trade rejects a summed formula', () => durationDivisorIsPerTrade(
+    mut(c => { c.duration_rule.formula = 'days = ceil( sum(installSecs) / (h*3600*crews) ), crews = sum of max_crews over the trades'; })) === false)
+  .invariant('redctl:per-trade rejects a drifted divisor_scope', () => durationDivisorIsPerTrade(
+    mut(c => { c.duration_rule.divisor_scope = 'pooled'; })) === false)
+  .invariant('redctl:capacity rejects placement-only', () => capacityRuleIsHard(
+    mut(c => { c.capacity_rule.applies_to = 'the times at first placement'; })) === false)
+  .invariant('redctl:capacity rejects a deleted rule', () => capacityRuleIsHard(
+    mut(c => { delete c.capacity_rule; })) === false)
+  .invariant('redctl:scope rejects a level phase claiming building scope',
+    () => phasesDeclareScope([{ scope: 'building', replicate_per_level: true }]) === false)
+  .invariant('redctl:edge-scope rejects a dropped empty-phase rule', () => dependencyScopeRulesDeclared(
+    mut(c => { delete c.dependencies._empty_phase_rule; })) === false)
+  .invariant('redctl:cover rejects an orphaned phase', () => withinLevelChainCoversAllPhases(
+    mut(c => { c.dependencies.within_level = c.dependencies.within_level.slice(0, 1); })) === false)
+  .invariant('redctl:trades reject an invented trade', () => tradesMatchClassification(
+    rows.map((r, i) => i ? r : Object.assign({}, r, { trades: r.trades.concat('WELDER') }))) === false)
   // RED CONTROL — reproduce the real defect this file exists to prevent: give an edge an absolute
   // date, which is exactly the shape schedule_author.js's derived lags have.
   .redControl(rs => {

--- a/witness_kit/invariants/4d_template.js
+++ b/witness_kit/invariants/4d_template.js
@@ -183,7 +183,40 @@ const dependencyScopeRulesDeclared = T => !!T.dependencies &&
   /LOWEST level/.test(T.dependencies._edge_scope_rule || '') &&
   /BRIDGED/.test(T.dependencies._empty_phase_rule || '');
 
+/**
+ * G-PT-LADDER — §4D_BAND_MONOTONIC as programme logic: EVERY level-scope phase must chain to
+ * ITSELF on the level below (an across_levels self-edge with level_offset 1).
+ *
+ * v1.1.0 declared the ladder for superstructure alone, which leaves every other trade free to run
+ * on three levels at once. MEASURED on HHS_Office_Federated (2026-08-25, probe_4d_motion.js):
+ * superstructure-only ladder -> PLUMBER peaks 3.67 crews vs cap 2 (1.84x), HVAC_TECH 3.48 (1.74x);
+ * full ladder -> ZERO breaches on every trade, programme 49d vs 41d. The 8 days buy legality.
+ *
+ * This is the gate that makes "packed but sequential" (user ruling 2026-08-25) actually hold: a
+ * within-level chain alone does not stop a trade overtaking itself up the building.
+ * @param {object} T
+ * @returns {boolean}
+ */
+function ladderCoversEveryLevelPhase(T) {
+  const levelPhases = T.phases.filter(p => p.scope === 'level').map(p => p.id);
+  if (!levelPhases.length) return false;
+  const self = new Set(T.dependencies.across_levels
+    .filter(e => e.pred === e.succ && e.level_offset === 1).map(e => e.pred));
+  return levelPhases.every(id => self.has(id));
+}
+
+/**
+ * G-PT-SERIAL — every declared edge is FS with zero lag: phases PACKED and STRICTLY SEQUENTIAL.
+ * User ruling 2026-08-25: an overlap must be a human's drag on the Gantt, never a solver artifact.
+ * @param {object} T
+ * @returns {boolean}
+ */
+const allEdgesAreSerialFS = T => T.dependencies.within_level
+  .concat(T.dependencies.across_levels)
+  .every(e => e.type === 'FS' && Number(e.lag_days) === 0);
+
 module.exports = {
+  ladderCoversEveryLevelPhase, allEdgesAreSerialFS,
   phasesMatchClassificationOrder, phaseBandsDoNotOverlap, tradesMatchClassification,
   edgesReferenceRealPhases, withinLevelChainCoversAllPhases, edgesAreDateIndependent,
   calendarMatchesEngine, durationRuleIsWorkContent, durationDivisorIsPerTrade,


### PR DESCRIPTION
USER RULING 2026-08-25: "wont it be safer to avoid the hell — we make phases packed but
sequential? User can then just drag them overlap if they want. As long it is editable."
Adopted, and PRICED first rather than assumed.

MEASURED (viewer/tests/probe_4d_motion.js, HHS_Office_Federated, 24h shift):
  packed+sequential, superstructure-only ladder (v1.1.0)  41d  BUT NOT crew-legal:
      PLUMBER peak 3.67 vs cap 2 (1.84x), HVAC_TECH 3.48 vs 2 (1.74x) — MEP Rough-in
      on Levels 1/2/3 runs simultaneously because only superstructure chained across levels
  packed+sequential, ladder on EVERY level phase (v1.2.0)  49d  ZERO breaches, every trade
  today's overlapping engine                               46.9d

So serialising costs +4% (2 days), not the much longer film that was feared, and it is
crew-legal by construction where the engine needed a repair pass to become so.

v1.2.0 therefore declares §4D_BAND_MONOTONIC — "a trade may not run ahead of ITSELF on the
floor below" — as PROGRAMME LOGIC for every level-scope phase, not just superstructure.
Different trades still overlap across floors; only a trade overtaking itself is forbidden.
New gates `ladder-covers-every-level-phase`, `all-edges-are-serial-fs`.

WITNESS HARDENING (the user relies on witness logs alone, no visual check):
the contract allows ONE .redControl(), which proves the witness as a whole can fail but NOT
that each gate can. Every gate added since v1.0.0 now carries a committed per-gate red control
that injects that gate's own real defect and asserts rejection — 10 of them, run every time,
instead of a throwaway console session nobody can re-run.
  §WITNESS_4D_TEMPLATE pass=29 fail=0 ran=6  (was 15, was 10)

PROBE additions — all three answer a specific user report, all measured across the fleet:
  §HOP0B_CONTAMINATION  "they can be contaminated with MEP elements in there"
      ZERO on all 6 buildings (HHS/Duplex/Terminal/Clinic/JKR/LTU_AHouse). No MEP class sits
      in Substructure or Superstructure anywhere. The reclassifications that do happen are all
      IfcPlate Superstructure->Architecture (the curtain-wall NAME_OVERRIDE), which is correct.
  §HOP2C_DAY0_STACK     "HR 0 truly stacked"
      5 of 6 buildings start structural-only. HHS is the exception: 2 Architecture elements at
      the first instant out of 6839. Real but tiny — not the reported symptom's main cause.
  §HOP3B_PHASE_STACK    "why all this while we cannot rein in phases stacking"
      THIS is the symptom, and it is large: same-level phase pairs overlapping —
      HHS 10/29 (34%), Clinic 13/65 (20%), Duplex 7/38 (18%), Terminal 18/109 (17%);
      1-3 pairs per building have INVERTED start order. Worst: HHS Level 1 Architecture sits
      entirely inside Superstructure, 13.4 days, 100% of the shorter bar.
  §HOP6/§HOP6B          prices the serial option and checks it for crew legality.

Suite: green=57 new_red=1 known_red=7 total=65. The one new_red
(witness_cpe_buildup_require_tm_first.js) is the same pre-existing unrelated red baselined in
§S67 — unchanged by this commit, which touches only the template JSON, its witness and the probe.

🤖 Generated with [Claude Code](https://claude.com/claude-code)