### PR TITLE
feat(4d): §TPL_MOVIE_BINDS_BARS — bind the movie to the bars, or §S69 is a regression (§S70)

### DIFF
--- a/viewer/schedule_author.js
+++ b/viewer/schedule_author.js
@@ -858,6 +858,70 @@
     return { ok: true, scheduleId: schedId, zoneCount: rolled.zones.length, edgeCount: edgeN, totalDays: totalDays };
   }
 
+  // ══ §TPL_MOVIE_BINDS_BARS (2026-08-25, bim-compiler prompts/4D_SCHEDULE_PERFECTION.md §S70) ══
+  // THE SECOND HALF OF THE INVERSION, and without it the first half is a REGRESSION.
+  //
+  // The legacy bars were ENVELOPES over the element solve, so an element was inside its own bar by
+  // construction: MEASURED 98.9% Hospital / 95.2% Terminal / 86.8% Duplex, worst offset 0.5 days
+  // (pure day-rounding). Emitting bars from the template instead makes the bar an INDEPENDENT
+  // statement — and the two timelines then disagree wildly: 54.5% / 35.4% / 18.8% inside, worst
+  // offset 274.3 days on Hospital, 81.1% of Duplex's elements appearing BEFORE their own bar.
+  // That is the user's reported hell — things appearing when no bar says they should — made worse,
+  // not better. So the movie must be bound to the bars.
+  //
+  // THE MAP: per task, an order-preserving affine map of that task's own solve envelope
+  // [minStart, maxEnd] onto its authored window [s, e]. Monotone, so EVERY ordering the solve
+  // established survives it — support-before-supported, host-before-hosted, band monotonicity are
+  // all preserved exactly, because a monotone map cannot swap two times. Relative widths survive
+  // too (uniform scale within a task), so nothing collapses to zero that was not already tiny.
+  // A degenerate task (every element solved at the same instant — the "zero minute stacking"
+  // shape) is spread EVENLY across its window instead, which is the one case an affine map cannot
+  // handle and the one case the user reported by name.
+  //
+  // This is the same seam §ZONE_DISPLAY_AUTHORING used, run the other way: that authored windows
+  // FROM the display timeline; this authors the display timeline FROM the windows. Only one of the
+  // two can be the source, and after §S68 it is the template.
+  function remapSolveToTasks(solve, tasks, startISO) {
+    var base = Date.parse(startISO || '2026-01-01');
+    var out = {}, degenerate = 0, mapped = 0;
+    for (var i = 0; i < tasks.length; i++) {
+      var t = tasks[i], g, st;
+      var wS = base + t.sDays * 86400000, wE = base + t.eDays * 86400000;
+      var lo = Infinity, hi = -Infinity, have = 0;
+      for (var j = 0; j < t.guids.length; j++) {
+        st = solve[t.guids[j]]; if (!st) continue;
+        have++;
+        if (st.start < lo) lo = st.start;
+        if (st.end > hi) hi = st.end;
+      }
+      if (!have) continue;
+      var span = hi - lo;
+      if (span <= 0) {
+        // Degenerate: everything solved at one instant. Spread evenly, in a deterministic order,
+        // so the bar shows work progressing instead of one silent stack at its left edge.
+        degenerate++;
+        var ordered = t.guids.filter(function (x) { return solve[x]; }).slice().sort();
+        var step = (wE - wS) / Math.max(1, ordered.length);
+        for (var k = 0; k < ordered.length; k++) {
+          out[ordered[k]] = { start: Math.round(wS + k * step), end: Math.round(wS + (k + 1) * step) };
+          mapped++;
+        }
+        continue;
+      }
+      var scale = (wE - wS) / span;
+      for (var m = 0; m < t.guids.length; m++) {
+        g = t.guids[m]; st = solve[g]; if (!st) continue;
+        var ns = Math.round(wS + (st.start - lo) * scale);
+        var ne = Math.round(wS + (st.end - lo) * scale);
+        if (ne <= ns) ne = ns + 1;                 // never a zero-width element
+        if (ne > wE) ne = wE;
+        out[g] = { start: ns, end: ne };
+        mapped++;
+      }
+    }
+    return { schedule: out, mapped: mapped, degenerateTasks: degenerate };
+  }
+
   // _writeTemplateSchedule — the §TEMPLATE_INSTANTIATE write path. Same tables, same schedule_id,
   // same idempotent rebuild as the legacy grouping path; the difference is WHERE the numbers come
   // from: task windows from 4D_template.json's duration_rule, task_sequences from its dependencies.
