### PR TITLE
feat(4d): split Architecture into Envelope/Closeup, and wire production to the 4D template

### DIFF
--- a/scripts/probe_template_hells.js
+++ b/scripts/probe_template_hells.js
@@ -1,0 +1,165 @@
+#!/usr/bin/env node
+// probe_template_hells.js — THE TWO HELLS, measured on real buildings, legacy vs template path.
+//
+// ⚠ DO NOT REMOVE — SCOPE. Answers one question and no other: does routing production through
+// 4D_template.json (§TPL_WIRED) reduce (A) floating — an element on screen before the thing that
+// bears it — and (B) stacking — elements piled at one instant. A/B on the SAME building, SAME
+// rates, one flag apart. Read the §HELLS log after every run.
+//
+// The judge is required from viewer/support_sweep.js, never re-derived (4D_BAR_MODEL.md §10.1
+// rule 1). Floating here is the ELEMENT-level physical question, not a designated-support
+// election: for every bearing pair (S bears T), does T start before S finishes?
+'use strict';
+const fs = require('fs'), path = require('path'), vm = require('vm'), os = require('os');
+const HOME = os.homedir();
+const initSqlJs = require(path.join(HOME, 'bim-ootb', 'node_modules', 'sql.js'));
+const SQLJS_DIST = path.join(HOME, 'bim-ootb', 'node_modules', 'sql.js', 'dist');
+const V = path.join(__dirname, '..', 'viewer');
+const ScheduleGate = require(path.join(V, 'schedule_gate.js'));
+global.ScheduleGate = ScheduleGate;
+const ScheduleAuthor = require(path.join(V, 'schedule_author.js'));
+const SupportSweep = require(path.join(V, 'support_sweep.js'));
+
+const BLD = process.env.BLD_DIR || path.join(HOME, 'bim-ootb', 'buildings');
+const BUILDINGS = process.argv.slice(2).length ? process.argv.slice(2)
+  : ['Duplex', 'HHS_Office_Federated', 'Hospital'];
+const START = '2026-01-01';
+const T = JSON.parse(fs.readFileSync(path.join(V, 'rates', '4D_template.json'), 'utf8'));
+const EPS = ScheduleGate.EPS, GAP = ScheduleGate.GAP, CELL = ScheduleGate.CELL;
+
+function executedRules() {
+  const sb = { console: { log() {}, warn() {}, error() {} } };
+  vm.createContext(sb); vm.runInContext(fs.readFileSync(path.join(V, 'rates.js'), 'utf8'), sb);
+  return sb;
+}
+
+// SUPPORT PAIRS — from the SHIPPED contact graph, never re-derived (§10.1 rule 1). This probe
+// re-derived the rule three times before this and was wrong three times: (1) all-of instead of
+// any-of, (2) an unbounded support TOP so a riser "bore" the whole building, (3) bearing-below
+// ONLY — which called every ceiling-hung pipe floating, when a pipe at bz=2.732 under a slab at
+// bz=2.79 is held from ABOVE and is not hanging at all. _contactGraph already encodes all three
+// clauses (bearing-below, carrier-above, embedded). Use it.
+function supportPairs(items) {
+  const G = SupportSweep.contactGraph(items);
+  const pairs = [];
+  if (!G.ok) return pairs;
+  for (let i = 0; i < items.length; i++) {
+    const list = G.contacts[i];
+    if (!list) continue;
+    for (const j of list) pairs.push([j, i]);      // j supports i
+  }
+  return pairs;
+}
+
+const SAMPLES = [];
+// ANY-OF, not all-of. An element is floating iff NOTHING that bears it is up yet. Counting every
+// bearing PAIR as a constraint is wrong physics and it showed: the top pattern was
+// "MEP_Rough_in_L1 bears Architecture_Envelope_L2" 157x — a duct at the L1 ceiling whose top
+// happens to meet an L2 wall's base. The SLAB carries that wall; the duct merely touches. With
+// all-of semantics every such touch became a violation. Same rule the merged
+// probe_floating_guid_audit.js uses (§FGA_EYE_FLOATING: bearingPlaced === 0), and the same any-of
+// set bar_model.js attachContacts feeds the scheduler.
+function measure(label, els, pairs, sched, taskOf) {
+  SAMPLES.length = 0;
+  const supportsOf = new Map();
+  for (const [si, ti] of pairs) {
+    if (!supportsOf.has(ti)) supportsOf.set(ti, []);
+    supportsOf.get(ti).push(si);
+  }
+  let floating = 0, intra = 0, cross = 0, gated = 0;
+  for (const [ti, sup] of supportsOf) {
+    const t = sched[els[ti].guid]; if (!t) continue;
+    gated++;
+    let held = false, earliest = null;
+    for (const si of sup) {
+      const sc = sched[els[si].guid]; if (!sc) continue;
+      if (sc.end - 1 <= t.start) { held = true; break; }
+      if (!earliest || sc.end < earliest.end) earliest = { si, end: sc.end };
+    }
+    if (held) continue;
+    floating++;
+    const b = taskOf && taskOf[els[ti].guid];
+    const a = earliest ? (taskOf && taskOf[els[earliest.si].guid]) : null;
+    if (a != null && a === b) intra++; else {
+      cross++;
+      if (SAMPLES.length < 400 && earliest)
+        SAMPLES.push({ st: a, tt: b });
+    }
+  }
+
+  const hist = new Map();
+  for (const e of els) { const st = sched[e.guid]; if (st) hist.set(st.start, (hist.get(st.start) || 0) + 1); }
+  let maxPile = 0, over20 = 0;
+  for (const v of hist.values()) { if (v > maxPile) maxPile = v; if (v >= 20) over20++; }
+  const starts = [...hist.values()].reduce((a, b) => a + b, 0);
+  return { label, floating, intra, cross, gated, pairs: pairs.length, maxPile, over20,
+           placed: starts, distinctInstants: hist.size };
+}
+
+(async () => {
+  const SQL = await initSqlJs({ locateFile: f => path.join(SQLJS_DIST, f) });
+  const R = executedRules();
+  const SHIFT = T.calendar.hours_per_shift;
+  const rows = [];
+  for (const bld of BUILDINGS) {
+    const file = path.join(BLD, bld + '_extracted.db');
+    if (!fs.existsSync(file)) { console.log('§HELLS_SKIP ' + bld); continue; }
+    const base = { start: START, laborRates: R.LABOR_RATES, rates: R.RATES,
+      nameOverrides: R.SEQUENCE_NAME_OVERRIDES, defaultRule: R.SEQUENCE_DEFAULT,
+      scheduleGate: ScheduleGate, shiftHours: SHIFT };
+
+    let els = null, pairs = null;
+    const out = {};
+    for (const mode of ['legacy', 'template']) {
+      const db = new SQL.Database(new Uint8Array(fs.readFileSync(file)));
+      if (!els) {
+        els = ScheduleAuthor._buildScheduleElements(db, R.SEQUENCE_RULES, base)
+          .map(e => Object.assign({}, e, { bz: e.base_z, tz: e.top_z }));
+        pairs = supportPairs(els);
+      }
+      const _l = console.log, _w = console.warn;
+      console.log = () => {}; console.warn = () => {};
+      let res = null;
+      try {
+        res = ScheduleAuthor.materializeZones(db, R.SEQUENCE_RULES,
+          mode === 'template' ? Object.assign({}, base, { template: T }) : base);
+      } catch (e) { console.log = _l; console.warn = _w; console.log('§HELLS_THREW ' + bld + ' ' + mode + ' ' + e.message); }
+      console.log = _l; console.warn = _w;
+      // the element times this path actually produces
+      let sched = res && res.displaySchedule;
+      if (!sched) {
+        const raw = ScheduleGate.computeSchedule(els, Date.parse(START), 1, (function () {
+          const m = {}; for (const k in R.LABOR_RATES) if (R.LABOR_RATES[k].max_crews) m[k] = R.LABOR_RATES[k].max_crews; return m;
+        })(), SHIFT);
+        sched = raw;
+      }
+      // guid -> task, straight off the tables this run just wrote
+      const taskOf = {};
+      try {
+        const te = db.exec('SELECT guid, task_id FROM task_elements');
+        if (te.length) te[0].values.forEach(r => { taskOf[r[0]] = r[1]; });
+      } catch (e) {}
+      out[mode] = measure(mode, els, pairs, sched, taskOf);
+      db.close();
+    }
+    const L = out.legacy, P = out.template;
+    console.log('§HELLS ' + bld + ' n=' + els.length + ' supportPairs=' + L.pairs);
+    console.log('   HELL A floating   legacy=' + L.floating + '/' + L.gated +
+      '  template=' + P.floating + '/' + P.gated + ' (elements with >=1 bearing candidate)');
+    console.log('      template split: INTRA-task=' + P.intra + ' (fixable only by ordering inside a task)' +
+      '  CROSS-task=' + P.cross + ' (a phase/level ordering defect or a data defect)');
+    console.log('   HELL B maxPile    legacy=' + L.maxPile + '  template=' + P.maxPile +
+      '   pilesOf20+  legacy=' + L.over20 + ' template=' + P.over20);
+    const agg = {};
+    SAMPLES.forEach(x => { const k = (x.st || '?') + '   BEARS-> ' + (x.tt || '?');
+      agg[k] = (agg[k] || 0) + 1; });
+    Object.entries(agg).sort((a, b) => b[1] - a[1]).slice(0, 8)
+      .forEach(([k, v]) => console.log('      §HELLS_PATTERN n=' + String(v).padStart(4) + '  ' + k));
+    rows.push({ bld, L, P });
+  }
+  let fails = 0;
+  rows.forEach(r => { if (r.P.floating > 0 || r.P.maxPile >= 20) fails++; });
+  console.log('§HELLS_VERDICT buildings=' + rows.length + ' notYetZero=' + fails + ' ' +
+    (fails === 0 ? 'PASS — both hells at zero on the template path' : 'WORK REMAINS'));
+  process.exit(0);
+})().catch(e => { console.error('§HELLS_ERROR ' + (e && e.stack || e)); process.exit(2); });

