### PR TITLE
feat(4d): §BAR_LIVE — wire the Bar model as the live 4D authoring path

### DIFF
--- a/viewer/bar_model.js
+++ b/viewer/bar_model.js
@@ -92,65 +92,14 @@
     return Object.keys(min).sort(function (a, b) { return min[a] - min[b]; });
   }
 
-  // ══ §BAR_LEVEL_FROM_GEOMETRY (2026-08-25) ═══════════════════════════════════════════════════
-  // The IFC storey STRING is not the location. Location-Based Management (Kenley & Seppanen) makes
-  // the Location Breakdown Structure a deliberate physical decision precisely because inherited
-  // storey labels do not survive contact with a real model — and the same literature splits elements
-  // that span two locations rather than forcing each into one.
-  //
-  // MEASURED, all 28 remaining structural floaters across HHS/Hospital/Terminal after every other
-  // fix: EVERY ONE of them has its support physically LOWER, while the labels put that support in a
-  // LATER bar. 24 are same-phase cross-level (`Superstructure Level 1` resting on
-  // `Superstructure Level 2`; Terminal's `Ceiling Level 04` resting on `Aras 03`), 4 are cross-phase
-  // same-level. deriveBandRanks already ranks storeys by median element height, so the RANKING is
-  // geometric and correct — it is the per-element storey ASSIGNMENT that disagrees with physics.
-  //
-  // So: where an element's own label contradicts what it demonstrably rests on, the geometry wins
-  // and the element is moved to its support's level. Nothing is invented — the correction comes
-  // from the bearing relation the model already extracted. Reported, never silent.
-  function correctLevelsByGeometry(elements, edges, collapse, bandRank) {
-    var lvl = {}, byGuid = {}, i;
-    for (i = 0; i < elements.length; i++) {
-      var e = elements[i];
-      byGuid[e.guid] = e;
-      lvl[e.guid] = collapse(e.storey);
-    }
-    // bearing supports only: the relation the midair judge itself tests.
-    var supOf = {};
-    for (i = 0; i < edges.length; i++) {
-      if (edges[i].kind !== 'bearing') continue;
-      (supOf[edges[i].to] = supOf[edges[i].to] || []).push(edges[i].from);
-    }
-    function rankOf(g) { var r = bandRank[lvl[g]]; return r == null ? -1 : r; }
-
-    var moved = 0, detail = {}, pass;
-    // A correction can expose another one up the chain, so iterate to a fixpoint. Bounded: each
-    // pass either moves something or stops, and an element only ever moves UP a rank.
-    for (pass = 0; pass < 8; pass++) {
-      var movedThisPass = 0;
-      for (var g in supOf) {
-        var E = byGuid[g]; if (!E) continue;
-        var myRank = rankOf(g), bestLvl = null, bestRank = myRank;
-        var sups = supOf[g];
-        for (var k = 0; k < sups.length; k++) {
-          var S = byGuid[sups[k]]; if (!S) continue;
-          // only trust a support the GEOMETRY agrees is underneath — never relabel off a
-          // relation the heights contradict.
-          if (!(S.base_z < E.base_z)) continue;
-          var sr = rankOf(sups[k]);
-          if (sr > bestRank) { bestRank = sr; bestLvl = lvl[sups[k]]; }
-        }
-        if (bestLvl !== null) {
-          var from = lvl[g];
-          lvl[g] = bestLvl; moved++; movedThisPass++;
-          var dk = from + ' -> ' + bestLvl;
-          detail[dk] = (detail[dk] || 0) + 1;
-        }
-      }
-      if (!movedThisPass) break;
-    }
-    return { level: lvl, moved: moved, passes: pass, detail: detail };
-  }
+  // ⛔ §BAR_LEVEL_FROM_GEOMETRY — REMOVED 2026-08-26. It moved an element to its support's level
+  // where its own storey label contradicted what it demonstrably rested on. That looked like a fix
+  // and was a SYMPTOM PATCH for missing storey metadata (§S72): it fired 1,986 times on Terminal
+  // and ZERO times once Terminal's 23 storey labels are mapped onto its 6 EXTRACTED storeys.
+  // MEASURED cost of keeping it — removing it is free on three buildings and a large win on the
+  // fourth: midair Duplex 12->12, HHS 70->70, Hospital 92->92, TERMINAL 513->336; force-placed
+  // Terminal 5,779->3,924. Band inversions move 0->4 on Terminal, negligible.
+  // The real fix is the WalkerDoctrine §14/§15 storey injection, not this.
 
   // ══ §BAR_LEVEL_BANDS (2026-08-25) — the granularity DIAL ════════════════════════════════════
   // The two hells trade against each other, smoothly and monotonically, and level granularity is
@@ -599,7 +548,7 @@
   }
 
   var API = { Bar: Bar, ElementBar: ElementBar, GroupBar: GroupBar, isStructural: isStructural,
-              correctLevelsByGeometry: correctLevelsByGeometry, attachContacts: attachContacts,
+              attachContacts: attachContacts,
               coarsenLevels: coarsenLevels,
               phaseOrder: phaseOrder, buildTree: buildTree, attachNeeds: attachNeeds,
               schedule: schedule, reportCycles: reportCycles };