@@ -936,8 +1000,15 @@
       ' edges=' + inst.edges.length + ' (withinLevel=' + wl + ' acrossLevels=' + al + ')' +
       ' elements=' + elements.length + ' totalDays=' + inst.totalDays +
       ' — every lag is the TEMPLATE\'s, none derived from the dates it constrains');
+    // §TPL_MOVIE_BINDS_BARS — bind the movie to the bars we just authored, from the SAME task
+    // objects, so the two can never be computed off different grids.
+    var _rm = remapSolveToTasks(schedule, inst.tasks, start);
+    console.log('§TPL_MOVIE_BINDS_BARS remapped=' + _rm.mapped + '/' + elements.length +
+      ' degenerateTasksSpreadEvenly=' + _rm.degenerateTasks +
+      ' — every element now plays inside the bar that claims it');
     return { ok: true, scheduleId: schedId, zoneCount: inst.tasks.length, edgeCount: inst.edges.length,
-             totalDays: inst.totalDays, templateVersion: T.meta.version, reports: inst.reports };
+             totalDays: inst.totalDays, templateVersion: T.meta.version, reports: inst.reports,
+             tasks: inst.tasks, displaySchedule: _rm.schedule };
   }
 
   // materializeDefault(db, rules, opts) — originate the smart-default schedule on a blank model.
@@ -2251,6 +2322,7 @@
     materializeZones: materializeZones,
     _buildScheduleElements: _buildScheduleElements,
     instantiateTemplate: instantiateTemplate,
+    remapSolveToTasks: remapSolveToTasks,
     scheduleContiguous: scheduleContiguous,
     activeSchedule: activeSchedule,
     assignElement: assignElement,

