### PR TITLE
feat(4d): §TEMPLATE_INSTANTIATE — emit the task grid FROM 4D_template.json (§S69)

### DIFF
--- a/viewer/schedule_author.js
+++ b/viewer/schedule_author.js
@@ -401,6 +401,243 @@
       ' — slab-on-grade reclassified Substructure (bears on grade/piles/footings only, lowest Superstructure band)');
   }
 
+  // ══ §TEMPLATE_INSTANTIATE (2026-08-25, bim-compiler prompts/4D_SCHEDULE_PERFECTION.md §S69) ══
+  // THE INVERSION. Until now the chain ran elements -> phases: computeSchedule placed elements, and
+  // deriveZones CREATED phases afterwards by grouping the placed elements and taking each group's
+  // min-start/max-end. A phase bar was an ENVELOPE over what the elements did, and an envelope
+  // cannot constrain what drew it — which is why phase stacking could never be reined in (§S68: the
+  // solver has no phase in it at all; `phaseTrade` is keyed by collapsePhase(el.STOREY)).
+  //
+  // This function runs phases -> elements. It reads viewer/rates/4D_template.json and EMITS the
+  // task grid: one task per (phase x real level) the template declares, each priced by
+  // duration_rule (per-trade work content, never the solve's span) and placed by dependencies
+  // (FS+0 within a level, plus the §4D_BAND_MONOTONIC ladder across levels). Elements are then
+  // ASSIGNED to tasks; they no longer define them.
+  //
+  // PURE + node-testable: no DB, no globals, no console side effects beyond the reports it returns.
+  // `collapse` is passed in (ScheduleGate.collapsePhase composed with the §S18 merge map) so the
+  // storey names here and the ones materializeZones writes can never diverge.
+  //
+  // Returns { tasks, edges, reports, totalDays } where a task is
+  //   { id, phase, storey, level, sDays, eDays, days, guids, crewDays, bottleneck }
+  // and an edge is { predId, succId, type, lagDays, kind } — kind 'within_level' | 'across_levels'.
+  // EVERY edge's lag comes from the TEMPLATE, never from the dates it constrains.
+  function instantiateTemplate(elements, T, laborRates, shiftHours, bandRank, collapse) {
+    laborRates = laborRates || {};
+    var shiftSecs = (shiftHours > 0 ? shiftHours : (T.calendar && T.calendar.hours_per_shift) || 24) * 3600;
+    var minDays = (T.duration_rule && T.duration_rule.min_days) || 1;
+    collapse = collapse || function (x) { return x; };
+
+    // (phase, storey) -> { secs per trade, guids }
+    var cell = {}, storeySeen = {};
+    for (var i = 0; i < elements.length; i++) {
+      var e = elements[i], st = collapse(e.storey), ph = e.phase || '_UNPHASED';
+      storeySeen[st] = 1;
+      var k = ph + '||' + st, c = cell[k] || (cell[k] = { secs: {}, guids: [] });
+      var tr = (e.resource && e.resource !== '_DEFAULT') ? e.resource : '_DEFAULT';
+      c.secs[tr] = (c.secs[tr] || 0) + (e.installSecs || 0);
+      c.guids.push(e.guid);
+    }
+    // levels bottom-up. bandRank is the SAME rank deriveBandRanks gives the movie, so "the level
+    // below" means the same thing here as it does in the solver's own band gate.
+    var levels = Object.keys(storeySeen).sort(function (a, b) {
+      var ra = bandRank && bandRank[a] != null ? bandRank[a] : 1e9;
+      var rb = bandRank && bandRank[b] != null ? bandRank[b] : 1e9;
+      return ra - rb || (a < b ? -1 : a > b ? 1 : 0);
+    });
+
+    // duration_rule: days = ceil( MAX over trades t of ( secs[t] / (shift * max_crews[t]) ) )
+    function priceCell(c) {
+      var d = 0, bott = null, any = 0;
+      for (var t in c.secs) {
+        if (t === '_DEFAULT') continue;
+        any = 1;
+        var cap = (laborRates[t] && laborRates[t].max_crews) || 1;
+        var td = c.secs[t] / (shiftSecs * cap);
+        if (td > d) { d = td; bott = t + '(' + cap + ')'; }
+      }
+      if (!any) { d = (c.secs._DEFAULT || 0) / shiftSecs; bott = '_DEFAULT(1)'; }
+      return { crewDays: d, days: Math.max(minDays, Math.ceil(d)), bottleneck: bott };
+    }
+
+    // dependencies._ladder_rule — which phases chain to themselves one level down.
+    var ladder = {};
+    (T.dependencies.across_levels || []).forEach(function (ed) {
+      if (ed.pred === ed.succ && ed.level_offset === 1) ladder[ed.pred] = ed;
+    });
+    var byId = {};
+    T.phases.forEach(function (p) { byId[p.id] = p; });
+
+    var tasks = [], edges = [], reports = [], taskAt = {}, totalDays = 0;
+    levels.forEach(function (lv, li) {
+      var prevOnLevel = null;   // for the BRIDGED within-level chain (_empty_phase_rule)
+      var cursor = 0;
+      T.phases.forEach(function (p) {
+        // _edge_scope_rule: a building-scope phase instantiates ONCE, on the lowest level. But its
+        // ELEMENTS must all come with it — an element of a building-scope phase that happens to sit
+        // on an upper storey belongs to that single task, it is not dropped. Silently losing it is
+        // exactly the failure class this lane exists to kill: MEASURED on Hospital before this
+        // guard, 1 of 63,182 elements reached no task at all (a Substructure element above the
+        // lowest level — §GROUNDWORK_SLAB reclassifies slab-on-grade by geometry, not by storey).
+        var k, c;
+        if (p.scope === 'building') {
+          if (li > 0) return;                       // emitted once, on the lowest level
+          c = { secs: {}, guids: [] };
+          levels.forEach(function (anyLv) {
+            var cc = cell[p.name + '||' + anyLv];
+            if (!cc) return;
+            for (var tr in cc.secs) c.secs[tr] = (c.secs[tr] || 0) + cc.secs[tr];
+            c.guids = c.guids.concat(cc.guids);
+          });
+          k = p.name + '||' + lv;
+          cell[k] = c;                              // so the levelling pass prices the merged cell
+        } else {
+          k = p.name + '||' + lv; c = cell[k];
+        }
+        if (!c || !c.guids.length) {
+          reports.push({ kind: 'phase_absent_on_level', phase: p.name, level: lv, why: 'no elements classify here' });
+          return;                                   // chain BRIDGES: prevOnLevel is left untouched
+        }
+        var pr = priceCell(c);
+        var start = cursor;
+        // across_levels: the §4D_BAND_MONOTONIC ladder — this phase on the level below.
+        if (ladder[p.id] && li > 0) {
+          var below = taskAt[p.name + '||' + levels[li - 1]];
+          if (below) {
+            var need = below.eDays + (ladder[p.id].lag_days || 0);
+            if (need > start) start = need;
+          }
+        }
+        var t = {
+          id: 'TASK_' + _slug(p.name) + '_' + _slug(lv),
+          phase: p.name, storey: lv, level: li, phaseId: p.id,
+          sDays: start, eDays: start + pr.days, days: pr.days,
+          crewDays: pr.crewDays, bottleneck: pr.bottleneck, guids: c.guids
+        };
+        tasks.push(t); taskAt[k] = t;
+        if (t.eDays > totalDays) totalDays = t.eDays;
+        cursor = t.eDays;
+        // within_level edge, from the last phase that ACTUALLY instantiated on this level.
+        if (prevOnLevel) {
+          var wl = (T.dependencies.within_level || []).filter(function (ed) { return ed.succ === p.id; })[0];
+          edges.push({ predId: prevOnLevel.id, succId: t.id, type: (wl && wl.type) || 'FS',
+                       lagDays: wl ? (wl.lag_days || 0) : 0, kind: 'within_level' });
+        }
+        if (ladder[p.id] && li > 0) {
+          var b2 = taskAt[p.name + '||' + levels[li - 1]];
+          if (b2) edges.push({ predId: b2.id, succId: t.id, type: ladder[p.id].type || 'FS',
+                               lagDays: ladder[p.id].lag_days || 0, kind: 'across_levels' });
+        }
+        prevOnLevel = t;
+      });
+    });
+    // ── capacity_rule LEVELLING ────────────────────────────────────────────────────────────
+    // The ladder forbids a phase overtaking ITSELF up the building. It does NOT stop two DIFFERENT
+    // phases that share a crew pool from running at once on different levels: MEP Rough-in on
+    // level 5 and MEP Final on level 2 both consume PLUMBER. MEASURED on Hospital (63,182 elements,
+    // 8 levels, 2026-08-25): logic dates alone give PLUMBER peak 3.26 crews against a cap of 2
+    // (1.63x). HHS and Duplex are clean at 3-4 levels; it takes a tall building to expose it.
+    //
+    // So the template's own capacity_rule ("at no instant may more than max_crews[t] elements of
+    // trade t be in progress") is applied here as ordinary resource levelling: walk the tasks in
+    // topological order, delay each to the earliest day its whole span fits inside every trade's
+    // remaining capacity, then push its successors out by the declared lag. Delay-only, so the
+    // graph stays acyclic and every dependency the logic pass established still holds.
+    //
+    // A task's demand for trade t is its own seconds of t spread over its own duration:
+    // secs_t / (shift * days) crews, held for every day of the span. That is the same average-crew
+    // model duration_rule prices with, not a second one.
+    var succOf = {}, indeg = {};
+    tasks.forEach(function (t) { indeg[t.id] = 0; });
+    edges.forEach(function (e) {
+      (succOf[e.predId] = succOf[e.predId] || []).push(e);
+      indeg[e.succId] = (indeg[e.succId] || 0) + 1;
+    });
+    var byIdT = {}; tasks.forEach(function (t) { byIdT[t.id] = t; });
+    // Kahn order; ties by (logic start, level, template phase order) so the result is deterministic.
+    var phaseOrder = {}; T.phases.forEach(function (p, i) { phaseOrder[p.name] = i; });
+    function rank(t) { return [t.sDays, t.level, phaseOrder[t.phase] != null ? phaseOrder[t.phase] : 99]; }
+    var ready = tasks.filter(function (t) { return !indeg[t.id]; });
+    var topo = [], deg = {};
+    for (var ti in indeg) deg[ti] = indeg[ti];
+    while (ready.length) {
+      ready.sort(function (a, b) {
+        var ra = rank(a), rb = rank(b);
+        return ra[0] - rb[0] || ra[1] - rb[1] || ra[2] - rb[2] || (a.id < b.id ? -1 : 1);
+      });
+      var cur = ready.shift();
+      topo.push(cur);
+      (succOf[cur.id] || []).forEach(function (e) {
+        if (--deg[e.succId] === 0) ready.push(byIdT[e.succId]);
+      });
+    }
+    if (topo.length !== tasks.length) topo = tasks.slice().sort(function (a, b) { return a.sDays - b.sDays; });
+
+    var demand = {};                       // trade -> day -> crews committed
+    function taskTradeCrews(t) {
+      var c = cell[t.phase + '||' + t.storey], out = {};
+      if (!c) return out;
+      for (var tr in c.secs) {
+        if (tr === '_DEFAULT') continue;
+        out[tr] = c.secs[tr] / (shiftSecs * Math.max(1, t.days));
+      }
+      return out;
+    }
+    function fits(t, at) {
+      var need = taskTradeCrews(t);
+      for (var tr in need) {
+        var cap = (laborRates[tr] && laborRates[tr].max_crews) || 1;
+        for (var d = at; d < at + t.days; d++)
+          if (((demand[tr] && demand[tr][d]) || 0) + need[tr] > cap + 1e-9) return false;
+      }
+      return true;
+    }
+    var levelled = 0, levelledDays = 0, LEVEL_SCAN_MAX = 100000;
+    topo.forEach(function (t) {
+      var at = t.sDays, guard = 0;
+      while (!fits(t, at) && guard++ < LEVEL_SCAN_MAX) at++;
+      if (at > t.sDays) { levelled++; levelledDays += at - t.sDays; }
+      var shift = at - t.sDays;
+      t.sDays = at; t.eDays = at + t.days;
+      var need = taskTradeCrews(t);
+      for (var tr in need) {
+        var dd = demand[tr] || (demand[tr] = {});
+        for (var d = t.sDays; d < t.eDays; d++) dd[d] = (dd[d] || 0) + need[tr];
+      }
+      if (t.eDays > totalDays) totalDays = t.eDays;
+      // push successors out so every declared edge still holds after the delay
+      (succOf[t.id] || []).forEach(function (e) {
+        var st = byIdT[e.succId];
+        var min = t.eDays + (e.lagDays || 0);
+        if (st && st.sDays < min) { st.eDays = min + st.days; st.sDays = min; }
+      });
+    });
+    if (levelled) reports.push({ kind: 'capacity_levelled', tasksDelayed: levelled, totalDaysAdded: levelledDays });
+
+    // ORPHANS — an element whose phase the template does not declare lands in NO task and would
+    // vanish from the Gantt silently. That is the exact failure class this whole lane exists to
+    // kill, so it is counted and named, never dropped. MEASURED on Hospital: 1 of 63,182.
+    var declared = {}; T.phases.forEach(function (p) { declared[p.name] = 1; });
+    var orphanBy = {}, orphanN = 0;
+    for (var oi = 0; oi < elements.length; oi++) {
+      var oe = elements[oi], oph = oe.phase || '_UNPHASED';
+      if (declared[oph]) continue;
+      orphanN++;
+      var ok2 = oph + '|' + oe.cls;
+      orphanBy[ok2] = (orphanBy[ok2] || 0) + 1;
+    }
+    if (orphanN) reports.push({ kind: 'elements_orphaned', count: orphanN, byPhaseClass: orphanBy });
+
+    // A phase the template declares that never instantiated ANYWHERE is reported once, loudly —
+    // 4D_template.json's own instantiation rule: "REPORTS (never silently drops)".
+    T.phases.forEach(function (p) {
+      if (!tasks.some(function (t) { return t.phase === p.name; }))
+        reports.push({ kind: 'phase_absent_everywhere', phase: p.name, level: null,
+                       why: p._empty_ok ? 'declared _empty_ok' : 'NOT marked _empty_ok' });
+    });
+    return { tasks: tasks, edges: edges, reports: reports, totalDays: totalDays, levels: levels };
+  }
+
   // materializeZones(db, rules, opts) — CPM_FLOAT_GAP.md Gap 1 (element-level, rolled up): the
   // DETAIL-granularity sibling of materializeDefault. Where materializeDefault gives 5 coarse phase
   // tasks, this persists one task per (phase × real floor) ZONE — built from