--- a/viewer/bar_needs.js
+++ b/viewer/bar_needs.js
@@ -45,12 +45,25 @@
 'use strict';
 (function (root) {
 
-  var fs = require('fs');
-  var path = require('path');
+  // BROWSER-SAFE (2026-08-26). This module used to `require('fs')` at load and slice
+  // schedule_gate.js's SOURCE TEXT to recover predicates trapped in computeSchedule's closure.
+  // That cannot run in a browser — `ReferenceError: require is not defined`, caught by
+  // witness_real_placement_resolver.js the moment the live wiring landed. The predicates are now
+  // LIFTED and EXPORTED from schedule_gate.js (same move, same reason as §S26.2's supportPool), so
+  // this module CALLS them. No text scraping, no drift possible, and it loads in both runtimes.
+  var ScheduleGate = (typeof require === 'function' && typeof module !== 'undefined')
+    ? require('./schedule_gate.js')
+    : (root.ScheduleGate || (typeof window !== 'undefined' && window.ScheduleGate));
+  if (!ScheduleGate) throw new Error('bar_needs.js: ScheduleGate not available');
 
-  var SG_PATH = path.join(__dirname, 'schedule_gate.js');
-  var SG_SRC = fs.readFileSync(SG_PATH, 'utf8');
-  var ScheduleGate = require('./schedule_gate.js');
+  // Node-only, and only for the WITNESS's anti-re-derivation check — never on the live path.
+  var fs = null, path = null, SG_SRC = '';
+  if (typeof require === 'function' && typeof module !== 'undefined') {
+    try {
+      fs = require('fs'); path = require('path');
+      SG_SRC = fs.readFileSync(path.join(__dirname, 'schedule_gate.js'), 'utf8');
+    } catch (e) { SG_SRC = ''; }
+  }
 
   // sliceFn(src, name) — balanced-brace extraction of a named function declaration, wherever it
   // sits in the source text (module scope or trapped inside another function's closure — pure text
@@ -71,23 +84,24 @@
   // The lifted geometric core, bound to ScheduleGate's own CELL/EPS/GAP (never a second hand-typed
   // copy of those constants — the reason schedule_gate.js exports them in the first place, per its
   // own comment at schedule_gate.js:1250-1252).
-  var _slicedSrc =
-    'var CELL = ' + ScheduleGate.CELL + ';\n' +
-    'var EPS = ' + ScheduleGate.EPS + ';\n' +
-    'var GAP = ' + ScheduleGate.GAP + ';\n' +
-    sliceFn(SG_SRC, 'cellsOf') + '\n' +          // schedule_gate.js:174 — CELL-keyed XY bucketer
-    sliceFn(SG_SRC, 'overlap') + '\n' +           // schedule_gate.js:180 — AABB XY overlap test
-    sliceFn(SG_SRC, 'isPromotedSlab') + '\n' +    // schedule_gate.js:549 — §DEQ_V1 roof-role slab
-    sliceFn(SG_SRC, 'edgeBelow') + '\n' +         // schedule_gate.js:790 — geoGate "below"
-    sliceFn(SG_SRC, 'edgeContained') + '\n' +     // schedule_gate.js:793 — geoGate §GEO_SUPPORT_LEAK
-    sliceFn(SG_SRC, 'edgeBearing') + '\n' +       // schedule_gate.js:794 — hasBearingBelow/audit
-    sliceFn(SG_SRC, 'wallCarries') + '\n' +       // schedule_gate.js:797 — wallGate's relation
-    sliceFn(SG_SRC, 'edgeCarrier') + '\n' +       // schedule_gate.js:798 — hangGate
-    sliceFn(SG_SRC, 'bboxVol');                   // schedule_gate.js:323 — §HANG_NEAREST volume test
-  var G = (new Function(_slicedSrc +
-    '\nreturn { cellsOf: cellsOf, overlap: overlap, isPromotedSlab: isPromotedSlab, ' +
-    'edgeBelow: edgeBelow, edgeContained: edgeContained, edgeBearing: edgeBearing, ' +
-    'wallCarries: wallCarries, edgeCarrier: edgeCarrier, bboxVol: bboxVol };'))();
+  // The predicates, CALLED not sliced (2026-08-26). Every one of these is exported from
+  // schedule_gate.js — cellsOf/overlap were already at module scope; isPromotedSlab and the five
+  // edge* predicates were lifted out of computeSchedule's closure for exactly this. Slicing them
+  // out of the file's source text worked in node and threw `require is not defined` in a browser,
+  // which is what stopped the live wiring. There is now nothing to drift: this IS the engine's own
+  // function object, not a copy of its text.
+  var G = {
+    cellsOf: ScheduleGate.cellsOf, overlap: ScheduleGate.overlap,
+    isPromotedSlab: ScheduleGate.isPromotedSlab, edgeBelow: ScheduleGate.edgeBelow,
+    edgeContained: ScheduleGate.edgeContained, edgeBearing: ScheduleGate.edgeBearing,
+    wallCarries: ScheduleGate.wallCarries, edgeCarrier: ScheduleGate.edgeCarrier,
+    bboxVol: ScheduleGate.bboxVol
+  };
+  (function () {
+    var missing = Object.keys(G).filter(function (k) { return typeof G[k] !== 'function'; });
+    if (missing.length) throw new Error('bar_needs.js: schedule_gate.js is not exporting ' +
+      missing.join(',') + ' — lift them to module scope, do not re-derive them here');
+  })();
 
   // buildIndex(elements, predFn) — CELL-bucket every element for which predFn holds, indexed the
   // same way structIdxGrid/wallIdxGrid are inside computeSchedule (schedule_gate.js:786-788).
@@ -131,24 +145,24 @@
   // The three clauses are census()'s own, lifted by balanced-brace slicing from
   // viewer/tests/witness_midair_zero.js, never retyped — same discipline as every other provider
   // here, and the discipline whose breach cost 4,706-vs-716 support edges earlier in this session.
+  // census()'s three contact clauses, held HERE rather than sliced out of
+  // viewer/tests/witness_midair_zero.js at runtime (that read a test file off disk — node-only, and
+  // a test is not a runtime dependency). They must stay byte-equivalent to census()'s own, which is
+  // not a hope: witness_bar_needs.js slices census() in node and asserts the two agree on the REAL
+  // contact set of all four buildings. Behavioural equality, checked, beats a comment saying "keep
+  // these in sync".
+  //   bearing  — S sits below E and reaches up to it
+  //   carrier  — S sits at or above E's top and rises past it (E hangs from S)
+  //   embedded — S brackets E vertically
   function contactClauses() {
-    var src = fs.readFileSync(path.join(__dirname, 'tests', 'witness_midair_zero.js'), 'utf8');
-    var i = src.indexOf('const bearing = S.bz < T.bz - EPS');
-    if (i < 0) throw new Error('census() contact clauses not found in witness_midair_zero.js — ' +
-      'do not retype them, fix the slice');
-    var j = src.indexOf('if (!bearing && !carrier && !embedded)', i);
-    if (j < 0) throw new Error('census() contact clause terminator not found');
-    var body = src.slice(i, j);
-    // census names its fields bz/tz; elements here carry base_z/top_z. Rename at the boundary only.
-    body = body.replace(/\.bz\b/g, '.base_z').replace(/\.tz\b/g, '.top_z');
-    return new Function('S', 'T', 'EPS', 'GAP', body + ' return bearing || carrier || embedded;');
+    return function (S, T, EPS, GAP) {
+      var bearing  = S.base_z < T.base_z - EPS && S.top_z >= T.base_z - GAP;
+      var carrier  = S.base_z >= T.top_z - GAP && S.top_z > T.top_z + EPS;
+      var embedded = S.base_z <= T.base_z + EPS && S.top_z >= T.top_z - EPS;
+      return bearing || carrier || embedded;
+    };
   }
 
-  // buildContacts(elements) — the ANY-OF set: for each element, every OTHER element it touches by
-  // census()'s own three clauses. Returned as {toGuid: [fromGuid,...]} rather than flat edges,
-  // because the gate only ever needs "the earliest of these", and a flat list on Terminal runs to
-  // roughly a million rows. Grounded elements (nothing meaningfully below them) get no entry —
-  // they stand on the earth, which is census()'s own rule and its own GAP constant.
   function buildContacts(elements) {
     var touches = contactClauses();
     var idx = {}, i, c, cs;

--- a/viewer/rates.js
+++ b/viewer/rates.js
@@ -557,6 +557,55 @@ var LOCALE_RATE_MAP = {
  * hardcoded fallback already in place is retained.
  * @returns {Promise<boolean>} true if the JSON was applied, false on fallback.
  */
+// ══ §4D_POLICY (2026-08-26) — the ONLY authored input to 4D scheduling ═══════════════════════
+// Spec: bim-compiler prompts/4D_BAR_MODEL.md §4. Everything else is EXTRACTED: phase order from
+// SEQUENCE_RULES' min sequence per phase, trades from the union of each phase's resources, level
+// from ScheduleGate.deriveBandRanks, work from _installSecs, crews from LABOR_RATES.max_crews,
+// shift from SHIFT_HOURS above.
+//
+// WHY A LITERAL AND A JSON. rates/4D_policy.json is the reviewable source and IS read — but a fetch
+// is async and generation can run before it lands. The literal below is the same five values, so a
+// pre-fetch generation is identical rather than broken, and loadFourDPolicy() overwrites in place
+// when the JSON arrives. This is deliberately NOT §RULES_TABLE_SOURCE's situation, where
+// loadSequenceRules() is never called by viewer.html at all and the JSON is dead (§S65 STAGE 1):
+// viewer.html DOES call loadFourDPolicy(), and a drift between the two is a witness failure.
+var FOURD_POLICY = {
+  "days_per_week": 7,
+  "phase_link": "serial",
+  "level_link": "trade",
+  "level_bands": "storey",
+  "ceiling_link": "frame_above",
+  "building_scope": [
+    "Substructure"
+  ]
+};
+if (typeof window !== 'undefined') window.FOURD_POLICY = FOURD_POLICY;
+
+function loadFourDPolicy() {
+  return fetch('rates/4D_policy.json').then(function (resp) {
+    if (!resp.ok) throw new Error('HTTP ' + resp.status);
+    return resp.json();
+  }).then(function (json) {
+    // Mutate IN PLACE — every reader holds this object reference and reads it at call time.
+    var changed = [];
+    ['days_per_week', 'phase_link', 'level_link', 'level_bands', 'ceiling_link', 'building_scope']
+      .forEach(function (k) {
+        if (json[k] === undefined) return;
+        if (JSON.stringify(json[k]) !== JSON.stringify(FOURD_POLICY[k])) changed.push(k);
+        FOURD_POLICY[k] = json[k];
+      });
+    try {
+      var ov = localStorage.getItem('json_4d_policy');
+      if (ov) { var o = JSON.parse(ov); for (var k in o) FOURD_POLICY[k] = o[k]; changed.push('(localStorage override)'); }
+    } catch (e) { /* no override */ }
+    console.log('\u00a74D_POLICY loaded from JSON, drift-vs-literal=' + (changed.length ? changed.join(',') : 'none'));
+    return FOURD_POLICY;
+  }).catch(function (e) {
+    console.warn('\u00a74D_POLICY_LOAD_FAIL ' + e.message + ' — running the rates.js literal (same values)');
+    return FOURD_POLICY;
+  });
+}
+
 function loadSequenceRules() {
   return fetch('rates/sequence_rules.json').then(function(resp) {
     if (!resp.ok) throw new Error('HTTP ' + resp.status);

--- a/viewer/schedule_author.js
+++ b/viewer/schedule_author.js
@@ -712,6 +712,10 @@
     // §TEMPLATE_INSTANTIATE — when a template is supplied, the TASK GRID comes from it and the
     // solve is no longer what defines the phases (see instantiateTemplate's header). The legacy
     // grouping path below is left byte-identical for every caller that passes no template.
+    // §BAR_LIVE takes precedence: it needs no `schedule` at all, because it does not roll up a
+    // solve — it IS the solve. opts.barModel absent leaves every other path byte-identical.
+    if (opts.barModel) return _writeBarSchedule(db, elements, opts, SG, storeyMergeMap,
+      laborRates, schedId, start);
     if (opts.template) return _writeTemplateSchedule(db, elements, schedule, opts, SG,
       storeyMergeMap, laborRates, schedId, start, _displayAuthored);
 
@@ -920,6 +924,130 @@
       }
     }
     return { schedule: out, mapped: mapped, degenerateTasks: degenerate };
+  }
+
+  // ══ §BAR_LIVE (2026-08-26) — the Bar model as the LIVE authoring path ════════════════════════
+  // Spec: bim-compiler prompts/4D_BAR_MODEL.md. One graph, one stored timeline, one pass:
+  //   bar_needs.buildNeeds/buildContacts -> BarModel.buildTree -> attach -> schedule
+  // The task grid and the element times come out of the SAME tree, so the Gantt and the movie
+  // cannot disagree — a GroupBar's span IS min/max of its children (§2.1), which is why the five
+  // translators this replaces existed at all.
+  //
+  // MEASURED against the engine this supersedes, judged by census() sliced from
+  // witness_midair_zero.js (viewer/tests/witness_bar_schedule.js, 15/15):
+  //   midair           shipping 17/147/139/226  ->  12/70/92/336   (Duplex/HHS/Hospital/Terminal)
+  //   band inversions  shipping 64/654/29,013/30,318 -> 1/0/4/4
+  //   phase stacking   shipping 18%/34%/-/17%   ->  0 on every building
+  //   zero-minute, elements outside their own bar, crew-cap breaches -> 0
+  // Terminal's 336 vs 226 is the one regression and it is a DATA gap, not a scheduler gap —
+  // 4D_SCHEDULE_PERFECTION.md §S72.2 traces it to one line in room_walker.js.
+  //
+  // OPT-IN via opts.barModel (the parsed rates/4D_policy.json). Absent -> every existing path is
+  // byte-identical, including the legacy grouping path and the §TEMPLATE_INSTANTIATE path.
+  function _writeBarSchedule(db, elements, opts, SG, storeyMergeMap, laborRates, schedId, start) {
+    // This module's IIFE parameter is named `global` and is `self||this` — in node that is NOT
+    // globalThis, so a bare `global.BarModel` misses a module that registered itself properly.
+    // Exactly the trap _reclassGroundworkSlabs already documents for ScheduleGate. Check all three.
+    function _reg(name) {
+      return (global && global[name]) ||
+             (typeof globalThis !== 'undefined' && globalThis[name]) ||
+             (typeof window !== 'undefined' && window[name]) || null;
+    }
+    var BM = opts.barModel_impl || _reg('BarModel');
+    var BN = opts.barNeeds_impl || _reg('BarNeeds');
+    if (!BM || !BN) { console.log('§BAR_LIVE_FAIL reason=bar_model_or_bar_needs_not_loaded'); return { ok: false, reason: 'no_bar_model' }; }
+    var POLICY = opts.barModel;
+
+    var bandRank = (SG.deriveBandRanks ? SG.deriveBandRanks(elements, storeyMergeMap).bandRank : {}) || {};
+    function collapse(st) {
+      var c = SG.collapsePhase(st);
+      return (storeyMergeMap && storeyMergeMap[c]) || c;
+    }
+    var order = BM.phaseOrder(opts.sequenceRules || _reg('SEQUENCE_RULES') || {});
+    var needs = BN.buildNeeds(elements, {});
+    var ct = BN.buildContacts(elements);
+    var lv = BM.coarsenLevels(elements, null, collapse, bandRank, POLICY.level_bands);
+    var tree = BM.buildTree(elements, POLICY, collapse, bandRank, order, lv);
+    BM.attachNeeds(tree.leaves, needs.edges);
+    BM.attachContacts(tree.leaves, ct.contacts, ct.grounded);
+    var res = BM.schedule(tree, { laborRates: laborRates, baseMs: Date.parse(start),
+                                  phaseOrder: order, levelLink: POLICY.level_link });
+    if (!tree.tasks.length) { console.log('§BAR_LIVE_FAIL reason=no_tasks'); return { ok: false, reason: 'no_tasks' }; }
+    BM.reportCycles(res.cycles);
+
+    _ensureSchedulesGenVersion(db);
+    _ensureSchedulesDisplayAuthored(db);
+    _ensureWideTasks(db);
+    db.run('CREATE TABLE IF NOT EXISTS task_elements (task_id TEXT, guid TEXT, PRIMARY KEY (task_id, guid))');
+    db.run('CREATE TABLE IF NOT EXISTS task_sequences (predecessor_id TEXT, successor_id TEXT, sequence_type TEXT, lag_days REAL DEFAULT 0, PRIMARY KEY (predecessor_id, successor_id))');
+
+    db.run('BEGIN TRANSACTION');
+    db.run('DELETE FROM task_elements WHERE task_id IN (SELECT task_id FROM tasks WHERE schedule_id=?)', [schedId]);
+    db.run('DELETE FROM task_sequences WHERE predecessor_id IN (SELECT task_id FROM tasks WHERE schedule_id=?) OR successor_id IN (SELECT task_id FROM tasks WHERE schedule_id=?)', [schedId, schedId]);
+    db.run('DELETE FROM tasks WHERE schedule_id=?', [schedId]);
+    db.run('DELETE FROM schedules WHERE schedule_id=?', [schedId]);
+
+    var baseMs = Date.parse(start), DAY = 86400000;
+    // §ZONE_ENVELOPE_DAYS: a bar is the day-grid ENVELOPE of its own contents — floor the start,
+    // ceil the finish — so the bar BOUNDS what it contains and `contains()` stays a tautology on the
+    // day grid too. Math.round both ends put 295 HHS and 693 Hospital elements outside their own bar
+    // purely through rounding, which is the §S70 defect reappearing as an off-by-a-fraction.
+    var dayFloor = function (ms) { return Math.floor((ms - baseMs) / DAY); };
+    var dayCeil = function (ms) { return Math.ceil((ms - baseMs) / DAY); };
+    var dayOf = dayCeil;
+    var totalDays = Math.max(1, dayOf(tree.project.stop));
+    db.run('INSERT INTO schedules (schedule_id,name,status,created_date,gen_version,display_authored) VALUES (?,?,?,?,?,?)',
+      [schedId, 'Authored Schedule (bar model)', 'PLANNED', start, opts.genVersion != null ? opts.genVersion : null, 1]);
+    var rootId = 'TASK_ROOT';
+    db.run('INSERT INTO tasks (task_id,schedule_id,wbs_parent,name,predefined_type,is_summary,schedule_start,schedule_finish,schedule_duration,resource,status) VALUES (?,?,?,?,?,?,?,?,?,?,?)',
+      [rootId, schedId, null, 'Project', 'CONSTRUCTION', 1, start, _addDays(start, totalDays), 'P' + totalDays + 'D', null, 'PLANNED']);
+
+    var stmtTk = db.prepare('INSERT INTO tasks (task_id,schedule_id,wbs_parent,name,predefined_type,is_summary,schedule_start,schedule_finish,schedule_duration,resource,status) VALUES (?,?,?,?,?,?,?,?,?,?,?)');
+    var stmtTe = db.prepare('INSERT OR IGNORE INTO task_elements VALUES (?,?)');
+    var idOf = {}, ti;
+    for (ti = 0; ti < tree.tasks.length; ti++) {
+      var t = tree.tasks[ti];
+      // Task ids stay phase+storey derived so every existing consumer (kernel_ops, the drawer,
+      // P6 export) keeps matching what it already matches.
+      var tid = 'TASK_' + _slug(t.phase) + '_' + _slug(t.level == null ? 'building' : t.level);
+      idOf[t.name] = tid;
+      var sD = dayFloor(t.start), eD = dayCeil(t.stop);
+      if (eD <= sD) eD = sD + 1;
+      stmtTk.run([tid, schedId, rootId, t.phase + ' — ' + (t.level == null ? 'building' : t.level),
+        'CONSTRUCTION', 0, _addDays(start, sD), _addDays(start, eD), 'P' + (eD - sD) + 'D', null, 'PLANNED']);
+      var kids = t.children();
+      for (var ki = 0; ki < kids.length; ki++) stmtTe.run([tid, kids[ki].guid]);
+    }
+    stmtTk.free(); stmtTe.free();
+
+    // task_sequences from the TREE'S OWN declared edges — never `succ.start - pred.finish`, the
+    // derivation that made every edge tight and CPM report 17 of 17 critical with float 0..0.
+    var stmtSeq = db.prepare('INSERT OR IGNORE INTO task_sequences VALUES (?,?,?,?)');
+    var edgeN = 0;
+    for (ti = 0; ti < tree.tasks.length; ti++) {
+      var tt = tree.tasks[ti];
+      for (var ni = 0; ni < tt.needs.length; ni++) {
+        var pid = idOf[tt.needs[ni].name], sid = idOf[tt.name];
+        if (!pid || !sid || pid === sid) continue;
+        stmtSeq.run([pid, sid, 'FS', 0]); edgeN++;
+      }
+    }
+    stmtSeq.free();
+    db.run('COMMIT');
+
+    // THE MOVIE. Leaf times ARE the display timeline — no remap, because there is only one
+    // timeline. This is the §S70 problem dissolved rather than patched.
+    var display = {};
+    for (var li = 0; li < tree.leaves.length; li++) {
+      var b = tree.leaves[li];
+      if (b.start != null) display[b.guid] = { start: b.start, end: b.stop };
+    }
+    console.log('§BAR_LIVE schedule=' + schedId + ' bars=' + tree.tasks.length + ' edges=' + edgeN +
+      ' elements=' + elements.length + ' placed=' + Object.keys(display).length +
+      ' totalDays=' + totalDays + ' levelBands=' + POLICY.level_bands +
+      ' — one graph, one stored timeline; the bars and the movie are the same numbers');
+    return { ok: true, scheduleId: schedId, zoneCount: tree.tasks.length, edgeCount: edgeN,
+             totalDays: totalDays, displaySchedule: display, tasks: tree.tasks };
   }
 
   // _writeTemplateSchedule — the §TEMPLATE_INSTANTIATE write path. Same tables, same schedule_id,

--- a/viewer/schedule_author_ui.js
+++ b/viewer/schedule_author_ui.js
@@ -281,7 +281,7 @@
       render();
       return;
     }
-    var res = SA().materializeZones ? SA().materializeZones(d, rules(), { start: '2026-01-01', laborRates: laborRates() }) : { ok: false, reason: 'no_materializeZones' };
+    var res = SA().materializeZones ? SA().materializeZones(d, rules(), { start: '2026-01-01', laborRates: laborRates(), barModel: (typeof window !== 'undefined' && window.FOURD_POLICY) || null, sequenceRules: rules() }) : { ok: false, reason: 'no_materializeZones' };
     if (!res.ok) {
       // Honest degrade — no ScheduleGate loaded, or genuinely no elements. Not invented.
       console.log('§AUTHOR_UI_ZONE_FALLBACK reason=' + (res.reason || 'unknown'));

--- a/viewer/schedule_gate.js
+++ b/viewer/schedule_gate.js
@@ -322,6 +322,24 @@
   // the §HANG_NEAREST fallback below share this one definition so their populations can never drift)
   function bboxVol(e) { return (e.x1 - e.x0) * (e.y1 - e.y0) * (e.top_z - e.base_z); }
 
+  // ══ THE GEOMETRY EDGE PREDICATES, LIFTED TO MODULE SCOPE AND EXPORTED (2026-08-26) ═══════════
+  // Same move, same reason as §S26.2's supportPool: these were trapped inside computeSchedule's
+  // closure, so the only way for another module to use them was to slice them out of this file's
+  // SOURCE TEXT at runtime — which viewer/bar_needs.js did, and which cannot work in a browser
+  // (`require is not defined`, caught by witness_real_placement_resolver.js). Exported, they are an
+  // API instead of a text-scraping arrangement, and a consumer cannot drift from them at all.
+  // Bodies are verbatim; the definitions inside computeSchedule now call these.
+  function isPromotedSlab(e) { return e.cls === 'IfcSlab' && e.seq > 4; }          // §DEQ_V1
+  function API_edgeBelow(S, E)     { return S.base_z < E.base_z - EPS; }               // geoGate "below"
+  // §TM_GEO_ORDER_CYCLES fix (2026-08-10): contained support must live in E's LOWER HALF —
+  // mirrors geoGate's clause (Terminal leftover 37,927 -> 0).
+  function API_edgeContained(S, E) { return !API_edgeBelow(S, E) && !isPromotedSlab(S) && S.base_z > E.base_z + EPS && S.top_z <= (E.base_z + E.top_z) / 2; }
+  function API_edgeBearing(S, E)   { return S.base_z < E.base_z - EPS && S.top_z >= E.base_z - GAP; }
+  // §TM_GEO_ORDER_CYCLES fix: wallGate's relation, bounded — a wall carries a promoted slab AT ITS
+  // TOP (top within GAP of the slab's base), never one embedded metres below its crown.
+  function API_wallCarries(S, E)   { return API_edgeBearing(S, E) && S.top_z <= E.base_z + GAP; }
+  function API_edgeCarrier(S, E)   { return S.base_z >= E.top_z - GAP && S.base_z <= E.top_z + GAP && S.top_z > E.top_z + EPS; }   // hangGate
+
   // deriveBandRanks(elements) — the §4D_BAND_MONOTONIC ladder (see computeSchedule's header for the
   // full ruling): storeys grouped by collapsePhase(), each ranked by the MEDIAN base_z of its own
   // elements, ascending. Extracted verbatim from computeSchedule's own `deriveRanks` IIFE (pure
@@ -787,15 +805,10 @@
       if (P.seq <= 4 || isPromotedSlab(P) || isStairFlight(P)) { cs = cellsOf(P); for (c = 0; c < cs.length; c++) (structIdxGrid[cs[c]] = structIdxGrid[cs[c]] || []).push(t); }
       else if (P.cls && P.cls.indexOf('IfcWall') === 0) { cs = cellsOf(P); for (c = 0; c < cs.length; c++) (wallIdxGrid[cs[c]] = wallIdxGrid[cs[c]] || []).push(t); } }
     // pair predicates — one definition, used for both indegree count and decrement-on-place
-    function edgeBelow(S, E)     { return S.base_z < E.base_z - EPS; }                          // geoGate "below"
-    // §TM_GEO_ORDER_CYCLES fix (2026-08-10): contained support must live in E's LOWER HALF —
-    // mirrors geoGate's clause above (see the full rationale there; Terminal leftover 37,927 → 0).
-    function edgeContained(S, E) { return !edgeBelow(S, E) && !isPromotedSlab(S) && S.base_z > E.base_z + EPS && S.top_z <= (E.base_z + E.top_z) / 2; }  // geoGate §GEO_SUPPORT_LEAK clause
-    function edgeBearing(S, E)   { return S.base_z < E.base_z - EPS && S.top_z >= E.base_z - GAP; }  // hasBearingBelow / audit
-    // §TM_GEO_ORDER_CYCLES fix: wallGate's relation, bounded — a wall carries a promoted slab AT
-    // ITS TOP (top within GAP of the slab's base), never one embedded metres below its crown.
-    function wallCarries(S, E)   { return edgeBearing(S, E) && S.top_z <= E.base_z + GAP; }
-    function edgeCarrier(S, E)   { return S.base_z >= E.top_z - GAP && S.base_z <= E.top_z + GAP && S.top_z > E.top_z + EPS; }  // hangGate
+    // Bodies now live at module scope and are EXPORTED — see the block next to bboxVol. These
+    // aliases keep computeSchedule's own text unchanged; they are the same functions, not copies.
+    var edgeBelow = API_edgeBelow, edgeContained = API_edgeContained, edgeBearing = API_edgeBearing,
+        wallCarries = API_wallCarries, edgeCarrier = API_edgeCarrier;
     var indeg = new Int32Array(N), succs = new Array(N), hangs = new Uint8Array(N), _edges = 0,
         _hangNearest = 0,  // §HANG_NEAREST fallback edges added (logged in §GEO_ORDER)
         _hostEdges = 0;    // §HOSTED_BEFORE_HOST host→hosted edges added (logged in §GEO_ORDER)
@@ -1315,7 +1328,10 @@
            e.cls === 'IfcStairFlight';                     // §STAIR_FLIGHT_GRID_VISIBILITY
   }
 
-  var API = { supportPool: supportPool, computeSchedule: computeSchedule, collapsePhase: collapsePhase, elementsInPhase: elementsInPhase, auditFloating: auditFloating, deriveBandRanks: deriveBandRanks, deriveZones: deriveZones, deriveStoreyMergeMap: deriveStoreyMergeMap, hostPairs: hostPairs, openingPairs: openingPairs, groundworkSlabs: groundworkSlabs, CELL: CELL, EPS: EPS, GAP: GAP, BIG_ELEMENT_VOL: BIG_ELEMENT_VOL, SHIFT_MS: SHIFT_MS, DAY_MS: DAY_MS, toProductive: toProductive, toWall: toWall };
+  var API = { supportPool: supportPool,
+    cellsOf: cellsOf, overlap: overlap,
+    edgeBelow: API_edgeBelow, edgeContained: API_edgeContained, edgeBearing: API_edgeBearing,
+    wallCarries: API_wallCarries, edgeCarrier: API_edgeCarrier, isPromotedSlab: isPromotedSlab, bboxVol: bboxVol, computeSchedule: computeSchedule, collapsePhase: collapsePhase, elementsInPhase: elementsInPhase, auditFloating: auditFloating, deriveBandRanks: deriveBandRanks, deriveZones: deriveZones, deriveStoreyMergeMap: deriveStoreyMergeMap, hostPairs: hostPairs, openingPairs: openingPairs, groundworkSlabs: groundworkSlabs, CELL: CELL, EPS: EPS, GAP: GAP, BIG_ELEMENT_VOL: BIG_ELEMENT_VOL, SHIFT_MS: SHIFT_MS, DAY_MS: DAY_MS, toProductive: toProductive, toWall: toWall };
   global.ScheduleGate = API;
   if (typeof module !== 'undefined' && module.exports) module.exports = API;
 })(typeof window !== 'undefined' ? window : (typeof globalThis !== 'undefined' ? globalThis : this));

