### PR TITLE
feat(4d): needs() edge providers for the Bar model (§3, 4D_BAR_MODEL.md)

### DIFF
--- a/viewer/bar_needs.js
+++ b/viewer/bar_needs.js
@@ -1,0 +1,263 @@
+// bar_needs.js — the needs() edge PROVIDERS for the 4D Bar model.
+// Spec: bim-compiler prompts/4D_BAR_MODEL.md §3 (`needs()` — ONE LIST, MANY PROVIDERS) and §3.1
+// (EXTRACTION IS MANDATORY). Consumed by viewer/bar_model.js's attachNeeds(leaves, edges) — see
+// that file's own header: "needs() is injected (see viewer/bar_needs.js)".
+//
+// §3.1 HARD RULE, and why every provider below is a LIFT, never a re-derivation: on 2026-08-25 a
+// hand-written "support = anything below" gave Duplex 4,706 edges / 52 midair; calling the shipped
+// ScheduleGate.supportPool filter gave 716 edges / 0 midair (§S26.2). This module exists so that
+// number can never happen again by construction: every geometric test used here is either CALLED
+// straight off ScheduleGate's own exported API, or LIFTED verbatim (balanced-brace source slice —
+// the same technique viewer/tests/witness_gantt_native_generate.js already uses to pull
+// generateGanttSchedule out of time_machine.js) off schedule_gate.js's real source text. None of
+// the five relations below are retyped from memory.
+//
+// WHY THE LIFTED SET IS edgeBelow/edgeContained/edgeBearing/wallCarries/edgeCarrier, NOT
+// geoGate/wallGate/hangGate THEMSELVES (schedule_gate.js's own five runtime "gates" the spec's
+// READ FIRST names): those five gate functions read the INCREMENTAL grids computeSchedule fills in
+// AS it places elements one at a time — called cold, on an empty grid, every one of them returns
+// baseMs regardless of the real building, because nothing has been placed yet. buildNeeds() has to
+// solve the exact opposite problem: a STATIC needs-before-any-placement graph. computeSchedule's
+// own §GEOMETRIC_SUPPORT_ORDER section (schedule_gate.js:758-862) already had to solve that same
+// problem, for the same reason (the topological placement order has to exist BEFORE any element is
+// placed) — and it did so by hoisting each gate's geometric core into a small, pure, stateless
+// predicate, each one commented as mirroring its gate verbatim:
+//   edgeBelow      // geoGate "below"                       (schedule_gate.js:790)
+//   edgeContained  // geoGate §GEO_SUPPORT_LEAK clause       (schedule_gate.js:793)
+//   edgeBearing    // hasBearingBelow / audit                (schedule_gate.js:794)
+//   wallCarries    // wallGate's relation, bounded            (schedule_gate.js:797, cited again :845)
+//   edgeCarrier    // hangGate                                (schedule_gate.js:798)
+// Those five ARE geoGate/wallGate/hangGate, already extracted by schedule_gate.js's own authors for
+// exactly this "static DAG, not runtime gate" job. Lifting them (instead of the runtime gates) is
+// the non-re-derivation path, not a shortcut around it — see the header of each provider below for
+// the exact source line each edge type reproduces.
+//
+// openingGate and hostGate needed NO slicing at all: schedule_gate.js already exports hostPairs()
+// and openingPairs(), pure geometry functions that were written for exactly this reuse (their own
+// headers: "a caller pairs once and then compares whatever stage of the timeline it owns" / "a
+// consumer that honours every pair reproduces the gate's exact bound"). OpeningNeeds/HostNeeds
+// below just CALL them.
+//
+// "Use ScheduleGate.CELL for the spatial grid" (task instruction) — cellsOf() (the CELL-keyed
+// bucketer every gate above indexes through) is itself sliced off schedule_gate.js rather than
+// re-typed, bound to ScheduleGate.CELL/EPS/GAP so a constant change there can never silently
+// diverge from what this module computes.
+'use strict';
+(function (root) {
+
+  var fs = require('fs');
+  var path = require('path');
+
+  var SG_PATH = path.join(__dirname, 'schedule_gate.js');
+  var SG_SRC = fs.readFileSync(SG_PATH, 'utf8');
+  var ScheduleGate = require('./schedule_gate.js');
+
+  // sliceFn(src, name) — balanced-brace extraction of a named function declaration, wherever it
+  // sits in the source text (module scope or trapped inside another function's closure — pure text
+  // scan, nesting is irrelevant to it). Verbatim from viewer/tests/witness_gantt_native_generate.js
+  // ("Sliced by balanced braces from the real shipped function — same convention as
+  // commitGanttDrag/undoLastGanttEdit's witnesses, never reimplemented.").
+  function sliceFn(src, name) {
+    var idx = src.indexOf('function ' + name + '(');
+    if (idx < 0) throw new Error('bar_needs: ' + name + ' not found in ' + SG_PATH);
+    var depth = 0, i = idx, seenOpen = false;
+    for (; i < src.length; i++) {
+      if (src[i] === '{') { depth++; seenOpen = true; }
+      else if (src[i] === '}') { depth--; if (seenOpen && depth === 0) return src.slice(idx, i + 1); }
+    }
+    throw new Error('bar_needs: unbalanced braces for ' + name);
+  }
+
+  // The lifted geometric core, bound to ScheduleGate's own CELL/EPS/GAP (never a second hand-typed
+  // copy of those constants — the reason schedule_gate.js exports them in the first place, per its
+  // own comment at schedule_gate.js:1250-1252).
+  var _slicedSrc =
+    'var CELL = ' + ScheduleGate.CELL + ';\n' +
+    'var EPS = ' + ScheduleGate.EPS + ';\n' +
+    'var GAP = ' + ScheduleGate.GAP + ';\n' +
+    sliceFn(SG_SRC, 'cellsOf') + '\n' +          // schedule_gate.js:174 — CELL-keyed XY bucketer
+    sliceFn(SG_SRC, 'overlap') + '\n' +           // schedule_gate.js:180 — AABB XY overlap test
+    sliceFn(SG_SRC, 'isPromotedSlab') + '\n' +    // schedule_gate.js:549 — §DEQ_V1 roof-role slab
+    sliceFn(SG_SRC, 'edgeBelow') + '\n' +         // schedule_gate.js:790 — geoGate "below"
+    sliceFn(SG_SRC, 'edgeContained') + '\n' +     // schedule_gate.js:793 — geoGate §GEO_SUPPORT_LEAK
+    sliceFn(SG_SRC, 'edgeBearing') + '\n' +       // schedule_gate.js:794 — hasBearingBelow/audit
+    sliceFn(SG_SRC, 'wallCarries') + '\n' +       // schedule_gate.js:797 — wallGate's relation
+    sliceFn(SG_SRC, 'edgeCarrier') + '\n' +       // schedule_gate.js:798 — hangGate
+    sliceFn(SG_SRC, 'bboxVol');                   // schedule_gate.js:323 — §HANG_NEAREST volume test
+  var G = (new Function(_slicedSrc +
+    '\nreturn { cellsOf: cellsOf, overlap: overlap, isPromotedSlab: isPromotedSlab, ' +
+    'edgeBelow: edgeBelow, edgeContained: edgeContained, edgeBearing: edgeBearing, ' +
+    'wallCarries: wallCarries, edgeCarrier: edgeCarrier, bboxVol: bboxVol };'))();
+
+  // buildIndex(elements, predFn) — CELL-bucket every element for which predFn holds, indexed the
+  // same way structIdxGrid/wallIdxGrid are inside computeSchedule (schedule_gate.js:786-788).
+  function buildIndex(elements, predFn) {
+    var idx = {};
+    for (var t = 0; t < elements.length; t++) {
+      if (!predFn(elements[t])) continue;
+      var cs = G.cellsOf(elements[t]);
+      for (var c = 0; c < cs.length; c++) (idx[cs[c]] = idx[cs[c]] || []).push(t);
+    }
+    return idx;
+  }
+
+  // isWallCls(e) — the exact class-prefix test wallGrid/wallIdxGrid population already uses
+  // (schedule_gate.js:575, :788): `el.cls && el.cls.indexOf('IfcWall') === 0`. A literal string
+  // prefix test, not a judgment predicate — copied character-for-character, nothing to slice.
+  function isWallCls(e) { return !!(e.cls && e.cls.indexOf('IfcWall') === 0); }
+
+  /**
+   * buildNeeds(elements, opts) — the needs() edge providers (4D_BAR_MODEL.md §3).
+   * @param {object[]} elements - ScheduleAuthor._buildScheduleElements() shape: guid, cls, name,
+   *   storey, base_z, top_z, x0, x1, y0, y1, seq, phase, resource, installSecs.
+   * @param {object} [opts] - opts.scheduleGate overrides the ScheduleGate module used for the
+   *   CALLED providers (supportPool/hostPairs/openingPairs) — defaults to this file's own require.
+   * @returns {{edges: {from:string,to:string,kind:string}[], counts: object, cycles: []}}
+   */
+  function buildNeeds(elements, opts) {
+    opts = opts || {};
+    var SG = opts.scheduleGate || ScheduleGate;
+    var N = elements.length;
+    var edges = [], seenEdge = {};
+    var countSupport = 0, countHost = 0, countCarrier = 0, countOpening = 0, countWall = 0;
+
+    function addEdge(from, to, kind) {
+      if (from === to) return false;                 // no self-edges
+      var key = kind + '|' + from + '|' + to;
+      if (seenEdge[key]) return false;                // no duplicate edges
+      seenEdge[key] = 1;
+      edges.push({ from: from, to: to, kind: kind });
+      return true;
+    }
+
+    // ── source populations, both CALLED off ScheduleGate, never reimplemented ──────────────────
+    // structIdx membership === SG.supportPool(el) — schedule_gate.js:786-787's own structIdxGrid
+    // population is `P.seq<=4 || isPromotedSlab(P) || isStairFlight(P)` written out longhand; that
+    // IS supportPool(P) (schedule_gate.js:1264-1268, §S26.2) — calling the exported function here
+    // instead of retyping that expression a second time is the entire point of §S26.2 existing.
+    var structIdx = buildIndex(elements, function (e) { return SG.supportPool(e); });
+    // wallIdx membership === place()'s own wallGrid population (schedule_gate.js:575,578) and
+    // computeSchedule's wallIdxGrid population (schedule_gate.js:788) — an IfcWall*-prefixed class.
+    var wallIdx = buildIndex(elements, isWallCls);
+
+    var stamp = new Int32Array(N), gen = 0;
+
+    for (var ti = 0; ti < N; ti++) {
+      var E = elements[ti];
+      var isPoolE = SG.supportPool(E);   // CALLED — same var name/role as computeSchedule's isPoolE
+
+      // ── SupportNeeds + CarrierNeeds candidate scan ──────────────────────────────────────────
+      // Verbatim structure of schedule_gate.js:805-828's per-E candidate gather: one CELL scan of
+      // structIdx (supportPool members only), deduped per E via the same stamp/gen technique
+      // (schedule_gate.js:804,810), overlap-filtered.
+      gen++;
+      var cs = G.cellsOf(E), cands = [];
+      for (var c = 0; c < cs.length; c++) {
+        var arr = structIdx[cs[c]]; if (!arr) continue;
+        for (var k = 0; k < arr.length; k++) {
+          var si = arr[k]; if (si === ti || stamp[si] === gen) continue;
+          stamp[si] = gen;
+          if (!G.overlap(elements[si], E)) continue;
+          cands.push(si);
+        }
+      }
+
+      // hasBearingBelow(E) (schedule_gate.js:601-606), computed STATICALLY over the full candidate
+      // set rather than the incremental placement grid — computeSchedule's own comment at
+      // schedule_gate.js:814-815 establishes these agree by construction ("with topological order
+      // every bearing support is placed before E, so the runtime hasBearingBelow() the hangGate
+      // consults agrees with this static fact"), and this is exactly the static check
+      // computeSchedule's own DAG builder performs (schedule_gate.js:806,813) to decide the same
+      // thing before any placement has happened at all.
+      var hasB = false;
+      for (var q = 0; q < cands.length; q++) if (G.edgeBearing(elements[cands[q]], E)) { hasB = true; break; }
+      var hangs = (!hasB && E.seq > 4);   // schedule_gate.js:816
+
+      var hadCarrier = false;
+      for (var q2 = 0; q2 < cands.length; q2++) {
+        var S = elements[cands[q2]];
+        // isCarrierEdge — verbatim schedule_gate.js:824-825.
+        var isCarrierEdge = hangs && G.edgeCarrier(S, E) &&
+            !(isPoolE && E.base_z < S.base_z - ScheduleGate.EPS) &&
+            !(G.isPromotedSlab(S) && E.cls && E.cls.indexOf('IfcWall') === 0 && G.edgeBearing(E, S));
+        if (isCarrierEdge) hadCarrier = true;
+        // support-vs-carrier tie-break: geometrically near-mutually-exclusive (support requires S
+        // strictly below E's base; carrier requires S at/above E's top), but computeSchedule itself
+        // never has to choose a KIND — it only needs "an edge exists" for the topological sort
+        // (schedule_gate.js:827-828 adds ONE edge on the OR of all three). This module has to tag a
+        // kind, so support is checked first as the more fundamental of the two relations.
+        if (G.edgeBelow(S, E) || (!isPoolE && G.edgeContained(S, E))) {
+          if (addEdge(S.guid, E.guid, 'support')) countSupport++;
+        } else if (isCarrierEdge) {
+          if (addEdge(S.guid, E.guid, 'carrier')) countCarrier++;
+        }
+      }
+
+      // §HANG_NEAREST fallback — schedule_gate.js:829-844 verbatim (a big pure-sink hanger with
+      // zero in-band carriers gets an edge from every co-planar member of its nearest carrier
+      // plane above).
+      if (hangs && !isPoolE && !(E.cls && E.cls.indexOf('IfcWall') === 0) && !hadCarrier &&
+          G.bboxVol(E) > ScheduleGate.BIG_ELEMENT_VOL) {
+        var nb = Infinity;
+        for (var q3 = 0; q3 < cands.length; q3++) {
+          var S3 = elements[cands[q3]];
+          if (S3.base_z > E.top_z + ScheduleGate.GAP && S3.base_z < nb) nb = S3.base_z;
+        }
+        if (nb < Infinity) {
+          for (var q4 = 0; q4 < cands.length; q4++) {
+            var S4 = elements[cands[q4]];
+            if (S4.base_z > E.top_z + ScheduleGate.GAP && S4.base_z <= nb + ScheduleGate.GAP) {
+              if (addEdge(S4.guid, E.guid, 'carrier')) countCarrier++;
+            }
+          }
+        }
+      }
+
+      // ── WallNeeds — schedule_gate.js:845-851 verbatim, commented there "// wallGate's relation" ──
+      if (G.isPromotedSlab(E)) {
+        gen++;
+        var cs2 = G.cellsOf(E);
+        for (var c2 = 0; c2 < cs2.length; c2++) {
+          var arr2 = wallIdx[cs2[c2]]; if (!arr2) continue;
+          for (var k2 = 0; k2 < arr2.length; k2++) {
+            var si2 = arr2[k2]; if (si2 === ti || stamp[si2] === gen) continue;
+            stamp[si2] = gen;
+            var S2 = elements[si2];
+            if (!G.overlap(S2, E)) continue;
+            if (G.wallCarries(S2, E)) { if (addEdge(S2.guid, E.guid, 'wall')) countWall++; }
+          }
+        }
+      }
+    }
+
+    // ── HostNeeds — SG.hostPairs(elements), CALLED directly (schedule_gate.js:151, exported) ────
+    var hp = SG.hostPairs(elements);
+    for (var hi = 0; hi < hp.length; hi++) {
+      if (addEdge(elements[hp[hi].h].guid, elements[hp[hi].i].guid, 'host')) countHost++;
+    }
+
+    // ── OpeningNeeds — SG.openingPairs(elements), CALLED directly (schedule_gate.js:292, exported)
+    // openingPairs' own header (schedule_gate.js:288-291): "EVERY host of the chosen pool is
+    // returned, not the nearest — openingGate returns the MAX end over its whole pool, so a
+    // consumer that honours every pair reproduces the gate's exact bound." Honouring every pair is
+    // exactly what this loop does.
+    var op = SG.openingPairs(elements);
+    for (var oi = 0; oi < op.length; oi++) {
+      if (addEdge(elements[op[oi].h].guid, elements[op[oi].i].guid, 'opening')) countOpening++;
+    }
+
+    var counts = { support: countSupport, host: countHost, carrier: countCarrier,
+                   opening: countOpening, wall: countWall };
+    var total = edges.length;
+    if (typeof console !== 'undefined' && console.log) {
+      console.log('§BAR_NEEDS n=' + N + ' support=' + counts.support + ' host=' + counts.host +
+        ' carrier=' + counts.carrier + ' opening=' + counts.opening + ' wall=' + counts.wall +
+        ' total=' + total);
+    }
+    return { edges: edges, counts: counts, cycles: [] };
+  }
+
+  var API = { buildNeeds: buildNeeds };
+  root.BarNeeds = API;
+  if (typeof module !== 'undefined' && module.exports) module.exports = API;
+})(typeof window !== 'undefined' ? window : (typeof globalThis !== 'undefined' ? globalThis : this));