@@ -472,6 +709,12 @@
         }
       } catch (e) { console.log('§S18_STOREY_MERGE_FAIL ' + e.message + ' — no elevation data, bands unmerged'); }
     }
+    // §TEMPLATE_INSTANTIATE — when a template is supplied, the TASK GRID comes from it and the
+    // solve is no longer what defines the phases (see instantiateTemplate's header). The legacy
+    // grouping path below is left byte-identical for every caller that passes no template.
+    if (opts.template) return _writeTemplateSchedule(db, elements, schedule, opts, SG,
+      storeyMergeMap, laborRates, schedId, start, _displayAuthored);
+
     var rolled = SG.deriveZones(elements, schedule, storeyMergeMap);
     if (!rolled.zones.length) { console.log('§AUTHOR_ZONES_FAIL reason=no_zones'); return { ok: false, reason: 'no_zones' }; }
 
@@ -613,6 +856,88 @@
     console.log('§AUTHOR_ZONES schedule=' + schedId + ' zones=' + rolled.zones.length + ' edges=' + edgeN +
       ' elements=' + elements.length + ' totalDays=' + totalDays);
     return { ok: true, scheduleId: schedId, zoneCount: rolled.zones.length, edgeCount: edgeN, totalDays: totalDays };
+  }
+
+  // _writeTemplateSchedule — the §TEMPLATE_INSTANTIATE write path. Same tables, same schedule_id,
+  // same idempotent rebuild as the legacy grouping path; the difference is WHERE the numbers come
+  // from: task windows from 4D_template.json's duration_rule, task_sequences from its dependencies.
+  // Nothing here reads a date to produce an edge, which is the whole point — the persisted lag used
+  // to be `sd.s - pd.e`, i.e. the answer restated as its own constraint (§S67 HOP 5 measured 25/25).
+  function _writeTemplateSchedule(db, elements, schedule, opts, SG, storeyMergeMap, laborRates, schedId, start, displayAuthored) {
+    var T = opts.template;
+    var bandRank = (SG.deriveBandRanks ? SG.deriveBandRanks(elements, storeyMergeMap).bandRank : {}) || {};
+    function collapse(st) {
+      var c = SG.collapsePhase(st);
+      return (storeyMergeMap && storeyMergeMap[c]) || c;
+    }
+    var inst = instantiateTemplate(elements, T, laborRates, opts.shiftHours, bandRank, collapse);
+    if (!inst.tasks.length) { console.log('§AUTHOR_TPL_FAIL reason=no_tasks'); return { ok: false, reason: 'no_tasks' }; }
+
+    // Absence is REPORTED, never silent — 4D_template.json's own instantiation rule, and the
+    // defect §S67 HOP 1/HOP 3 found (Substructure simply vanished from HHS with nothing said).
+    var _absLevel = inst.reports.filter(function (r) { return r.kind === 'phase_absent_on_level'; });
+    var _absAll = inst.reports.filter(function (r) { return r.kind === 'phase_absent_everywhere'; });
+    var _orph = inst.reports.filter(function (r) { return r.kind === 'elements_orphaned'; })[0];
+    if (_orph) console.log('§TPL_ELEMENT_ORPHAN n=' + _orph.count + ' — element(s) whose phase the template does not declare, so they land in NO task: ' +
+      JSON.stringify(_orph.byPhaseClass));
+    else console.log('§TPL_ELEMENT_ORPHAN n=0 — every element landed in a declared phase');
+    var _lev = inst.reports.filter(function (r) { return r.kind === 'capacity_levelled'; })[0];
+    console.log('§TPL_CAPACITY_LEVEL tasksDelayed=' + (_lev ? _lev.tasksDelayed : 0) +
+      ' daysAdded=' + (_lev ? _lev.totalDaysAdded : 0) +
+      ' (a task was pushed later because its trade had no free crew at its logic date; 0 = the' +
+      ' declared logic was already crew-legal on its own)');
+    console.log('§TPL_PHASE_COVERAGE declared=' + T.phases.length + ' levels=' + inst.levels.length +
+      ' tasksEmitted=' + inst.tasks.length + ' absentPhaseLevels=' + _absLevel.length +
+      ' absentPhasesEntirely=' + _absAll.length);
+    _absAll.forEach(function (r) {
+      console.log('§TPL_PHASE_ABSENT phase="' + r.phase + '" on NO level of this building — ' + r.why);
+    });
+    _absLevel.forEach(function (r) {
+      console.log('§TPL_PHASE_GAP phase="' + r.phase + '" level="' + r.level + '" — ' + r.why + ' (chain bridged)');
+    });
+
+    _ensureSchedulesGenVersion(db);
+    _ensureSchedulesDisplayAuthored(db);
+    _ensureWideTasks(db);
+    db.run('CREATE TABLE IF NOT EXISTS task_elements (task_id TEXT, guid TEXT, PRIMARY KEY (task_id, guid))');
+    db.run('CREATE TABLE IF NOT EXISTS task_sequences (predecessor_id TEXT, successor_id TEXT, sequence_type TEXT, lag_days REAL DEFAULT 0, PRIMARY KEY (predecessor_id, successor_id))');
+
+    db.run('BEGIN TRANSACTION');
+    db.run('DELETE FROM task_elements WHERE task_id IN (SELECT task_id FROM tasks WHERE schedule_id=?)', [schedId]);
+    db.run('DELETE FROM task_sequences WHERE predecessor_id IN (SELECT task_id FROM tasks WHERE schedule_id=?) OR successor_id IN (SELECT task_id FROM tasks WHERE schedule_id=?)', [schedId, schedId]);
+    db.run('DELETE FROM tasks WHERE schedule_id=?', [schedId]);
+    db.run('DELETE FROM schedules WHERE schedule_id=?', [schedId]);
+    db.run('INSERT INTO schedules (schedule_id,name,status,created_date,gen_version,display_authored) VALUES (?,?,?,?,?,?)',
+      [schedId, 'Authored Schedule (4D template)', 'PLANNED', start, opts.genVersion != null ? opts.genVersion : null, displayAuthored || 0]);
+
+    var rootId = 'TASK_ROOT';
+    db.run('INSERT INTO tasks (task_id,schedule_id,wbs_parent,name,predefined_type,is_summary,schedule_start,schedule_finish,schedule_duration,resource,status) VALUES (?,?,?,?,?,?,?,?,?,?,?)',
+      [rootId, schedId, null, 'Project', 'CONSTRUCTION', 1, start, _addDays(start, inst.totalDays), 'P' + inst.totalDays + 'D', null, 'PLANNED']);
+
+    var stmtTk = db.prepare('INSERT INTO tasks (task_id,schedule_id,wbs_parent,name,predefined_type,is_summary,schedule_start,schedule_finish,schedule_duration,resource,status) VALUES (?,?,?,?,?,?,?,?,?,?,?)');
+    var stmtTe = db.prepare('INSERT OR IGNORE INTO task_elements VALUES (?,?)');
+    inst.tasks.forEach(function (t) {
+      stmtTk.run([t.id, schedId, rootId, t.phase + ' — ' + t.storey, 'CONSTRUCTION', 0,
+        _addDays(start, t.sDays), _addDays(start, t.eDays), 'P' + t.days + 'D', null, 'PLANNED']);
+      for (var i = 0; i < t.guids.length; i++) stmtTe.run([t.id, t.guids[i]]);
+    });
+    stmtTk.free(); stmtTe.free();
+
+    var stmtSeq = db.prepare('INSERT OR IGNORE INTO task_sequences VALUES (?,?,?,?)');
+    var wl = 0, al = 0;
+    inst.edges.forEach(function (e) {
+      stmtSeq.run([e.predId, e.succId, e.type, e.lagDays]);
+      if (e.kind === 'across_levels') al++; else wl++;
+    });
+    stmtSeq.free();
+    db.run('COMMIT');
+
+    console.log('§AUTHOR_TPL schedule=' + schedId + ' v=' + T.meta.version + ' tasks=' + inst.tasks.length +
+      ' edges=' + inst.edges.length + ' (withinLevel=' + wl + ' acrossLevels=' + al + ')' +
+      ' elements=' + elements.length + ' totalDays=' + inst.totalDays +
+      ' — every lag is the TEMPLATE\'s, none derived from the dates it constrains');
+    return { ok: true, scheduleId: schedId, zoneCount: inst.tasks.length, edgeCount: inst.edges.length,
+             totalDays: inst.totalDays, templateVersion: T.meta.version, reports: inst.reports };
   }
 
   // materializeDefault(db, rules, opts) — originate the smart-default schedule on a blank model.