--- a/viewer/tests/probe_4d_movie_vs_bars.js
+++ b/viewer/tests/probe_4d_movie_vs_bars.js
@@ -1,0 +1,94 @@
+#!/usr/bin/env node
+// PROBE — the movie plays the ELEMENT SOLVE; the bars now come from 4D_template.json. Two
+// timelines. This measures whether they agree, before anything is wired live.
+// Spec: bim-compiler prompts/4D_SCHEDULE_PERFECTION.md §S70.
+// Command: node viewer/tests/probe_4d_movie_vs_bars.js [Building ...]
+'use strict';
+const fs = require('fs'), path = require('path'), vm = require('vm'), os = require('os');
+const HOME = os.homedir();
+const initSqlJs = require(path.join(HOME, 'bim-ootb', 'node_modules', 'sql.js'));
+const SQLJS_DIST = path.join(HOME, 'bim-ootb', 'node_modules', 'sql.js', 'dist');
+const V = path.join(__dirname, '..');
+const SG = require(path.join(V, 'schedule_gate.js')); global.ScheduleGate = SG;
+const SA = require(path.join(V, 'schedule_author.js'));
+const T = JSON.parse(fs.readFileSync(path.join(V, 'rates', '4D_template.json'), 'utf8'));
+const START = '2026-01-01';
+
+function rules() {
+  const sb = { console: { log() {}, warn() {}, error() {} } };
+  vm.createContext(sb);
+  vm.runInContext(fs.readFileSync(path.join(V, 'rates.js'), 'utf8'), sb);
+  return sb;
+}
+const BUILDINGS = process.argv.slice(2).length ? process.argv.slice(2)
+  : ['Hospital', 'Terminal', 'HHS_Office_Federated', 'Duplex'];
+
+(async () => {
+  const SQL = await initSqlJs({ locateFile: f => path.join(SQLJS_DIST, f) });
+  const R = rules(), SHIFT = T.calendar.hours_per_shift;
+  const maxCrews = {};
+  for (const k in R.LABOR_RATES) if (R.LABOR_RATES[k].max_crews) maxCrews[k] = R.LABOR_RATES[k].max_crews;
+
+  for (const bld of BUILDINGS) {
+    const f = path.join(HOME, 'bim-ootb', 'buildings', bld + '_extracted.db');
+    if (!fs.existsSync(f)) { console.log('§MVB_SKIP ' + bld); continue; }
+    const db = new SQL.Database(new Uint8Array(fs.readFileSync(f)));
+    const _l = console.log, _w = console.warn;
+    console.log = () => {}; console.warn = () => {};
+    const els = SA._buildScheduleElements(db, R.SEQUENCE_RULES, {
+      laborRates: R.LABOR_RATES, rates: R.RATES,
+      nameOverrides: R.SEQUENCE_NAME_OVERRIDES, defaultRule: R.SEQUENCE_DEFAULT });
+    const solve = SG.computeSchedule(els, Date.parse(START), 1, maxCrews, SHIFT);
+    const mres = SA.materializeZones(db, R.SEQUENCE_RULES, { start: START, laborRates: R.LABOR_RATES, rates: R.RATES,
+      nameOverrides: R.SEQUENCE_NAME_OVERRIDES, defaultRule: R.SEQUENCE_DEFAULT,
+      scheduleGate: SG, shiftHours: SHIFT, template: process.env.LEGACY ? undefined : T });
+    // REMAP=1 measures the movie AFTER §TPL_MOVIE_BINDS_BARS binds it to the authored windows.
+    const play = (process.env.REMAP && mres && mres.displaySchedule) ? mres.displaySchedule : solve;
+    console.log = _l; console.warn = _w;
+
+    const q = s => { const r = db.exec(s); return r.length ? r[0].values : []; };
+    const win = {};
+    q("SELECT task_id,schedule_start,schedule_finish FROM tasks WHERE schedule_id='SCH_AUTHORED' AND is_summary=0")
+      .forEach(([t, s, e]) => { win[t] = { s: Date.parse(s), e: Date.parse(e) }; });
+    const taskOf = {};
+    q("SELECT task_id,guid FROM task_elements").forEach(([t, g]) => { taskOf[g] = t; });
+
+    let inside = 0, early = 0, late = 0, noTask = 0, n = 0;
+    let worstEarly = 0, worstLate = 0;
+    let sMin = Infinity, sMax = -Infinity, tMin = Infinity, tMax = -Infinity;
+    els.forEach(e => {
+      const st = play[e.guid]; if (!st) return;
+      n++;
+      if (st.start < sMin) sMin = st.start;
+      if (st.end > sMax) sMax = st.end;
+      const w = win[taskOf[e.guid]];
+      if (!w) { noTask++; return; }
+      if (w.s < tMin) tMin = w.s;
+      if (w.e > tMax) tMax = w.e;
+      const eBy = (w.s - st.start) / 86400000, lBy = (st.end - w.e) / 86400000;
+      if (eBy > 0) { early++; if (eBy > worstEarly) worstEarly = eBy; }
+      if (lBy > 0) { late++; if (lBy > worstLate) worstLate = lBy; }
+      if (eBy <= 0 && lBy <= 0) inside++;
+    });
+    // A monotone map cannot swap two times. Verify that claim rather than assert it: for every
+    // task, compare the raw-solve ordering of its members against the played ordering.
+    let inv = 0, cmp = 0;
+    Object.keys(win).forEach(tid => {
+      const gs = [];
+      for (const g in taskOf) if (taskOf[g] === tid && solve[g] && play[g]) gs.push(g);
+      gs.sort((a, b) => solve[a].start - solve[b].start || (a < b ? -1 : 1));
+      for (let i = 1; i < gs.length; i++) { cmp++; if (play[gs[i]].start < play[gs[i - 1]].start) inv++; }
+    });
+    const pct = x => (100 * x / Math.max(1, n)).toFixed(1) + '%';
+    console.log('§MVB[' + (process.env.LEGACY ? 'LEGACY' : (process.env.REMAP ? 'TEMPLATE+REMAP' : 'TEMPLATE')) + '] ' + bld + ' n=' + n +
+      ' movieSpan=' + ((sMax - sMin) / 86400000).toFixed(1) + 'd' +
+      ' barsSpan=' + ((tMax - tMin) / 86400000).toFixed(1) + 'd' +
+      ' ratio=' + ((tMax - tMin) / Math.max(1, sMax - sMin)).toFixed(2) + 'x');
+    console.log('   insideItsOwnBar=' + inside + ' (' + pct(inside) + ')' +
+      '  startsBeforeItsBar=' + early + ' (' + pct(early) + ', worst ' + worstEarly.toFixed(1) + 'd)' +
+      '  endsAfterItsBar=' + late + ' (' + pct(late) + ', worst ' + worstLate.toFixed(1) + 'd)' +
+      (noTask ? '  UNASSIGNED=' + noTask : '') +
+      '\n   orderInversionsVsSolve=' + inv + '/' + cmp + ' (a monotone remap must be 0)');
+    db.close();
+  }
+})();