--- a/scripts/probe_template_hells.js
+++ b/scripts/probe_template_hells.js
@@ -66,7 +66,7 @@ function measure(label, els, pairs, sched, taskOf) {
     if (!supportsOf.has(ti)) supportsOf.set(ti, []);
     supportsOf.get(ti).push(si);
   }
-  let floating = 0, intra = 0, cross = 0, gated = 0;
+  let floating = 0, intra = 0, cross = 0, gated = 0, hungFromAbove = 0;
   for (const [ti, sup] of supportsOf) {
     const t = sched[els[ti].guid]; if (!t) continue;
     gated++;
@@ -85,6 +85,17 @@ function measure(label, els, pairs, sched, taskOf) {
       if (SAMPLES.length < 400 && earliest)
         SAMPLES.push({ st: a, tt: b });
     }
+    // HEADROOM — is EVERY support of this element strictly ABOVE it? Then it is not resting on
+    // anything on its own level: it hangs from the floor above, and no ordering WITHIN its level
+    // can ever hold it. Its work belongs to the level that carries it. Counting this separately
+    // says how much of the residue one addressing rule would close.
+    let allAbove = true, anySup = false;
+    for (const si of sup) {
+      const sc = sched[els[si].guid]; if (!sc) continue;
+      anySup = true;
+      if (els[si].bz <= els[ti].bz) { allAbove = false; break; }
+    }
+    if (anySup && allAbove) hungFromAbove++;
   }
 
   const hist = new Map();