@@ -1925,6 +2250,7 @@
     materializeDefault: materializeDefault,
     materializeZones: materializeZones,
     _buildScheduleElements: _buildScheduleElements,
+    instantiateTemplate: instantiateTemplate,
     scheduleContiguous: scheduleContiguous,
     activeSchedule: activeSchedule,
     assignElement: assignElement,

--- a/viewer/tests/witness_4d_template_instantiation.js
+++ b/viewer/tests/witness_4d_template_instantiation.js
@@ -1,0 +1,152 @@
+#!/usr/bin/env node
+// WITNESS — §TEMPLATE_INSTANTIATE: the task grid is EMITTED FROM 4D_template.json, not grouped out
+// of the element solve. Spec: bim-compiler prompts/4D_SCHEDULE_PERFECTION.md §S69.
+//
+// WHICH LAYER THIS PROVES (WITNESS_INTERFACE_FRAMEWORK.md §CRISIS LESSON 1):
+//   the PERSISTED TASK GRID only — `tasks`, `task_sequences`, `task_elements` as materializeZones
+//   writes them with opts.template. It says nothing about drawn bars, the movie, or kernel_ops.
+//
+// ISSUE THIS PROVES OR DISPROVES (§S68): until now the chain ran elements -> phases. deriveZones
+// CREATED phases after the solve by grouping placed elements and taking min-start/max-end, so a
+// phase bar was an ENVELOPE over what the elements did — and an envelope cannot constrain what drew
+// it. That is why phase stacking was never reined in: MEASURED before this change, same-level phase
+// pairs overlapping were HHS 10/29 (34%), Clinic 13/65, Duplex 7/38, Terminal 18/109, and 25/25
+// persisted lags were the observed date gap restated as its own constraint.
+//
+// Command: node viewer/tests/witness_4d_template_instantiation.js [Building ...]
+'use strict';
+const fs = require('fs');
+const path = require('path');
+const vm = require('vm');
+const HOME = require('os').homedir();
+const initSqlJs = require(path.join(HOME, 'bim-ootb', 'node_modules', 'sql.js'));
+const SQLJS_DIST = path.join(HOME, 'bim-ootb', 'node_modules', 'sql.js', 'dist');
+const VIEWER_DIR = process.env.VIEWER_DIR || path.join(__dirname, '..');
+const ScheduleGate = require(path.join(VIEWER_DIR, 'schedule_gate.js'));
+global.ScheduleGate = ScheduleGate;
+const ScheduleAuthor = require(path.join(VIEWER_DIR, 'schedule_author.js'));
+
+const KIT = path.join(__dirname, '..', '..', 'witness_kit');
+const { Witness } = require(path.join(KIT, 'contract'));
+const { TemplateTaskRow } = require(path.join(KIT, 'schemas', '4d_instantiation'));
+const INV = require(path.join(KIT, 'invariants', '4d_instantiation'));
+
+const BLD_DIR = process.env.BLD_DIR || path.join(HOME, 'bim-ootb', 'buildings');
+const BUILDINGS = process.argv.slice(2).length ? process.argv.slice(2)
+  : ['Hospital', 'HHS_Office_Federated', 'Duplex'];
+const START = '2026-01-01';
+
+// The EXECUTED table, whole-file — slicing rates.js drops SEQUENCE_NAME_OVERRIDES and SHIFT_HOURS.
+function executedRules() {
+  const sb = { console: { log() {}, warn() {}, error() {} } };
+  vm.createContext(sb);
+  vm.runInContext(fs.readFileSync(path.join(VIEWER_DIR, 'rates.js'), 'utf8'), sb);
+  return sb;
+}
+const T = JSON.parse(fs.readFileSync(path.join(VIEWER_DIR, 'rates', '4D_template.json'), 'utf8'));
+const dayOf = iso => Math.round((Date.parse(iso) - Date.parse(START)) / 86400000);
+
+(async () => {
+  const SQL = await initSqlJs({ locateFile: f => path.join(SQLJS_DIST, f) });
+  const R = executedRules();
+  const SHIFT = T.calendar.hours_per_shift;
+  const rows = [];
+  const perBuilding = [];
+
+  for (const bld of BUILDINGS) {
+    const file = path.join(BLD_DIR, bld + '_extracted.db');
+    if (!fs.existsSync(file)) { console.log('§4DTI_SKIP ' + bld); continue; }
+    const db = new SQL.Database(new Uint8Array(fs.readFileSync(file)));
+    const _l = console.log, _w = console.warn;
+    const logs = [];
+    console.log = (...a) => { const s = a.join(' '); if (s.indexOf('§TPL_') === 0 || s.indexOf('§AUTHOR_TPL') === 0) logs.push(s); };
+    console.warn = () => {};
+    const res = ScheduleAuthor.materializeZones(db, R.SEQUENCE_RULES, {
+      start: START, laborRates: R.LABOR_RATES, rates: R.RATES,
+      nameOverrides: R.SEQUENCE_NAME_OVERRIDES, defaultRule: R.SEQUENCE_DEFAULT,
+      scheduleGate: ScheduleGate, shiftHours: SHIFT, template: T
+    });
+    const els = ScheduleAuthor._buildScheduleElements(db, R.SEQUENCE_RULES, {
+      laborRates: R.LABOR_RATES, rates: R.RATES,
+      nameOverrides: R.SEQUENCE_NAME_OVERRIDES, defaultRule: R.SEQUENCE_DEFAULT
+    });
+    console.log = _l; console.warn = _w;
+    if (!res.ok) { console.log('§4DTI_FAIL ' + bld + ' ' + res.reason); db.close(); continue; }
+
+    // Read back what was PERSISTED — never the in-memory return value. A witness that trusts the
+    // function's own report cannot catch a write that silently dropped rows.
+    const q = s => { const r = db.exec(s); return r.length ? r[0].values : []; };
+    const taskRows = q("SELECT task_id,name,schedule_start,schedule_finish FROM tasks WHERE schedule_id='SCH_AUTHORED' AND is_summary=0");
+    const seqRows = q("SELECT predecessor_id,successor_id,sequence_type,lag_days FROM task_sequences");
+    const teRows = q("SELECT task_id,guid FROM task_elements");
+
+    const byGuid = {}; els.forEach(e => { byGuid[e.guid] = e; });
+    const work = {}, guidsOf = {};
+    teRows.forEach(([tid, g]) => {
+      (guidsOf[tid] = guidsOf[tid] || []).push(g);
+      const e = byGuid[g]; if (!e) return;
+      const w = work[tid] || (work[tid] = {});
+      const tr = (e.resource && e.resource !== '_DEFAULT') ? e.resource : '_DEFAULT';
+      w[tr] = (w[tr] || 0) + (e.installSecs || 0);
+    });
+    const shiftSecs = SHIFT * 3600;
+    const mc = t => (R.LABOR_RATES[t] && R.LABOR_RATES[t].max_crews) || 1;
+
+    const bRows = taskRows.map(([tid, name, s, f]) => {
+      const w = work[tid] || {};
+      let crewDays = 0, any = 0;
+      Object.keys(w).forEach(t => {
+        if (t === '_DEFAULT') return; any = 1;
+        const d = w[t] / (shiftSecs * mc(t)); if (d > crewDays) crewDays = d;
+      });
+      if (!any) crewDays = (w._DEFAULT || 0) / shiftSecs;
+      const dash = name.indexOf(' — ');
+      return {
+        building: bld, taskId: tid, name,
+        phase: dash > 0 ? name.slice(0, dash) : name,
+        storey: dash > 0 ? name.slice(dash + 3) : '',
+        startDay: dayOf(s), endDay: dayOf(f), crewDays,
+        guids: guidsOf[tid] || [],
+        members: (guidsOf[tid] || []).length
+      };
+    });
+    rows.push(...bRows);
+    perBuilding.push({ bld, tasks: bRows, seq: seqRows, els, logs, te: teRows, totalDays: res.totalDays });
+
+    const stack = INV.phaseOverlapCount(bRows, T);
+    const breaches = INV.gridCrewBreaches(bRows, els, R.LABOR_RATES, SHIFT);
+    console.log('§4DTI_CREW ' + bld + ' breaches=' + breaches.length + (breaches.length ? ' [' + breaches.join('; ') + ']' : ' — every trade within max_crews'));
+    console.log('§4DTI_ASSIGN ' + bld + ' elements=' + els.length + ' assignedToTasks=' + new Set(teRows.map(r => r[1])).size +
+      ' orphaned=' + (els.length - new Set(teRows.map(r => r[1])).size));
+    console.log('§4DTI ' + bld + ' els=' + els.length + ' tasks=' + bRows.length + ' edges=' + seqRows.length +
+      ' totalDays=' + res.totalDays + ' sameLevelPhaseOverlaps=' + stack.overlapping + '/' + stack.pairs +
+      ' distinctLags=' + JSON.stringify(Array.from(new Set(seqRows.map(r => r[3])))));
+    logs.filter(l => l.indexOf('§TPL_PHASE_ABSENT') === 0 || l.indexOf('§TPL_PHASE_COVERAGE') === 0)
+      .forEach(l => console.log('   ' + l));
+    db.close();
+  }
+
+  Witness('4d_template_instantiation')
+    .population(() => rows)
+    .schema(TemplateTaskRow)
+    // THE POINT (§S68): packed and strictly sequential — no two phases on the same level overlap.
+    .invariant('no-same-level-phase-overlap', () => perBuilding.every(b => INV.phaseOverlapCount(b.tasks, T).overlapping === 0))
+    // duration_rule: a task's window must cover its own per-trade work content.
+    .invariant('window-covers-per-trade-work', rs => INV.windowCoversWork(rs))
+    // The tautology killer: every persisted lag is the TEMPLATE's declared value, not a date gap.
+    .invariant('lags-come-from-the-template', () => perBuilding.every(b => INV.lagsAreTemplateDeclared(b.seq, T)))
+    // §4D_BAND_MONOTONIC as data: a phase never starts before the same phase one level below ends.
+    .invariant('ladder-holds-across-levels', () => perBuilding.every(b => INV.ladderHolds(b.tasks, b.seq)))
+    // Float must EXIST — an edge graph that is tight everywhere is the old tautology in a new shape.
+    .invariant('float-exists-somewhere', () => perBuilding.every(b => INV.slackEdgeCount(b.tasks, b.seq) > 0))
+    // Crew capacity across the emitted grid, the HOP6b check as a gate.
+    .invariant('task-grid-is-crew-legal', () => perBuilding.every(b => INV.gridCrewBreaches(b.tasks, b.els, R.LABOR_RATES, SHIFT).length === 0))
+    // NO SILENT LOSS: every element the engine built must land in exactly one task. Caught a real
+    // defect in the instantiator (a building-scope phase dropped its own upper-level elements) that
+    // every other number — tasks, edges, days, coverage — reported as fine.
+    .invariant('every-element-lands-in-a-task', () => perBuilding.every(b => INV.everyElementLandsInATask(b.els.length, b.te)))
+    // Absence is REPORTED, never silent — the §S67 HOP1/HOP3 defect.
+    .invariant('absence-is-reported', () => perBuilding.every(b => b.logs.some(l => l.indexOf('§TPL_PHASE_COVERAGE') === 0)))
+    .redControl(rs => rs.map((r, i) => i ? r : Object.assign({}, r, { endDay: r.startDay })))
+    .run();
+})();