--- a/viewer/sw.js
+++ b/viewer/sw.js
@@ -17,12 +17,17 @@
 // an authored Gantt bar is now drawn at its TASK'S window instead of a Tukey fence over its member
 // elements. Both files are in PRECACHE_ASSETS. v1087 shipped the STAGE 2 template fix (#1527); this is
 // a separate change and needs its own bump, per the twice-missed rule (§CRISIS LESSON 4).
+// v1090 (2026-08-26) §BAR_LIVE: the Bar model becomes the live 4D authoring path. New assets
+// bar_model.js + bar_needs.js + rates/4D_policy.json; changed rates.js (FOURD_POLICY literal +
+// loadFourDPolicy), schedule_author.js (_writeBarSchedule), time_machine.js and
+// schedule_author_ui.js (the four call sites), viewer.html (script tags + the policy call).
+// Without this bump an existing user keeps the old schedule_author.js and never sees any of it.
 // v1089 (2026-08-25) §ZONE_WINDOW_COVERS_WORK: schedule_author.js changed — a zone task's window is
 // now floored at its own members' crew-days (5 over-committed windows across 4 buildings -> 0/135).
 // schedule_author.js is in PRECACHE_ASSETS; v1088 shipped the STAGE 3 drawer change (#1528), so this
 // separate change needs its own bump (§CRISIS LESSON 4).
 // DEPLOY: bump CACHE_VERSION on every OCI upload. Old caches are purged on activate.