--- a/viewer/tests/witness_4d_movie_binds_bars.js
+++ b/viewer/tests/witness_4d_movie_binds_bars.js
@@ -1,0 +1,102 @@
+#!/usr/bin/env node
+// WITNESS — §TPL_MOVIE_BINDS_BARS: the movie plays inside the bars the 4D template authored.
+// Spec: bim-compiler prompts/4D_SCHEDULE_PERFECTION.md §S70.
+//
+// WHICH LAYER THIS PROVES (WITNESS_INTERFACE_FRAMEWORK.md §CRISIS LESSON 1):
+//   the RELATIONSHIP between two layers — ScheduleGate.computeSchedule's element times as remapped
+//   for display, and the persisted `tasks` windows. It says nothing about drawn pixels or kernel_ops.
+//
+// ISSUE THIS PROVES OR DISPROVES: under the legacy path a bar was an ENVELOPE over the element
+// solve, so an element was inside its own bar by construction — MEASURED 98.9% Hospital / 95.2%
+// Terminal / 86.8% Duplex, worst offset 0.5d (day rounding). §S69 made the bar an INDEPENDENT
+// statement authored from 4D_template.json, and the pair went wrong immediately: 54.5% / 35.4% /
+// 18.8% inside, worst 274.3d on Hospital, and 81.1% of Duplex's elements appearing BEFORE their own
+// bar. That is the user's reported hell made worse. This witness gates the bind that fixes it, and
+// gates that the bind does not spend the orderings the solve was expensive to win.
+//
+// Command: node viewer/tests/witness_4d_movie_binds_bars.js [Building ...]
+'use strict';
+const fs = require('fs'), path = require('path'), vm = require('vm'), os = require('os');
+const HOME = os.homedir();
+const initSqlJs = require(path.join(HOME, 'bim-ootb', 'node_modules', 'sql.js'));
+const SQLJS_DIST = path.join(HOME, 'bim-ootb', 'node_modules', 'sql.js', 'dist');
+const V = process.env.VIEWER_DIR || path.join(__dirname, '..');
+const SG = require(path.join(V, 'schedule_gate.js')); global.ScheduleGate = SG;
+const SA = require(path.join(V, 'schedule_author.js'));
+const KIT = path.join(__dirname, '..', '..', 'witness_kit');
+const { Witness } = require(path.join(KIT, 'contract'));
+const { PlayedElementRow } = require(path.join(KIT, 'schemas', '4d_movie_bars'));
+const INV = require(path.join(KIT, 'invariants', '4d_movie_bars'));
+
+const T = JSON.parse(fs.readFileSync(path.join(V, 'rates', '4D_template.json'), 'utf8'));
+const BLD_DIR = process.env.BLD_DIR || path.join(HOME, 'bim-ootb', 'buildings');
+const BUILDINGS = process.argv.slice(2).length ? process.argv.slice(2)
+  : ['Hospital', 'HHS_Office_Federated', 'Duplex'];
+const START = '2026-01-01';
+
+function executedRules() {
+  const sb = { console: { log() {}, warn() {}, error() {} } };
+  vm.createContext(sb);
+  vm.runInContext(fs.readFileSync(path.join(V, 'rates.js'), 'utf8'), sb);
+  return sb;
+}
+
+(async () => {
+  const SQL = await initSqlJs({ locateFile: f => path.join(SQLJS_DIST, f) });
+  const R = executedRules(), SHIFT = T.calendar.hours_per_shift;
+  const maxCrews = {};
+  for (const k in R.LABOR_RATES) if (R.LABOR_RATES[k].max_crews) maxCrews[k] = R.LABOR_RATES[k].max_crews;
+  const rows = [];
+
+  for (const bld of BUILDINGS) {
+    const f = path.join(BLD_DIR, bld + '_extracted.db');
+    if (!fs.existsSync(f)) { console.log('§MBB_SKIP ' + bld); continue; }
+    const db = new SQL.Database(new Uint8Array(fs.readFileSync(f)));
+    const _l = console.log, _w = console.warn;
+    let bindLog = '';
+    console.log = (...a) => { const s = a.join(' '); if (s.indexOf('§TPL_MOVIE_BINDS_BARS') === 0) bindLog = s; };
+    console.warn = () => {};
+    const els = SA._buildScheduleElements(db, R.SEQUENCE_RULES, {
+      laborRates: R.LABOR_RATES, rates: R.RATES,
+      nameOverrides: R.SEQUENCE_NAME_OVERRIDES, defaultRule: R.SEQUENCE_DEFAULT });
+    const solve = SG.computeSchedule(els, Date.parse(START), 1, maxCrews, SHIFT);
+    const res = SA.materializeZones(db, R.SEQUENCE_RULES, {
+      start: START, laborRates: R.LABOR_RATES, rates: R.RATES,
+      nameOverrides: R.SEQUENCE_NAME_OVERRIDES, defaultRule: R.SEQUENCE_DEFAULT,
+      scheduleGate: SG, shiftHours: SHIFT, template: T });
+    console.log = _l; console.warn = _w;
+    if (!res.ok || !res.displaySchedule) { console.log('§MBB_FAIL ' + bld); db.close(); continue; }
+
+    // Windows read back from the PERSISTED tasks, never from the return value.
+    const q = s => { const r = db.exec(s); return r.length ? r[0].values : []; };
+    const win = {};
+    q("SELECT task_id,schedule_start,schedule_finish FROM tasks WHERE schedule_id='SCH_AUTHORED' AND is_summary=0")
+      .forEach(([t, s, e]) => { win[t] = { s: Date.parse(s), e: Date.parse(e) }; });
+    const taskOf = {};
+    q("SELECT task_id,guid FROM task_elements").forEach(([t, g]) => { taskOf[g] = t; });
+
+    const play = res.displaySchedule;
+    let added = 0;
+    els.forEach(e => {
+      const p = play[e.guid], w = win[taskOf[e.guid]], sv = solve[e.guid];
+      if (!p || !w || !sv) return;
+      rows.push({ building: bld, guid: e.guid, taskId: taskOf[e.guid],
+        solveStart: sv.start, playStart: p.start, playEnd: p.end, winStart: w.s, winEnd: w.e });
+      added++;
+    });
+    console.log('§MBB ' + bld + ' elements=' + els.length + ' played=' + added + '  ' + bindLog.replace('§TPL_MOVIE_BINDS_BARS ', ''));
+    db.close();
+  }
+
+  Witness('4d_movie_binds_bars')
+    .population(() => rows)
+    .schema(PlayedElementRow)
+    .invariant('every-element-inside-its-bar', INV.everyElementInsideItsBar)
+    .invariant('remap-preserves-solve-order', INV.remapPreservesSolveOrder)
+    .invariant('no-zero-width-element', INV.noZeroWidthElement)
+    .invariant('movie-span-equals-bars-span', INV.movieSpanEqualsBarsSpan)
+    // RED CONTROL — reproduce the real defect: put one element back on its RAW solve time, which is
+    // exactly the shape measured before the bind (81.1% of Duplex outside its own bar).
+    .redControl(rs => rs.map((r, i) => i ? r : Object.assign({}, r, { playStart: r.winStart - 86400000 })))
+    .run();
+})();