--- a/witness_kit/invariants/4d_instantiation.js
+++ b/witness_kit/invariants/4d_instantiation.js
@@ -1,0 +1,149 @@
+// witness_kit/invariants/4d_instantiation.js — predicates for the §TEMPLATE_INSTANTIATE task grid.
+// Spec: bim-compiler prompts/4D_SCHEDULE_PERFECTION.md §S69.
+//
+// These check the INVERSION described in §S68: phases are now emitted from 4D_template.json and
+// elements assigned to them, instead of phases being grouped out of the element solve afterwards.
+// The old shape could not be gated at all — an envelope over the solve agrees with the solve by
+// construction, so there was nothing for a predicate to contradict.
+'use strict';
+
+/**
+ * G-TI-STACK — how many same-level phase PAIRS overlap in time. The template declares FS+0 within
+ * a level, so the answer must be 0. MEASURED before the inversion: HHS 10/29 (34%), Clinic 13/65,
+ * Duplex 7/38, Terminal 18/109, worst = HHS Level 1 Architecture sitting entirely inside
+ * Superstructure for 13.4 days.
+ * @param {object[]} tasks
+ * @param {object} T - the parsed template, for phase order
+ * @returns {{pairs:number, overlapping:number}}
+ */
+function phaseOverlapCount(tasks, T) {
+  const order = {}; T.phases.forEach((p, i) => { order[p.name] = i; });
+  const byLevel = {};
+  tasks.forEach(t => { if (order[t.phase] != null) (byLevel[t.storey] = byLevel[t.storey] || []).push(t); });
+  let pairs = 0, overlapping = 0;
+  Object.keys(byLevel).forEach(lv => {
+    const list = byLevel[lv];
+    for (let i = 0; i < list.length; i++) for (let j = i + 1; j < list.length; j++) {
+      pairs++;
+      const ov = Math.min(list[i].endDay, list[j].endDay) - Math.max(list[i].startDay, list[j].startDay);
+      if (ov > 0) overlapping++;
+    }
+  });
+  return { pairs, overlapping };
+}
+
+/**
+ * G-TI-WORK — duration_rule: a task's window must cover its own per-trade work content. Per-trade,
+ * never total-seconds over pooled crews (§S67: the sum form understated HHS by 1.74x).
+ * @param {object[]} rows
+ * @returns {boolean}
+ */
+const windowCoversWork = rows => rows.every(r => (r.endDay - r.startDay) >= Math.ceil(r.crewDays) - 1e-9);
+
+/**
+ * G-TI-LAGS — THE TAUTOLOGY KILLER. Every persisted lag must be a value the TEMPLATE declares, not
+ * a number computed from the dates the edge is supposed to constrain. Before the inversion,
+ * schedule_author.js wrote `lagDays = sd.s - pd.e` — the answer restated as its own constraint —
+ * and §S67 HOP 5 measured 25 of 25 edges that way on HHS.
+ * @param {Array[]} seqRows - [pred, succ, type, lag]
+ * @param {object} T
+ * @returns {boolean}
+ */
+function lagsAreTemplateDeclared(seqRows, T) {
+  const allowed = new Set(T.dependencies.within_level.concat(T.dependencies.across_levels)
+    .map(e => Number(e.lag_days || 0)));
+  const types = new Set(T.dependencies.within_level.concat(T.dependencies.across_levels)
+    .map(e => e.type || 'FS'));
+  return seqRows.length > 0 && seqRows.every(r => allowed.has(Number(r[3])) && types.has(r[2]));
+}
+
+/**
+ * G-TI-LADDER — §4D_BAND_MONOTONIC as persisted data: for every across-level edge, the successor
+ * may not start before the predecessor finishes (plus its declared lag).
+ * @param {object[]} tasks
+ * @param {Array[]} seqRows
+ * @returns {boolean}
+ */
+function ladderHolds(tasks, seqRows) {
+  const byId = {}; tasks.forEach(t => { byId[t.taskId] = t; });
+  return seqRows.every(([p, s, , lag]) => {
+    const pt = byId[p], st = byId[s];
+    if (!pt || !st) return true;                   // summary rows / foreign edges are not ours
+    return st.startDay >= pt.endDay + Number(lag) - 1e-9;
+  });
+}
+
+/**
+ * G-TI-FLOAT — at least one edge must have SLACK. A graph that is tight on every edge is the old
+ * tautology in a new shape: CPM would again report every task critical with float 0..0 (§S67
+ * measured exactly that, 17 of 17 on HHS). Slack appears because levels run in parallel under the
+ * ladder while each level's own chain is packed.
+ * @param {object[]} tasks
+ * @param {Array[]} seqRows
+ * @returns {number} count of edges whose successor starts strictly after pred.finish + lag
+ */
+function slackEdgeCount(tasks, seqRows) {
+  const byId = {}; tasks.forEach(t => { byId[t.taskId] = t; });
+  let n = 0;
+  seqRows.forEach(([p, s, , lag]) => {
+    const pt = byId[p], st = byId[s];
+    if (pt && st && st.startDay > pt.endDay + Number(lag) + 1e-9) n++;
+  });
+  return n;
+}
+
+/**
+ * G-TI-CREW — capacity_rule across the whole emitted grid. Tasks on different levels run in
+ * parallel, so the same trade can be demanded twice at once; average crew demand per task per trade
+ * is secs_t / (shift * durationDays), summed over every task live on a given day.
+ * MEASURED need: with a superstructure-only ladder this fails (HHS PLUMBER 3.67 vs cap 2), which is
+ * why 4D_template.json v1.2.0 chains EVERY level-scope phase.
+ * @param {object[]} tasks
+ * @param {object[]} els
+ * @param {object} laborRates
+ * @param {number} shiftHours
+ * @returns {string[]} one string per breaching trade, empty when legal
+ */
+function gridCrewBreaches(tasks, els, laborRates, shiftHours) {
+  const shiftSecs = shiftHours * 3600;
+  const byGuid = {}; els.forEach(e => { byGuid[e.guid] = e; });
+  const demand = {};
+  tasks.forEach(t => {
+    const span = Math.max(1, t.endDay - t.startDay);
+    const secs = {};
+    (t.guids || []).forEach(g => {
+      const e = byGuid[g]; if (!e || !e.resource || e.resource === '_DEFAULT') return;
+      secs[e.resource] = (secs[e.resource] || 0) + (e.installSecs || 0);
+    });
+    Object.keys(secs).forEach(tr => {
+      const crews = secs[tr] / (shiftSecs * span);
+      const d = demand[tr] || (demand[tr] = {});
+      for (let day = t.startDay; day < t.endDay; day++) d[day] = (d[day] || 0) + crews;
+    });
+  });
+  const out = [];
+  Object.keys(demand).forEach(tr => {
+    const cap = (laborRates[tr] && laborRates[tr].max_crews) || 1;
+    let pk = 0; Object.keys(demand[tr]).forEach(d => { if (demand[tr][d] > pk) pk = demand[tr][d]; });
+    if (pk > cap + 1e-6) out.push(tr + ' peak=' + pk.toFixed(2) + ' cap=' + cap);
+  });
+  return out;
+}
+
+/**
+ * G-TI-NOLOSS — every element the engine built must land in exactly one task. This is the gate that
+ * caught a real defect in the instantiator itself: a building-scope phase (Substructure) emits ONE
+ * task on the lowest level, and the first cut skipped that phase's cells on every OTHER level —
+ * silently dropping their elements. MEASURED on Hospital: 63,181 of 63,182 assigned, one lost, and
+ * it was invisible in every other number (tasks, edges, days, phase coverage all looked right).
+ * @param {number} elementCount
+ * @param {Array[]} teRows - [task_id, guid]
+ * @returns {boolean}
+ */
+const everyElementLandsInATask = (elementCount, teRows) => {
+  const seen = new Set();
+  teRows.forEach(r => seen.add(r[1]));
+  return seen.size === elementCount;
+};
+
+module.exports = { everyElementLandsInATask, phaseOverlapCount, windowCoversWork, lagsAreTemplateDeclared, ladderHolds, slackEdgeCount, gridCrewBreaches };