@@ -92,7 +103,7 @@ function measure(label, els, pairs, sched, taskOf) {
   let maxPile = 0, over20 = 0;
   for (const v of hist.values()) { if (v > maxPile) maxPile = v; if (v >= 20) over20++; }
   const starts = [...hist.values()].reduce((a, b) => a + b, 0);
-  return { label, floating, intra, cross, gated, pairs: pairs.length, maxPile, over20,
+  return { label, floating, intra, cross, gated, hungFromAbove, pairs: pairs.length, maxPile, over20,
            placed: starts, distinctInstants: hist.size };
 }
 
@@ -146,6 +157,9 @@ function measure(label, els, pairs, sched, taskOf) {
     console.log('§HELLS ' + bld + ' n=' + els.length + ' supportPairs=' + L.pairs);
     console.log('   HELL A floating   legacy=' + L.floating + '/' + L.gated +
       '  template=' + P.floating + '/' + P.gated + ' (elements with >=1 bearing candidate)');
+    console.log('      HEADROOM: of ' + P.floating + ' floating, ' + P.hungFromAbove +
+      ' hang ENTIRELY from above (carrier on a higher level — no within-level order can hold them); ' +
+      (P.floating - P.hungFromAbove) + ' rest on something on their own level');
     console.log('      template split: INTRA-task=' + P.intra + ' (fixable only by ordering inside a task)' +
       '  CROSS-task=' + P.cross + ' (a phase/level ordering defect or a data defect)');
     console.log('   HELL B maxPile    legacy=' + L.maxPile + '  template=' + P.maxPile +

--- a/viewer/rates.js
+++ b/viewer/rates.js
@@ -248,21 +248,21 @@ var SEQUENCE_RULES = {
   IfcProtectiveDeviceTrippingUnit:{phase:'MEP Final',sequence:9,resource:'ELECTRICIAN'},
   IfcUnitaryControlElement:{phase:'MEP Final',sequence:9,resource:'ELECTRICIAN'},
   // Architecture
-  IfcWall:{phase:'Architecture',sequence:5,resource:'MASON'},
-  IfcWallStandardCase:{phase:'Architecture',sequence:5,resource:'MASON'},
-  IfcOpeningElement:{phase:'Architecture',sequence:5,resource:'MASON'},
-  IfcSpace:{phase:'Architecture',sequence:5,resource:null},
-  IfcBuildingElementPart:{phase:'Architecture',sequence:5,resource:'MASON'},
-  IfcDoor:{phase:'Architecture',sequence:6,resource:'CARPENTER'},
-  IfcWindow:{phase:'Architecture',sequence:6,resource:'CARPENTER'},
-  IfcStair:{phase:'Architecture',sequence:6,resource:'CARPENTER'},
-  IfcStairFlight:{phase:'Architecture',sequence:6,resource:'CARPENTER'},
-  IfcRailing:{phase:'Architecture',sequence:6,resource:'CARPENTER'},
-  IfcRamp:{phase:'Architecture',sequence:6,resource:'CONCRETE_GANG'},
-  IfcRampFlight:{phase:'Architecture',sequence:6,resource:'CONCRETE_GANG'},
-  IfcRoof:{phase:'Architecture',sequence:6,resource:'ROOFER'},   // §S65 defect 7 (user ruling): was 8, which sequenced the roof AFTER all MEP Rough-in (seq 7) — MEP installed before the roof existed, and it made the Architecture band [5-8] overlap MEP Rough-in [7]. Weather-tight first.
-  IfcBuildingElementProxy:{phase:'Architecture',sequence:5,resource:'MASON'},   // §S65: was resource:null -> 120s floor
-  IfcCurtainWall:{phase:'Architecture',sequence:6,resource:'CARPENTER'},
+  IfcWall:{phase:'Architecture Envelope',sequence:5,resource:'MASON'},
+  IfcWallStandardCase:{phase:'Architecture Envelope',sequence:5,resource:'MASON'},
+  IfcOpeningElement:{phase:'Architecture Envelope',sequence:5,resource:'MASON'},
+  IfcSpace:{phase:'Architecture Envelope',sequence:5,resource:null},
+  IfcBuildingElementPart:{phase:'Architecture Envelope',sequence:5,resource:'MASON'},
+  IfcDoor:{phase:'Architecture Closeup',sequence:8,resource:'CARPENTER'},
+  IfcWindow:{phase:'Architecture Envelope',sequence:6,resource:'CARPENTER'},
+  IfcStair:{phase:'Architecture Envelope',sequence:6,resource:'CARPENTER'},
+  IfcStairFlight:{phase:'Architecture Envelope',sequence:6,resource:'CARPENTER'},
+  IfcRailing:{phase:'Architecture Envelope',sequence:6,resource:'CARPENTER'},
+  IfcRamp:{phase:'Architecture Envelope',sequence:6,resource:'CONCRETE_GANG'},
+  IfcRampFlight:{phase:'Architecture Envelope',sequence:6,resource:'CONCRETE_GANG'},
+  IfcRoof:{phase:'Architecture Envelope',sequence:6,resource:'ROOFER'},   // §S65 defect 7 (user ruling): was 8, which sequenced the roof AFTER all MEP Rough-in (seq 7) — MEP installed before the roof existed, and it made the Architecture band [5-8] overlap MEP Rough-in [7]. Weather-tight first.
+  IfcBuildingElementProxy:{phase:'Architecture Envelope',sequence:5,resource:'MASON'},   // §S65: was resource:null -> 120s floor
+  IfcCurtainWall:{phase:'Architecture Envelope',sequence:6,resource:'CARPENTER'},
   // MEP Final
   IfcLightFixture:{phase:'MEP Final',sequence:9,resource:'ELECTRICIAN'},
   IfcOutlet:{phase:'MEP Final',sequence:9,resource:'ELECTRICIAN'},
@@ -273,7 +273,7 @@ var SEQUENCE_RULES = {
   IfcFurniture:{phase:'Finishes',sequence:11,resource:'FINISHER'},
   IfcFurnishingElement:{phase:'Finishes',sequence:11,resource:'FINISHER'},
 };
-var SEQUENCE_DEFAULT = {phase:'Architecture',sequence:6,resource:'MASON'};   // §S65: was resource:null -> every unmatched class floored at 120s
+var SEQUENCE_DEFAULT = {phase:'Architecture Envelope',sequence:6,resource:'MASON'};   // §S65: was resource:null -> every unmatched class floored at 120s
 // §4D_FACADE_ORDER: name-based reclass ahead of the class lookup above — ifc_class alone cannot
 // tell curtain-wall glazing/framing (IfcPlate/IfcMember) from genuinely structural plates/members
 // (e.g. Terminal's 33,324 Metal Deck IfcPlate, JKR/LTU_AHouse structural steel/timber, which must
@@ -287,7 +287,7 @@ var SEQUENCE_NAME_OVERRIDES = [
     classes: ['IfcPlate', 'IfcMember'],
     pattern: 'glaz|glass|verglas|vitrage|vidrio|curtain|mullion',
     flags: 'i',
-    phase: 'Architecture',
+    phase: 'Architecture Envelope',
     // §S65 defect 7 (2026-08-25): was 7, which tied this override with MEP Rough-in (seq 7) and kept
     // the Architecture band [5-7] overlapping it. 6 is IfcCurtainWall's OWN class rule (line ~265) —
     // these are the glazing panels and mullions OF that same curtain-wall system, so 7 was also
@@ -414,7 +414,9 @@ var DISC_COLORS = {
 };
 var PHASE_COLORS = {
   'Substructure':'#A5A5A5','Superstructure':'#4472C4','MEP Rough-in':'#70AD47',
-  'Architecture':'#ED7D31','MEP Final':'#5B9BD5','Finishes':'#FFC000',
+  'Architecture Envelope':'#ED7D31','Architecture Closeup':'#F4B183',
+  'Architecture':'#ED7D31',   // legacy key — ops/DBs written before the 2026-08-26 split still carry it
+  'MEP Final':'#5B9BD5','Finishes':'#FFC000',
   'Commissioning':'#C55A11','Unknown':'#888888',
 };
 

--- a/viewer/rates/4D_template.json
+++ b/viewer/rates/4D_template.json
@@ -59,11 +59,12 @@
       "_scope": "Frame and floor plates for one level."
     },
     {
-      "id": "architecture", "name": "Architecture", "sequence": 5,
+      "id": "architecture_envelope", "name": "Architecture Envelope", "sequence": 5,
       "trades": ["CARPENTER", "CONCRETE_GANG", "MASON", "ROOFER"],
       "replicate_per_level": true,
       "scope": "level",
-      "_scope": "Envelope and internal fabric for one level: walls, doors, windows, curtain walling, roof."
+      "_scope": "The weather-tight skin for one level: walls, curtain walling, roof, windows, and the circulation structure (stairs/ramps) that is built with the frame.",
+      "_why_split": "v1.2.0 had ONE 'Architecture' phase scoped 'Envelope AND internal fabric'. Those two halves sit on OPPOSITE SIDES of MEP Rough-in — you make a level weather-tight BEFORE first fix, and you hang doors AFTER it — so no single ordering of that phase could be correct: whichever way it was placed, half of it was wrong. A phase that straddles another phase is not atomic, which is the BOM rule this file otherwise keeps (each level self-contained). Split 2026-08-26. NOTE the repo carried BOTH readings at once: templates/4D_phases.json (April) has IfcWall predecessors [IfcDuct, IfcPipe] — services first, walls close them in — while this file had envelope-before-services. The contradiction is what the split resolves."
     },
     {
       "id": "mep_rough_in", "name": "MEP Rough-in", "sequence": 7,
@@ -71,6 +72,17 @@
       "replicate_per_level": true,
       "scope": "level",
       "_scope": "First-fix services for one level, after that level is weather-tight."
+    },
+    {
+      "id": "architecture_closeup", "name": "Architecture Closeup", "sequence": 8,
+      "trades": ["CARPENTER"],
+      "replicate_per_level": true,
+      "scope": "level",
+      "_scope": "Internal fabric closed up AFTER first fix: doors, and anything hung on or into a wall once the services inside it are in.",
+      "_band": "Sequence 8 was FREE — IfcRoof vacated it in PR #1527 (§S65 #7 moved roof 8 -> 6). So the split needs no renumbering of any other phase: bands stay contiguous and non-overlapping at Substructure 1, Superstructure 2-4, Architecture Envelope 5-6, MEP Rough-in 7, Architecture Closeup 8, MEP Final 9, Finishes 10-11.",
+      "_empty_ok": true,
+      "_empty_ok_why": "A model with no doors legitimately has no closeup work. Absent must be REPORTED as absent, never silently skipped.",
+      "_open": "ONLY IfcDoor moves here. IfcWall/IfcWallStandardCase stay in the envelope and that is the KNOWN AMBIGUITY: ifc_class cannot tell an external skin wall from an internal partition, and moving all walls on a class name is the same mistake as a load-bearing class whitelist (4D_BAR_MODEL.md §18 — a structural-class regex re-admitted 438 curtain-wall glazing panels as load-bearing). An internal partition genuinely belongs in closeup; the signal to separate it must be MEASURED (perimeter/adjacency), not read off the class. Reported, not guessed."
     },
     {
       "id": "mep_final", "name": "MEP Final", "sequence": 9,
@@ -100,17 +112,20 @@
     "_empty_phase_rule": "When a phase is dropped for empty population, its within-level edge is BRIDGED (pred of the dropped phase -> succ of the dropped phase), never left dangling, and the drop is REPORTED. Verified need: HHS_Office_Federated drops Substructure, which is the head of the chain — an unbridged drop leaves Superstructure with no predecessor.",
     "within_level": [
       { "pred": "substructure",   "succ": "superstructure", "type": "FS", "lag_days": 0, "_why": "Frame bears on the foundations." },
-      { "pred": "superstructure", "succ": "architecture",   "type": "FS", "lag_days": 0, "_why": "Envelope and partitions need the frame and slab of their own level." },
-      { "pred": "architecture",   "succ": "mep_rough_in",   "type": "FS", "lag_days": 0, "_why": "First fix follows weather-tight. This is the same precedence the 2026-08-25 IfcRoof 8->6 ruling encoded at class level; stated here as programme logic rather than a sequence number." },
-      { "pred": "mep_rough_in",   "succ": "mep_final",      "type": "FS", "lag_days": 0, "_why": "Second fix follows first fix." },
+      { "pred": "superstructure", "succ": "architecture_envelope", "type": "FS", "lag_days": 0, "_why": "The envelope needs the frame and slab of its own level." },
+      { "pred": "architecture_envelope", "succ": "mep_rough_in", "type": "FS", "lag_days": 0, "_why": "First fix follows weather-tight. Same precedence the 2026-08-25 IfcRoof 8->6 ruling encoded at class level; stated here as programme logic rather than a sequence number." },
+      { "pred": "mep_rough_in",   "succ": "architecture_closeup", "type": "FS", "lag_days": 0, "_why": "Close up only once the services inside the fabric are in. This edge is the whole reason for the split — under one 'Architecture' phase it could not be expressed at all." },
+      { "pred": "architecture_closeup", "succ": "mep_final", "type": "FS", "lag_days": 0, "_why": "Second fix follows close-up." },
       { "pred": "mep_final",      "succ": "finishes",       "type": "FS", "lag_days": 0, "_why": "Finishes close up completed services." }
     ],
     "_ladder_rule": "EVERY level-scope phase chains to ITSELF on the level below (FS+0, level_offset 1). This is the project's own §4D_BAND_MONOTONIC ruling — 'a trade may not run ahead of ITSELF on the floor below' — declared here as programme logic instead of living only inside the solver's gates. v1.1.0 declared the ladder for superstructure ALONE, and MEASURED on HHS_Office_Federated (2026-08-25, probe_4d_motion.js) that is NOT crew-legal: with levels otherwise free to run in parallel, MEP Rough-in on Levels 1/2/3 overlaps and PLUMBER peaks at 3.67 crews against a cap of 2 (1.84x), HVAC_TECH at 3.48 (1.74x). With the full ladder: ZERO breaches on every trade, and the programme costs 49 days against 41 — the 8 days that buy physical legality. Different trades still overlap ACROSS floors, which is what a trade train is; only a trade overtaking itself is forbidden.",
     "across_levels": [
       { "pred": "superstructure", "succ": "superstructure", "type": "FS", "lag_days": 0, "level_offset": 1,
         "_why": "A level's frame cannot start before the level below it is framed. The one constraint that is structural as well as logistical." },
-      { "pred": "architecture",   "succ": "architecture",   "type": "FS", "lag_days": 0, "level_offset": 1,
-        "_why": "§4D_BAND_MONOTONIC: the envelope/fabric trades may not run ahead of themselves. The user's own report that produced that ruling was 'upper floors gets walled first'." },
+      { "pred": "architecture_envelope", "succ": "architecture_envelope", "type": "FS", "lag_days": 0, "level_offset": 1,
+        "_why": "§4D_BAND_MONOTONIC: the envelope trades may not run ahead of themselves. The user's own report that produced that ruling was 'upper floors gets walled first'." },
+      { "pred": "architecture_closeup", "succ": "architecture_closeup", "type": "FS", "lag_days": 0, "level_offset": 1,
+        "_why": "§4D_BAND_MONOTONIC, same CARPENTER pool as the envelope's doors were in before the split." },
       { "pred": "mep_rough_in",   "succ": "mep_rough_in",   "type": "FS", "lag_days": 0, "level_offset": 1,
         "_why": "§4D_BAND_MONOTONIC, and the measured binding case: without it PLUMBER runs 1.84x over cap across three simultaneous levels." },
       { "pred": "mep_final",      "succ": "mep_final",      "type": "FS", "lag_days": 0, "level_offset": 1,

--- a/viewer/rates/sequence_rules.json
+++ b/viewer/rates/sequence_rules.json
@@ -13,7 +13,7 @@
       ],
       "pattern": "glaz|glass|verglas|vitrage|vidrio|curtain|mullion",
       "flags": "i",
-      "phase": "Architecture",
+      "phase": "Architecture Envelope",
       "sequence": 6,
       "resource": "CARPENTER",
       "reason": "ifc_class alone cannot separate curtain-wall glazing/framing from structural steel plates/members — a Revit curtain-wall panel is IfcPlate and its mullions are IfcMember, same classes as genuinely structural plates/members (e.g. Terminal's 33,324 Metal Deck IfcPlate, JKR's CHS/RHS steel framing, LTU_AHouse's timber beams, which must all stay at their structural seq). Name is the only extracted signal that discriminates them. Matched, measured against 8 shipped buildings: Hospital 'System Panel:Glazed' (2211/2211 IfcPlate) + 'Curtain Wall:...Framing'/'Curtain System' (7122/7127 IfcMember), Clinic 'Rectangular/Circular Mullion' (522/534 IfcMember), HHS 'Systemelement:Verglasung' (438/629 IfcPlate, German) — zero false positives on Terminal/JKR/LTU_AHouse/TermRooms. See bim-compiler prompts/RESUME_4D_TRUTH_AND_BE_HERE_WHEN.md §STAGE A A.3/A.4 and prompts/GANTT_ACCURACY.md §4D_HOST_BEFORE_HOSTED. Elements not matching this pattern keep their class-default seq (measured, never guessed) — known remaining blind spot: HHS 'Rechteckiger Pfosten' (German curtain-wall posts, 1450 IfcMember) not matched, deliberately not covered by a generic 'post' pattern (too ambiguous vs real structural posts) — reported, not silently dropped."
@@ -238,77 +238,77 @@
       "resource": "ELECTRICIAN"
     },
     "IfcWall": {
-      "phase": "Architecture",
+      "phase": "Architecture Envelope",
       "sequence": 5,
       "resource": "MASON"
     },
     "IfcWallStandardCase": {
-      "phase": "Architecture",
+      "phase": "Architecture Envelope",
       "sequence": 5,
       "resource": "MASON"
     },
     "IfcOpeningElement": {
-      "phase": "Architecture",
+      "phase": "Architecture Envelope",
       "sequence": 5,
       "resource": "MASON"
     },
     "IfcSpace": {
-      "phase": "Architecture",
+      "phase": "Architecture Envelope",
       "sequence": 5,
       "resource": null
     },
     "IfcBuildingElementPart": {
-      "phase": "Architecture",
+      "phase": "Architecture Envelope",
       "sequence": 5,
       "resource": "MASON"
     },
     "IfcDoor": {
-      "phase": "Architecture",
-      "sequence": 6,
+      "phase": "Architecture Closeup",
+      "sequence": 8,
       "resource": "CARPENTER"
     },
     "IfcWindow": {
-      "phase": "Architecture",
+      "phase": "Architecture Envelope",
       "sequence": 6,
       "resource": "CARPENTER"
     },
     "IfcStair": {
-      "phase": "Architecture",
+      "phase": "Architecture Envelope",
       "sequence": 6,
       "resource": "CARPENTER"
     },
     "IfcStairFlight": {
-      "phase": "Architecture",
+      "phase": "Architecture Envelope",
       "sequence": 6,
       "resource": "CARPENTER"
     },
     "IfcRailing": {
-      "phase": "Architecture",
+      "phase": "Architecture Envelope",
       "sequence": 6,
       "resource": "CARPENTER"
     },
     "IfcRamp": {
-      "phase": "Architecture",
+      "phase": "Architecture Envelope",
       "sequence": 6,
       "resource": "CONCRETE_GANG"
     },
     "IfcRampFlight": {
-      "phase": "Architecture",
+      "phase": "Architecture Envelope",
       "sequence": 6,
       "resource": "CONCRETE_GANG"
     },
     "IfcRoof": {
-      "phase": "Architecture",
+      "phase": "Architecture Envelope",
       "sequence": 6,
       "resource": "ROOFER"
     },
     "IfcBuildingElementProxy": {
-      "phase": "Architecture",
+      "phase": "Architecture Envelope",
       "sequence": 5,
       "resource": "MASON"
     },
     "IfcCurtainWall": {
-      "phase": "Architecture",
+      "phase": "Architecture Envelope",
       "sequence": 6,
       "resource": "CARPENTER"
     },
@@ -349,7 +349,7 @@
     }
   },
   "SEQUENCE_DEFAULT": {
-    "phase": "Architecture",
+    "phase": "Architecture Envelope",
     "sequence": 6,
     "resource": "MASON"
   },

--- a/viewer/schedule_author_ui.js
+++ b/viewer/schedule_author_ui.js
@@ -281,7 +281,12 @@
       render();
       return;
     }
-    var res = SA().materializeZones ? SA().materializeZones(d, rules(), { start: '2026-01-01', laborRates: laborRates() }) : { ok: false, reason: 'no_materializeZones' };
+    // §TPL_WIRED (2026-08-26) — the authoring UI draws from the SAME 4D programme template as the
+    // Time Machine, so a draft and the movie can never describe two different programmes.
+    // window._4dTemplate is set by time_machine.js's _load4DTemplate(); absent -> null -> the
+    // legacy zone path, byte-identical to pre-2026-08-26.
+    var _tpl = (typeof window !== 'undefined' && window._4dTemplate) || null;
+    var res = SA().materializeZones ? SA().materializeZones(d, rules(), { start: '2026-01-01', laborRates: laborRates(), template: _tpl }) : { ok: false, reason: 'no_materializeZones' };
     if (!res.ok) {
       // Honest degrade — no ScheduleGate loaded, or genuinely no elements. Not invented.
       console.log('§AUTHOR_UI_ZONE_FALLBACK reason=' + (res.reason || 'unknown'));

--- a/viewer/tests/baselines/midair.json
+++ b/viewer/tests/baselines/midair.json
@@ -1,47 +1,48 @@
 {
-  "_readme": "Locked regression baselines for viewer/tests/witness_midair_zero.js. DATA ONLY — the WHY for every number stays in the witness's own comment blocks, which cite the prompts/4D_GANTT_TM_REFACTOR.md section that measured it. Split out of the witness source 2026-08-21 so a re-lock is a data edit with a readable diff, and so adding an eighth building never edits test code. Re-lock discipline is unchanged: first run with placeholder -1s, read the real numbers off the FAIL lines, re-run to PASS. Never hand-write a number you have not seen a run produce.",
-  "_relocked": "2026-08-21 — §S50 cell-grain schedule (bim-ootb #1442), carried unchanged through §S51 (#1444). float_after_cpm ONLY re-locked 2026-08-22 (§S64): HHS 889->884, LTU_AHouse 5023->4998, JKR 1222->1212 — auditFloating shed false positives when its tPool was made to mirror hangGate's elPool and its wall pool given wallCarries' carry-at-top bound. NO schedule time changed (both fixes are inside auditFloating, which no gate reads); midair and orphans are byte-identical on all 7, which is the proof this was the audit and not the engine.",
-  "float_after_cpm": {
-    "_what": "W-MZ-8 — ScheduleGate.auditFloating AFTER _displayTimeline. The measured TRADE: a dependent may start before its support FINISHES. Deliberate and named, never silent.",
-    "Terminal": 554,
-    "Hospital": 935,
-    "Duplex": 44,
-    "HHS_Office_Federated": 884,
-    "Clinic": 324,
-    "LTU_AHouse": 4998,
-    "JKR": 1212
+ "_readme": "Locked regression baselines for viewer/tests/witness_midair_zero.js. DATA ONLY — the WHY for every number stays in the witness's own comment blocks, which cite the prompts/4D_GANTT_TM_REFACTOR.md section that measured it. Split out of the witness source 2026-08-21 so a re-lock is a data edit with a readable diff, and so adding an eighth building never edits test code. Re-lock discipline is unchanged: first run with placeholder -1s, read the real numbers off the FAIL lines, re-run to PASS. Never hand-write a number you have not seen a run produce.",
+ "_relocked": "2026-08-21 — §S50 cell-grain schedule (bim-ootb #1442), carried unchanged through §S51 (#1444). float_after_cpm ONLY re-locked 2026-08-22 (§S64): HHS 889->884, LTU_AHouse 5023->4998, JKR 1222->1212 — auditFloating shed false positives when its tPool was made to mirror hangGate's elPool and its wall pool given wallCarries' carry-at-top bound. NO schedule time changed (both fixes are inside auditFloating, which no gate reads); midair and orphans are byte-identical on all 7, which is the proof this was the audit and not the engine.",
+ "float_after_cpm": {
+  "_what": "W-MZ-8 — ScheduleGate.auditFloating AFTER _displayTimeline. The measured TRADE: a dependent may start before its support FINISHES. Deliberate and named, never silent.",
+  "Terminal": 554,
+  "Hospital": 935,
+  "Duplex": 44,
+  "HHS_Office_Federated": 884,
+  "Clinic": 324,
+  "LTU_AHouse": 4998,
+  "JKR": 1212
+ },
+ "midair": {
+  "_what": "W-MZ-2 — this witness's own census(): elements appearing before the first thing they touch. Non-zero ONLY on the CELL-path buildings (the §S26.11 leg-4 exception surface); GRAPH-path buildings stay at 0. W-MZ-7 is the proof this judge can go red.",
+  "Terminal": 684,
+  "Hospital": 218,
+  "Duplex": 0,
+  "HHS_Office_Federated": 0,
+  "Clinic": 422,
+  "LTU_AHouse": 0,
+  "JKR": 0
+ },
+ "zda_display_float": {
+  "_what": "W-ZDA-4a — the floating census under DISPLAY-AUTHORED windows vs the raw-authored baseline, from witness_zone_display_authoring.js. The display path IS measurably worse and always has been; this locks the exact pair so a CHANGE reddens, replacing an inequality assert that shipped permanently red. base = raw-authored windows + shipped rescale/sweep/parity; display = display-authored windows, rescale + parity, no sweep. Deliberately NOT a % threshold — that judge transfer was tried and retracted.",
+  "_measured": "2026-08-22 on origin/main 6ec0dcc (§S63); HHS_Office_Federated RE-LOCKED 2026-08-25 (§S65) — see _relocked_2026_08_25 below",
+  "Duplex_extracted": {
+   "base": 25,
+   "display": 46
   },
-  "midair": {
-    "_what": "W-MZ-2 — this witness's own census(): elements appearing before the first thing they touch. Non-zero ONLY on the CELL-path buildings (the §S26.11 leg-4 exception surface); GRAPH-path buildings stay at 0. W-MZ-7 is the proof this judge can go red.",
-    "Terminal": 684,
-    "Hospital": 218,
-    "Duplex": 0,
-    "HHS_Office_Federated": 0,
-    "Clinic": 422,
-    "LTU_AHouse": 0,
-    "JKR": 0
+  "HHS_Office_Federated_extracted": {
+   "base": 967,
+   "display": 1849
   },
-  "zda_display_float": {
-    "_what": "W-ZDA-4a — the floating census under DISPLAY-AUTHORED windows vs the raw-authored baseline, from witness_zone_display_authoring.js. The display path IS measurably worse and always has been; this locks the exact pair so a CHANGE reddens, replacing an inequality assert that shipped permanently red. base = raw-authored windows + shipped rescale/sweep/parity; display = display-authored windows, rescale + parity, no sweep. Deliberately NOT a % threshold — that judge transfer was tried and retracted.",
-    "_measured": "2026-08-22 on origin/main 6ec0dcc (§S63); HHS_Office_Federated RE-LOCKED 2026-08-25 (§S65) — see _relocked_2026_08_25 below",
-    "Duplex_extracted": {
-      "base": 22,
-      "display": 37
-    },
-    "HHS_Office_Federated_extracted": {
-      "base": 977,
-      "display": 1727
-    },
-    "_relocked_2026_08_25": "HHS_Office_Federated 894->1839 becomes 977->1727. CAUSE ISOLATED BY A/B, not assumed. PR #1527 (§S65 STAGE 2) changed two things that feed the solve: element DURATIONS (1217 elements were on _installSecs' silent 120s floor, now on real productivity math) and two SEQUENCE moves (IfcRoof 8->6, glazed_curtainwall_facade 7->6, the user's weather-tight-before-rough-in ruling). Ran the template with the duration fixes but the sequences reverted: 891->1815. So the durations cost NOTHING in raw floating (894->891, three better) and improved the display side by 24; the entire +88 raw regression is the SEQUENCE moves, and they leave the display timeline byte-unchanged at 1815 — the movie is unaffected, only the raw generative audit moves. Accepted as the measured price of a deliberate ruling. PR #1529 (§ZONE_WINDOW_COVERS_WORK) then took the display side 1815->1727 by flooring each zone's window at its own members' crew-days. Net vs the old lock: raw +83, display -112."
-  },
-  "orphans": {
-    "_what": "W-MZ-4 — elements touching nothing in the model. Purely geometric (never reads .s/.e), so independent of which display-authoring path produced the times. An extraction limit, reported never gated.",
-    "Terminal": 25,
-    "Hospital": 35,
-    "Duplex": 1,
-    "HHS_Office_Federated": 36,
-    "Clinic": 27,
-    "LTU_AHouse": 865,
-    "JKR": 1
-  }
+  "_relocked_2026_08_25": "HHS_Office_Federated 894->1839 becomes 977->1727. CAUSE ISOLATED BY A/B, not assumed. PR #1527 (§S65 STAGE 2) changed two things that feed the solve: element DURATIONS (1217 elements were on _installSecs' silent 120s floor, now on real productivity math) and two SEQUENCE moves (IfcRoof 8->6, glazed_curtainwall_facade 7->6, the user's weather-tight-before-rough-in ruling). Ran the template with the duration fixes but the sequences reverted: 891->1815. So the durations cost NOTHING in raw floating (894->891, three better) and improved the display side by 24; the entire +88 raw regression is the SEQUENCE moves, and they leave the display timeline byte-unchanged at 1815 — the movie is unaffected, only the raw generative audit moves. Accepted as the measured price of a deliberate ruling. PR #1529 (§ZONE_WINDOW_COVERS_WORK) then took the display side 1815->1727 by flooring each zone's window at its own members' crew-days. Net vs the old lock: raw +83, display -112.",
+  "_relocked_2026_08_26": "Duplex 22->37 becomes 25->46; HHS_Office_Federated 977->1727 becomes 967->1849. CAUSE: the Architecture phase was SPLIT into Architecture Envelope (seq 5-6) and Architecture Closeup (seq 8), with IfcDoor moving to closeup — bim-compiler prompts/4D_BAR_MODEL.md §19. One 'Architecture' phase was scoped 'Envelope AND internal fabric', and those halves sit on OPPOSITE SIDES of MEP Rough-in (weather-tight before first fix, doors hung after it), so no ordering of that phase could be correct — a phase that straddles another phase is not atomic. WHAT MOVED AND WHY IT IS ACCEPTED: this witness measures the LEGACY deriveZones path, which groups elements into zones AFTER the solve; moving doors into their own phase changes those groupings, so both halves of the pair shift. The DISPLAY half is worse (37->46, 1727->1849) and the WINDOW FIDELITY half is much better — outWindow Duplex 16->0 and HHS 1146->8, i.e. elements riding outside their own bar essentially disappear. Accepted as the measured price of a deliberate ruling, exactly as the 2026-08-25 re-lock accepted the IfcRoof 8->6 sequence move. READ THIS BEFORE TREATING EITHER NUMBER AS A QUALITY SIGNAL: §14.3 established that 783 of HHS's floating on this path is MANUFACTURED by _tmRescaleToTaskWindow, a per-task affine rescale applied after the judge runs — so this pair measures a path that is itself the defect, and it is locked to catch CHANGE, never to certify quality. The path is scheduled for retirement (§14.6 / §20 item 6); when it goes, this lock goes with it."
+ },
+ "orphans": {
+  "_what": "W-MZ-4 — elements touching nothing in the model. Purely geometric (never reads .s/.e), so independent of which display-authoring path produced the times. An extraction limit, reported never gated.",
+  "Terminal": 25,
+  "Hospital": 35,
+  "Duplex": 1,
+  "HHS_Office_Federated": 36,
+  "Clinic": 27,
+  "LTU_AHouse": 865,
+  "JKR": 1
+ }
 }

--- a/viewer/tests/witness_4d_template_reached.js
+++ b/viewer/tests/witness_4d_template_reached.js
@@ -1,0 +1,150 @@
+#!/usr/bin/env node
+// WITNESS — §TPL_REACHED: the PRODUCTION call sites reach 4D_template.json's instantiator.
+// Spec: bim-compiler prompts/4D_BAR_MODEL.md §19 (blueprint verdict).
+//
+// WHICH LAYER THIS PROVES (WITNESS_INTERFACE_FRAMEWORK.md §CRISIS LESSON 1):
+//   REACHABILITY of the template path from the live call sites — nothing else. It says nothing
+//   about whether the emitted grid is correct; witness_4d_template_instantiation.js owns that.
+//
+// ISSUE THIS PROVES OR DISPROVES — 4D_BAR_MODEL.md line 693, recorded and never acted on:
+//   "No witness exercises the LIVE call sites. Every schedule witness calls materializeZones..."
+// Every existing template witness PASSES `template: T` ITSELF. They construct an invocation the
+// shipped code never makes, so the whole template path can be green and dead at the same time.
+// §13.1 read that same fact ("no call site has ever passed opts.template") and concluded DELETE —
+// the evidence was right and the conclusion inverted. This witness states it as a gate instead:
+// if production does not reach the instantiator, the model is not running, and that is RED.
+//
+// TWO HALVES, because a keyword check alone can be satisfied without the path executing:
+//   A (static)      every production materializeZones(...) call passes `template:`.
+//   B (behavioural) replaying a production opts shape against a real DB actually emits §TPL_*,
+//                   i.e. instantiateTemplate() ran.
+//
+// Command: node viewer/tests/witness_4d_template_reached.js [Building ...]
+'use strict';
+const fs = require('fs');
+const path = require('path');
+const vm = require('vm');
+const HOME = require('os').homedir();
+const initSqlJs = require(path.join(HOME, 'bim-ootb', 'node_modules', 'sql.js'));
+const SQLJS_DIST = path.join(HOME, 'bim-ootb', 'node_modules', 'sql.js', 'dist');
+const VIEWER_DIR = process.env.VIEWER_DIR || path.join(__dirname, '..');
+const ScheduleGate = require(path.join(VIEWER_DIR, 'schedule_gate.js'));
+global.ScheduleGate = ScheduleGate;
+const ScheduleAuthor = require(path.join(VIEWER_DIR, 'schedule_author.js'));
+
+const KIT = path.join(__dirname, '..', '..', 'witness_kit');
+const { Witness } = require(path.join(KIT, 'contract'));
+
+const BLD_DIR = process.env.BLD_DIR || path.join(HOME, 'bim-ootb', 'buildings');
+const BUILDINGS = process.argv.slice(2).length ? process.argv.slice(2) : ['Duplex'];
+const START = '2026-01-01';
+
+// The PRODUCTION consumers. Test files are deliberately excluded: they are exactly the population
+// that already passes `template:`, and counting them is how this gap stayed invisible.
+const PROD_FILES = ['time_machine.js', 'schedule_author_ui.js'];
+
+// Extract every materializeZones(...) call and its opts text by brace-matching from the call's
+// open paren — robust to line breaks and nested objects, unlike a per-line regex.
+function prodCallSites() {
+  const out = [];
+  for (const f of PROD_FILES) {
+    const p = path.join(VIEWER_DIR, f);
+    if (!fs.existsSync(p)) continue;
+    const src = fs.readFileSync(p, 'utf8');
+    const re = /materializeZones\s*\(/g;
+    let m;
+    while ((m = re.exec(src)) !== null) {
+      // Skip a match inside a line comment — those are prose, not call sites.
+      const lineStart = src.lastIndexOf('\n', m.index) + 1;
+      if (/^\s*(\/\/|\*)/.test(src.slice(lineStart, m.index))) continue;
+      let depth = 0, i = m.index + m[0].length - 1;
+      for (; i < src.length; i++) {
+        if (src[i] === '(') depth++;
+        else if (src[i] === ')') { depth--; if (depth === 0) break; }
+      }
+      const argText = src.slice(m.index, i + 1);
+      out.push({
+        file: f,
+        line: src.slice(0, m.index).split('\n').length,
+        passesTemplate: /(^|[^A-Za-z_$])template\s*:/.test(argText)
+      });
+    }
+  }
+  return out;
+}
+
+// The EXECUTED rates table, whole-file (slicing drops SEQUENCE_NAME_OVERRIDES/SHIFT_HOURS).
+function executedRules() {
+  const sb = { console: { log() {}, warn() {}, error() {} } };
+  vm.createContext(sb);
+  vm.runInContext(fs.readFileSync(path.join(VIEWER_DIR, 'rates.js'), 'utf8'), sb);
+  return sb;
+}
+
+(async () => {
+  const SQL = await initSqlJs({ locateFile: f => path.join(SQLJS_DIST, f) });
+  const R = executedRules();
+  const sites = prodCallSites();
+  sites.forEach(s => console.log('§TPL_REACHED_SITE ' + s.file + ':' + s.line +
+    ' passesTemplate=' + s.passesTemplate));
+
+  // ── HALF B: replay a production opts shape verbatim (time_machine.js:6858/6900 minus the
+  // browser-only handles) and see whether the instantiator actually runs. §TPL_*/§AUTHOR_TPL on
+  // stdout is instantiateTemplate's own evidence that it executed.
+  const behavioural = [];
+  for (const bld of BUILDINGS) {
+    const file = path.join(BLD_DIR, bld + '_extracted.db');
+    if (!fs.existsSync(file)) { console.log('§TPL_REACHED_SKIP ' + bld); continue; }
+    const db = new SQL.Database(new Uint8Array(fs.readFileSync(file)));
+    const _l = console.log, _w = console.warn;
+    const logs = [];
+    console.log = (...a) => { logs.push(a.join(' ')); };
+    console.warn = () => {};
+    let ok = false;
+    try {
+      // VERBATIM the production opts keys, INCLUDING `template:` — since §TPL_WIRED (2026-08-26)
+      // every production call site loads viewer/rates/4D_template.json and passes it. Replaying
+      // the shape without it would prove nothing about what ships.
+      const T = JSON.parse(fs.readFileSync(path.join(VIEWER_DIR, 'rates', '4D_template.json'), 'utf8'));
+      ScheduleAuthor.materializeZones(db, R.SEQUENCE_RULES, {
+        start: START, laborRates: R.LABOR_RATES, rates: R.RATES,
+        scheduleGate: ScheduleGate, shiftHours: (R.SHIFT_HOURS > 0 ? R.SHIFT_HOURS : 24),
+        genVersion: 1, template: T
+      });
+      ok = true;
+    } catch (e) { logs.push('§TPL_REACHED_THREW ' + e.message); }
+    console.log = _l; console.warn = _w;
+    const emitted = logs.some(l => l.indexOf('§TPL_') === 0 || l.indexOf('§AUTHOR_TPL') === 0);
+    behavioural.push({ file: bld, line: 0, passesTemplate: emitted });
+    console.log('§TPL_REACHED_REPLAY ' + bld + ' ranWithoutThrow=' + ok +
+      ' instantiateTemplateRan=' + emitted +
+      ' (the SHIPPED opts shape, template included — §TPL_WIRED)');
+    db.close();
+  }
+
+  const rows = sites.concat(behavioural);
+
+  Witness('4d_template_reached')
+    .population(() => rows)
+    .schema({
+      type: 'object',
+      required: ['file', 'line', 'passesTemplate'],
+      properties: {
+        file: { type: 'string', minLength: 1 },
+        line: { type: 'integer', minimum: 0 },
+        passesTemplate: { type: 'boolean' }
+      }
+    })
+    // A — the static gate. Every production call site must hand over the template.
+    .invariant('every-production-call-site-passes-template',
+      rs => rs.filter(r => r.line > 0).every(r => r.passesTemplate === true))
+    // B — the behavioural gate. The shipped opts shape must actually reach the instantiator.
+    .invariant('production-opts-shape-reaches-instantiateTemplate',
+      rs => rs.filter(r => r.line === 0).every(r => r.passesTemplate === true))
+    // Guard against the gap that let this hide: if no production site is found at all, the
+    // extractor has rotted and a vacuous `every()` would read as PASS.
+    .invariant('production-call-sites-were-actually-found',
+      rs => rs.filter(r => r.line > 0).length >= 3)
+    .redControl(rs => rs.map(r => Object.assign({}, r, { passesTemplate: !r.passesTemplate })))
+    .run();
+})();

--- a/viewer/tests/witness_gantt_native_generate.js
+++ b/viewer/tests/witness_gantt_native_generate.js
@@ -41,6 +41,12 @@ const _verMatch = tmSrc.match(/var _GANTT_CACHE_VERSION = (\d+);/);
 if (!_verMatch) throw new Error('_GANTT_CACHE_VERSION not found in time_machine.js');
 const sliced = 'var _GANTT_CACHE_VERSION = ' + _verMatch[1] + ';\n' +
   'var _tmDisplayRemap = function () { return null; };\n' +
+  // §TPL_WIRED (2026-08-26): generateGanttSchedule now hands materializeZones the loaded 4D
+  // programme template. Stubbed NULL here for the same reason _tmDisplayRemap is — this
+  // witness owns the native-generate WIRING, and a null template takes materializeZones'
+  // legacy branch, which is the branch this witness has always measured. The template path's
+  // own behaviour is witnessed by witness_4d_template_instantiation.js.
+  'var _4dTemplate = null;\n' +
   sliceFn(tmSrc, '_tmBusyRecording') + '\n' +   // §S56: the §TM_BAKE_LOCK guard the verb now calls
   sliceFn(tmSrc, '_tmEditLocked') + '\n' +      // §S69: ...through the one shared refusal helper
   sliceFn(tmSrc, 'generateGanttSchedule');

--- a/viewer/tests/witness_tm_silent_refusal_tips.js
+++ b/viewer/tests/witness_tm_silent_refusal_tips.js
@@ -118,6 +118,7 @@ assert(src.indexOf('function _tmSay(') >= 0, 'W-SRT-1 _tmSay (shared #tm-gantt-t
 const SITE_RE = /console\.(?:log|warn)\('(§[A-Z0-9_]*?(?:_REJECT|_FAIL))\b/g;
 const EXCLUDED = {
   '§GANTT_SCHEDULE_STALE_REGEN_FAIL': 'load-time self-heal catch (buildTaskIndex), not a user gesture; tip may not exist yet; flow continues to a working fallback',
+  '§TPL_WIRED_FAIL': 'load-time fetch catch (_load4DTemplate), not a user gesture; the template is loaded before the drawer exists, and an absent template degrades to the legacy deriveZones path byte-identically — nothing is refused, so a tip would report a non-event',
   '§LOAD_FAIL': 'missing gantt_model.js script at load — fires on internal recompute paths (computeDays / buildGanttTasks, the latter on EVERY redraw), not on a gesture; a tip would spam and the drawer may not exist yet',
   '§GHOST_GROUND_TRIGGER_FAIL': 'DB-probe catch inside tmFirstAboveGroundMs/tmGroundSchedule — CPE bake helpers with a documented null-return contract ("treat null as never ghost"), consumed by cinema code, not a TM user gesture'
 };

--- a/viewer/time_machine.js
+++ b/viewer/time_machine.js
@@ -4123,6 +4123,9 @@
             if (!r.ok) throw new Error('HTTP ' + r.status);
             return r.json();
           });
+      // published so schedule_author_ui.js's draft path uses the SAME template object — one
+      // programme, not a second copy loaded on its own.
+      try { window._4dTemplate = _4dTemplate; } catch (e) {}
       console.log('§TPL_WIRED loaded ' + url + ' v' +
         ((_4dTemplate && _4dTemplate.meta && _4dTemplate.meta.version) || '?') +
         ' phases=' + ((_4dTemplate && _4dTemplate.phases || []).length) +

--- a/viewer/time_machine.js
+++ b/viewer/time_machine.js
@@ -4095,6 +4095,46 @@
   // touch computeSchedule's own body or the existing display-timeline reuse contract.
   var _rawScheduleRemember = null;   // { map: {guid:{start,end}}, n }
 
+  // §TPL_WIRED (2026-08-26, bim-compiler prompts/4D_BAR_MODEL.md §19/§20) — the 4D programme
+  // template, loaded ONCE and handed to every materializeZones call site in this file.
+  //
+  // WHY THIS EXISTS. viewer/rates/4D_template.json shipped 2026-08-25 (PR #1531-#1534) and
+  // schedule_author.js's instantiateTemplate() has read it since — but NO production call site
+  // ever passed `opts.template`, so the whole template path was dead code while every live
+  // schedule came from deriveZones grouping the geometry solve after the fact. Four schedule
+  // witnesses pass `template:` THEMSELVES, so the path was green and unreached at the same time
+  // (4D_BAR_MODEL.md line 693: "No witness exercises the LIVE call sites").
+  //
+  // ROUTED THROUGH loadJsonWithOverrides so a Settings edit (json_4d_template) applies, exactly
+  // as grid_drag.js does for json_grid_rules — one convention, not a second loader.
+  //
+  // NULL IS THE SAFE FALLBACK, BY CONSTRUCTION: materializeZones ignores an absent opts.template
+  // and runs the legacy zone path byte-identically, so a fetch failure degrades to today's
+  // behaviour instead of breaking generation.
+  var _4dTemplate = null, _4dTemplateTried = false;
+  async function _load4DTemplate() {
+    if (_4dTemplateTried) return _4dTemplate;
+    _4dTemplateTried = true;
+    var url = 'rates/4D_template.json';
+    try {
+      _4dTemplate = (typeof window.loadJsonWithOverrides === 'function')
+        ? await window.loadJsonWithOverrides(url, 'json_4d_template')
+        : await fetch(url).then(function (r) {
+            if (!r.ok) throw new Error('HTTP ' + r.status);
+            return r.json();
+          });
+      console.log('§TPL_WIRED loaded ' + url + ' v' +
+        ((_4dTemplate && _4dTemplate.meta && _4dTemplate.meta.version) || '?') +
+        ' phases=' + ((_4dTemplate && _4dTemplate.phases || []).length) +
+        ' — the programme is AUTHORED; deriveZones no longer defines the phases');
+    } catch (e) {
+      _4dTemplate = null;
+      console.warn('§TPL_WIRED_FAIL ' + e.message +
+        ' — falling back to the legacy deriveZones path (byte-identical to pre-2026-08-26)');
+    }
+    return _4dTemplate;
+  }
+
   // §TUKEY_BOUND (4D_GANTT_TM_REFACTOR.md stage 2, 2026-08-17) — hoisted out of _tmDisplayRemap
   // (was a nested closure there) so buildGanttTasks() can share the SAME envelope math instead of
   // re-deriving its own. This is the proven, already-shipped, already-measured rule (Hospital
@@ -5286,7 +5326,7 @@
         var _shGantt = (window.SHIFT_HOURS > 0) ? window.SHIFT_HOURS : 24;
         var rres = SA.materializeZones(db, _SR, { start: '2026-01-01', laborRates: _LR, rates: _RT,
           scheduleGate: window.ScheduleGate, shiftHours: _shGantt, genVersion: _GANTT_CACHE_VERSION,
-          displayRemap: _tmDisplayRemap });   // §ZONE_DISPLAY_AUTHORING
+          displayRemap: _tmDisplayRemap, template: _4dTemplate });   // §ZONE_DISPLAY_AUTHORING + §TPL_WIRED
         if ((!rres || !rres.ok) && SA.materializeDefault) {
           rres = SA.materializeDefault(db, _SR, { start: '2026-01-01', laborRates: _LR, blank: false,
             genVersion: _GANTT_CACHE_VERSION });
@@ -6855,7 +6895,7 @@
     var todayStart = new Date().toISOString().slice(0, 10);
     var SR = window.SEQUENCE_RULES || {}, LR = window.LABOR_RATES || {}, RT = window.RATES || {};
     var _shiftHoursGantt = (window.SHIFT_HOURS > 0) ? window.SHIFT_HOURS : 24; // §GANTT_SHIFT_HOURS_DESYNC — match injectGantt's real clock
-    var res = SA.materializeZones(app.db, SR, { start: todayStart, laborRates: LR, rates: RT, scheduleGate: window.ScheduleGate, shiftHours: _shiftHoursGantt, genVersion: _GANTT_CACHE_VERSION, displayRemap: _tmDisplayRemap });   // §ZONE_DISPLAY_AUTHORING
+    var res = SA.materializeZones(app.db, SR, { start: todayStart, laborRates: LR, rates: RT, scheduleGate: window.ScheduleGate, shiftHours: _shiftHoursGantt, genVersion: _GANTT_CACHE_VERSION, displayRemap: _tmDisplayRemap, template: _4dTemplate });   // §ZONE_DISPLAY_AUTHORING + §TPL_WIRED
     if (!res.ok && SA.materializeDefault) res = SA.materializeDefault(app.db, SR, { start: todayStart, laborRates: LR, blank: false, genVersion: _GANTT_CACHE_VERSION });
     console.log('§GANTT_PREMATERIALIZE ' + (res.ok
       ? 'native schedule written BEFORE first injectGantt (zones=' + (res.zoneCount != null ? res.zoneCount : 'n/a') + ') — single-pass cold open'
@@ -6897,7 +6937,7 @@
     var todayStart = new Date().toISOString().slice(0, 10);
     var SR = window.SEQUENCE_RULES || {}, LR = window.LABOR_RATES || {}, RT = window.RATES || {};
     var _shiftHoursGantt = (window.SHIFT_HOURS > 0) ? window.SHIFT_HOURS : 24; // §GANTT_SHIFT_HOURS_DESYNC — match injectGantt's real clock
-    var res = SA.materializeZones(app.db, SR, { start: todayStart, laborRates: LR, rates: RT, scheduleGate: window.ScheduleGate, shiftHours: _shiftHoursGantt, genVersion: _GANTT_CACHE_VERSION, displayRemap: _tmDisplayRemap });   // §ZONE_DISPLAY_AUTHORING
+    var res = SA.materializeZones(app.db, SR, { start: todayStart, laborRates: LR, rates: RT, scheduleGate: window.ScheduleGate, shiftHours: _shiftHoursGantt, genVersion: _GANTT_CACHE_VERSION, displayRemap: _tmDisplayRemap, template: _4dTemplate });   // §ZONE_DISPLAY_AUTHORING + §TPL_WIRED
     if (!res.ok) {
       console.log('§GANTT_AUTHOR_ENTRY_ZONE_FALLBACK reason=' + (res.reason || 'unknown'));
       res = SA.materializeDefault ? SA.materializeDefault(app.db, SR, { start: todayStart, laborRates: LR, blank: false, genVersion: _GANTT_CACHE_VERSION }) : { ok: false };
@@ -8496,6 +8536,7 @@
         // real task_ids, and the auto-generate branch never fires. refoldSchedule() itself is
         // untouched — its external-edit caller (4D_SCHED_EDIT in main.js) still needs the round-trip.
         console.log('§S4_ACTIVATION_TIMING_MID beforeMaterializeNative=' + (performance.now() - _s4ActT0).toFixed(0));
+        await _load4DTemplate();   // §TPL_WIRED — before the first materialize, not after
         _materializeNativeSchedule(app);
         console.log('§S4_ACTIVATION_TIMING_MID afterMaterializeNative=' + (performance.now() - _s4ActT0).toFixed(0));
         if (!(await injectGantt())) {
@@ -8522,7 +8563,7 @@
       console.warn('§GANTT_CACHE_ERR ' + e.message);
       // Fallback: compute without cache
       _ops = loadOps(); _ganttDirty = true;
-      if (!_ops.length) { _materializeNativeSchedule(A()); await injectGantt(); _ops = loadOps(); _ganttDirty = true; }  // §GANTT_SINGLE_LOAD, same as the main path (await: loadOps must see the chunked writes)
+      if (!_ops.length) { await _load4DTemplate(); _materializeNativeSchedule(A()); await injectGantt(); _ops = loadOps(); _ganttDirty = true; }  // §GANTT_SINGLE_LOAD, same as the main path (await: loadOps must see the chunked writes)
       if (_ops.length) { _finishActivate(app, silent); resolve(true); }
       else resolve(false);
     });

--- a/witness_kit/generators/sandbox_model.js
+++ b/witness_kit/generators/sandbox_model.js
@@ -1,0 +1,85 @@
+// witness_kit/generators/sandbox_model.js — THE SANDBOX. A ~20-element synthetic building that
+// reproduces every NAMED, MEASURED 4D defect, so the model can be tested without a 6,839-element
+// building whose noise hides which rule broke.
+//
+// USER RULING 2026-08-26: "no more long winded building to building because all of them exhibit
+// the same hell, thus a sandbox is representative."
+//
+// NOTHING HERE IS INVENTED FOR FLAVOUR. Every element exists to reproduce a defect that was
+// measured on a real building and written down; the citation is on the row. The sandbox is a
+// MINIMAL REPRODUCTION of recorded findings, not a guess at what a building looks like.
+//
+// Schema is exactly what schedule_author.js _buildScheduleElements reads:
+//   elements_meta(guid, ifc_class, element_name, storey)
+//   element_transforms(guid, center_x/y/z, bbox_x/y/z)
+'use strict';
+
+// [cls, name, storey, cx, cy, cz, bx, by, bz, why]
+const ROWS = [
+  // ── Level 1 structure — the ordinary spine every phase chain assumes exists.
+  ['IfcFooting', 'Footing L1',   'L1',  0, 0, -0.50, 4.0, 4.0, 1.00, 'substructure root'],
+  ['IfcColumn',  'Column L1',    'L1', -1.8, 0, 1.50, 0.4, 0.4, 3.00, 'superstructure'],
+  ['IfcSlab',    'Slab L1',      'L1',  0, 0, 3.10, 4.0, 4.0, 0.20, 'superstructure'],
+
+  // ── HELL A — WALL BEARS WALL, SAME CELL. 4D_BAR_MODEL.md §16: Duplex
+  // 2O2Fr$t4X7Zf8NOew3FNhv, IfcWallStandardCase seq=5 elected an IfcSlab 2.99m ABOVE as its
+  // support because the wall beneath it is also seq=5 and outside supportPool. Both walls are
+  // (Architecture, L1) — ONE CELL — so no phase-level ordering can separate them. This is the
+  // 10.2% / 28.9% / 69.3% intra-bar population measured in the review session's §S10.
+  ['IfcWallStandardCase', 'Wall lower L1', 'L1', 0, -1.9, -0.50, 4.0, 0.2, 1.00, 'HELL A: bears the wall above, same cell'],
+  ['IfcWallStandardCase', 'Wall upper L1', 'L1', 0, -1.9,  1.50, 4.0, 0.2, 3.00, 'HELL A: stands on the wall below, same cell'],
+
+  // ── HELL B — STACKING. Every element in a cell inheriting the cell window starts at the same
+  // instant. Review session §S14: kernel_ops max 12 -> 139, 315 elements in piles >= 20.
+  // Four more walls in the SAME (Architecture, L1) cell make the pile visible at n=6.
+  ['IfcWallStandardCase', 'Wall N L1', 'L1',  0,  1.9, 1.50, 4.0, 0.2, 3.00, 'HELL B: stacking'],
+  ['IfcWallStandardCase', 'Wall E L1', 'L1',  1.9, 0,  1.50, 0.2, 4.0, 3.00, 'HELL B: stacking'],
+  ['IfcWallStandardCase', 'Wall W L1', 'L1', -1.9, 0,  1.50, 0.2, 4.0, 3.00, 'HELL B: stacking'],
+  ['IfcDoor',             'Door L1',   'L1',  0, -1.9, 1.05, 0.9, 0.2, 2.10, 'ARCH closeup vs envelope: straddles MEP (4D_BAR_MODEL §19)'],
+
+  // ── HELL C — MEP UNDER ARCH. The original complaint: pipes hanging in air at DAY 0 HR 3.
+  // A duct below the slab it hangs from, and a light fixture whose only contacts are above it
+  // (4D_BAR_MODEL.md §14.2: HHS 00szGmqsL8Tv_ErgPOhgVh, 8 contacts ALL above, judged "ground").
+  ['IfcFlowSegment',  'Duct L1',  'L1', 0, 0, 2.75, 3.0, 0.3, 0.30, 'HELL C: hangs from the slab above'],
+  ['IfcFlowTerminal', 'Light L1', 'L1', 0.8, 0.8, 2.92, 0.6, 0.6, 0.06, 'HELL C: all contacts above (§14.2)'],
+  ['IfcCovering',     'Floor fin L1', 'L1', 0, 0, 0.02, 4.0, 4.0, 0.02, 'finishes'],
+
+  // ── Level 2 — the ladder needs a second level to be testable at all.
+  ['IfcColumn',           'Column L2',    'L2', -1.8, 0, 4.80, 0.4, 0.4, 3.00, 'superstructure L2'],
+  ['IfcSlab',             'Slab L2',      'L2',  0, 0, 6.30, 4.0, 4.0, 0.20, 'superstructure L2'],
+  ['IfcWallStandardCase', 'Wall S L2',    'L2',  0, -1.9, 4.80, 4.0, 0.2, 3.00, 'ladder: must follow Wall * L1'],
+  ['IfcFlowSegment',      'Duct L2',      'L2',  0, 0, 5.95, 3.0, 0.3, 0.30, 'ladder + HELL C on L2'],
+  ['IfcCovering',         'Floor fin L2', 'L2',  0, 0, 3.22, 4.0, 4.0, 0.02, 'finishes L2'],
+
+  // ── HOLE 1 — NO LEVEL. 4D_BAR_MODEL.md §12.4: HHS §ZONE_INDEX noStorey=2120 (30.8%);
+  // Terminal carries 33,848 "Unknown". task = (phase x level) gives these no cell at all.
+  ['IfcBuildingElementProxy', 'Unlevelled proxy', null, 1.5, 1.5, 2.00, 0.3, 0.3, 1.00, 'HOLE 1: no storey -> no address'],
+
+  // ── HOLE 2 — SPANS LEVELS. A riser crossing both storeys belongs to no single level.
+  // CONSTRUCTION_GRID_BOM_DUAL_MODEL.md §SHELL-N-ZSPAN measured these on Terminal: pipe risers
+  // to 40m, columns 45m, walls 44m. A cell cannot contain one.
+  ['IfcFlowSegment', 'Riser L1-L2', 'L1', 1.7, 1.7, 3.10, 0.2, 0.2, 6.40, 'HOLE 2: spans both levels'],
+
+  // ── ORPHAN — touches nothing. HHS measured 36-39 of these; they are des=-1 forever (§14.2).
+  ['IfcBuildingElementProxy', 'Orphan', 'L2', 3.6, 3.6, 5.00, 0.2, 0.2, 0.40, 'orphan: zero contacts (§14.2)']
+];
+
+// buildSandbox(SQL) -> sql.js Database, in memory. Deterministic guids so a failure names a row.
+function buildSandbox(SQL) {
+  const db = new SQL.Database();
+  db.run('CREATE TABLE elements_meta (guid TEXT PRIMARY KEY, ifc_class TEXT, element_name TEXT, ' +
+         'storey TEXT, discipline TEXT, material_name TEXT, material_rgba TEXT, building TEXT)');
+  db.run('CREATE TABLE element_transforms (guid TEXT PRIMARY KEY, center_x REAL, center_y REAL, ' +
+         'center_z REAL, bbox_x REAL, bbox_y REAL, bbox_z REAL)');
+  const m = db.prepare('INSERT INTO elements_meta (guid,ifc_class,element_name,storey,building) VALUES (?,?,?,?,?)');
+  const t = db.prepare('INSERT INTO element_transforms VALUES (?,?,?,?,?,?,?)');
+  ROWS.forEach((r, i) => {
+    const guid = 'SBX' + String(i).padStart(3, '0');
+    m.run([guid, r[0], r[1], r[2], 'Sandbox']);
+    t.run([guid, r[3], r[4], r[5], r[6], r[7], r[8]]);
+  });
+  m.free(); t.free();
+  return db;
+}
+
+module.exports = { buildSandbox, ROWS };


### PR DESCRIPTION
## Two changes, one cause

The 4D programme template (`viewer/rates/4D_template.json`, shipped 2026-08-25 in #1531–#1534) was **never reached**. Every production `materializeZones` call omitted `opts.template`, so `instantiateTemplate()` was dead code while every live schedule came from `deriveZones` grouping the geometry solve *after the fact*. Four template witnesses pass `template:` **themselves**, so the path was green and unreached at the same time — exactly what `4D_BAR_MODEL.md` line 693 recorded and nobody acted on:

> **No witness exercises the LIVE call sites.**

### 1. Architecture was not atomic

v1.2.0 scoped one `Architecture` phase as *"Envelope **and** internal fabric"*. Those halves sit on **opposite sides of MEP Rough-in** — weather-tight before first fix, doors hung after it — so no ordering of that phase could be right. A phase that straddles another phase is not atomic.

The repo carried **both** readings at once: `templates/4D_phases.json` (April) has `IfcWall predecessors: [IfcDuct, IfcPipe]` (services first), while `4D_template.json` had envelope-before-services. The split resolves that contradiction.

**No renumbering needed** — sequence 8 was free (IfcRoof vacated it in #1527). Bands stay contiguous and non-overlapping:

```
Substructure 1 · Superstructure 2-4 · Architecture Envelope 5-6 · MEP Rough-in 7
· Architecture Closeup 8 · MEP Final 9 · Finishes 10-11
```

**Only `IfcDoor` moves.** Walls stay in the envelope, recorded in-file as the known ambiguity: `ifc_class` cannot tell an external skin wall from an internal partition, and moving all walls on a class name is the §18 mistake (a structural-class regex re-admitted 438 curtain-wall glazing panels as load-bearing). Reported, not guessed.

All three shipped files edited in one commit — `4D_template.json`, `sequence_rules.json`, and `rates.js` (the **executed** table; its own header demands both). Mirror verified: 58 classes, drift=0.

### 2. Wire production to the template

All four call sites now pass `opts.template`, loaded once via `loadJsonWithOverrides('rates/4D_template.json', 'json_4d_template')` — the same convention `grid_drag.js` uses — and awaited before the first materialize. `schedule_author_ui.js` reads the same object off `window`, so a draft and the movie cannot describe two different programmes.

**Null is the safe fallback by construction:** `materializeZones` ignores an absent template and runs the legacy path byte-identically, so a fetch failure degrades to today's behaviour.

## New gate

`witness_4d_template_reached.js` — two halves, because a keyword check can pass without the path executing:

| | |
|---|---|
| A static | every production call site passes `template:` — **4/4** |
| B behavioural | replaying the **shipped** opts shape emits `§TPL_*`, i.e. `instantiateTemplate` ran — **true** |

`§WITNESS_4D_TEMPLATE_REACHED pass=6 fail=0`

## Measured on real buildings

`scripts/probe_template_hells.js`, legacy vs template, same building one flag apart:

| | Duplex | HHS_Office_Federated |
|---|---|---|
| **Stacking** maxPile | 7 → 7 | 7 → 6 |
| **Stacking** piles ≥20 | 0 → 0 | 0 → 0 |
| **Floating** | 21/1118 → 25/1118 | 187/6800 → 209/6800 |

**Stacking is at zero** — nowhere near the ≥20 piles §S14 recorded. **Floating is 2–3% and the template does not improve it**, stated plainly rather than claimed. Of HHS's 209: **61 hang entirely from above** (carrier on a higher level — no within-level ordering can hold them, an addressing question) and **148 rest on something on their own level classified into a later phase** (a §5.1 data defect: named, never scheduled around).

The probe was **wrong three times** first, each time by re-deriving a rule `support_sweep.js` already owns (§10.1 rule 1, paid for again): all-of instead of any-of (1961 → 95); an unbounded support top so a 6.4m riser "bore" everything above its base; bearing-below only, which called every ceiling-hung pipe floating (95 → 25). It now calls `SupportSweep.contactGraph` directly.

## Witnesses that caught real defects in this change

- `witness_4d_template_instantiation` — the glazed curtain-wall `NAME_OVERRIDE` still named the retired phase, orphaning exactly **438** elements. Fixed; `orphaned=0` on Hospital/HHS/Duplex.
- `witness_tm_silent_refusal_tips` — `§TPL_WIRED_FAIL` was a refusal with no user tip. It's a load-time catch that degrades byte-identically, so it joins the **excluded** list with that reason stated.
- `witness_gantt_native_generate` — slices 3 functions and runs them; `_4dTemplate` is a new module-level dep the slice doesn't include. Declared in the sandbox stubbed null, same treatment as `_tmDisplayRemap`.

## Re-locked baseline

`witness_zone_display_authoring`: Duplex 22→37 becomes 25→46, HHS 977→1727 becomes 967→1849. Cause is the Architecture split changing `deriveZones`' groupings. **Window fidelity improves sharply** — outWindow Duplex 16→0, HHS 1146→8. The note in `baselines/midair.json` records that this pair measures the **legacy** path, that §14.3 proved 783 of HHS's floating there is manufactured by `_tmRescaleToTaskWindow`, and that the lock catches **change** and never certifies quality.

## Suite

**green 62, new_red 2** — both pre-existing on clean `main` (`witness_bar_needs`, `witness_cpe_buildup_require_tm_first`). Zero verdicts changed; one witness added.

🤖 Generated with [Claude Code](https://claude.com/claude-code)