### PR TITLE
fix(4d): §STOREY_DATUM_FLOOR + §STOREY_ROW_EMIT — the injected storey datum is the FLOOR, and every walked storey gets a row

### DIFF
--- a/scripts/probe_storey_datum.js
+++ b/scripts/probe_storey_datum.js
@@ -1,0 +1,119 @@
+#!/usr/bin/env node
+// probe_storey_datum.js — Implementing bim-compiler prompts/4D_MODEL_INTEGRITY.md §K.4 + §L item 1.
+//
+// ⚠ DO NOT REMOVE — SCOPE. Two questions, no others:
+//   1. Is the injected storey datum (`room_walker.js` `compileRooms()` -> stZ) the FLOOR, or is it
+//      mean wall CENTRE-z? §K.4 measured it 0.64-3.16 m high on Terminal, which bands every element
+//      one level DOWN under §STOREY_DATUM (`schedule_author.js`, PR #1551).
+//   2. How many storeys does the walker WALK but never emit a `spatial_structure` row for, because
+//      `writeRooms()` emits one only where a room compiled?
+// Read the §STOREY_DATUM_PROBE log after every run. Nothing here re-derives the walker's own
+// numbers from scratch: the wall set is taken from the EXPORTED `storeyWalls()` primitive with the
+// EXACT arguments `compileRooms()` passes it, so the cross-check is an independent read of the same
+// source rows, not a copy of the internal reduce.
+//
+// The shipped building DB is NEVER mutated — it is copied to a scratch path first and writeRooms()
+// runs against the copy.
+'use strict';
+const fs = require('fs'), path = require('path'), os = require('os');
+const HOME = os.homedir();
+const initSqlJs = require(path.join(HOME, 'bim-ootb', 'node_modules', 'sql.js'));
+const SQLJS_DIST = path.join(HOME, 'bim-ootb', 'node_modules', 'sql.js', 'dist');
+const RW = require(path.join(__dirname, '..', 'viewer', 'lib', 'room_walker.js'));
+
+const BLD = process.env.BLD_DIR || path.join(HOME, 'bim-ootb', 'buildings');
+const SCRATCH = process.env.SCRATCH || '/tmp/storey_datum_probe';
+const BUILDINGS = process.argv.slice(2).length ? process.argv.slice(2) : ['Terminal'];
+
+const mean = a => a.reduce((s, x) => s + x, 0) / a.length;
+const med = a => { const v = a.slice().sort((x, y) => x - y); const n = v.length;
+  return n ? (n % 2 ? v[(n - 1) / 2] : (v[n / 2 - 1] + v[n / 2]) / 2) : NaN; };
+const f3 = x => (x === null || x === undefined || Number.isNaN(x)) ? '   n/a' : x.toFixed(3).padStart(8);
+const rows = (db, q) => { let r; try { r = db.exec(q); } catch (e) { return []; }
+  if (!r.length) return []; return r[0].values.map(v => { const o = {};
+    r[0].columns.forEach((c, i) => { o[c] = v[i]; }); return o; }); };
+
+(async () => {
+  const SQL = await initSqlJs({ locateFile: f => path.join(SQLJS_DIST, f) });
+  fs.mkdirSync(SCRATCH, { recursive: true });
+
+  for (const bld of BUILDINGS) {
+    let src = path.join(BLD, bld + '_meta.db');
+    if (!fs.existsSync(src) || fs.statSync(src).size === 0) src = path.join(BLD, bld + '_extracted.db');
+    if (!fs.existsSync(src)) { console.log('§STOREY_DATUM_PROBE ' + bld + ' SKIP no DB'); continue; }
+    const work = path.join(SCRATCH, bld + '_probe.db');
+    fs.copyFileSync(src, work);                       // never touch the shipped DB
+    const db = new SQL.Database(fs.readFileSync(work));
+
+    console.log('\n══════ §STOREY_DATUM_PROBE ' + bld + '  (src=' + path.basename(src) + ') ══════');
+
+    // ── independent read of the SAME wall set compileRooms() uses (exported primitives, same args)
+    const ds = RW.doorStats(db);
+    const vertMin = ds.h > 0 ? RW.VERT_FACTOR * ds.h : 0.0;
+    const anchors = RW.storeyZAnchors(db);
+    const wallsBy = RW.storeyWalls(db, vertMin, anchors);   // rows: [cx,cy,cz,bx,by,bz]
+
+    // ── the walker's own output
+    const compiled = RW.compileRooms(db);
+    const stZ = compiled.stZ, allrooms = compiled.rooms;
+
+    // ── reference "where is the floor really": median slab TOP per raw storey label
+    const slabTop = {};
+    rows(db, "SELECT m.storey st, t.center_z cz, t.bbox_z bz FROM elements_meta m " +
+             "JOIN element_transforms t ON t.guid=m.guid WHERE m.ifc_class LIKE 'IfcSlab%' " +
+             "AND t.center_z IS NOT NULL")
+      .forEach(r => { (slabTop[r.st] = slabTop[r.st] || []).push(r.cz + (r.bz || 0) / 2); });
+
+    console.log('storey                |walls| stZ(shipped)| meanCentreZ| meanBaseZ | rooms | slabTop | err_vs_slab');
+    console.log('----------------------|-----|-------------|------------|-----------|-------|---------|------------');
+    const walked = Object.keys(wallsBy).sort();
+    let emitted = 0, walkedGate = 0, dropped = 0;
+    for (const st of walked) {
+      const ws = wallsBy[st];
+      const tooFew = ws.length < 3;                        // the walker's own gate (:1157)
+      if (!tooFew) walkedGate++;
+      const mc = mean(ws.map(w => w[2]));                  // mean wall CENTRE-z  (the bug)
+      const mb = mean(ws.map(w => w[2] - w[5] / 2));       // mean wall BASE-z    (the fix)
+      const nRooms = allrooms.filter(r => r.storey === st).length;
+      if (!tooFew && nRooms > 0) emitted++;
+      if (!tooFew && nRooms === 0) dropped++;
+      const stop = slabTop[st] ? med(slabTop[st]) : null;
+      const shipped = stZ[st];
+      const err = (shipped !== undefined && stop !== null) ? shipped - stop : null;
+      console.log(st.slice(0, 21).padEnd(22) + '|' + String(ws.length).padStart(5) + '|' +
+        (shipped === undefined ? '   (not set)' : f3(shipped)).padStart(13) + '|' + f3(mc).padStart(12) + '|' +
+        f3(mb).padStart(11) + '|' + String(nRooms).padStart(7) + '|' + f3(stop) + '|' + f3(err));
+    }
+
+    // ── which reduce does the shipped stZ actually match?
+    let matchCentre = 0, matchBase = 0, n = 0;
+    for (const st of Object.keys(stZ)) {
+      const ws = wallsBy[st]; if (!ws) continue; n++;
+      if (Math.abs(stZ[st] - mean(ws.map(w => w[2]))) < 1e-9) matchCentre++;
+      if (Math.abs(stZ[st] - mean(ws.map(w => w[2] - w[5] / 2))) < 1e-9) matchBase++;
+    }
+    console.log('§STOREY_DATUM_PROBE ' + bld + ' stZ_reduce: matches_meanCentreZ=' + matchCentre +
+                '/' + n + '  matches_meanBaseZ=' + matchBase + '/' + n +
+                '   VERDICT=' + (matchBase === n && n > 0 ? 'FLOOR (fixed)'
+                              : matchCentre === n && n > 0 ? 'MID-WALL (§K.4 defect present)'
+                              : n === 0 ? 'INCONCLUSIVE (no storeys walked)' : 'MIXED'));
+
+    // ── Bug 2: how many walked storeys never reach spatial_structure
+    console.log('§STOREY_DATUM_PROBE ' + bld + ' emit: storeysInStZ=' + Object.keys(stZ).length +
+                ' withRooms=' + emitted + ' withoutRooms=' + dropped +
+                ' -> old guard would DROP ' + dropped + ' storey row(s)');
+
+    // ── run the real writeRooms() against the copy and COUNT what actually landed
+    RW.writeRooms(db, compiled);
+    const st_rows = rows(db, "SELECT guid,name,center_z FROM spatial_structure " +
+      "WHERE type='IfcBuildingStorey' AND guid LIKE 'STC\\_%' ESCAPE '\\' ORDER BY center_z");
+    console.log('§STOREY_DATUM_PROBE ' + bld + ' writeRooms -> STC_ rows=' + st_rows.length);
+    st_rows.forEach(r => console.log('   STC row  ' + String(r.name).padEnd(24) + f3(r.center_z)));
+    // what the §STOREY_DATUM consumer (schedule_author.js) will actually read
+    const usable = rows(db, "SELECT name, center_z FROM spatial_structure " +
+      "WHERE type='IfcBuildingStorey' AND center_z IS NOT NULL");
+    console.log('§STOREY_DATUM_PROBE ' + bld + ' consumer-visible datum rows (center_z NOT NULL)=' +
+                usable.length + '  [schedule_author.js §STOREY_DATUM band source]');
+    db.close();
+  }
+})().catch(e => { console.error('PROBE FAILED', e); process.exit(1); });