--- a/witness_kit/invariants/4d_movie_bars.js
+++ b/witness_kit/invariants/4d_movie_bars.js
@@ -1,0 +1,73 @@
+// witness_kit/invariants/4d_movie_bars.js — predicates for §TPL_MOVIE_BINDS_BARS.
+// Spec: bim-compiler prompts/4D_SCHEDULE_PERFECTION.md §S70.
+//
+// The bar and the movie are TWO independent computations of one real-world fact — when a thing gets
+// built — which is exactly the "two clocks" shape WITNESS_INTERFACE_FRAMEWORK.md §8 names. Under the
+// legacy path they agreed by construction (the bar was an envelope over the solve), so nothing had
+// to check the relationship. Emitting bars from 4D_template.json makes the bar an INDEPENDENT
+// statement, and the pair immediately went wrong: MEASURED 54.5% / 35.4% / 18.8% of elements still
+// inside their own bar, worst offset 274.3 days. These predicates check the relationship.
+'use strict';
+
+/**
+ * G-MB-INSIDE — every element must play inside the bar that claims it. No tolerance: the remap is
+ * an affine map ONTO the window, so an element outside it is a bug, not a rounding artifact.
+ * @param {object[]} rows - {guid, playStart, playEnd, winStart, winEnd}
+ * @returns {boolean}
+ */
+const everyElementInsideItsBar = rows =>
+  rows.every(r => r.playStart >= r.winStart && r.playEnd <= r.winEnd);
+
+/**
+ * G-MB-ORDER — the remap must not reorder anything. It is a monotone (order-preserving) affine map
+ * per task, so every ordering the solve established survives: support-before-supported,
+ * host-before-hosted, band monotonicity. Those were expensive to win (§HOSTED_BEFORE_HOST,
+ * §STAIR_FLIGHT_GRID_VISIBILITY, §4D_BAND_MONOTONIC) and a display remap must not spend them.
+ * Verified by comparing raw-solve order against played order within each task, not asserted.
+ * @param {object[]} rows
+ * @returns {boolean}
+ */
+function remapPreservesSolveOrder(rows) {
+  const byTask = {};
+  // Keyed by BUILDING + taskId. Task ids are derived from phase+storey, so
+  // TASK_SUPERSTRUCTURE_LEVEL_1 exists in Hospital, HHS and Duplex alike — grouping on taskId alone
+  // pools three buildings' elements into one "task" and manufactures inversions that do not exist.
+  // (That is exactly what it did on first run: FAIL here, 0 inversions when checked per building.)
+  rows.forEach(r => { const k = r.building + '|' + r.taskId; (byTask[k] = byTask[k] || []).push(r); });
+  return Object.keys(byTask).every(t => {
+    const list = byTask[t].slice().sort((a, b) => a.solveStart - b.solveStart || (a.guid < b.guid ? -1 : 1));
+    for (let i = 1; i < list.length; i++) if (list[i].playStart < list[i - 1].playStart) return false;
+    return true;
+  });
+}
+
+/**
+ * G-MB-NOZERO — no element may play for zero time. A zero-width element is invisible in the movie
+ * and stacks at its bar's left edge: the user's "zero minute stacking", reported by name. The
+ * degenerate-task branch of the remap (every member solved at one instant) exists for exactly this.
+ * @param {object[]} rows
+ * @returns {boolean}
+ */
+const noZeroWidthElement = rows => rows.every(r => r.playEnd > r.playStart);
+
+/**
+ * G-MB-SPAN — the movie's total span must equal the programme's. Two different totals is the
+ * §GANTT_SHIFT_HOURS_DESYNC failure in another costume: the needle and the model disagreeing about
+ * how long the job takes.
+ * @param {object[]} rows
+ * @returns {boolean}
+ */
+function movieSpanEqualsBarsSpan(rows) {
+  if (!rows.length) return false;
+  const per = {};
+  rows.forEach(r => {
+    const b = per[r.building] || (per[r.building] = { pS: Infinity, pE: -Infinity, wS: Infinity, wE: -Infinity });
+    if (r.playStart < b.pS) b.pS = r.playStart;
+    if (r.playEnd > b.pE) b.pE = r.playEnd;
+    if (r.winStart < b.wS) b.wS = r.winStart;
+    if (r.winEnd > b.wE) b.wE = r.winEnd;
+  });
+  return Object.keys(per).every(k => per[k].pS === per[k].wS && per[k].pE === per[k].wE);
+}
+
+module.exports = { everyElementInsideItsBar, remapPreservesSolveOrder, noZeroWidthElement, movieSpanEqualsBarsSpan };

