### PR TITLE
probe(4d): §D0 — the DAY-0 sub/super residue is IfcColumn, not IfcMember

### DIFF
--- a/scripts/cache_4d_run.js
+++ b/scripts/cache_4d_run.js
@@ -1,0 +1,136 @@
+#!/usr/bin/env node
+// cache_4d_run.js — RUN THE PIPELINE ONCE PER BUILDING, PERSIST IT, READ IT FOREVER AFTER.
+//
+// ⚠ DO NOT REMOVE — SCOPE. USER, 2026-08-26: "Cant u get that to persist instead of endless
+// running?" Terminal (48k elements) and Hospital (63k) take minutes through materializeZones, and
+// every probe/analysis was paying that cost again from scratch. This runs the SHIPPED pipeline
+// once, with its §-logging ON (never suppressed — USER, same session: "Why dont u refer WITNESS
+// debug logging?"), and persists two artifacts every downstream reader can consume:
+//
+//   witness.log — the FULL §-tagged log the shipped pipeline emitted. This is the primary
+//                 evidence, per the project Log Mandate. Read it; do not re-derive what it says.
+//   run.json    — elements (guid, cls, seq, phase, storey, name, bbox) + displaySchedule
+//                 (guid -> {s,e}) exactly as the run produced them.
+//
+// CACHE KEY = building db (size+mtime) + the CONTENT of every input that can change the answer
+// (the five viewer modules, rates.js, 4D_template.json). Change any of them and the key changes,
+// so a stale cache is impossible — which matters here: this lane already lost hours to two
+// measurements that silently disagreed because they ran against different viewer checkouts
+// (4D_MODEL_INTEGRITY.md §H.4).
+//
+// Usage:  node scripts/cache_4d_run.js Terminal Hospital        (build if missing)
+//         node scripts/cache_4d_run.js --force Terminal         (rebuild)
+//         node scripts/cache_4d_run.js --list                   (what is cached)
+'use strict';
+const fs = require('fs'), path = require('path'), vm = require('vm'), os = require('os'), crypto = require('crypto');
+const HOME = os.homedir();
+const V = path.join(__dirname, '..', 'viewer');
+const BLD = process.env.BLD_DIR || path.join(HOME, 'bim-ootb', 'buildings');
+const ROOT = process.env.CACHE_4D_DIR || path.join(HOME, '.cache', 'bim4d');
+
+const INPUTS = ['schedule_gate.js', 'schedule_author.js', 'support_sweep.js', 'cpm_schedule.js',
+                'rates.js', 'rates/4D_template.json'];
+
+function codeKey() {
+  const h = crypto.createHash('sha1');
+  for (const f of INPUTS) h.update(f).update(fs.readFileSync(path.join(V, f)));
+  return h.digest('hex').slice(0, 12);
+}
+function dbKey(file) {
+  const st = fs.statSync(file);
+  return crypto.createHash('sha1').update(st.size + ':' + st.mtimeMs).digest('hex').slice(0, 12);
+}
+function dirFor(bld) { return path.join(ROOT, bld, codeKey() + '_' + dbKey(path.join(BLD, bld + '_extracted.db'))); }
+
+// read(bld) — what every downstream probe should call. Returns {els, sched, log, dir} or null.
+function read(bld) {
+  const d = dirFor(bld);
+  if (!fs.existsSync(path.join(d, 'run.json'))) return null;
+  const j = JSON.parse(fs.readFileSync(path.join(d, 'run.json'), 'utf8'));
+  return { els: j.els, sched: j.sched, storeys: j.storeys || null, log: fs.readFileSync(path.join(d, 'witness.log'), 'utf8'), dir: d };
+}
+
+function build(bld, force) {
+  const d = dirFor(bld);
+  if (!force && fs.existsSync(path.join(d, 'run.json'))) { console.log('§CACHE_HIT ' + bld + ' ' + d); return read(bld); }
+  const file = path.join(BLD, bld + '_extracted.db');
+  if (!fs.existsSync(file)) { console.log('§CACHE_SKIP ' + bld + ' — no db'); return null; }
+
+  // Modules are loaded FRESH per build so one process building several buildings cannot carry
+  // module-level state from one into the next.
+  for (const k of Object.keys(require.cache)) if (k.startsWith(V)) delete require.cache[k];
+  const SG = require(path.join(V, 'schedule_gate.js')); global.ScheduleGate = SG;
+  const SA = require(path.join(V, 'schedule_author.js'));
+  const SS = require(path.join(V, 'support_sweep.js')); global.SupportSweep = SS;
+  const CP = require(path.join(V, 'cpm_schedule.js')); global.CpmSchedule = CP;
+  const T = JSON.parse(fs.readFileSync(path.join(V, 'rates', '4D_template.json'), 'utf8'));
+  const sb = { console: { log() {}, warn() {}, error() {} } };
+  vm.createContext(sb); vm.runInContext(fs.readFileSync(path.join(V, 'rates.js'), 'utf8'), sb);
+
+  const initSqlJs = require(path.join(HOME, 'bim-ootb', 'node_modules', 'sql.js'));
+  return initSqlJs({ locateFile: f => path.join(HOME, 'bim-ootb', 'node_modules', 'sql.js', 'dist', f) })
+    .then(SQL => {
+      const lines = [];
+      const _l = console.log, _w = console.warn;
+      // TEE, not suppress: the §-log is the evidence, so it goes to the file AND to the terminal.
+      console.log = function () { const s = Array.prototype.join.call(arguments, ' '); lines.push(s); _l(s); };
+      console.warn = function () { const s = Array.prototype.join.call(arguments, ' '); lines.push(s); _w(s); };
+      let els = null, sched = null, storeys = null, err = null;
+      try {
+        const db = new SQL.Database(new Uint8Array(fs.readFileSync(file)));
+        const base = { start: '2026-01-01', laborRates: sb.LABOR_RATES, rates: sb.RATES,
+          nameOverrides: sb.SEQUENCE_NAME_OVERRIDES, defaultRule: sb.SEQUENCE_DEFAULT,
+          scheduleGate: SG, shiftHours: T.calendar.hours_per_shift, template: T, db: db };
+        els = SA._buildScheduleElements(db, sb.SEQUENCE_RULES, base).map(e => ({
+          guid: e.guid, cls: e.cls, seq: e.seq, phase: e.phase, storey: e.storey, name: e.name || '',
+          resource: e.resource, installSecs: e.installSecs,
+          x0: e.x0, x1: e.x1, y0: e.y0, y1: e.y1, bz: e.base_z, tz: e.top_z }));
+        const res = SA.materializeZones(db, sb.SEQUENCE_RULES, base);
+        sched = res && res.displaySchedule;
+        // The IFC's OWN declared spatial structure, persisted alongside the run so a witness can
+        // compare "storeys the model declares" against "bands the schedule invents" without a
+        // tolerance constant anywhere. Absent on some shipped DBs (Duplex/Hospital have no
+        // spatial_structure table at all) — absent must be REPORTED as absent, never guessed.
+        try {
+          const q = db.exec("SELECT name,center_z,size_z FROM spatial_structure WHERE type='IfcBuildingStorey'");
+          if (q.length) {
+            const c = q[0].columns, ni = c.indexOf('name'), zi = c.indexOf('center_z'), si = c.indexOf('size_z');
+            storeys = q[0].values.map(v => ({ name: v[ni], center_z: v[zi], size_z: v[si] }));
+          }
+        } catch (e) { storeys = null; }   // no table / no columns — reported, not invented
+        db.close();
+      } catch (e) { err = e; }
+      console.log = _l; console.warn = _w;
+      if (err || !sched) { console.log('§CACHE_FAIL ' + bld + ' ' + (err ? err.message : 'no displaySchedule')); return null; }
+      const flat = {};
+      for (const g in sched) flat[g] = { s: sched[g].start, e: sched[g].end };
+      fs.mkdirSync(d, { recursive: true });
+      fs.writeFileSync(path.join(d, 'witness.log'), lines.join('\n') + '\n');
+      fs.writeFileSync(path.join(d, 'run.json'), JSON.stringify({ bld: bld, builtAt: new Date().toISOString(),
+        codeKey: codeKey(), els: els, sched: flat, storeys: storeys }));
+      console.log('§CACHE_BUILT ' + bld + ' n=' + els.length + ' scheduled=' + Object.keys(flat).length +
+        ' logLines=' + lines.length + ' declaredStoreys=' + (storeys ? storeys.length : 'ABSENT') + ' -> ' + d);
+      return read(bld);
+    });
+}
+
+module.exports = { read: read, build: build, dirFor: dirFor, codeKey: codeKey };
+
+if (require.main === module) {
+  const args = process.argv.slice(2);
+  const force = args.includes('--force');
+  if (args.includes('--list')) {
+    if (!fs.existsSync(ROOT)) { console.log('§CACHE_LIST empty (' + ROOT + ')'); process.exit(0); }
+    for (const b of fs.readdirSync(ROOT)) for (const k of fs.readdirSync(path.join(ROOT, b))) {
+      const rj = path.join(ROOT, b, k, 'run.json');
+      if (!fs.existsSync(rj)) continue;
+      const st = fs.statSync(rj);
+      console.log('§CACHE_LIST ' + b.padEnd(24) + ' ' + k + '  ' + (st.size / 1048576).toFixed(1) + 'MB  ' +
+        st.mtime.toISOString() + (k.startsWith(codeKey()) ? '  <- CURRENT code' : '  (stale code)'));
+    }
+    process.exit(0);
+  }
+  const list = args.filter(a => a[0] !== '-');
+  (async () => { for (const b of (list.length ? list : ['Duplex', 'HHS_Office_Federated', 'Hospital', 'Terminal'])) await build(b, force); })()
+    .catch(e => { console.error('§CACHE_ERROR ' + (e && e.stack || e)); process.exit(2); });
+}