--- a/viewer/lib/room_walker.js
+++ b/viewer/lib/room_walker.js
@@ -1188,7 +1188,19 @@
       var rescued = rooms.filter(function (r) { return r.door_rescued; }).length;
       var partitioned = rooms.filter(function (r) { return r.door_partitioned; }).length;
       var suspects = rooms.filter(function (r) { return r.suspect; }).length;
-      stZ[st] = ws.reduce(function (s, w) { return s + w[2]; }, 0) / ws.length; // storey z = mean wall centre-z
+      // §STOREY_DATUM_FLOOR (bim-compiler prompts/4D_MODEL_INTEGRITY.md §K.4, 2026-08-27):
+      // a storey datum is its FLOOR, not wall mid-height. The wall row is [cx,cy,cz,bx,by,bz], so a
+      // wall's base is `w[2] - w[5]/2`. This line read `w[2]` (the CENTRE) until 2026-08-27, which
+      // put every Terminal datum 0.64-3.07 m above the real floor; since `schedule_author.js`
+      // §STOREY_DATUM bands by `base_z ∈ [datum_i, datum_i+1)`, an element standing on the Aras 03
+      // floor (base_z ≈ 16.11) fell into the Aras 02 band — EVERY element on EVERY floor was
+      // assigned one level DOWN, uniformly. The uniformity is why §W_D0 passed over it.
+      var _mCentre = ws.reduce(function (s, w) { return s + w[2]; }, 0) / ws.length;
+      stZ[st] = ws.reduce(function (s, w) { return s + (w[2] - w[5] / 2); }, 0) / ws.length; // storey z = mean wall BASE-z (the floor)
+      // §-log the pair, so the next session reads the datum instead of re-deriving it (PRIMAL LAW 3).
+      console.log('§STOREY_DATUM_FLOOR st=' + st + ' walls=' + ws.length +
+        ' meanCentreZ=' + _mCentre.toFixed(3) + ' meanBaseZ=' + stZ[st].toFixed(3) +
+        ' drop=' + (_mCentre - stZ[st]).toFixed(3));
       report.push({
         storey: st, walls: ws.length, doors: doors.length, method: method, roomCount: rooms.length,
         doorRescued: rescued, doorPartitioned: partitioned, suspect: suspects,
@@ -1349,11 +1361,31 @@
     // per floor via parent_guid -> IfcBuildingStorey.name. Idempotent on the STC_ prefix.
     db.run("DELETE FROM spatial_structure WHERE type='IfcBuildingStorey' AND guid LIKE 'STC\\_%' ESCAPE '\\'");
     var stStmt = db.prepare("INSERT INTO spatial_structure (guid,type,name,parent_guid,object_type,predefined_type,center_z) VALUES (?,?,?,?,?,?,?)");
-    Object.keys(stZ).sort().forEach(function (st) {
-      if (!allrooms.some(function (r) { return r.storey === st; })) return;
+    // §STOREY_ROW_EMIT (bim-compiler prompts/4D_MODEL_INTEGRITY.md §K.3/§K.4, 2026-08-27):
+    // emit a row for EVERY storey the walker walked, not only those where a room happened to
+    // compile. The old guard here was `if (!allrooms.some(r => r.storey === st)) return;`, which
+    // silently dropped real storeys from spatial_structure — a storey whose rooms were all merged
+    // or rejected still HAS a floor, and `schedule_author.js` §STOREY_DATUM reads these rows as its
+    // band source (`WHERE type='IfcBuildingStorey' AND center_z IS NOT NULL`). A missing row is a
+    // missing band, so every element on that floor was banded onto the floor below it.
+    // The guard was NOT protecting against duplicates: it keyed on rooms, not on whether the DB
+    // already had a storey of that name, and MEASURED on Terminal the shipped DB already carries 6
+    // same-name real rows per storey alongside each STC_ row. Those real rows have center_z NULL on
+    // every shipped DB, so the datum consumer never sees them and cannot be confused by them.
+    // `stZ` only ever holds storeys that PASSED the >=3-wall gate, so this cannot emit a row for a
+    // storey the walker never actually walked.
+    var stKeys = Object.keys(stZ).sort(), stWithRooms = 0;
+    stKeys.forEach(function (st) {
+      if (allrooms.some(function (r) { return r.storey === st; })) stWithRooms++;
       stStmt.run([('STC_' + st).replace(/ /g, '_'), 'IfcBuildingStorey', st, null, 'COMPILED', null, stZ[st]]);
     });
     stStmt.free();
+    // A pass that cannot report a no-op is not a witness (PRIMAL LAW 4): say how many rows the old
+    // guard would have dropped, and say VACUOUS out loud when there was nothing to emit at all.
+    console.log('§STOREY_ROW_EMIT walked=' + stKeys.length + ' withRooms=' + stWithRooms +
+      ' withoutRooms=' + (stKeys.length - stWithRooms) + ' emitted=' + stKeys.length +
+      ' (old guard would have emitted ' + stWithRooms + ')' +
+      (stKeys.length === 0 ? ' VACUOUS: no storey passed the >=3-wall gate — this 0 means nothing' : ''));
     // remove any prior compiled rooms (idempotent)
     db.run("DELETE FROM spatial_structure WHERE type='IfcSpace' AND guid LIKE 'RM\\_%' ESCAPE '\\'");
     var roomStmt = db.prepare("INSERT INTO spatial_structure (guid,type,name,parent_guid,object_type,predefined_type," +


### PR DESCRIPTION
Implementing bim-compiler `prompts/4D_MODEL_INTEGRITY.md` **§K.4 / §L item 1**. Two one-line defects in `viewer/lib/room_walker.js`, both measured.

## Bug 1 — the datum was mid-wall, not a floor (`:1191`)

`stZ[st] = mean(w[2])` averaged wall **centre**-z. The wall row is `[cx,cy,cz,bx,by,bz]`, so the floor is `w[2] - w[5]/2`.

`schedule_author.js` §STOREY_DATUM bands by `base_z ∈ [datum_i, datum_i+1)`, so a datum ~2 m high pushed **every element on every floor into the band below it, uniformly** — which is exactly why §W_D0 stayed green over it.

Terminal, injected datum vs that storey's own median slab top:

| storey | before | after |
|---|---|---|
| Aras Tanah | +3.072 | +0.511 |
| Aras 01 | +1.947 | +0.146 |
| Aras 02 | +1.779 | +0.102 |
| Aras 03 | +1.770 | **+0.001** |
| Aras 04 | +2.374 | +0.200 |
| Aras Bumbung | +0.638 | -0.000 |

Fleet: **22/22** storeys across Terminal/Hospital/Clinic/Duplex/HHS now equal mean wall base-z (**0/22** equal mean centre-z). HHS lands within 30 mm on all three levels.

## Bug 2 — a storey row was emitted only where a room compiled (`:1353`)

The `allrooms.some(...)` early-return dropped storeys the walker *had* walked. A storey whose pockets were all merged or rejected still has a floor, and these rows **are** the §STOREY_DATUM band source — a missing row is a missing band.

- Terminal **6 → 7** rows (`GROUND FLOOR LEVEL`)
- Hospital **7 → 8** (`Level 7A`, a mezzanine at 196.470 with no band at all between Level 6 @192.159 and Level 7 @199.814)

**Guard removal is safe — checked, not assumed.** It keyed on *rooms*, never on whether the DB already had a storey of that name, so it never prevented duplicates: Terminal already ships 6 same-name real rows per storey beside each `STC_` row. Those real rows carry `center_z` NULL on every shipped DB, so the consumer's `WHERE type='IfcBuildingStorey' AND center_z IS NOT NULL` never sees them. And `stZ` only holds storeys past the `>=3`-wall gate, so this cannot emit a storey that was never walked.

## Evidence

Both sites now `§`-log (PRIMAL LAW 3/4). `§STOREY_DATUM_FLOOR` prints centre and base side by side so the pair is never re-derived by hand; `§STOREY_ROW_EMIT` reports walked/withRooms/withoutRooms and says `VACUOUS` out loud when nothing passed the gate.

```
§STOREY_DATUM_FLOOR st=Aras 03 walls=39 meanCentreZ=17.879 meanBaseZ=16.110 drop=1.769
§STOREY_ROW_EMIT walked=7 withRooms=6 withoutRooms=1 emitted=7 (old guard would have emitted 6)
```

## Regression

- `witness_s50_cell_engine` — `bad=0`
- `witness_s55_identity_vs_cell` — 6 pass / 0 fail
- `witness_stair_flight_assembly_merge` — 4 pass / 0 fail (the only caller of *both* `compileRooms` and `writeRooms`)
- `witness_midair_zero` — **10 pass / 3 fail both before and after**, run on unmodified `main` to confirm. Its judged numbers (makespan 247.3, midair 903, float 543, orphans 25) are byte-identical across the fix; the diff is only the new `§` lines plus ms jitter. Those 3 locked baselines are pre-existing and are §L item 2's re-baseline, **not** a regression from this PR.

No `sw.js` CACHE_VERSION bump needed: `sw.js:552` already exempts `lib/room_walker.js` to network-first.

## Follow-ups (named, not done here — out of this PR's scope)

1. **The shipped DBs and baked patches still carry the old mid-wall datums.** This fixes the *generator*; `buildings/Terminal_meta.db` and `buildings/patches/Terminal_meta.db.sql` still hold the 6 old values (10.066, 13.838, 17.819, 22.629, 25.126, 3.049) and no `GROUND FLOOR LEVEL` row. Regenerating those is a DB-content change and needs the patch + self-heal-loader flow.
2. **py/js lockstep is now diverged.** `bim-compiler/scripts/compile_rooms.py:1232` (Bug 1) and `:1267` (Bug 2), and the stale copy at `bim-compiler/build/room_walker.js:1169`/`:1253`, still carry both bugs. They remain in lockstep *with each other*, so `witness_room_walker_parity.js` (which compares those two, not this file) is unaffected today — but the discipline says they should be mirrored, together with a `ROOM_WALKER_V` bump.
3. Terminal's `GROUND FLOOR LEVEL` datum (0.109) now sits only 0.511 m under `Aras Tanah` (0.620), making a thin band. It is a real walked storey with 3 walls whose own slab top is -0.490; worth a look, not touched here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)