--- a/viewer/tests/witness_bar_needs.js
+++ b/viewer/tests/witness_bar_needs.js
@@ -1,0 +1,149 @@
+#!/usr/bin/env node
+// WITNESS — the needs() edge PROVIDERS of the 4D Bar model (viewer/bar_needs.js).
+// Spec: bim-compiler prompts/4D_BAR_MODEL.md §3 ("needs() — ONE LIST, MANY PROVIDERS") and §3.1
+// ("EXTRACTION IS MANDATORY").
+//
+// WHICH LAYER THIS PROVES (WITNESS_INTERFACE_FRAMEWORK.md §CRISIS LESSON 1): the EDGE PROVIDERS
+// only — that SupportNeeds/HostNeeds/CarrierNeeds/OpeningNeeds/WallNeeds each LIFT a real shipped
+// schedule_gate.js predicate instead of re-deriving one, on real building geometry. It says nothing
+// about the tree arithmetic (witness_bar_composite.js) or the scheduled result — midair, phase
+// stacking, crew caps (witness_bar_schedule.js, not yet built).
+//
+// ISSUE THIS PROVES OR DISPROVES: §3.1's own measured near-miss — a hand-written "support = anything
+// below" gave Duplex 4,706 edges / 52 midair; calling ScheduleGate.supportPool gave far fewer edges
+// and 0 midair. The anti-re-derivation gate here (G-BN-EDGECOUNT) makes that regression fail loudly:
+// SupportNeeds+CarrierNeeds+WallNeeds+HostNeeds must sum to EXACTLY what the real
+// ScheduleGate.computeSchedule's own §GEOMETRIC_SUPPORT_ORDER DAG builder reports building the SAME
+// elements (its own §GEO_ORDER `edges=` log line, parsed, not trusted by inspection) — a hand-
+// rederived geometry can drift from bar_needs.js's own internal bookkeeping without ever tripping a
+// bug in bar_needs.js itself, but it cannot also drift the REAL shipped function's own count, so
+// comparing against that is what actually catches it.
+//
+// Command: node viewer/tests/witness_bar_needs.js [Building ...]
+'use strict';
+const fs = require('fs'), path = require('path'), vm = require('vm'), os = require('os');
+const HOME = os.homedir();
+const initSqlJs = require(path.join(HOME, 'bim-ootb', 'node_modules', 'sql.js'));
+const SQLJS_DIST = path.join(HOME, 'bim-ootb', 'node_modules', 'sql.js', 'dist');
+const V = process.env.VIEWER_DIR || path.join(__dirname, '..');
+const SG = require(path.join(V, 'schedule_gate.js')); global.ScheduleGate = SG;
+const SA = require(path.join(V, 'schedule_author.js'));
+const BN = require(path.join(V, 'bar_needs.js'));
+const KIT = path.join(__dirname, '..', '..', 'witness_kit');
+const { Witness } = require(path.join(KIT, 'contract'));
+const { NeedsEdgeRow } = require(path.join(KIT, 'schemas', 'bar_needs'));
+const INV = require(path.join(KIT, 'invariants', 'bar_needs'));
+
+const BLD_DIR = process.env.BLD_DIR || path.join(HOME, 'bim-ootb', 'buildings');
+const BUILDINGS = process.argv.slice(2).length ? process.argv.slice(2)
+  : ['Duplex', 'HHS_Office_Federated', 'Hospital', 'Terminal'];   // §7 fleet, all four mandatory
+
+function executedRules() {
+  const sb = { console: { log() {}, warn() {}, error() {} } };
+  vm.createContext(sb);
+  vm.runInContext(fs.readFileSync(path.join(V, 'rates.js'), 'utf8'), sb);
+  return sb;
+}
+
+// spyOn(obj, method) — G-BN-SUPPORTPOOL-CALLED needs proof that bar_needs.js CALLS
+// ScheduleGate.supportPool rather than reimplementing its expression. A shallow-copied API object
+// with one method wrapped, passed in as opts.scheduleGate, real behavior delegated through —
+// bar_needs.js's own output must be byte-identical whether or not it's being watched.
+function spyOn(obj, method) {
+  let calls = 0;
+  const wrapped = Object.assign({}, obj);
+  wrapped[method] = function () { calls++; return obj[method].apply(obj, arguments); };
+  return { wrapped, count: () => calls };
+}
+
+const GEO_ORDER_RE = /§GEO_ORDER n=(\d+) edges=(\d+) hangNearest=(\d+) hostEdges=(\d+)/;
+
+(async () => {
+  const SQL = await initSqlJs({ locateFile: f => path.join(SQLJS_DIST, f) });
+  const R = executedRules();
+  const spy = spyOn(SG, 'supportPool');
+  const rows = [], perBuilding = [];
+
+  for (const bld of BUILDINGS) {
+    const file = path.join(BLD_DIR, bld + '_extracted.db');
+    if (!fs.existsSync(file)) { console.log('§BN_SKIP ' + bld + ' fixture missing'); continue; }
+    const db = new SQL.Database(new Uint8Array(fs.readFileSync(file)));
+    const _l = console.log, _w = console.warn;
+    console.log = () => {}; console.warn = () => {};
+    const els = SA._buildScheduleElements(db, R.SEQUENCE_RULES, {
+      laborRates: R.LABOR_RATES, rates: R.RATES,
+      nameOverrides: R.SEQUENCE_NAME_OVERRIDES, defaultRule: R.SEQUENCE_DEFAULT });
+    console.log = _l; console.warn = _w;
+
+    // ── bar_needs.js under test — the spied ScheduleGate proves supportPool is CALLED ──────────
+    console.log = () => {};   // suppress the module's own §BAR_NEEDS line here, printed once below
+    const res = BN.buildNeeds(els, { scheduleGate: spy.wrapped });
+    console.log = _l;
+
+    // ── the independent, second computation: run the REAL shipped DAG builder and READ ITS OWN
+    // COUNT off its own log line — never trust bar_needs.js's bookkeeping against itself ──────────
+    let geoLine = null;
+    console.log = function (s) { if (typeof s === 'string' && GEO_ORDER_RE.test(s)) geoLine = s; };
+    SG.computeSchedule(els, 0, 1, undefined, 8);
+    console.log = _l;
+    const m = GEO_ORDER_RE.exec(geoLine || '');
+    if (!m) { console.log('§BN_SKIP ' + bld + ' — §GEO_ORDER line not found, cannot verify'); db.close(); continue; }
+    const shippedEdges = +m[2], shippedHostEdges = +m[4];
+    const hostPairsLen = SG.hostPairs(els).length;
+    const openingPairsLen = SG.openingPairs(els).length;
+    const mySum = res.counts.support + res.counts.carrier + res.counts.wall + res.counts.host;
+
+    res.edges.forEach(e => rows.push({ building: bld, from: e.from, to: e.to, kind: e.kind }));
+    perBuilding.push({
+      bld, elements: els.length, counts: res.counts, mySum, shippedEdges,
+      myHost: res.counts.host, shippedHostEdges, hostPairsLen,
+      myOpening: res.counts.opening, openingPairsLen
+    });
+
+    console.log('§BAR_NEEDS ' + bld + ' n=' + els.length +
+      ' support=' + res.counts.support + ' host=' + res.counts.host +
+      ' carrier=' + res.counts.carrier + ' opening=' + res.counts.opening +
+      ' wall=' + res.counts.wall + ' total=' + res.edges.length +
+      ' | shippedEdges=' + shippedEdges + ' mySum=' + mySum +
+      ' shippedHostEdges=' + shippedHostEdges + ' hostPairsLen=' + hostPairsLen +
+      ' openingPairsLen=' + openingPairsLen);
+    db.close();
+  }
+
+  Witness('bar_needs')
+    .population(() => rows)
+    .schema(NeedsEdgeRow)
+    .invariant('no-self-edges', INV.noSelfEdges)
+    .invariant('no-duplicate-edges', INV.noDuplicateEdges)
+    // THE anti-re-derivation gate (§3.1) — checked against the REAL shipped predicate's own count.
+    .invariant('edge-count-matches-shipped-geo-order', () => INV.edgeCountMatchesShipped(perBuilding))
+    .invariant('host-count-matches-shipped-hostpairs', () => INV.hostCountMatchesShipped(perBuilding))
+    .invariant('opening-count-matches-shipped-openingpairs', () => INV.openingCountMatchesShipped(perBuilding))
+    .invariant('supportPool-called-not-reimplemented', () => INV.supportPoolWasCalled(spy.count()))
+    // RED CONTROLS — each gate must reject its OWN defect, in the committed witness
+    // (feedback_extract_dont_author_then_gate.md), not asserted only in a throwaway session.
+    .invariant('redctl:no-self-edges rejects from===to',
+      () => INV.noSelfEdges([{ building: 'X', from: 'A', to: 'A', kind: 'support' }]) === false)
+    .invariant('redctl:no-duplicate-edges rejects a repeated tuple',
+      () => INV.noDuplicateEdges([
+        { building: 'X', kind: 'support', from: 'A', to: 'B' },
+        { building: 'X', kind: 'support', from: 'A', to: 'B' }]) === false)
+    .invariant('redctl:edge-count gate rejects a mismatched sum',
+      () => INV.edgeCountMatchesShipped([{ mySum: 5, shippedEdges: 6 }]) === false)
+    .invariant('redctl:host-count gate rejects a mismatched hostPairs call',
+      () => INV.hostCountMatchesShipped([{ myHost: 5, shippedHostEdges: 5, hostPairsLen: 6 }]) === false)
+    .invariant('redctl:opening-count gate rejects a mismatched openingPairs call',
+      () => INV.openingCountMatchesShipped([{ myOpening: 5, openingPairsLen: 6 }]) === false)
+    .invariant('redctl:supportPool-called gate rejects a zero call count',
+      () => INV.supportPoolWasCalled(0) === false)
+    // Population-level red control: corrupt the FIRST real row into a self-edge and duplicate the
+    // SECOND — noSelfEdges/noDuplicateEdges (which read the passed rows, not the closure) must
+    // catch this even though the closure-based §GEO_ORDER comparisons cannot see a rows mutation.
+    .redControl(rs => {
+      const c = rs.map(r => Object.assign({}, r));
+      if (c[0]) c[0].to = c[0].from;
+      if (c[1]) c.push(Object.assign({}, c[1]));
+      return c;
+    })
+    .run();
+})();