--- a/scripts/probe_day0_unsupported.js
+++ b/scripts/probe_day0_unsupported.js
@@ -125,6 +125,43 @@ const quiet = fn => { const l = console.log, w = console.warn; console.log = () 
         heldH: first === Infinity ? 'never' : ((first - t0) / 3600000).toFixed(2),
         contacts: list.length, bearingAny, embeddedAny, carrierAny });
     }
+    // ── §D0_TOPBOUND — BLAST RADIUS OF THE ONE INCONSISTENCY, measured, not shipped ────────────
+    // The shipped judge holds TWO copies of "S bears T" and they disagree on the upper bound:
+    //   _contactGraph (support_sweep.js:411)   S.bz < T.bz - EPS && S.tz >= T.bz - GAP     <- no top bound
+    //   auditFloating wall pool (schedule_gate.js:1195, §S64)  ... && S.top_z <= T.base_z + GAP
+    // §S64's own comment says the wall pool needed the bound because without it "a wall carries a
+    // promoted slab AT ITS TOP, never one embedded metres below its crown" — 73 fleet-wide false
+    // verdicts. _contactGraph's clause never got it, and that is measurably admitting supports
+    // whose top is metres above the base they supposedly carry (Hospital: 11.4m). Bounding it does
+    // NOT reduce the unsupported count — it REMOVES FALSE SUPPORTS, so the count can only rise.
+    // That is the point: the current number is flattered by contacts that are not carrying anything.
+    // Reported here as a measurement. Changing _contactGraph is a construct change across the
+    // scheduler, the lock gate and the audit, and is not made from inside a probe.
+    let bearingTotal = 0, bearingOverTop = 0, boundedUnsupported = 0, boundedJudged = 0;
+    for (let i = 0; i < els.length; i++) {
+      const Tt = els[i];
+      if (!SCOPE_SEQ[Tt.seq] || Tt.seq === 1 || G.grounded[i]) continue;
+      const st = startOf(Tt.guid); if (!Number.isFinite(st)) continue;
+      boundedJudged++;
+      let firstB = Infinity;
+      for (const j of (G.contacts[i] || [])) {
+        const S = els[j];
+        const bearing  = (S.bz < Tt.bz - EPS && S.tz >= Tt.bz - GAP);
+        const embedded = (S.bz <= Tt.bz + EPS && S.tz >= Tt.tz - EPS);
+        if (bearing) {
+          bearingTotal++;
+          if (!(S.tz <= Tt.bz + GAP)) { bearingOverTop++; continue; }   // §S64 bound applied
+        } else if (!embedded) continue;
+        const ss = startOf(S.guid);
+        if (Number.isFinite(ss) && ss < firstB) firstB = ss;
+      }
+      if (firstB > st) boundedUnsupported++;
+    }
+    console.log('   §D0_TOPBOUND bearingContacts=' + bearingTotal + ' droppedByS64TopBound=' +
+      bearingOverTop + ' (' + (bearingTotal ? (100 * bearingOverTop / bearingTotal).toFixed(1) : '0') +
+      '%)  unsupportedWouldBecome=' + boundedUnsupported + '/' + boundedJudged +
+      ' — a support whose TOP is above the base it carries is not carrying it');
+
     // max concurrency by sweep-line over the interval endpoints — exact, no sampling
     const evts = [];
     spans.forEach(([a, b]) => { evts.push([a, 1]); if (b !== Infinity) evts.push([b, -1]); });

--- a/scripts/probe_day0_unsupported.js
+++ b/scripts/probe_day0_unsupported.js
@@ -125,6 +125,48 @@ const quiet = fn => { const l = console.log, w = console.warn; console.log = () 
         heldH: first === Infinity ? 'never' : ((first - t0) / 3600000).toFixed(2),
         contacts: list.length, bearingAny, embeddedAny, carrierAny });
     }