--- a/witness_kit/schemas/4d_instantiation.js
+++ b/witness_kit/schemas/4d_instantiation.js
@@ -1,0 +1,25 @@
+// witness_kit/schemas/4d_instantiation.js — the contract for ONE task emitted from 4D_template.json.
+// Spec: bim-compiler prompts/4D_SCHEDULE_PERFECTION.md §S69.
+//
+// Read back out of the PERSISTED `tasks` rows, never from materializeZones' return value: a witness
+// that trusts the writer's own report cannot catch a write that silently dropped rows.
+'use strict';
+
+const TemplateTaskRow = {
+  type: 'object',
+  required: ['building', 'taskId', 'name', 'phase', 'storey', 'startDay', 'endDay', 'crewDays', 'members'],
+  properties: {
+    building:  { type: 'string', minLength: 1 },
+    taskId:    { type: 'string', pattern: '^TASK_' },
+    name:      { type: 'string', minLength: 1 },
+    phase:     { type: 'string', minLength: 1 },
+    storey:    { type: 'string' },
+    startDay:  { type: 'integer', minimum: 0 },
+    endDay:    { type: 'integer', minimum: 1 },
+    crewDays:  { type: 'number', minimum: 0 },
+    members:   { type: 'integer', minimum: 1 }
+  },
+  additionalProperties: true
+};
+
+module.exports = { TemplateTaskRow };