--- a/witness_kit/invariants/bar_needs.js
+++ b/witness_kit/invariants/bar_needs.js
@@ -1,0 +1,89 @@
+// witness_kit/invariants/bar_needs.js — the needs() edge PROVIDERS of the 4D Bar model.
+// Spec: bim-compiler prompts/4D_BAR_MODEL.md §3 + §3.1 (EXTRACTION IS MANDATORY).
+//
+// The one rule these gate: every provider LIFTS a shipped schedule_gate.js predicate — none are
+// re-derived. §3.1's own measured cost of getting this wrong: a hand-written "support = anything
+// below" gave Duplex 4,706 edges / 52 midair; ScheduleGate.supportPool-filtered gave far fewer and
+// 0 midair. `edgeCountMatchesShipped` is the gate that makes THAT specific regression impossible to
+// ship unnoticed — it doesn't re-check bar_needs.js's own arithmetic, it checks bar_needs.js's
+// output against a SECOND, INDEPENDENT computation: the real ScheduleGate.computeSchedule's own
+// self-reported §GEO_ORDER edge count, parsed out of its console.log — the shipped predicate,
+// called directly, not trusted by inspection.
+'use strict';
+
+/**
+ * G-BN-NOSELF — no edge may point an element at itself.
+ * @param {object[]} rows - {from, to, kind, ...}
+ * @returns {boolean}
+ */
+const noSelfEdges = rows => rows.every(r => r.from !== r.to);
+
+/**
+ * G-BN-NODUP — no (building, kind, from, to) tuple may repeat. Duplicate edges are exactly the
+ * shape a stray second grid-cell scan of the same pair would produce if the per-element dedup
+ * (schedule_gate.js's own stamp/gen technique, lifted into bar_needs.js) were ever dropped.
+ * @param {object[]} rows - {building, from, to, kind}
+ * @returns {boolean}
+ */
+function noDuplicateEdges(rows) {
+  const seen = new Set();
+  for (const r of rows) {
+    const k = r.building + '|' + r.kind + '|' + r.from + '|' + r.to;
+    if (seen.has(k)) return false;
+    seen.add(k);
+  }
+  return true;
+}
+
+/**
+ * G-BN-EDGECOUNT — the anti-re-derivation gate, the whole point of this witness
+ * (4D_BAR_MODEL.md §3.1). support+carrier+wall+host must sum to EXACTLY the real
+ * ScheduleGate.computeSchedule's own §GEO_ORDER `edges=` count for the SAME element set —
+ * computeSchedule's own §GEOMETRIC_SUPPORT_ORDER DAG builder (schedule_gate.js:758-862) is the
+ * predicate bar_needs.js's SupportNeeds/CarrierNeeds/WallNeeds providers lift their geometry from,
+ * so their combined total (opening excluded — it is not part of that DAG at all, see below) has no
+ * freedom to differ from what the shipped function itself reports building the identical elements.
+ * A hand-rederived support definition changes this SUM without changing computeSchedule's own
+ * count, so any drift between an author's private geometry and the shipped one fails here.
+ * @param {{mySum:number, shippedEdges:number}[]} perBuilding
+ * @returns {boolean}
+ */
+const edgeCountMatchesShipped = perBuilding =>
+  perBuilding.every(b => b.mySum === b.shippedEdges);
+
+/**
+ * G-BN-HOSTCOUNT — HostNeeds' edge count equals BOTH computeSchedule's own hostEdges= tally AND a
+ * fresh, independent call to ScheduleGate.hostPairs() on the same elements. Two independent
+ * re-derivations of "did bar_needs.js actually call hostPairs, not reimplement §HOSTED_BEFORE_HOST".
+ * @param {{myHost:number, shippedHostEdges:number, hostPairsLen:number}[]} perBuilding
+ * @returns {boolean}
+ */
+const hostCountMatchesShipped = perBuilding =>
+  perBuilding.every(b => b.myHost === b.shippedHostEdges && b.myHost === b.hostPairsLen);
+
+/**
+ * G-BN-OPENINGCOUNT — OpeningNeeds' edge count equals a fresh, independent call to
+ * ScheduleGate.openingPairs() on the same elements. openingPairs is not part of computeSchedule's
+ * DAG (doors/windows are gated at runtime by openingGate, never ordered by the Kahn-topological
+ * pass), so this is checked against openingPairs directly rather than against §GEO_ORDER.
+ * @param {{myOpening:number, openingPairsLen:number}[]} perBuilding
+ * @returns {boolean}
+ */
+const openingCountMatchesShipped = perBuilding =>
+  perBuilding.every(b => b.myOpening === b.openingPairsLen);
+
+/**
+ * G-BN-SUPPORTPOOL-CALLED — ScheduleGate.supportPool was invoked at least once while building
+ * SupportNeeds/CarrierNeeds — the exact call the §3.1 hard rule requires in place of retyping
+ * `e.seq<=4 || isPromotedSlab(e) || isStairFlight(e)` a second time. A count of 0 means the source
+ * population was built some other way — this witness's own §W-REDCONTROL proves that shape is
+ * catchable (see witness_bar_needs.js's own redControl / supportPoolCallCount=0 assertion).
+ * @param {number} callCount
+ * @returns {boolean}
+ */
+const supportPoolWasCalled = callCount => callCount > 0;
+
+module.exports = {
+  noSelfEdges, noDuplicateEdges, edgeCountMatchesShipped,
+  hostCountMatchesShipped, openingCountMatchesShipped, supportPoolWasCalled
+};