+    // ── §D0_OPENING — WHAT DOES DAY 0 ACTUALLY OPEN WITH? ─────────────────────────────────────
+    // USER QUESTION 2026-08-26: "Will DAY 0 start with an early-days success — for Hospital and
+    // Terminal, where only substructure (if it exists) gets built up, with no columns and beams
+    // hanging?" That is two separate measurable claims and they are reported separately:
+    //   COMPOSITION — what phases/classes are on screen during DAY 0 at all. A clean opening is
+    //                 Substructure only (or, where a building models none, nothing that needs one).
+    //   HANGING     — of everything on screen (ALL classes, not only sub/super — the eye does not
+    //                 filter by phase), how many have a bearing/embedded contact that is NOT yet
+    //                 placed. This is the "no columns and beams hanging" half of the question.
+    // Checkpoints are hourly across DAY 0 and the verdict quotes the END of DAY 0 (h=24), because
+    // a clean h=3 says nothing about what the rest of the day drags in.
+    for (const hh of [1, 3, 6, 12, 18, 24]) {
+      const cur = t0 + hh * 3600000;
+      const pl = new Uint8Array(els.length);
+      let scr = 0;
+      for (let i = 0; i < els.length; i++) { const st = startOf(els[i].guid); if (Number.isFinite(st) && st <= cur) { pl[i] = 1; scr++; } }
+      const byPhase = {}, byClass = {}, hangCls = {};
+      let hanging = 0, structural = 0;
+      for (let i = 0; i < els.length; i++) {
+        if (!pl[i]) continue;
+        const Tt = els[i];
+        byPhase[Tt.phase || '_UNPHASED'] = (byPhase[Tt.phase || '_UNPHASED'] || 0) + 1;
+        byClass[Tt.cls] = (byClass[Tt.cls] || 0) + 1;
+        if (Tt.seq === 1 || G.grounded[i]) continue;          // shipped 1c + rests on soil
+        structural++;
+        let held = 0;
+        for (const j of (G.contacts[i] || [])) {
+          const S = els[j];
+          const bearing  = (S.bz < Tt.bz - EPS && S.tz >= Tt.bz - GAP);
+          const embedded = (S.bz <= Tt.bz + EPS && S.tz >= Tt.tz - EPS);
+          if ((bearing || embedded) && pl[j]) { held = 1; break; }
+        }
+        if (!held) { hanging++; hangCls[Tt.cls] = (hangCls[Tt.cls] || 0) + 1; }
+      }
+      const ph = Object.entries(byPhase).sort((a, b) => b[1] - a[1]).map(([k, n]) => k + ':' + n).join(' ');
+      const cl = Object.entries(byClass).sort((a, b) => b[1] - a[1]).slice(0, 6).map(([k, n]) => k + ':' + n).join(' ');
+      console.log('   §D0_OPENING ' + bld + ' h=' + String(hh).padStart(2) + ' onScreen=' + String(scr).padStart(5) +
+        '  HANGING=' + hanging + '/' + structural +
+        (hanging ? ' [' + Object.entries(hangCls).sort((a, b) => b[1] - a[1]).map(([k, n]) => k + ':' + n).join(' ') + ']' : '') +
+        '  phases{' + ph + '}  top classes{' + cl + '}');
+    }
+
     // ── §D0_TOPBOUND — BLAST RADIUS OF THE ONE INCONSISTENCY, measured, not shipped ────────────
     // The shipped judge holds TWO copies of "S bears T" and they disagree on the upper bound:
     //   _contactGraph (support_sweep.js:411)   S.bz < T.bz - EPS && S.tz >= T.bz - GAP     <- no top bound