--- a/witness_kit/schemas/4d_movie_bars.js
+++ b/witness_kit/schemas/4d_movie_bars.js
@@ -1,0 +1,21 @@
+// witness_kit/schemas/4d_movie_bars.js — one element as the movie plays it, beside the bar that
+// claims it. Spec: bim-compiler prompts/4D_SCHEDULE_PERFECTION.md §S70.
+'use strict';
+
+const PlayedElementRow = {
+  type: 'object',
+  required: ['building', 'guid', 'taskId', 'solveStart', 'playStart', 'playEnd', 'winStart', 'winEnd'],
+  properties: {
+    building:   { type: 'string', minLength: 1 },
+    guid:       { type: 'string', minLength: 1 },
+    taskId:     { type: 'string', pattern: '^TASK_' },
+    solveStart: { type: 'number' },
+    playStart:  { type: 'number' },
+    playEnd:    { type: 'number' },
+    winStart:   { type: 'number' },
+    winEnd:     { type: 'number' }
+  },
+  additionalProperties: true
+};
+
+module.exports = { PlayedElementRow };


### PR DESCRIPTION
MEASURED FIRST, as asked. The legacy bars were ENVELOPES over the element solve, so an element sat
inside its own bar by construction. Emitting bars from 4D_template.json makes the bar an
INDEPENDENT statement — and the two timelines immediately disagreed, badly:

  building   legacy: inside its own bar    template (§S69): inside its own bar
  Hospital   62494/63182  98.9%  worst 0.5d   34438/63182  54.5%  worst 274.3d late
  Terminal   46125/48428  95.2%  worst 0.5d   17153/48428  35.4%  worst 123.9d late
  Duplex       971/1119   86.8%  worst 0.5d      210/1119  18.8%  81.1% start BEFORE their bar
  HHS               n/a                        4169/6839   61.0%  26.3% start before their bar