--- a/witness_kit/schemas/bar_needs.js
+++ b/witness_kit/schemas/bar_needs.js
@@ -1,0 +1,17 @@
+// witness_kit/schemas/bar_needs.js — one needs() edge from the 4D Bar model.
+// Spec: bim-compiler prompts/4D_BAR_MODEL.md §3.
+'use strict';
+
+const NeedsEdgeRow = {
+  type: 'object',
+  required: ['building', 'from', 'to', 'kind'],
+  properties: {
+    building: { type: 'string', minLength: 1 },
+    from:     { type: 'string', minLength: 1 },   // GUID that must finish first
+    to:       { type: 'string', minLength: 1 },   // GUID that needs it
+    kind:     { type: 'string', enum: ['support', 'host', 'carrier', 'opening', 'wall'] }
+  },
+  additionalProperties: true
+};
+
+module.exports = { NeedsEdgeRow };


### PR DESCRIPTION
## Summary
- Adds `viewer/bar_needs.js` — `buildNeeds(elements, opts)`, the `needs()` edge providers §3 of `4D_BAR_MODEL.md` calls for: SupportNeeds, HostNeeds, CarrierNeeds, OpeningNeeds, WallNeeds. Consumed by `viewer/bar_model.js`'s `attachNeeds()` (already merged, #1537 — its header already named this file as the injection point).
- Every provider LIFTS a real shipped `schedule_gate.js` predicate (§3.1, EXTRACTION IS MANDATORY) — none are re-derived:
  - `supportPool`, `hostPairs`, `openingPairs` are CALLED directly off `ScheduleGate`'s own exported API.
  - `edgeBelow`/`edgeContained`/`edgeBearing`/`wallCarries`/`edgeCarrier` — the pure static relations `computeSchedule`'s own `§GEOMETRIC_SUPPORT_ORDER` DAG builder already hoisted out of `geoGate`/`wallGate`/`hangGate` for exactly this "static needs-graph, not runtime gate" purpose — are LIFTED verbatim via balanced-brace source slicing (`sliceFn`, the same technique `viewer/tests/witness_gantt_native_generate.js` already uses on `time_machine.js`).