--- a/scripts/probe_day0_unsupported.js
+++ b/scripts/probe_day0_unsupported.js
@@ -1,0 +1,160 @@
+#!/usr/bin/env node
+// probe_day0_unsupported.js — Implementing bim-compiler prompts/4D_MODEL_INTEGRITY.md §G.3 item 1.
+//
+// ⚠ DO NOT REMOVE — SCOPE. One question, no other: on the TEMPLATE timeline the movie plays, at
+// DAY 0 | HR <HR>, how many Substructure+Superstructure elements are on screen with nothing under
+// them that is also on screen — after the footprint-local ground exemption — and WHICH CLASSES.
+// §G's headline (Hospital 0 · HHS 1 · Duplex 2 · Terminal 5, "all remaining are IfcMember") was
+// measured once and never committed as a script, so it could not be re-run. This is that script.
+// Read the §D0 log after every run. MEP is out of scope by the user's own ruling (§G.1).
+//
+// RULES THIS FILE OBEYS (each one is a defect this lane already paid for):
+//  - The judge is REQUIRED from viewer/support_sweep.js. The contact relation is NEVER re-derived
+//    here (4D_MODEL_INTEGRITY §G.0 / 4D_BAR_MODEL §10.1 rule 1 — wrong four times in one session).
+//  - Ground exemption is `G.grounded[i]`, the footprint-local test: nothing beneath me in my own
+//    column ⇒ I rest on soil. `min(bz)` over the whole building is NOT the ground datum (§G.0 —
+//    one deep outlier put every HHS ground-floor column 4.70m "in the air").
+//  - ANY-OF, not all-of: an element needs ONE support up, not all of them (1961 → 95).
+//  - No class whitelist decides what is structural. `seq` is the classifier's OUTPUT (§G.0 — a
+//    class-based structural pool re-admits HHS's 438 curtain-wall glazing panels as load-bearing).
+'use strict';
+const fs = require('fs'), path = require('path'), vm = require('vm'), os = require('os');
+const HOME = os.homedir();
+const initSqlJs = require(path.join(HOME, 'bim-ootb', 'node_modules', 'sql.js'));
+const SQLJS_DIST = path.join(HOME, 'bim-ootb', 'node_modules', 'sql.js', 'dist');
+const V = path.join(__dirname, '..', 'viewer');
+const ScheduleGate = require(path.join(V, 'schedule_gate.js'));
+global.ScheduleGate = ScheduleGate;                       // support_sweep resolves it bare at call time
+const ScheduleAuthor = require(path.join(V, 'schedule_author.js'));
+const SupportSweep = require(path.join(V, 'support_sweep.js'));
+
+const BLD = process.env.BLD_DIR || path.join(HOME, 'bim-ootb', 'buildings');
+const BUILDINGS = process.argv.slice(2).length ? process.argv.slice(2)
+  : ['Duplex', 'HHS_Office_Federated', 'Hospital', 'Terminal'];
+const START = '2026-01-01';
+const DAY = process.env.DAY != null ? Number(process.env.DAY) : 0;
+const HR  = process.env.HR  != null ? Number(process.env.HR)  : 3;
+const DAY_MS = 86400000;
+const T = JSON.parse(fs.readFileSync(path.join(V, 'rates', '4D_template.json'), 'utf8'));
+// SCOPE = the user's, §G.1: "Do not report lesser issues. Their scope is DAY 0,
+// Substructure/Superstructure, no MEP." Read off the template, never typed as a number here.
+const SCOPE_SEQ = {};
+T.phases.filter(p => p.id === 'substructure' || p.id === 'superstructure')
+        .forEach(p => { SCOPE_SEQ[p.sequence] = p.name; });
+
+function executedRules() {                                 // viewer/rates.js IS the executed table
+  const sb = { console: { log() {}, warn() {}, error() {} } };
+  vm.createContext(sb); vm.runInContext(fs.readFileSync(path.join(V, 'rates.js'), 'utf8'), sb);
+  return sb;
+}
+const quiet = fn => { const l = console.log, w = console.warn; console.log = () => {}; console.warn = () => {};
+  try { return fn(); } finally { console.log = l; console.warn = w; } };
+
+(async () => {
+  const SQL = await initSqlJs({ locateFile: f => path.join(SQLJS_DIST, f) });
+  const R = executedRules();
+  const SHIFT = T.calendar.hours_per_shift;
+  const EPS = ScheduleGate.EPS, GAP = ScheduleGate.GAP;
+  const rows = [];
+
+  for (const bld of BUILDINGS) {
+    const file = path.join(BLD, bld + '_extracted.db');
+    if (!fs.existsSync(file)) { console.log('§D0_SKIP ' + bld); continue; }
+    const db = new SQL.Database(new Uint8Array(fs.readFileSync(file)));
+    const base = { start: START, laborRates: R.LABOR_RATES, rates: R.RATES,
+      nameOverrides: R.SEQUENCE_NAME_OVERRIDES, defaultRule: R.SEQUENCE_DEFAULT,
+      scheduleGate: ScheduleGate, shiftHours: SHIFT, template: T };
+    const els = ScheduleAuthor._buildScheduleElements(db, R.SEQUENCE_RULES, base)
+      .map(e => Object.assign({}, e, { bz: e.base_z, tz: e.top_z }));
+    let res = null;
+    try { res = quiet(() => ScheduleAuthor.materializeZones(db, R.SEQUENCE_RULES, base)); }
+    catch (e) { console.log('§D0_THREW ' + bld + ' ' + e.message); db.close(); continue; }
+    db.close();
+    const sched = res && res.displaySchedule;
+    if (!sched) { console.log('§D0_NO_SCHEDULE ' + bld); continue; }
+
+    // THE JUDGE, verbatim. Geometry only — times are read after, never inside.
+    const G = SupportSweep.contactGraph(els);
+    if (!G.ok) { console.log('§D0_JUDGE_UNAVAILABLE ' + bld); continue; }
+
+    // ── THE ANSWER IS AN INTERVAL, NOT A SAMPLE ────────────────────────────────────────────────
+    // First draft of this probe sampled ONE cursor (DAY 0 HR 3) and read 0 on all four buildings,
+    // because at that instant every in-scope element on screen was exempt. A green number from a
+    // cursor that has nothing to judge is the failure this file exists to kill. So compute the
+    // thing exactly instead: element i is unsupported over [start_i, firstSupportStart_i), which
+    // is empty when a support is already up and UNBOUNDED when it has no support at all. Max
+    // concurrency over those intervals is the worst-case count, and it needs no cursor.
+    //
+    // EXEMPTION — the SHIPPED rule, not a re-derived one. schedule_gate.js:1210 `T.seq !== 1`:
+    // "1c exemption: seq===1 (phase==='Substructure') legitimately rests on unmodeled soil, never
+    // flagged." An earlier draft here used only `G.grounded[i]`, the footprint-local test, and so
+    // flagged Duplex's 2 'Floor:150mm Exterior Slab on Grade' (bz=-0.137) as unsupported: their
+    // only neighbour is an IfcFooting whose TOP is 1.113m below them (fill in between), so nothing
+    // bears them AND grounded is 0. rates.js's own §SLAB_ON_GRADE_RECLASS already names exactly
+    // that case. Both exemptions are reported SEPARATELY below so the log says how much of the
+    // population the exemption absorbs — a metric must be able to tell you it has gone vacuous.
+    const startOf = g => (sched[g] || {}).start;
+    const t0 = Math.min.apply(null, els.map(e => startOf(e.guid)).filter(Number.isFinite));
+    let inScopeTotal = 0, exemptSeq1 = 0, exemptGrounded = 0, judged = 0;
+    const spans = [];                       // [from, to) in ms, to = Infinity when never held
+    const byCls = {}, detail = [];
+    for (let i = 0; i < els.length; i++) {
+      const Tt = els[i];
+      if (!SCOPE_SEQ[Tt.seq]) continue;
+      const st = startOf(Tt.guid); if (!Number.isFinite(st)) continue;
+      inScopeTotal++;
+      if (Tt.seq === 1) { exemptSeq1++; continue; }          // shipped 1c, schedule_gate.js:1210
+      if (G.grounded[i]) { exemptGrounded++; continue; }     // footprint-local: rests on soil
+      judged++;
+      const list = G.contacts[i] || [];
+      let first = Infinity, bearingAny = 0, embeddedAny = 0, carrierAny = 0;
+      for (const j of list) {
+        const S = els[j];
+        const bearing  = (S.bz < Tt.bz - EPS && S.tz >= Tt.bz - GAP);
+        const embedded = (S.bz <= Tt.bz + EPS && S.tz >= Tt.tz - EPS);
+        if (bearing) bearingAny++; else if (embedded) embeddedAny++; else { carrierAny++; continue; }
+        const ss = startOf(S.guid);
+        if (Number.isFinite(ss) && ss < first) first = ss;
+      }
+      if (first <= st) continue;                              // a support is already up: held
+      spans.push([st, first]);
+      byCls[Tt.cls] = (byCls[Tt.cls] || 0) + 1;
+      if (detail.length < 40) detail.push({ cls: Tt.cls, guid: Tt.guid, name: Tt.name || '',
+        phase: SCOPE_SEQ[Tt.seq], storey: Tt.storey, bz: Tt.bz, tz: Tt.tz,
+        startH: ((st - t0) / 3600000).toFixed(2),
+        heldH: first === Infinity ? 'never' : ((first - t0) / 3600000).toFixed(2),
+        contacts: list.length, bearingAny, embeddedAny, carrierAny });
+    }
+    // max concurrency by sweep-line over the interval endpoints — exact, no sampling
+    const evts = [];
+    spans.forEach(([a, b]) => { evts.push([a, 1]); if (b !== Infinity) evts.push([b, -1]); });
+    evts.sort((x, y) => x[0] - y[0] || x[1] - y[1]);
+    let cur = 0, peak = 0, peakAt = t0;
+    for (const [tt, d] of evts) { cur += d; if (cur > peak) { peak = cur; peakAt = tt; } }
+    const everUnsupported = spans.length;
+    const neverHeld = spans.filter(s => s[1] === Infinity).length;
+
+    console.log('§D0 ' + bld + ' n=' + els.length + ' inScope(sub+super)=' + inScopeTotal +
+      ' exemptSeq1=' + exemptSeq1 + ' exemptGrounded=' + exemptGrounded + ' judged=' + judged +
+      '  UNSUPPORTED ever=' + everUnsupported + ' neverHeld=' + neverHeld +
+      ' peakConcurrent=' + peak + ' peakAtH=' + ((peakAt - t0) / 3600000).toFixed(2));
+    if (judged === 0) console.log('   §D0_VACUOUS ' + bld +
+      ' — every in-scope element is exempt; this building\'s 0 means the judge had nothing to judge, not that the model is right');
+    const hist = Object.entries(byCls).sort((a, b) => b[1] - a[1]);
+    if (hist.length) console.log('   §D0_CLASS ' + hist.map(([c, n]) => c + '=' + n).join(' '));
+    detail.forEach(d => console.log('      §D0_ELEM ' + d.cls + ' ' + d.guid + ' phase=' + d.phase +
+      ' storey=' + d.storey + ' bz=' + d.bz.toFixed(3) + ' tz=' + d.tz.toFixed(3) +
+      ' startH=' + d.startH + ' heldH=' + d.heldH + ' contacts=' + d.contacts +
+      ' (bearing=' + d.bearingAny + ' embedded=' + d.embeddedAny + ' carrier=' + d.carrierAny + ')' +
+      ' name=' + JSON.stringify(d.name)));
+    rows.push({ bld, unsupported: everUnsupported, peak, judged, byCls });
+  }
+
+  const total = rows.reduce((a, r) => a + r.unsupported, 0);
+  const vac = rows.filter(r => r.judged === 0).map(r => r.bld);
+  console.log('§D0_VERDICT ' + rows.map(r => r.bld + '=' + r.unsupported + '/' + r.judged).join(' · ') +
+    ' total=' + total + (vac.length ? '  VACUOUS(nothing judged)=' + vac.join(',') : '') + ' ' +
+    (vac.length ? 'INCONCLUSIVE — a 0 over an empty population is not a pass'
+     : total === 0 ? 'PASS' : 'WORK REMAINS'));
+  process.exit(0);
+})().catch(e => { console.error('§D0_ERROR ' + (e && e.stack || e)); process.exit(2); });

