### PR TITLE
feat(4d): the Bar model core — one type, one stored timeline, one pass

### DIFF
--- a/viewer/bar_model.js
+++ b/viewer/bar_model.js
@@ -1,0 +1,242 @@
+// bar_model.js — THE 4D MODEL. Spec: bim-compiler prompts/4D_BAR_MODEL.md.
+//
+// WHY THIS EXISTS (§1 of the spec, and §S68/§S71 of 4D_SCHEDULE_PERFECTION.md):
+// midair, phase stacking, zero-minute bars and movie-vs-bars disagreement are NOT four bugs. They
+// are four symptoms of ONE structural defect — element time and task time were stored separately,
+// in two modules, with no shared type, so every crossing needed a translator, and every translator
+// is where a hell got in. There were five: deriveZones (task times as an envelope),
+// _writeTemplateSchedule (task times as a window), remapSolveToTasks (element times, rewritten to
+// match the windows), the §DEQ_REPAIR sweep loop, and the §CREW_CAP_FINAL re-pack. Each existed
+// only to keep two stored copies of one fact in agreement.
+//
+// THE ONE RULE: only leaves store time. Every group DERIVES it.
+// GroupBar.start/stop are getters, never fields. With one stored timeline there is nothing to
+// reconcile, so no translator can exist, so no hell can enter through one. `contains()` stops being
+// a test and becomes a tautology; the movie and the bars stop being two things.
+//
+// This module owns the TYPES and the SINGLE PASS. It deliberately does NOT build edges — `needs()`
+// is injected (see viewer/bar_needs.js), so adding a new physical rule is adding a provider and the
+// scheduler never changes. That is the open/closed fix for schedule_gate.js placeNonst's
+// `Math.max(gg, wg, hangGate, openingGate, hostGate, tg, bg, slot.time)` — eight terms, edited by
+// every rule ever added.
+'use strict';
+(function (root) {
+
+  // ══ Bar — the root Object. Everything in 4D is one. ═════════════════════════════════════════
+  function Bar() { this._s = null; this._e = null; }
+  Bar.prototype.duration = function () {
+    var s = this.start, e = this.stop;
+    return (s == null || e == null) ? 0 : e - s;
+  };
+  Bar.prototype.contains = function (b) {
+    return this.start != null && b.start != null && b.start >= this.start && b.stop <= this.stop;
+  };
+  Bar.prototype.overlaps = function (b) {
+    return this.start != null && b.start != null && this.start < b.stop && b.start < this.stop;
+  };
+  Object.defineProperty(Bar.prototype, 'start', { get: function () { return this._s; }, configurable: true });
+  Object.defineProperty(Bar.prototype, 'stop', { get: function () { return this._e; }, configurable: true });
+
+  // ══ ElementBar — the LEAF. The only place a time is ever stored. ════════════════════════════
+  function ElementBar(e) { Bar.call(this); this.e = e; this.guid = e.guid; this.needs = []; this.grounded = false; }
+  ElementBar.prototype = Object.create(Bar.prototype);
+  ElementBar.prototype.constructor = ElementBar;
+  ElementBar.prototype.work = function () { return this.e.installSecs || 120; };
+  ElementBar.prototype.trade = function () { return this.e.resource || '_DEFAULT'; };
+  ElementBar.prototype.children = function () { return EMPTY; };
+  ElementBar.prototype.place = function (startMs, durMs) { this._s = startMs; this._e = startMs + durMs; };
+  var EMPTY = [];
+
+  // ══ GroupBar — the COMPOSITE. start/stop are GETTERS over its children, never fields. ═══════
+  // witness_bar_composite.js asserts in SOURCE that no assignment to _s/_e exists on this
+  // prototype — a stored group time is the defect this whole model removes, and a comment saying
+  // "don't store it" is not a gate.
+  function GroupBar(name) { Bar.call(this); this.name = name; this._kids = []; this.needs = []; }
+  GroupBar.prototype = Object.create(Bar.prototype);
+  GroupBar.prototype.constructor = GroupBar;
+  GroupBar.prototype.add = function (c) { this._kids.push(c); return c; };
+  GroupBar.prototype.children = function () { return this._kids; };
+  Object.defineProperty(GroupBar.prototype, 'start', {
+    get: function () {
+      var m = Infinity;
+      for (var i = 0; i < this._kids.length; i++) { var s = this._kids[i].start; if (s != null && s < m) m = s; }
+      return m === Infinity ? null : m;
+    }, configurable: true });
+  Object.defineProperty(GroupBar.prototype, 'stop', {
+    get: function () {
+      var m = -Infinity;
+      for (var i = 0; i < this._kids.length; i++) { var e = this._kids[i].stop; if (e != null && e > m) m = e; }
+      return m === -Infinity ? null : m;
+    }, configurable: true });
+  GroupBar.prototype.work = function () {
+    var w = 0; for (var i = 0; i < this._kids.length; i++) w += this._kids[i].work(); return w;
+  };
+  GroupBar.prototype.trade = function () { return null; };   // a group has no single trade
+
+  // ══ phaseOrder — EXTRACTED, never authored (spec §4). ═══════════════════════════════════════
+  // A phase's rank is the MINIMUM sequence its own classes carry in sequence_rules.json. The old
+  // 4D_template.json copied these numbers out and then gated the copy against its source; the copy
+  // is deleted and this reads the source.
+  function phaseOrder(sequenceRules) {
+    var min = {};
+    for (var cls in sequenceRules) {
+      var r = sequenceRules[cls];
+      if (!r || !r.phase || r.sequence == null) continue;
+      if (min[r.phase] == null || r.sequence < min[r.phase]) min[r.phase] = r.sequence;
+    }
+    return Object.keys(min).sort(function (a, b) { return min[a] - min[b]; });
+  }
+
+  // ══ buildTree — Project > Level > Task(phase x level) > Element ═════════════════════════════
+  // policy: { phase_link, level_link, building_scope[] } — viewer/rates/4D_policy.json.
+  // collapse(storey) and bandRank come from ScheduleGate, so a level means the same thing here as
+  // it does in the band gate.
+  function buildTree(elements, policy, collapse, bandRank, order) {
+    var project = new GroupBar('Project');
+    var levels = {}, tasks = {}, buildingScope = {};
+    (policy.building_scope || []).forEach(function (p) { buildingScope[p] = 1; });
+
+    var leaves = [];
+    for (var i = 0; i < elements.length; i++) {
+      var e = elements[i], b = new ElementBar(e);
+      leaves.push(b);
+      var ph = e.phase || '_UNPHASED';
+      var lv = collapse(e.storey);
+      var isBuilding = !!buildingScope[ph];
+      var key = ph + '||' + (isBuilding ? '*' : lv);
+      var t = tasks[key];
+      if (!t) {
+        t = new GroupBar(ph + ' — ' + (isBuilding ? 'building' : lv));
+        t.phase = ph; t.level = isBuilding ? null : lv;
+        // A building-scope task hangs off the PROJECT, never off one LevelBar. Putting it under a
+        // level made its bar span every storey and overlap that level's own tasks — measured as 2
+        // of 34 false phase-stacking pairs on Duplex in the 2026-08-25 prototype.
+        t.rank = isBuilding ? -1 : (bandRank[lv] != null ? bandRank[lv] : 1e9);
+        tasks[key] = t;
+        if (isBuilding) project.add(t);
+        else {
+          var L = levels[lv];
+          if (!L) { L = levels[lv] = new GroupBar(lv); L.level = lv; L.rank = t.rank; project.add(L); }
+          L.add(t);
+        }
+      }
+      t.add(b);
+    }
+
+    // Task ordering + PhaseNeeds/LadderNeeds, both from POLICY (spec §3).
+    var taskList = Object.keys(tasks).map(function (k) { return tasks[k]; })
+      .sort(function (a, b) { return (a.rank - b.rank) || (order.indexOf(a.phase) - order.indexOf(b.phase)); });
+    var prevOnLevel = {}, prevOfPhase = {};
+    taskList.forEach(function (t) {
+      var lk = t.level == null ? '*' : t.level;
+      // phase_link=serial: FS+0 after the previous phase that actually instantiated on this level.
+      // A dropped phase BRIDGES — prevOnLevel is only advanced by a task that exists.
+      if (policy.phase_link === 'serial' && prevOnLevel[lk]) t.needs.push(prevOnLevel[lk]);
+      // level_link=self: §4D_BAND_MONOTONIC, a phase waits for itself one level below.
+      if (policy.level_link === 'self' && prevOfPhase[t.phase]) t.needs.push(prevOfPhase[t.phase]);
+      prevOnLevel[lk] = t; prevOfPhase[t.phase] = t;
+    });
+
+    return { project: project, tasks: taskList, levels: levels, leaves: leaves };
+  }
+
+  // ══ attachNeeds — inject the physical edges (viewer/bar_needs.js builds them) ════════════════
+  // edges: [{ from, to, kind }] by GUID. from must finish before to.
+  function attachNeeds(leaves, edges) {
+    var byGuid = {}, i;
+    for (i = 0; i < leaves.length; i++) byGuid[leaves[i].guid] = leaves[i];
+    var attached = 0, dangling = 0;
+    for (i = 0; i < edges.length; i++) {
+      var f = byGuid[edges[i].from], t = byGuid[edges[i].to];
+      if (!f || !t || f === t) { dangling++; continue; }
+      t.needs.push(f); attached++;
+      if (edges[i].kind === 'support') t.grounded = false;
+    }
+    return { attached: attached, dangling: dangling };
+  }
+
+  // ══ schedule — THE SINGLE PASS (spec §5) ════════════════════════════════════════════════════
+  // Tasks in topological order over PhaseNeeds+LadderNeeds; within a task, elements in support
+  // order; crews capped per trade. Groups need no pass at all — their span is their children's.
+  //
+  // §5.1 A support edge pointing backwards against phase order is a CYCLE: the thing holding this
+  // element up is scheduled in a LATER task. That is a CLASSIFICATION defect in the model, not a
+  // scheduling problem, and it is REPORTED by name rather than scheduled around. Measured
+  // backwards-support today: Terminal 27, Hospital 38, HHS 35, Duplex 8 — e.g. an Architecture
+  // IfcWall holding up a Superstructure IfcMember.
+  function schedule(tree, opts) {
+    opts = opts || {};
+    var laborRates = opts.laborRates || {};
+    var baseMs = opts.baseMs || 0;
+    var crews = {}, cycles = [], placed = 0;
+
+    function cap(tr) { return (laborRates[tr] && laborRates[tr].max_crews) || 1; }
+    function claim(tr, notBefore) {
+      var n = cap(tr), slots = crews[tr] || (crews[tr] = new Array(n).fill(baseMs)), k = 0;
+      for (var i = 1; i < slots.length; i++) if (slots[i] < slots[k]) k = i;
+      return { at: Math.max(notBefore, slots[k]), commit: function (end) { slots[k] = end; } };
+    }
+    function put(b, at) {
+      var s = claim(b.trade(), at), dur = Math.round(b.work() * 1000);
+      b.place(s.at, dur); s.commit(s.at + dur); placed++;
+    }
+
+    tree.tasks.forEach(function (t) {
+      var gate = baseMs;
+      t.needs.forEach(function (p) { var e = p.stop; if (e != null && e > gate) gate = e; });
+
+      var pending = t.children().slice(), guard = 0;
+      while (pending.length && guard++ <= pending.length + 2) {
+        var again = [];
+        for (var i = 0; i < pending.length; i++) {
+          var b = pending[i], at = gate, sawPlaced = false, earliest = Infinity;
+          if (!b.grounded && b.needs.length) {
+            for (var j = 0; j < b.needs.length; j++) {
+              var st = b.needs[j].stop;
+              if (st != null) { sawPlaced = true; if (st < earliest) earliest = st; }
+            }
+            // Nothing this element rests on has been placed yet — defer it one round.
+            if (!sawPlaced) { again.push(b); continue; }
+            if (earliest > at) at = earliest;
+          }
+          put(b, at);
+        }
+        if (again.length === pending.length) {          // a full round with nothing placeable
+          for (var k = 0; k < again.length; k++) {
+            var c = again[k];
+            cycles.push({ guid: c.guid, cls: c.e.cls, phase: c.e.phase, task: t.name });
+            put(c, gate);                                // placed anyway, but REPORTED
+          }
+          break;
+        }
+        pending = again;
+      }
+    });
+    return { placed: placed, cycles: cycles };
+  }
+
+  // §BAR_CYCLE — aggregated per (predClass -> succPhase/succClass), never one line per element:
+  // §CLASS_UNMATCHED's per-element warn alone overflowed run_witness_suite.js's 1MB spawnSync
+  // maxBuffer on Hospital (WITNESS_INTERFACE_FRAMEWORK.md §6).
+  function reportCycles(cycles, log) {
+    log = log || (typeof console !== 'undefined' ? console.log : function () {});
+    var by = {};
+    cycles.forEach(function (c) {
+      var k = (c.phase || '?') + '/' + c.cls;
+      by[k] = (by[k] || 0) + 1;
+    });
+    var keys = Object.keys(by).sort(function (a, b) { return by[b] - by[a]; });
+    log('§BAR_CYCLE n=' + cycles.length + ' kinds=' + keys.length +
+      ' — support scheduled in a LATER task than the element it holds up. This is a CLASSIFICATION ' +
+      'defect in the model, not a scheduling problem; it is reported, never scheduled around.');
+    keys.slice(0, 8).forEach(function (k) { log('   §BAR_CYCLE ' + k + ' x' + by[k]); });
+    return by;
+  }
+
+  var API = { Bar: Bar, ElementBar: ElementBar, GroupBar: GroupBar,
+              phaseOrder: phaseOrder, buildTree: buildTree, attachNeeds: attachNeeds,
+              schedule: schedule, reportCycles: reportCycles };
+  if (typeof module !== 'undefined' && module.exports) module.exports = API;
+  root.BarModel = API;
+  if (typeof console !== 'undefined' && console.log) console.log('§BAR_MODEL_LOADED v1');
+})(typeof self !== 'undefined' ? self : this);