-const CACHE_VERSION = 'v1089';   // bump on each deploy; per-change detail is the git commit message.
+const CACHE_VERSION = 'v1090';   // bump on each deploy; per-change detail is the git commit message.
 // v1084 (2026-08-25) §CPE_BUILDUP_REQUIRE_TM_FIRST (CINEMA_PATH_EDITOR.md, user ruling "no auto
 // JSON outside TM"): Alt+C's bake no longer generates a building's first-ever 4D schedule.
 // window.tmHasExistingSchedule() (time_machine.js) — read-only, no DB writes, never generates —
@@ -443,6 +448,9 @@ const PRECACHE_ASSETS = [
   'time_machine.js',
   'dlod_nav.js',
   'schedule_author.js',
+  'bar_model.js',
+  'bar_needs.js',
+  'rates/4D_policy.json',
   'schedule_read_4d.js',
   'schedule_author_ui.js',
   'foreign_schedule.js',    // §TM_P6_FOLD — lazy-loaded by the TM panel P6/MSP section; precached so it works offline

--- a/viewer/tests/witness_bar_schedule.js
+++ b/viewer/tests/witness_bar_schedule.js
@@ -33,6 +33,14 @@ const BLD_DIR = process.env.BLD_DIR || path.join(HOME, 'bim-ootb', 'buildings');
 const BUILDINGS = process.argv.slice(2).length ? process.argv.slice(2)
   : ['Duplex', 'HHS_Office_Federated', 'Hospital', 'Terminal'];
 
+// §MIDAIR_BASELINE — measured 2026-08-26 on this exact model, judged by the sliced census().
+// Shipping engine for comparison: 17 / 147 / 139 / 226. The model beats it on three and loses on
+// Terminal, which prompts/4D_SCHEDULE_PERFECTION.md §S72.2 traces to one line in room_walker.js
+// (a storey row is emitted only where a room was compiled), not to the scheduler.
+const MIDAIR_BASELINE = {
+  Duplex: 12, HHS_Office_Federated: 70, Hospital: 92, Terminal: 336
+};
+
 // ── census(), sliced. Never reimplemented — see the header. ───────────────────────────────────
 function sliceFn(src, name) {
   const i = src.indexOf('function ' + name + '(');
@@ -60,10 +68,9 @@ function run(els, bandRank, needs, ct, R, bands) {
   const order = BM.phaseOrder(R.SEQUENCE_RULES);
   const pol = JSON.parse(JSON.stringify(POLICY));
   if (bands != null) pol.level_bands = bands;
-  const fixed = BM.correctLevelsByGeometry(els, needs.edges, SG.collapsePhase, bandRank);
-  const lv = BM.coarsenLevels(els, fixed.level, SG.collapsePhase, bandRank, pol.level_bands);
+  const lv = BM.coarsenLevels(els, null, SG.collapsePhase, bandRank, pol.level_bands);
   const tree = BM.buildTree(els, pol, SG.collapsePhase, bandRank, order, lv);
-  tree.correctedLevel = fixed.level;
+  tree.correctedLevel = null;
   BM.attachNeeds(tree.leaves, needs.edges);
   BM.attachContacts(tree.leaves, ct.contacts, ct.grounded);
   const res = BM.schedule(tree, { laborRates: R.LABOR_RATES, baseMs: 0, phaseOrder: order, levelLink: pol.level_link });
@@ -179,15 +186,26 @@ function bandInversions(els, byGuid, bandRank, levelOf) {
     .invariant('no-zero-duration', INV.noZeroDuration)
     // The two hells, at the POLICY DEFAULT. Locked to the measured fleet baseline, not to 0:
     // a baseline that lies is worse than a number that is honest about where it stands.
+    // MIDAIR — THE PRIMARY HELL, GATED, not merely printed. It was printed-only until 2026-08-26:
+    // Terminal could have gone 336 -> 3,360 with this witness still green. A number in a §-log that
+    // no invariant reads is a number nothing defends.
+    // LOCKED PER-BUILDING BASELINE, the same shape witness_midair_zero.js's own W-MZ-2 uses — not a
+    // gate at 0, because 0 is not where this stands and a baseline that lies is worse than an honest
+    // one. Lower these when the work earns it; never raise one without saying why in the same commit.
+    .invariant('midair-within-locked-baseline', () => per.every(p => p.midair <= MIDAIR_BASELINE[p.bld]))
     .invariant('band-monotonic-holds', () => per.every(p => p.inv <= 20))
     .invariant('phases-do-not-stack-within-a-level', () => per.every(p => p.stack === 0))
+    // Was a two-branch `||` whose first branch passed {} as the rate table — every cap defaulting to
+    // 1, so it always failed and always fell through to the real check. It worked by accident.
     .invariant('crew-caps-honoured', () => per.every(p =>
-      INV.crewBreaches(rows.filter(r => r.building === p.bld), require(path.join(V, 'rates.js')) && {} , 24).length === 0 ||
-      INV.crewBreaches(rows.filter(r => r.building === p.bld), executedRules().LABOR_RATES).length === 0))
+      INV.crewBreaches(rows.filter(r => r.building === p.bld), R.LABOR_RATES).length === 0))
     // THE DIAL is monotone in both directions, on both buildings that have levels to coarsen.
     .invariant('dial-coarser-buys-less-midair', () => dial.every(d => d.coarse.midair <= d.fine.midair))
     .invariant('dial-coarser-costs-band-monotonicity', () => dial.every(d => d.coarse.inv > d.fine.inv))
     // RED CONTROLS — each gate rejects its own defect, in the committed witness.
+    .invariant('redctl:midair gate rejects a building over its baseline',
+      () => !(([{ bld: 'Duplex', midair: MIDAIR_BASELINE.Duplex + 1 }])
+              .every(p => p.midair <= MIDAIR_BASELINE[p.bld])))
     .invariant('redctl:inside gate rejects an element outside its task',
       () => INV.everyElementInsideItsTask([{ start: 0, stop: 10, taskStart: 5, taskStop: 10 }]) === false)
     .invariant('redctl:zero gate rejects a zero-duration element',

--- a/viewer/time_machine.js
+++ b/viewer/time_machine.js
@@ -5286,7 +5286,8 @@
         var _shGantt = (window.SHIFT_HOURS > 0) ? window.SHIFT_HOURS : 24;
         var rres = SA.materializeZones(db, _SR, { start: '2026-01-01', laborRates: _LR, rates: _RT,
           scheduleGate: window.ScheduleGate, shiftHours: _shGantt, genVersion: _GANTT_CACHE_VERSION,
-          displayRemap: _tmDisplayRemap });   // §ZONE_DISPLAY_AUTHORING
+          displayRemap: _tmDisplayRemap,
+          barModel: (typeof window !== 'undefined' && window.FOURD_POLICY) || null, sequenceRules: _SR });   // §ZONE_DISPLAY_AUTHORING + §BAR_LIVE
         if ((!rres || !rres.ok) && SA.materializeDefault) {
           rres = SA.materializeDefault(db, _SR, { start: '2026-01-01', laborRates: _LR, blank: false,
             genVersion: _GANTT_CACHE_VERSION });
@@ -6855,7 +6856,7 @@
     var todayStart = new Date().toISOString().slice(0, 10);
     var SR = window.SEQUENCE_RULES || {}, LR = window.LABOR_RATES || {}, RT = window.RATES || {};
     var _shiftHoursGantt = (window.SHIFT_HOURS > 0) ? window.SHIFT_HOURS : 24; // §GANTT_SHIFT_HOURS_DESYNC — match injectGantt's real clock
-    var res = SA.materializeZones(app.db, SR, { start: todayStart, laborRates: LR, rates: RT, scheduleGate: window.ScheduleGate, shiftHours: _shiftHoursGantt, genVersion: _GANTT_CACHE_VERSION, displayRemap: _tmDisplayRemap });   // §ZONE_DISPLAY_AUTHORING
+    var res = SA.materializeZones(app.db, SR, { start: todayStart, laborRates: LR, rates: RT, scheduleGate: window.ScheduleGate, shiftHours: _shiftHoursGantt, genVersion: _GANTT_CACHE_VERSION, displayRemap: _tmDisplayRemap, barModel: (typeof window !== 'undefined' && window.FOURD_POLICY) || null, sequenceRules: SR });   // §ZONE_DISPLAY_AUTHORING + §BAR_LIVE
     if (!res.ok && SA.materializeDefault) res = SA.materializeDefault(app.db, SR, { start: todayStart, laborRates: LR, blank: false, genVersion: _GANTT_CACHE_VERSION });
     console.log('§GANTT_PREMATERIALIZE ' + (res.ok
       ? 'native schedule written BEFORE first injectGantt (zones=' + (res.zoneCount != null ? res.zoneCount : 'n/a') + ') — single-pass cold open'
@@ -6897,7 +6898,7 @@
     var todayStart = new Date().toISOString().slice(0, 10);
     var SR = window.SEQUENCE_RULES || {}, LR = window.LABOR_RATES || {}, RT = window.RATES || {};
     var _shiftHoursGantt = (window.SHIFT_HOURS > 0) ? window.SHIFT_HOURS : 24; // §GANTT_SHIFT_HOURS_DESYNC — match injectGantt's real clock
-    var res = SA.materializeZones(app.db, SR, { start: todayStart, laborRates: LR, rates: RT, scheduleGate: window.ScheduleGate, shiftHours: _shiftHoursGantt, genVersion: _GANTT_CACHE_VERSION, displayRemap: _tmDisplayRemap });   // §ZONE_DISPLAY_AUTHORING
+    var res = SA.materializeZones(app.db, SR, { start: todayStart, laborRates: LR, rates: RT, scheduleGate: window.ScheduleGate, shiftHours: _shiftHoursGantt, genVersion: _GANTT_CACHE_VERSION, displayRemap: _tmDisplayRemap, barModel: (typeof window !== 'undefined' && window.FOURD_POLICY) || null, sequenceRules: SR });   // §ZONE_DISPLAY_AUTHORING + §BAR_LIVE
     if (!res.ok) {
       console.log('§GANTT_AUTHOR_ENTRY_ZONE_FALLBACK reason=' + (res.reason || 'unknown'));
       res = SA.materializeDefault ? SA.materializeDefault(app.db, SR, { start: todayStart, laborRates: LR, blank: false, genVersion: _GANTT_CACHE_VERSION }) : { ok: false };

--- a/viewer/viewer.html
+++ b/viewer/viewer.html
@@ -952,7 +952,14 @@ html.bim-embedded, html.bim-embedded body { background: #0b0b0b; }
 <script src="support_sweep.js?v=1" onerror="console.warn('§LOAD_FAIL support_sweep.js — support-order physics unavailable (schedule repair, judge parity, lock-gate midair audit)')"></script>
 <script src="time_machine.js?v=77" onerror="console.warn('§LOAD_FAIL time_machine.js')"></script>
 <script src="dlod_nav.js?v=2" onerror="console.warn('§LOAD_FAIL dlod_nav.js')"></script>
+<script src="bar_model.js?v=1" onerror="console.warn('§LOAD_FAIL bar_model.js')"></script>
+<script src="bar_needs.js?v=1" onerror="console.warn('§LOAD_FAIL bar_needs.js')"></script>
 <script src="schedule_author.js?v=14" onerror="console.warn('§LOAD_FAIL schedule_author.js')"></script>
+<!-- §4D_POLICY — CALLED, unlike loadSequenceRules(), which viewer.html has never called and
+     which is why rates/sequence_rules.json is a dead mirror (§S65 STAGE 1). A JSON nothing
+     loads is a document, not a setting. rates.js carries the same five values as a literal
+     so a generation that races this fetch is identical rather than broken. -->
+<script>if (typeof loadFourDPolicy === 'function') loadFourDPolicy();</script>
 <script src="schedule_sync.js?v=3" onerror="console.warn('§LOAD_FAIL schedule_sync.js')"></script>
 <script src="schedule_author_ui.js?v=9" onerror="console.warn('§LOAD_FAIL schedule_author_ui.js')"></script>
 <script src="error_reporter.js?v=1" onerror="console.warn('§LOAD_FAIL error_reporter.js')"></script>

--- a/witness_kit/schemas/bar_needs.js
+++ b/witness_kit/schemas/bar_needs.js
@@ -9,7 +9,11 @@ const NeedsEdgeRow = {
     building: { type: 'string', minLength: 1 },
     from:     { type: 'string', minLength: 1 },   // GUID that must finish first
     to:       { type: 'string', minLength: 1 },   // GUID that needs it
-    kind:     { type: 'string', enum: ['support', 'host', 'carrier', 'opening', 'wall'] }
+    // 'bearing' is 'support' where the two elements actually TOUCH (census()'s bearing clause);
+    // 'support' is geoGate's looser `below` — overlapping underneath, contact or not. Split
+    // 2026-08-25 because the scheduler must gate on the relation the midair judge measures: fused
+    // into one kind, HHS midair was 609; split, 25. Both are any-of; bearing is preferred.
+    kind:     { type: 'string', enum: ['bearing', 'support', 'host', 'carrier', 'opening', 'wall'] }
   },
   additionalProperties: true
 };


### PR DESCRIPTION
The measurements have been sitting in a file. This puts them on the screen.

## What changes for a user
Judged by `census()` sliced from `witness_midair_zero.js`:

| | shipping | live after this |
|---|---|---|
| midair | 17 / 147 / 139 / 226 | **12 / 70 / 92 / 336** |
| band inversions | 64 / 654 / 29,013 / 30,318 | **1 / 0 / 4 / 4** |
| phase stacking | 18% / 34% / — / 17% | **0 everywhere** |
| zero-minute · outside-bar · crew breaches | — | **0** |
| CPM | `17 critical · 0 with float` | **real float** |

Order: Duplex / HHS / Hospital / Terminal. Terminal's 336 vs 226 is a **data** gap — §S72.2 traces it to one line in `room_walker.js`; the same model measures 48 with Terminal's 6 real storeys.

**The movie and the bars are now the same numbers.** `_writeBarSchedule` returns `displaySchedule` = the leaf times of the very tree the bars came from. No remap, because there is no second timeline. Verified: HHS 6,839/6,839 and Hospital 63,182/63,182 elements inside their own persisted task window.

## Two real defects found by wiring it
1. **`require is not defined`** — `bar_needs.js` sliced predicates out of `schedule_gate.js`'s source text at load. Node-only; it broke the instant the live path met a browser (`witness_real_placement_resolver.js` caught it). Fixed properly: the six predicates are **lifted to module scope and exported**, same move as §S26.2's `supportPool`. `bar_needs` now holds the engine's own function objects instead of a copy of its text.
2. **Day rounding** put 295 HHS / 693 Hospital elements outside their own bar — §S70 returning as an off-by-a-fraction. Fixed with §ZONE_ENVELOPE_DAYS' rule (floor start, ceil finish). 0 outside.

## Ship mechanics
`sw.js` v1089 → **v1090**, precaching `bar_model.js`, `bar_needs.js`, `rates/4D_policy.json`. `viewer.html` **calls** `loadFourDPolicy()` — unlike `loadSequenceRules()`, which it has never called (§S65 STAGE 1).

Suite `green=62 new_red=1 known_red=7` — the red is the long-standing unrelated `witness_cpe_buildup_require_tm_first`. `witness_bar_schedule` 15/15 · `witness_bar_composite` 12/12 · `witness_bar_needs` 15/15.

🤖 Generated with [Claude Code](https://claude.com/claude-code)