--- a/scripts/probe_enclosure_geometry.js
+++ b/scripts/probe_enclosure_geometry.js
@@ -1,0 +1,142 @@
+#!/usr/bin/env node
+// probe_enclosure_geometry.js — ENCLOSURE BY RAY-CAST, not adjacency by tolerance band.
+//
+// ⚠ DO NOT REMOVE — SCOPE. USER RULING 2026-08-26: "anything that hangs within a well formed room
+// is no issue." That is a CONTAINMENT question and it is computable. Everything this lane has used
+// so far — bbox XY-overlap plus a Z band, "is anything below me", class whitelists — is proxy
+// reasoning about ADJACENCY, and each proxy has been measured wrong (a pipe 'bearing' a wall; a
+// 6.4m riser 'bearing' the whole building; 438 glazing panels as load-bearing). Read the log.
+//
+// THE GEOMETRY. From an element's centroid cast 6 axis rays (+X -X +Y -Y +Z -Z). A ray is BLOCKED
+// if it hits another element's AABB (slab test). Enclosure = how many of the 6 are blocked.
+//   6/6  fully enclosed — inside a closed volume. A ceiling-hung pipe in a room is HERE.
+//   5/6  enclosed but for one opening (a doorway, a shaft) — still a formed room.
+//   <=4  genuinely open — not in a room; a bearing question is the right question for it.
+// No class names, no phase, no tolerance tuning. Slab-method ray/AABB is exact for AABBs.
+'use strict';
+const fs = require('fs'), path = require('path'), vm = require('vm'), os = require('os');
+const HOME = os.homedir();
+const initSqlJs = require(path.join(HOME, 'bim-ootb', 'node_modules', 'sql.js'));
+const V = path.join(__dirname, '..', 'viewer');
+const SG = require(path.join(V, 'schedule_gate.js')); global.ScheduleGate = SG;
+const SA = require(path.join(V, 'schedule_author.js'));
+const SupportSweep = require(path.join(V, 'support_sweep.js'));
+const BLD = path.join(HOME, 'bim-ootb', 'buildings');
+const CELL = 4;
+
+function rules() {
+  const sb = { console: { log() {}, warn() {}, error() {} } };
+  vm.createContext(sb); vm.runInContext(fs.readFileSync(path.join(V, 'rates.js'), 'utf8'), sb);
+  return sb;
+}
+
+// exact ray/AABB slab test; ray from p along unit axis dir, returns nearest t>0 or Infinity
+function hit(p, d, b) {
+  let t0 = 0, t1 = Infinity;
+  for (let a = 0; a < 3; a++) {
+    const lo = b[a * 2], hi = b[a * 2 + 1];
+    if (d[a] === 0) { if (p[a] < lo || p[a] > hi) return Infinity; continue; }
+    let ta = (lo - p[a]) / d[a], tb = (hi - p[a]) / d[a];
+    if (ta > tb) { const s = ta; ta = tb; tb = s; }
+    if (ta > t0) t0 = ta;
+    if (tb < t1) t1 = tb;
+    if (t0 > t1) return Infinity;
+  }
+  return t0 > 0 ? t0 : (t1 > 0 ? t1 : Infinity);
+}
+
+(async () => {
+  const SQL = await initSqlJs({ locateFile: f => path.join(HOME, 'bim-ootb', 'node_modules', 'sql.js', 'dist', f) });
+  const R = rules();
+  for (const bld of (process.argv.slice(2).length ? process.argv.slice(2) : ['Duplex', 'HHS_Office_Federated'])) {
+    const f = path.join(BLD, bld + '_extracted.db');
+    if (!fs.existsSync(f)) { console.log('§ENC_SKIP ' + bld); continue; }
+    const db = new SQL.Database(new Uint8Array(fs.readFileSync(f)));
+    const els = SA._buildScheduleElements(db, R.SEQUENCE_RULES, {
+      laborRates: R.LABOR_RATES, rates: R.RATES,
+      nameOverrides: R.SEQUENCE_NAME_OVERRIDES, defaultRule: R.SEQUENCE_DEFAULT })
+      .map(e => Object.assign({}, e, { bz: e.base_z, tz: e.top_z }));
+    db.close();
+
+    const box = els.map(e => [e.x0, e.x1, e.y0, e.y1, e.bz, e.tz]);
+    // XY grid so a ray only tests its own column of the model
+    const grid = new Map();
+    els.forEach((e, i) => {
+      for (let a = Math.floor(e.x0 / CELL); a <= Math.floor(e.x1 / CELL); a++)
+        for (let b = Math.floor(e.y0 / CELL); b <= Math.floor(e.y1 / CELL); b++) {
+          const k = a + ',' + b; if (!grid.has(k)) grid.set(k, []); grid.get(k).push(i);
+        }
+    });
+    const DIRS = [[1,0,0],[-1,0,0],[0,1,0],[0,-1,0],[0,0,1],[0,0,-1]];
+    const REACH = 12;                     // m — a room is not 12m to its wall in these buildings
+
+    // which elements does the CONTACT GRAPH think are unsupported? (des = -1, the §14.2 population)
+    const G = SupportSweep.contactGraph(els);
+    const des = SupportSweep.designatedSupport(els, G);
+
+    const encOf = new Array(els.length).fill(0);
+    for (let i = 0; i < els.length; i++) {
+      const e = els[i];
+      const p = [(e.x0 + e.x1) / 2, (e.y0 + e.y1) / 2, (e.bz + e.tz) / 2];
+      let blocked = 0;
+      for (const d of DIRS) {
+        // candidate columns along the ray's XY footprint
+        const cand = new Set();
+        for (let s = 0; s <= REACH; s += CELL / 2) {
+          const k = Math.floor((p[0] + d[0] * s) / CELL) + ',' + Math.floor((p[1] + d[1] * s) / CELL);
+          for (const j of (grid.get(k) || [])) cand.add(j);
+        }
+        let best = Infinity;
+        for (const j of cand) { if (j === i) continue; const t = hit(p, d, box[j]); if (t < best) best = t; }
+        if (best <= REACH) blocked++;
+      }
+      encOf[i] = blocked;
+    }
+    // §ENC_ON_FLOATING — the USER'S OWN RULE applied to the population that matters:
+    // "anything that hangs within a well formed room is no issue". Run the real template schedule,
+    // find what is unsupported on it, then ask of each whether it is enclosed.
+    const T = JSON.parse(fs.readFileSync(path.join(V, 'rates', '4D_template.json'), 'utf8'));
+    let floatIdx = [];
+    {
+      const db2 = new SQL.Database(new Uint8Array(fs.readFileSync(f)));
+      const _l = console.log, _w = console.warn; console.log = () => {}; console.warn = () => {};
+      let res = null;
+      try {
+        res = SA.materializeZones(db2, R.SEQUENCE_RULES, { start: '2026-01-01',
+          laborRates: R.LABOR_RATES, rates: R.RATES, nameOverrides: R.SEQUENCE_NAME_OVERRIDES,
+          defaultRule: R.SEQUENCE_DEFAULT, scheduleGate: SG, shiftHours: T.calendar.hours_per_shift,
+          template: T });
+      } catch (e) {}
+      console.log = _l; console.warn = _w;
+      const sched = res && res.displaySchedule;
+      if (sched) for (let i = 0; i < els.length; i++) {
+        const list = G.contacts[i]; if (!list || !list.length) continue;
+        const t = sched[els[i].guid]; if (!t) continue;
+        let held = false;
+        for (const j of list) { const sc = sched[els[j].guid];
+          if (sc && sc.end - 1 <= t.start) { held = true; break; } }
+        if (!held) floatIdx.push(i);
+      }
+      db2.close();
+    }
+
+    const hist = new Array(7).fill(0);
+    encOf.forEach(v => hist[v]++);
+    let unsupported = 0, unsupportedEnclosed = 0;
+    for (let i = 0; i < els.length; i++) {
+      if (des[i] >= 0) continue;
+      unsupported++;
+      if (encOf[i] >= 5) unsupportedEnclosed++;
+    }
+    console.log('§ENC ' + bld + ' n=' + els.length +
+      ' blockedRays 0..6 = [' + hist.join(', ') + ']  fullyEnclosed(6/6)=' + hist[6] +
+      ' (' + (100 * hist[6] / els.length).toFixed(1) + '%)');
+    let fEnc = 0; floatIdx.forEach(i => { if (encOf[i] >= 5) fEnc++; });
+    console.log('   §ENC_ON_FLOATING unsupported on the TEMPLATE schedule=' + floatIdx.length +
+      '  ENCLOSED (>=5/6 rays — hanging in a formed room, USER RULING: no issue)=' + fEnc +
+      '  GENUINELY OPEN=' + (floatIdx.length - fEnc));
+    console.log('   §ENC_VERDICT judge says UNSUPPORTED (des=-1): ' + unsupported +
+      ' — of those, ' + unsupportedEnclosed + ' are ENCLOSED (>=5/6 rays blocked), i.e. hanging ' +
+      'inside a formed room and not an issue at all. Genuinely open: ' + (unsupported - unsupportedEnclosed));
+  }
+})().catch(e => { console.error('§ENC_ERROR ' + (e && e.stack || e)); process.exit(2); });

