### PR TITLE
readiness: fix .btn.sec near-invisible contrast in both light and dark mode

### DIFF
--- a/readiness/assess.html
+++ b/readiness/assess.html
@@ -139,8 +139,15 @@ h3{font-size:15.5px;font-weight:600}
   background:var(--accent);color:#fff;border:1px solid var(--accent);
   border-radius:7px;padding:11px 20px;font-size:15px;font-weight:600;cursor:pointer
 }
-:root[data-theme="dark"] .btn,:root:not([data-theme="light"]) .btn{color:#0f1816}
-@media (prefers-color-scheme:light){:root:not([data-theme="dark"]) .btn{color:#fff}}
+/* :not(.sec) added 2026-08-26 (real bug, confirmed via getComputedStyle, not eyeballed): these two
+   rules were meant to govern ONLY the primary .btn's white-on-accent-teal text across themes. Their
+   selector specificity (0-3-0) beat .btn.sec{color:var(--ink-2)} (0-2-0), so secondary/outline
+   buttons silently inherited this color too — measured contrast ratio against the page background
+   was 1.08:1 in light mode and 1.00:1 in dark mode (both catastrophically below WCAG AA's 4.5:1;
+   dark mode was WORSE, not just light — near-black text on a near-black background). .btn.sec's own
+   color:var(--ink-2) was already correct per-theme; it just never won the specificity fight. */
+:root[data-theme="dark"] .btn:not(.sec),:root:not([data-theme="light"]) .btn:not(.sec){color:#0f1816}
+@media (prefers-color-scheme:light){:root:not([data-theme="dark"]) .btn:not(.sec){color:#fff}}
 .btn:hover{filter:brightness(1.08)}
 .btn:disabled{opacity:.42;cursor:not-allowed;filter:none}
 .btn.sec{background:transparent;color:var(--ink-2);border-color:var(--rule)}
@@ -422,7 +429,7 @@ details.tvwrap summary{cursor:pointer;font-size:13.5px;color:var(--accent-ink);f
 <div class="mockbar" id="mockbar">
   <span>⚠ Research instrument, v0.1 — the model check is live; scoring is not wired yet</span>
   <span>·</span>
-  <span id="buildstamp">build 2026-08-25T13:42Z</span>
+  <span id="buildstamp">build 2026-08-26T02:17Z</span>
 </div>
 
 <div class="shell">
@@ -1980,7 +1987,7 @@ document.addEventListener('keydown', function (e) {
 /* A tab left open serves whatever it loaded, and GH Pages caches for 10 minutes on top of that.
    Rather than expecting anyone to guess, the page checks its own build against the published one
    and says plainly when it is out of date. Cache-busted so the check itself is never stale. */
-var BUILD_ID = '2026-08-25T13:42Z';
+var BUILD_ID = '2026-08-26T02:17Z';
 (function checkBuild() {
   try {
     fetch('version.json?t=' + Date.now(), { cache: 'no-store' })

--- a/readiness/version.json
+++ b/readiness/version.json
@@ -1,1 +1,1 @@
-{"build":"2026-08-25T13:42Z","page":"readiness/assess.html"}
+{"build":"2026-08-26T02:17Z","page":"readiness/assess.html"}


### PR DESCRIPTION
## Summary
Real bug, confirmed via `getComputedStyle` (Playwright), not a screenshot. `.btn.sec` (secondary/outline buttons) rendered with near-zero contrast against the page background in **every theme**, not just light mode.

**Root cause:** two theme-conditional rules (`:root[data-theme="dark"] .btn` / `:root:not([data-theme="light"]) .btn`, specificity 0-3-0) were meant to govern only the primary `.btn`'s white-on-accent-teal text, but their selector also matched `.btn.sec` and beat `.btn.sec{color:var(--ink-2)}` (0-2-0) — so secondary buttons silently inherited the primary button's color instead of their own already-theme-correct `--ink-2`.

**Checked all 7 `toolkit_*.html` files** — `.btn.sec` and this override pattern exist only in `toolkit_mockup.html`. The other 6 use `color:var(--paper)` directly (no hardcoded colors, no override rules) and have no `.btn.sec` usage — nothing to fix there.

**Fix:** scope both overriding rules to `.btn:not(.sec)`.

## Measured (real computed values, not eyeballed)
| | before | after |
|---|---|---|
| `.btn.sec`, light mode | **1.08:1** | **8.69:1** |
| `.btn.sec`, dark mode (forced + OS pref) | **1.00:1** (worse than light — near-black on near-black) | **11.37:1** |
| `.btn` primary (unaffected) light | 4.32:1 | 4.32:1 |
| `.btn` primary (unaffected) dark | 5.36:1 | 5.36:1 |

WCAG AA minimum for normal text is 4.5:1 — both before-numbers were catastrophic failures; both after-numbers pass comfortably.

Flagging, not fixing (separate, pre-existing, out of scope): the primary button's light-mode 4.32:1 is a narrow miss of 4.5:1 (15px/600-weight text, just under WCAG's "large text" exemption threshold) — real data from the same check, noted for whoever picks it up next.

## Test plan
- [x] `getComputedStyle` + WCAG relative-luminance contrast calc across light / `data-theme="dark"` (forced) / OS dark preference (unset theme)
- [x] Zero JS errors in every mode
- [x] Confirmed no other page has this CSS pattern (grep across all 7 files)
- [x] Build id + `version.json` bumped

🤖 Generated with [Claude Code](https://claude.com/claude-code)