--- a/viewer/rates/4D_policy.json
+++ b/viewer/rates/4D_policy.json
@@ -1,0 +1,16 @@
+{
+  "_what": "The ONLY authored input to 4D scheduling. Everything else is EXTRACTED — phase order from sequence_rules.json's min sequence per phase, trades from the union of that phase's classes' resources, level from ScheduleGate.deriveBandRanks, work from ScheduleAuthor._installSecs, crews from LABOR_RATES.max_crews, shift from rates.js SHIFT_HOURS. Spec: bim-compiler prompts/4D_BAR_MODEL.md §4.",
+  "_replaces": "4D_template.json v1.2.0, which was 123 lines and 146 keys — 52 of them prose, and its data keys were copies: phases[].sequence and phases[].trades duplicated sequence_rules.json, its ten dependency edges restated the phase list order plus one flag, and `scope` and `replicate_per_level` were the same fact twice with an invariant written to check they agreed instead of deleting one. Audited 2026-08-25 on the user's observation that it was 'not even a recipe yet, it is just a mould — an extraction'.",
+
+  "days_per_week": 7,
+  "_days_per_week_why": "Matches what the engine does today (schedule_gate.js applies no week calendar; §CREW_DAY logs '24/7 calendar unchanged'). Stated so a 5-day week is an edit, not a rewrite. Hours per shift is NOT here — rates.js SHIFT_HOURS already owns it (user ruling 2026-08-13, 24h default).",
+
+  "phase_link": "serial",
+  "_phase_link_why": "USER RULING 2026-08-25: 'we make phases packed but sequential? User can then just drag them overlap if they want.' FS+0 between consecutive phases on a level. An overlap is a human's drag on the Gantt, never a solver artifact. Priced before adopting: 49d vs the overlapping engine's 46.9d on HHS_Office_Federated, +4%.",
+
+  "level_link": "self",
+  "_level_link_why": "§4D_BAND_MONOTONIC — a trade may not run ahead of ITSELF on the floor below. Different trades still overlap across floors, which is what a trade train is. Measured need: with the ladder on superstructure alone, HHS PLUMBER peaks at 3.67 crews against a cap of 2 (1.84x); with it on every level phase, zero breaches.",
+
+  "building_scope": ["Substructure"],
+  "_building_scope_why": "Phases that occur ONCE for the whole building instead of repeating per storey. Their TaskBar hangs off the ProjectBar, never off a LevelBar — hanging it under one level made its bar span every level and overlap that level's own tasks (measured as 2/34 false phase-stacking pairs on Duplex in the 2026-08-25 prototype). Their elements are collected from EVERY level: dropping the ones above the lowest silently lost an element on Hospital, 63,181 of 63,182, invisible in every other number."
+}