--- a/viewer/tests/witness_day0_integrity.js
+++ b/viewer/tests/witness_day0_integrity.js
@@ -1,0 +1,163 @@
+#!/usr/bin/env node
+// witness_day0_integrity.js — THE OPENING OF THE PROGRAMME, JUDGED IN ONE PLACE.
+//
+// ⚠ DO NOT REMOVE — SCOPE. USER, 2026-08-26: "Will DAY 0 start with as early days success? For
+// Hospital and Terminal where only substructure if exist gets buildup with no columns and beams
+// hanging?" — and then, on being shown a green log: "do not trust your WITNESS logging and keep on
+// constructing them to be foolproof covering the big picture issues."
+//
+// So this witness is built to FAIL LOUDLY, including at itself. Every claim reports the SIZE of the
+// population it judged, and a 0 over an empty population prints INCONCLUSIVE, never PASS. Read the
+// log after every run (project Log Mandate).
+//
+// WHY IT EXISTS AT ALL: the shipped pipeline already emits §S18_STOREY_MERGE_FAIL — and its wording,
+// "no elevation data, bands unmerged", reads like benign degradation. It is not. MEASURED
+// 2026-08-26: that line means Terminal's level model is 22 bands for a ~7-floor building (three
+// parallel naming systems: Malay "Aras *", English "0N ... FLOOR LEVEL", and "Ceiling Level *"
+// reference planes), which is why 16 ceiling fans and a light fixture are scheduled into HOUR 0 OF
+// DAY 0. A log line that understates is the same defect as a log line that lies. C1 below restates
+// it as a hard claim with a number.
+//
+// CLAIMS (each independently PASS / FAIL / INCONCLUSIVE):
+//   C1 BAND MODEL      every storey band resolves to a physical floor datum, and bands are disjoint.
+//   C2 DAY-0 PURITY    DAY 0 contains Substructure only (or, where the building models none, only
+//                      the lowest Superstructure band). No Architecture, no Finishes, no MEP.
+//   C3 DAY-0 SUPPORT   nothing on screen during DAY 0 is hanging: every non-exempt element has a
+//                      bearing/embedded support already placed.
+//   C4 NO EARLY MEP    no MEP phase appears in the opening window (default 3 days).
+//
+// The judge is REQUIRED from viewer/support_sweep.js and never re-derived here (4D_MODEL_INTEGRITY
+// §G.0). The ground exemption is the SHIPPED one, schedule_gate.js:1210 `T.seq !== 1`.
+// Input is the PERSISTED run (scripts/cache_4d_run.js) — the pipeline is not re-run per witness.
+'use strict';
+const path = require('path'), os = require('os');
+const ROOT = path.join(__dirname, '..', '..');
+const SG = require(path.join(ROOT, 'viewer', 'schedule_gate.js')); global.ScheduleGate = SG;
+const SS = require(path.join(ROOT, 'viewer', 'support_sweep.js'));
+const CACHE = require(path.join(ROOT, 'scripts', 'cache_4d_run.js'));
+
+const BUILDINGS = process.argv.slice(2).filter(a => a[0] !== '-').length
+  ? process.argv.slice(2).filter(a => a[0] !== '-')
+  : ['Duplex', 'HHS_Office_Federated', 'Hospital', 'Terminal'];
+const DAY_MS = 86400000;
+const MEP_WINDOW_D = process.env.MEP_WINDOW_D ? Number(process.env.MEP_WINDOW_D) : 3;
+
+// A claim that cannot say INCONCLUSIVE is not a claim. `pop` is the population it judged.
+function claim(id, bld, pop, bad, detail) {
+  const verdict = pop === 0 ? 'INCONCLUSIVE' : (bad === 0 ? 'PASS' : 'FAIL');
+  console.log('§W_D0 ' + id + ' ' + bld.padEnd(22) + verdict.padEnd(13) +
+    'judged=' + String(pop).padEnd(7) + 'bad=' + String(bad).padEnd(7) + (detail || ''));
+  return verdict;
+}
+
+function run(bld) {
+  const r = CACHE.read(bld);
+  if (!r) { console.log('§W_D0 CACHE_MISS ' + bld + ' — run: node scripts/cache_4d_run.js ' + bld); return ['INCONCLUSIVE']; }
+  const els = r.els, sched = r.sched;
+  const EPS = SG.EPS, GAP = SG.GAP;
+  const G = SS.contactGraph(els);
+  if (!G.ok) { console.log('§W_D0 JUDGE_UNAVAILABLE ' + bld); return ['INCONCLUSIVE']; }
+  const t0 = Math.min.apply(null, Object.keys(sched).map(g => sched[g].s));
+  const out = [];
+
+  // ── C1 BAND MODEL ──────────────────────────────────────────────────────────────────────────
+  // A level is a DATUM (4D_MODEL_INTEGRITY §C) and bands must be disjoint by construction.
+  //
+  // ⚠ THIS CLAIM WAS WRONG ON ITS FIRST WRITING AND IS KEPT HERE AS THE CORRECTION. The first
+  // version tested whether adjacent bands' element base_z percentile ranges overlapped, and it
+  // FAILED all four buildings — on Hospital by 0.01m (Level 2 p95=176.51 vs Level 3 p05=176.50),
+  // which is a floor-plate thickness, not a broken band model. That is a bounding-box test with a
+  // tolerance constant, i.e. exactly the proxy reasoning §E forbids, and it produced a red that
+  // meant nothing. Deleted.
+  //
+  // What replaces it needs NO tolerance at all: compare the storeys the IFC ITSELF DECLARES
+  // (spatial_structure IfcBuildingStorey rows, persisted by scripts/cache_4d_run.js) against the
+  // bands the schedule actually uses. A schedule that invents more levels than the model declares
+  // is wrong as a matter of fact, not of threshold. Where the DB carries no spatial_structure at
+  // all (Duplex and Hospital, measured) this claim reports INCONCLUSIVE — absent is reported as
+  // absent, never guessed.
+  //
+  // Datum collision is kept as a SECONDARY count and is honest about its own limit: it uses this
+  // module's existing GAP (0.5m), so it catches two names at the same floor and UNDERCOUNTS names
+  // one ceiling-void apart (Terminal's "Ceiling Level 04"@33.3m vs "Aras 03"@34.0m are 0.7m apart
+  // and are the same physical floor, but do not trip it). It is a floor on the defect, not a
+  // measure of it — which is why the declared-vs-scheduled test above is the actual claim.
+  const byBand = {};
+  els.forEach(e => { const b = SG.collapsePhase(e.storey); (byBand[b] = byBand[b] || []).push(e.bz); });
+  const bands = Object.keys(byBand).filter(b => !/^_?unknown$/i.test(b)).map(b => {
+    const zs = byBand[b].slice().sort((x, y) => x - y);
+    return { b: b, n: zs.length, mid: zs[Math.floor(zs.length / 2)] };
+  }).sort((a, b) => a.mid - b.mid);
+  let collide = 0; const collisions = [];
+  for (let i = 1; i < bands.length; i++) {
+    if (Math.abs(bands[i].mid - bands[i - 1].mid) <= GAP) {
+      collide++; collisions.push(bands[i - 1].b + ' ~ ' + bands[i].b + ' @' + bands[i].mid.toFixed(2) + 'm');
+    }
+  }
+  const declared = r.storeys ? r.storeys.length : null;
+  const excess = declared == null ? 0 : Math.max(0, bands.length - declared);
+  out.push(claim('C1_BAND_MODEL ', bld, declared == null ? 0 : bands.length, excess + collide,
+    (declared == null
+      ? 'spatial_structure ABSENT from this DB — the model declares no storeys to check against'
+      : 'declaredStoreys=' + declared + ' scheduledBands=' + bands.length + ' excess=' + excess) +
+    ' datumCollisions=' + collide +
+    (collisions.length ? ' [' + collisions.slice(0, 4).join(' | ') + ']' : '')));
+
+  // ── C2 DAY-0 PURITY + C3 DAY-0 SUPPORT ─────────────────────────────────────────────────────
+  const cur = t0 + DAY_MS;
+  const placed = els.map(e => (sched[e.guid] && sched[e.guid].s <= cur) ? 1 : 0);
+  const onScreen = placed.reduce((a, b) => a + b, 0);
+  const modelsSub = els.some(e => e.seq === 1);
+  const phaseHist = {}; let impure = 0; const impureCls = {};
+  for (let i = 0; i < els.length; i++) {
+    if (!placed[i]) continue;
+    const ph = els[i].phase || '_UNPHASED';
+    phaseHist[ph] = (phaseHist[ph] || 0) + 1;
+    // Pure opening = Substructure. Where the building models NO Substructure at all, the lowest
+    // Superstructure band is the legitimate opening (HHS models zero foundations — 4D_template.json
+    // says so explicitly and "_empty_ok": absent must be reported, never silently skipped).
+    const ok = modelsSub ? (els[i].seq === 1) : (els[i].seq <= 4);
+    if (!ok) { impure++; impureCls[els[i].cls] = (impureCls[els[i].cls] || 0) + 1; }
+  }
+  out.push(claim('C2_DAY0_PURITY', bld, onScreen, impure,
+    'modelsSubstructure=' + modelsSub + ' phases{' +
+    Object.entries(phaseHist).sort((a, b) => b[1] - a[1]).map(([k, n]) => k + ':' + n).join(' ') + '}' +
+    (impure ? '  INTRUDERS{' + Object.entries(impureCls).sort((a, b) => b[1] - a[1]).slice(0, 6).map(([k, n]) => k + ':' + n).join(' ') + '}' : '')));
+
+  let judged = 0, hanging = 0; const hangCls = {};
+  for (let i = 0; i < els.length; i++) {
+    if (!placed[i]) continue;
+    if (els[i].seq === 1 || G.grounded[i]) continue;      // shipped 1c + rests on soil
+    judged++;
+    const T = els[i]; let held = 0;
+    for (const j of (G.contacts[i] || [])) {
+      const S = els[j];
+      const bearing = (S.bz < T.bz - EPS && S.tz >= T.bz - GAP);
+      const embedded = (S.bz <= T.bz + EPS && S.tz >= T.tz - EPS);
+      if ((bearing || embedded) && placed[j]) { held = 1; break; }
+    }
+    if (!held) { hanging++; hangCls[T.cls] = (hangCls[T.cls] || 0) + 1; }
+  }
+  out.push(claim('C3_DAY0_SUPPORT', bld, judged, hanging,
+    (hanging ? 'hanging{' + Object.entries(hangCls).sort((a, b) => b[1] - a[1]).slice(0, 6).map(([k, n]) => k + ':' + n).join(' ') + '}' : 'nothing on screen is unheld')));
+
+  // ── C4 NO EARLY MEP ────────────────────────────────────────────────────────────────────────
+  const mepCur = t0 + MEP_WINDOW_D * DAY_MS;
+  let inWin = 0, mep = 0; const mepCls = {};
+  for (let i = 0; i < els.length; i++) {
+    const st = sched[els[i].guid]; if (!st || st.s > mepCur) continue;
+    inWin++;
+    if (/^MEP/.test(els[i].phase || '')) { mep++; mepCls[els[i].cls] = (mepCls[els[i].cls] || 0) + 1; }
+  }
+  out.push(claim('C4_NO_EARLY_MEP', bld, inWin, mep, 'window=' + MEP_WINDOW_D + 'd' +
+    (mep ? ' MEP{' + Object.entries(mepCls).map(([k, n]) => k + ':' + n).join(' ') + '}' : '')));
+  return out;
+}
+
+const all = [];
+for (const b of BUILDINGS) { all.push.apply(all, run(b)); console.log(''); }
+const fail = all.filter(v => v === 'FAIL').length, inc = all.filter(v => v === 'INCONCLUSIVE').length;
+console.log('§W_D0_VERDICT claims=' + all.length + ' PASS=' + (all.length - fail - inc) +
+  ' FAIL=' + fail + ' INCONCLUSIVE=' + inc + '  ' +
+  (fail ? 'RED' : inc ? 'NOT GREEN — a claim judged nothing; an empty population is not a pass' : 'GREEN'));
+process.exit(fail ? 1 : 0);