### PR DESCRIPTION
THE INVERSION §S68 named. Until now the chain ran elements -> phases: computeSchedule placed
elements and deriveZones CREATED phases afterwards by grouping them and taking min-start/max-end.
A phase bar was an ENVELOPE over what the elements did, and an envelope cannot constrain what
drew it — which is why phase stacking could never be reined in.

materializeZones(db, rules, {..., template}) now runs phases -> elements: one task per
(phase x real level) the template declares, priced by duration_rule (per-trade work content),
placed by dependencies (FS+0 within a level + the §4D_BAND_MONOTONIC ladder across levels),
levelled against capacity_rule, with elements ASSIGNED to tasks instead of defining them.
instantiateTemplate() is pure and node-testable (no DB, no globals).

OPT-IN, NOT YET LIVE: no call site passes opts.template, so every existing path is byte-identical.
Suite confirms: green=58 new_red=1 known_red=7 (the +1 green is the new witness; the one red is
the same pre-existing unrelated witness_cpe_buildup_require_tm_first baselined in §S67).

MEASURED, legacy vs template, same DBs, 24h shift:
  building     legacy            template          delta
  Hospital     356d 36t 58e      318d 35t 55e      -11%   (levelling: 7 tasks delayed, +81d)
  Terminal     132d 73t 107e      96d 71t 98e      -27%   (levelling: 11 tasks delayed, +226d)
  HHS          47d 17t 25e        49d 17t 25e       +4%   (levelling: none needed)
  Duplex       10d 19t 27e        12d 18t 26e      +20%   (2 days)