- Adds `viewer/tests/witness_bar_needs.js` + `witness_kit/schemas/bar_needs.js` + `witness_kit/invariants/bar_needs.js`.

## The anti-re-derivation gate
`SupportNeeds+CarrierNeeds+WallNeeds+HostNeeds` is asserted to sum to **exactly** the real `ScheduleGate.computeSchedule`'s own self-reported `§GEO_ORDER edges=` count on the identical elements — a second, independent computation (parsed off the real function's own log line), not `bar_needs.js` checked against itself. `supportPool` is proven CALLED (not reimplemented) via a call-counting spy.

## Measured (all 4 mandatory fleet buildings, `ScheduleAuthor._buildScheduleElements` source)
| building | support | host | carrier | opening | wall | total |
|---|---|---|---|---|---|---|
| Duplex | 4523 | 104 | 761 | 44 | 0 | 5432 |
| HHS_Office_Federated | 51654 | 725 | 3172 | 286 | 0 | 55837 |
| Hospital | 461359 | 2830 | 11951 | 936 | 0 | 477076 |
| Terminal | 416779 | 2090 | 6069 | 808 | 0 | 425746 |

`wall=0` on all four is a verified-correct finding, not a bug — see Caveats.

## Witness
`§WITNESS_BAR_NEEDS pass=15 fail=0 ran=964091` — every gate green, including a red control that demonstrably fails (schema/self-edge/duplicate-edge/count-match/supportPool-call gates each independently proven to reject their own defect).

## Caveats (reported honestly, not swept)
- `wall=0` on all four buildings: `ScheduleAuthor._buildScheduleElements` (the element source this task specifies) never calls `time_machine.js`'s separate `_promoteRoofLoadPath()` step, so `isPromotedSlab()` never fires true on this element source — `schedule_author.js`'s own `materializeZones` has the same gap (it calls `computeSchedule` on the same un-promoted elements). `WallNeeds`' `wallCarries` lift is unit-verified correct against a synthetic wall+promoted-roof-slab fixture (produces exactly 1 edge as expected) — the logic is right, the fleet's element source just never exercises it.
- `PhaseNeeds`/`LadderNeeds` (task-level, policy-driven, per §3's table) are out of scope for this PR — the task's own "Kinds required" list is exactly the 5 physical/geometric kinds shipped here.

## Test plan
- [x] `node viewer/tests/witness_bar_needs.js` — 15/15 pass, all four mandatory buildings (Duplex, HHS_Office_Federated, Hospital, Terminal)
- [x] Syntax-checked all 4 new files (`node -c`)
- [x] Manual synthetic-fixture check of `WallNeeds` (wall + promoted roof slab → exactly 1 edge)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0128gEW4c79FQsroLTB5vCfr