### PR DESCRIPTION
Closes the measurement `4D_MODEL_INTEGRITY.md` §G.3 item 1 rested on. That headline was measured once and never committed as a script, so it could not be re-run. It is now a script, and the script disagrees with it.

**Two probes, no shipped code changes.**

## The number

| building | judged | unsupported | class |
|---|---|---|---|
| Duplex | **0** | 0 | `§D0_VACUOUS` — all 11 in-scope elements are seq-1 |
| HHS_Office_Federated | 126 | **0** | — |
| Hospital | 566 | **13** | `IfcColumn` ×13 |
| Terminal | 158 | **6** | `IfcColumn` ×6 (4 never held at all) |

21 of 21 are `IfcColumn`. Zero `IfcMember`.

## It cannot go green on an empty population

The first draft sampled one cursor (DAY 0 HR 3) and read **0 on all four buildings** — because at that instant every in-scope element was ground-exempt and the judge had nothing to judge. `§D0_VACUOUS` now fires when `judged === 0` and the verdict prints `INCONCLUSIVE`, never `PASS`. The answer is also computed as an interval `[start_i, firstSupportStart_i)` with a sweep-line for peak concurrency, so there is no cursor to pick wrongly.

Exemption is the shipped one (`schedule_gate.js:1210` `T.seq !== 1`), not a re-derived one. Judge required from `support_sweep.js`; the contact relation is never re-derived here.