--- a/viewer/tests/witness_bar_composite.js
+++ b/viewer/tests/witness_bar_composite.js
@@ -1,0 +1,110 @@
+#!/usr/bin/env node
+// WITNESS — the COMPOSITE layer of the 4D Bar model: only leaves store time, every group derives it.
+// Spec: bim-compiler prompts/4D_BAR_MODEL.md §2.1.
+//
+// WHICH LAYER THIS PROVES (WITNESS_INTERFACE_FRAMEWORK.md §CRISIS LESSON 1):
+//   the TREE ARITHMETIC only — Bar/GroupBar/ElementBar over real building data. It deliberately
+//   schedules with NO physical edges, so it says nothing about midair, support order, or crews.
+//   Those belong to witness_bar_needs.js and witness_bar_schedule.js.
+//
+// ISSUE THIS PROVES OR DISPROVES: under the pre-Bar code an element inside its own bar was 54.5%
+// true on Hospital, 35.4% on Terminal and 18.8% on Duplex (§S70), because task time and element
+// time were two stored copies kept in sync by hand across five translators. If a group's span IS
+// its children's, that number is 100% by construction and cannot regress. This witness gates the
+// construction, not the number.
+//
+// Command: node viewer/tests/witness_bar_composite.js [Building ...]
+'use strict';
+const fs = require('fs'), path = require('path'), vm = require('vm'), os = require('os');
+const HOME = os.homedir();
+const initSqlJs = require(path.join(HOME, 'bim-ootb', 'node_modules', 'sql.js'));
+const SQLJS_DIST = path.join(HOME, 'bim-ootb', 'node_modules', 'sql.js', 'dist');
+const V = process.env.VIEWER_DIR || path.join(__dirname, '..');
+const SG = require(path.join(V, 'schedule_gate.js')); global.ScheduleGate = SG;
+const SA = require(path.join(V, 'schedule_author.js'));
+const BM = require(path.join(V, 'bar_model.js'));
+const KIT = path.join(__dirname, '..', '..', 'witness_kit');
+const { Witness } = require(path.join(KIT, 'contract'));
+const { GroupChildRow } = require(path.join(KIT, 'schemas', 'bar_composite'));
+const INV = require(path.join(KIT, 'invariants', 'bar_composite'));
+
+const POLICY = JSON.parse(fs.readFileSync(path.join(V, 'rates', '4D_policy.json'), 'utf8'));
+const SRC = fs.readFileSync(path.join(V, 'bar_model.js'), 'utf8');
+const BLD_DIR = process.env.BLD_DIR || path.join(HOME, 'bim-ootb', 'buildings');
+const BUILDINGS = process.argv.slice(2).length ? process.argv.slice(2)
+  : ['Duplex', 'HHS_Office_Federated', 'Hospital', 'Terminal'];
+
+function executedRules() {
+  const sb = { console: { log() {}, warn() {}, error() {} } };
+  vm.createContext(sb);
+  vm.runInContext(fs.readFileSync(path.join(V, 'rates.js'), 'utf8'), sb);
+  return sb;
+}
+
+(async () => {
+  const SQL = await initSqlJs({ locateFile: f => path.join(SQLJS_DIST, f) });
+  const R = executedRules();
+  const rows = [], allGroups = [], perBuilding = [];
+
+  for (const bld of BUILDINGS) {
+    const file = path.join(BLD_DIR, bld + '_extracted.db');
+    if (!fs.existsSync(file)) { console.log('§BC_SKIP ' + bld); continue; }
+    const db = new SQL.Database(new Uint8Array(fs.readFileSync(file)));
+    const _l = console.log, _w = console.warn;
+    console.log = () => {}; console.warn = () => {};
+    const els = SA._buildScheduleElements(db, R.SEQUENCE_RULES, {
+      laborRates: R.LABOR_RATES, rates: R.RATES,
+      nameOverrides: R.SEQUENCE_NAME_OVERRIDES, defaultRule: R.SEQUENCE_DEFAULT });
+    const bandRank = SG.deriveBandRanks(els, null).bandRank;
+    console.log = _l; console.warn = _w;
+
+    const order = BM.phaseOrder(R.SEQUENCE_RULES);
+    const tree = BM.buildTree(els, POLICY, SG.collapsePhase, bandRank, order);
+    // NO physical edges on purpose — this witness owns the tree arithmetic, nothing else.
+    const res = BM.schedule(tree, { laborRates: R.LABOR_RATES, baseMs: 0 });
+
+    // every (group, child) pair, at every level of the tree
+    const groups = [];
+    (function walk(g) {
+      if (!g.children || !g.children().length) return;
+      groups.push(g);
+      g.children().forEach(c => {
+        rows.push({ building: bld, group: g.name || 'Project',
+          groupStart: g.start, groupStop: g.stop, childStart: c.start, childStop: c.stop });
+        walk(c);
+      });
+    })(tree.project);
+    allGroups.push(...groups);
+    perBuilding.push({ bld, project: tree.project, leaves: tree.leaves });
+
+    console.log('§BAR_COMPOSITE ' + bld + ' elements=' + els.length + ' tasks=' + tree.tasks.length +
+      ' levels=' + Object.keys(tree.levels).length + ' groups=' + groups.length +
+      ' placed=' + res.placed + ' cycles=' + res.cycles.length +
+      ' spanD=' + ((tree.project.stop - tree.project.start) / 86400000).toFixed(1));
+    db.close();
+  }
+
+  Witness('bar_composite')
+    .population(() => rows)
+    .schema(GroupChildRow)
+    // THE RULE, checked in source: a group must not be able to store a time at all.
+    .invariant('group-time-is-a-getter', () => INV.groupTimeIsAGetter(SRC))
+    .invariant('only-leaves-store-time', () => INV.onlyLeavesStoreTime(allGroups))
+    // The tautology that replaces §S70's 54.5%/35.4%/18.8%.
+    .invariant('group-contains-every-child', INV.groupContainsEveryChild)
+    .invariant('project-span-equals-leaf-extent', () => perBuilding.every(b => INV.projectSpanEqualsLeafExtent(b.project, b.leaves)))
+    .invariant('no-zero-width-leaf', () => perBuilding.every(b => INV.noZeroWidthLeaf(b.leaves)))
+    // RED CONTROLS — each gate must reject its OWN defect, in the committed witness, not in a
+    // throwaway console session (feedback_extract_dont_author_then_gate.md).
+    .invariant('redctl:getter gate rejects a stored group time',
+      () => INV.groupTimeIsAGetter(SRC.replace("GroupBar.prototype.add = function (c) { this._kids.push(c); return c; };",
+        "GroupBar.prototype.add = function (c) { this._s = 0; this._kids.push(c); return c; };")) === false)
+    .invariant('redctl:contains gate rejects a child outside its group',
+      () => INV.groupContainsEveryChild([{ groupStart: 10, groupStop: 20, childStart: 5, childStop: 15 }]) === false)
+    .invariant('redctl:leaf-only gate rejects a group that stored a time',
+      () => INV.onlyLeavesStoreTime([{ _s: 1, _e: 2 }]) === false)
+    .invariant('redctl:zero-width gate rejects a zero-duration leaf',
+      () => INV.noZeroWidthLeaf([{ start: 5, stop: 5 }]) === false)
+    .redControl(rs => rs.map((r, i) => i ? r : Object.assign({}, r, { childStop: r.groupStop + 86400000 })))
+    .run();
+})();