Shorter on the two big buildings, marginally longer on the two small ones — and the quality
numbers move one way only.

WITNESS viewer/tests/witness_4d_template_instantiation.js — Hospital + HHS + Duplex, 70 tasks,
pass=11 fail=0:
  no-same-level-phase-overlap    0/65, 0/29, 0/33   (was HHS 10/29=34%, Duplex 7/38, Terminal 18/109)
  lags-come-from-the-template    every persisted lag = 0, the template's declared value
                                 (was `lagDays = sd.s - pd.e`, the answer restated as its constraint)
  float-exists-somewhere         edges have slack, so CPM can no longer report 100% critical
  ladder-holds-across-levels     a phase never starts before itself one level below finishes
  window-covers-per-trade-work   duration_rule honoured on every task
  task-grid-is-crew-legal        every trade within max_crews across the whole grid
  every-element-lands-in-a-task  63,182/63,182 on Hospital
  absence-is-reported            §TPL_PHASE_COVERAGE / §TPL_PHASE_ABSENT / §TPL_PHASE_GAP

TWO REAL DEFECTS FOUND BY THE WITNESS, both fixed here:
1. Hospital breached PLUMBER (peak 3.26 vs cap 2). The ladder stops a phase overtaking ITSELF; it
   does not stop MEP Rough-in on level 5 and MEP Final on level 2 sharing one plumber pool. Fixed
   by applying capacity_rule as ordinary delay-only resource levelling in topological order.
   HHS/Duplex never showed it — it takes 8 levels to expose.
2. A building-scope phase (Substructure) emitted its one task on the lowest level and SKIPPED its
   own cells on every other level, silently dropping their elements: 63,181 of 63,182 on Hospital.
   Invisible in tasks, edges, days and phase coverage — only the element count caught it. Now the
   building-scope task collects its elements from all levels, gated by every-element-lands-in-a-task.

New §-logs: §AUTHOR_TPL, §TPL_PHASE_COVERAGE, §TPL_PHASE_ABSENT, §TPL_PHASE_GAP,
§TPL_CAPACITY_LEVEL, §TPL_ELEMENT_ORPHAN.

🤖 Generated with [Claude Code](https://claude.com/claude-code)