The legacy 0.5d worst case is pure day-rounding. So §S69 alone would have made the user's reported
hell — things appearing when no bar says they should — dramatically WORSE. It is not shippable
without this half.

THE BIND: per task, an order-preserving affine map of that task's own solve envelope
[minStart,maxEnd] onto its authored window [s,e]. Monotone, so every ordering the solve was
expensive to win survives untouched — support-before-supported, host-before-hosted,
§4D_BAND_MONOTONIC — because a monotone map cannot swap two times. Relative widths survive too
(uniform scale per task). A degenerate task (every member solved at one instant, the "zero minute
stacking" shape the user reported by name) is spread evenly across its window instead.

AFTER: 100.0% inside on Hospital, Terminal, HHS and Duplex. 0 elements early, 0 late, worst offset
0.0d, movie span == bars span exactly (1.00x on all four), 0 order inversions vs the raw solve
(0/63147, 0/48356, 0/6822, 0/1101). Better than the legacy path was, with the template's phase
discipline on top.

WITNESS viewer/tests/witness_4d_movie_binds_bars.js — 71,140 played elements over Hospital + HHS +
Duplex, pass=7 fail=0:
  every-element-inside-its-bar   no tolerance: the remap maps ONTO the window
  remap-preserves-solve-order    verified per task, not asserted
  no-zero-width-element          the zero-minute-stacking gate
  movie-span-equals-bars-span    per building
  redControl                     puts one element back on its raw solve time (the measured defect)

A REAL WITNESS BUG CAUGHT AND FIXED HERE: the first run FAILED remap-preserves-solve-order. Cause
was the witness, not the remap — task ids are phase+storey derived, so TASK_SUPERSTRUCTURE_LEVEL_1
exists in Hospital, HHS and Duplex alike, and grouping on taskId alone pooled three buildings into
one "task" and manufactured inversions. Now keyed by building+taskId; movieSpanEqualsBarsSpan had
the same collision and is now per building too.

Still OPT-IN: no call site passes opts.template, so nothing live changed.
Suite: green=59 new_red=1 known_red=7 (the +1 green is this witness; the red is the same
pre-existing unrelated witness_cpe_buildup_require_tm_first baselined in §S67).

New §-log: §TPL_MOVIE_BINDS_BARS. materializeZones now also returns { tasks, displaySchedule }.

🤖 Generated with [Claude Code](https://claude.com/claude-code)