--- a/witness_kit/invariants/bar_composite.js
+++ b/witness_kit/invariants/bar_composite.js
@@ -1,0 +1,71 @@
+// witness_kit/invariants/bar_composite.js — the COMPOSITE layer of the 4D Bar model.
+// Spec: bim-compiler prompts/4D_BAR_MODEL.md §2.1.
+//
+// These check ONE rule: only leaves store time, every group derives it. That rule is the whole
+// model — with a single stored timeline there is nothing to reconcile, so none of the five
+// translators that each carried a hell (deriveZones, _writeTemplateSchedule, remapSolveToTasks,
+// §DEQ_REPAIR, §CREW_CAP_FINAL) can exist. A comment saying "don't store group time" is not a gate;
+// these are.
+'use strict';
+
+/**
+ * G-BC-GETTER — GroupBar.start/stop must be GETTERS with no backing assignment, verified in the
+ * SOURCE. A group that ever stores a time is a second copy of a fact the leaves already hold, and a
+ * second copy is what every hell came through. Checked textually because a runtime check cannot
+ * distinguish "currently null" from "assignable".
+ * @param {string} src - viewer/bar_model.js source
+ * @returns {boolean}
+ */
+function groupTimeIsAGetter(src) {
+  const i = src.indexOf('function GroupBar(');
+  const j = src.indexOf('// ══ phaseOrder', i);
+  if (i < 0 || j < 0) return false;
+  const body = src.slice(i, j);
+  const hasGetters = /defineProperty\(GroupBar\.prototype, 'start'[\s\S]*?get:/.test(body) &&
+                     /defineProperty\(GroupBar\.prototype, 'stop'[\s\S]*?get:/.test(body);
+  // no assignment to a backing field anywhere in GroupBar's own section
+  const stores = /this\._s\s*=|this\._e\s*=/.test(body.replace(/Bar\.call\(this\)/g, ''));
+  return hasGetters && !stores;
+}
+
+/**
+ * G-BC-CONTAINS — every group contains every one of its children. On this model this is a
+ * TAUTOLOGY, not a test: the group's span IS min/max of the children. It is gated anyway because
+ * the tautology is the deliverable — if it ever fails, someone reintroduced a stored group time.
+ * Contrast: under the pre-Bar code this was 54.5% true on Hospital and 18.8% on Duplex (§S70).
+ * @param {object[]} rows - {groupStart, groupStop, childStart, childStop}
+ * @returns {boolean}
+ */
+const groupContainsEveryChild = rows =>
+  rows.every(r => r.childStart >= r.groupStart && r.childStop <= r.groupStop);
+
+/**
+ * G-BC-LEAFONLY — no GroupBar may carry a stored time at runtime either.
+ * @param {object[]} groups - the live GroupBar instances
+ * @returns {boolean}
+ */
+const onlyLeavesStoreTime = groups => groups.every(g => g._s === null && g._e === null);
+
+/**
+ * G-BC-SPAN — the project's span equals the min/max over every leaf. Two different totals is
+ * §GANTT_SHIFT_HOURS_DESYNC in another costume: the needle and the model disagreeing about how long
+ * the job takes.
+ * @param {object} project
+ * @param {object[]} leaves
+ * @returns {boolean}
+ */
+function projectSpanEqualsLeafExtent(project, leaves) {
+  let s = Infinity, e = -Infinity;
+  leaves.forEach(l => { if (l.start != null) { if (l.start < s) s = l.start; if (l.stop > e) e = l.stop; } });
+  return project.start === s && project.stop === e;
+}
+
+/**
+ * G-BC-NOZERO — no leaf may have zero duration. A zero-width element is invisible in the movie and
+ * stacks at its bar's left edge: the user's "zero minute stacking", reported by name.
+ * @param {object[]} leaves
+ * @returns {boolean}
+ */
+const noZeroWidthLeaf = leaves => leaves.every(l => l.start == null || l.stop > l.start);
+
+module.exports = { groupTimeIsAGetter, groupContainsEveryChild, onlyLeavesStoreTime, projectSpanEqualsLeafExtent, noZeroWidthLeaf };

--- a/witness_kit/schemas/bar_composite.js
+++ b/witness_kit/schemas/bar_composite.js
@@ -1,0 +1,19 @@
+// witness_kit/schemas/bar_composite.js — one (group, child) pair of the 4D Bar tree.
+// Spec: bim-compiler prompts/4D_BAR_MODEL.md §2.1.
+'use strict';
+
+const GroupChildRow = {
+  type: 'object',
+  required: ['building', 'group', 'groupStart', 'groupStop', 'childStart', 'childStop'],
+  properties: {
+    building:   { type: 'string', minLength: 1 },
+    group:      { type: 'string', minLength: 1 },
+    groupStart: { type: 'number' },
+    groupStop:  { type: 'number' },
+    childStart: { type: 'number' },
+    childStop:  { type: 'number' }
+  },
+  additionalProperties: true
+};
+
+module.exports = { GroupChildRow };


### PR DESCRIPTION
Spec: bim-compiler prompts/4D_BAR_MODEL.md. User: "inherit a first Object a 'bar' defined as
start/stop like any gant chart bar" / "the OOP already sorted software design out".

THE ONE RULE: only leaves store time. Every group DERIVES it.
GroupBar.start/stop are getters over children, never fields. With one stored timeline there is
nothing to reconcile, so none of the five translators that each carried a hell can exist:
deriveZones (task times as an envelope), _writeTemplateSchedule (as a window), remapSolveToTasks
(element times rewritten to match), the §DEQ_REPAIR sweep, the §CREW_CAP_FINAL re-pack.

  Bar { start, stop, duration(), contains(), overlaps() }
   └─ ElementBar   leaf, time STORED
   └─ GroupBar     composite, time COMPUTED = min/max of children
       └─ TaskBar / LevelBar / ProjectBar

`needs()` is INJECTED, not built here (viewer/bar_needs.js, in flight separately). Adding a
physical rule is adding a provider; the scheduler never changes. That is the open/closed fix for
schedule_gate.js placeNonst's `Math.max(gg, wg, hangGate, openingGate, hostGate, tg, bg, slot.time)`
— eight terms, edited by every rule ever added.

viewer/rates/4D_policy.json REPLACES 4D_template.json: 4 authored values instead of 123 lines /
146 keys. Everything else is extracted — phase order from sequence_rules.json's min sequence per
phase (the old file copied those numbers out and then gated the copy against its own source), level
from deriveBandRanks, work from _installSecs, crews from LABOR_RATES, shift from rates.js.

Two prototype defects fixed here rather than inherited (spec §6):
 - a building-scope TaskBar now hangs off the ProjectBar, never off one LevelBar. Under a level its
   bar spanned every storey and overlapped that level's own tasks — 2 of 34 false phase-stacking
   pairs on Duplex.
 - building-scope tasks collect elements from EVERY level. Dropping the ones above the lowest lost
   an element on Hospital (63,181 of 63,182), invisible in every other number.

WITNESS viewer/tests/witness_bar_composite.js — Duplex + HHS + Hospital + Terminal, 119,748
(group, child) pairs, pass=12 fail=0. Scheduled with NO physical edges on purpose: this witness owns
the tree arithmetic and says nothing about midair, support or crews.

  group-time-is-a-getter        verified in SOURCE — a group must not be ABLE to store a time
  only-leaves-store-time        checked on the live instances too
  group-contains-every-child    119,748/119,748. Was 54.5% Hospital / 35.4% Terminal / 18.8% Duplex
                                under the pre-Bar code (§S70). Now a tautology, not a number.
  project-span-equals-leaf-extent · no-zero-width-leaf
  4 per-gate red controls + the contract red control

  §BAR_COMPOSITE Duplex 1119 els / 18 tasks / 8.7d · HHS 6839 / 17 / 44.4d
                 Hospital 63182 / 35 / 287.1d · Terminal 48428 / 72 / 84.1d

Additive only — no existing file touched, nothing wired. §8 of the spec (the delete list) is not
done: a PR that adds the Bar model without removing the five translators has added a sixth.

🤖 Generated with [Claude Code](https://claude.com/claude-code)