## Cause is the contact predicate, not scheduling

**(a) The support top is unbounded.** Hospital column `0Qqamdk$17GhXBxDp5aFcc` (bz 166.445) takes as its only "bearing" contacts elements topping at **177.811 and 170.611 — 11.4 m and 4.2 m above its own base** — while the pile cap actually under it (`IfcFooting`, top 165.511, 0.933 m below) and the slab (165.811, 0.633 m below) are rejected, because `GAP = 0.5`.

`support_sweep.js:411` has no top bound. `schedule_gate.js:1195` (§S64) applies `S.top_z <= T.base_z + GAP` to the same relation, for exactly this reason — 73 fleet-wide false verdicts.

`§D0_TOPBOUND` measures the gap between the two copies: **Hospital 941/2944 = 32.0%** of in-scope bearing contacts are supports whose top is above the base they carry (Terminal 10.7%, HHS 0.0%). Applying §S64's bound removes false supports, so the count **rises**: Hospital 13 → 30, Terminal 6 → 7. Reported only — changing `_contactGraph` moves the scheduler, the lock gate and the audit together.

**(b) Real vertical voids.** Terminal's 4 "never held" columns (bz 34.768, Observatory Deck) have nothing below within **4.000 m**; their only contact is a carrier above. A model defect, not a scheduling one.

## Also in here

`scripts/probe_enclosure_geometry.js` — cited by §E and §G.2 as the source of "63 uncountable → 10" — had been living unversioned on one disk. Committed. Re-run reproduces §E exactly (Duplex 1026/1119 = 91.7%, HHS 5217/6839 = 76.3%, `des=-1` 28→26/2 and 63→53/10). One §G.2 number is stale: HHS enclosure on floating is **245 → 20**, not 209 → 18.

## Flagged for `fix/tpl-layer-order` (#unmerged)

Deliberate A/B, same probe, same DBs, one `viewer/` checkout apart:

| viewer | Hospital | Terminal |
|---|---|---|
| `origin/main` @ `6b12783` | **13** | 6 |
| `fix/tpl-layer-order` @ `50a4cfe` | **15** | 6 |

`§TPL_LAYER_SELFCHECK` reports PASS on that run — it skips cross-task pairs (`if (_taskOf[_S.guid] !== _taskOf[_T.guid]) continue;`) and both extra columns are held from a different task. Worth measuring before that branch lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)