### PR TITLE
fix(4d): §TPL_MODEL — name which model ran, precache the template, and make the edit witness judge the canonical one

### DIFF
--- a/viewer/schedule_author.js
+++ b/viewer/schedule_author.js
@@ -712,8 +712,25 @@
     // §TEMPLATE_INSTANTIATE — when a template is supplied, the TASK GRID comes from it and the
     // solve is no longer what defines the phases (see instantiateTemplate's header). The legacy
     // grouping path below is left byte-identical for every caller that passes no template.
-    if (opts.template) return _writeTemplateSchedule(db, elements, schedule, opts, SG,
-      storeyMergeMap, laborRates, schedId, start, _displayAuthored);
+    //
+    // §TPL_MODEL (2026-08-27, bim-compiler prompts/4D_MODEL_INTEGRITY.md §L) — NAME WHICH OF THE
+    // TWO MODELS RAN, on BOTH branches. The 2026-08-27 user ruling makes the template path the
+    // CANONICAL model and deriveZones dead code, so this fork is no longer a graceful degrade: it
+    // is the difference between the model of record and a model nobody stands behind. It used to
+    // be SILENT, which is the exact defect class this lane keeps paying for — every downstream
+    // number was unattributable to a construct, and `witness_gantt_edit_coherence` passed 10/0
+    // while judging the legacy path (its materializeZones call passes no `template:`).
+    // PRIMAL LAW clause 4: a pass that cannot report that it took the dead branch is not a pass.
+    if (opts.template) {
+      var _tv = (opts.template.meta && opts.template.meta.version) || '?';
+      console.log('§TPL_MODEL model=template v=' + _tv +
+        ' — CANONICAL: the task grid is DECLARED by 4D_template.json');
+      return _writeTemplateSchedule(db, elements, schedule, opts, SG,
+        storeyMergeMap, laborRates, schedId, start, _displayAuthored);
+    }
+    console.warn('§TPL_MODEL model=legacy-deriveZones — ⛔ the CANONICAL template path did NOT ' +
+      'run (opts.template absent). Phases become an ENVELOPE over what the elements did, and an ' +
+      'envelope cannot constrain what drew it. Every number from this schedule is off-model.');
 
     var rolled = SG.deriveZones(elements, schedule, storeyMergeMap);
     if (!rolled.zones.length) { console.log('§AUTHOR_ZONES_FAIL reason=no_zones'); return { ok: false, reason: 'no_zones' }; }

--- a/viewer/sw.js
+++ b/viewer/sw.js
@@ -22,7 +22,11 @@
 // schedule_author.js is in PRECACHE_ASSETS; v1088 shipped the STAGE 3 drawer change (#1528), so this
 // separate change needs its own bump (§CRISIS LESSON 4).
 // DEPLOY: bump CACHE_VERSION on every OCI upload. Old caches are purged on activate.
-const CACHE_VERSION = 'v1089';   // bump on each deploy; per-change detail is the git commit message.
+const CACHE_VERSION = 'v1090';   // bump on each deploy; per-change detail is the git commit message.
+// v1090 (2026-08-27) §TPL_MODEL: rates/4D_template.json ADDED to PRECACHE_ASSETS (it defines the
+// canonical task grid and was never precached, so offline/cold-SW silently ran the dead deriveZones
+// path), plus schedule_author.js now names which model ran at the fork. Both are precached, so
+// without this bump an installed worker keeps serving the version with neither.
 // v1084 (2026-08-25) §CPE_BUILDUP_REQUIRE_TM_FIRST (CINEMA_PATH_EDITOR.md, user ruling "no auto
 // JSON outside TM"): Alt+C's bake no longer generates a building's first-ever 4D schedule.
 // window.tmHasExistingSchedule() (time_machine.js) — read-only, no DB writes, never generates —
@@ -477,6 +481,13 @@ const PRECACHE_ASSETS = [
   // Shared sequence/labour rules — one source for 4D schedule baker + drone order.
   // Precached so loadSequenceRules() resolves offline (else falls to hardcoded).
   'rates/sequence_rules.json',
+  // §TPL_MODEL (2026-08-27) — the 4D programme template DEFINES the canonical task grid
+  // (schedule_author.js instantiateTemplate; user ruling 2026-08-27). It was NOT precached while
+  // sequence_rules.json above was, so on a cold SW or offline the fetch in time_machine.js
+  // _load4DTemplate() fails, _4dTemplate stays null, and materializeZones silently takes the dead
+  // deriveZones path. _4dTemplateTried makes that one-shot, so ONE failed fetch drops the
+  // canonical model for the whole session. Precached so the model of record always loads.
+  'rates/4D_template.json',
   // §S280g: ground texture config + default tile (grass) precached for offline shadow mode.
   // earth/paved are lazy (cacheFirst caches on first selection).
   'ground_config.json',

--- a/viewer/tests/witness_gantt_edit_coherence.js
+++ b/viewer/tests/witness_gantt_edit_coherence.js
@@ -186,8 +186,36 @@ function sliceNamed(src, name) {
   var db = new SQL.Database(fs.readFileSync(dbPath));
   var rulesJson = JSON.parse(fs.readFileSync(path.join(__dirname, '..', 'rates', 'sequence_rules.json'), 'utf8'));
   var SEQUENCE_RULES = rulesJson.SEQUENCE_RULES || rulesJson;
+
+  // §TPL_MODEL (2026-08-27, bim-compiler prompts/4D_MODEL_INTEGRITY.md §L) — JUDGE THE CANONICAL
+  // MODEL. This call used to pass no `template:`, so schedule_author.js's fork fell through to the
+  // legacy deriveZones envelope and every claim below was measured on the model the 2026-08-27
+  // ruling calls DEAD CODE. The witness was 10/0 green over the wrong construct — the failure the
+  // user named as "WITNESS is moot if underlying design is poor", and PRIMAL LAW clause 2's
+  // §CRISIS case: an editor witness that never edited the canonical timeline.
+  var TPL_PATH = path.join(__dirname, '..', 'rates', '4D_template.json');
+  var TPL = fs.existsSync(TPL_PATH) ? JSON.parse(fs.readFileSync(TPL_PATH, 'utf8')) : null;
+
+  // Tee console.log so G-COH-10 can read the shipped §TPL_MODEL verdict rather than re-deriving
+  // which branch ran. PRIMAL LAW clause 3 — the line is still PRINTED, never suppressed.
+  var _seen = [];
+  var _log = console.log, _warn = console.warn;
+  console.log = function () { _seen.push(Array.prototype.join.call(arguments, ' ')); _log.apply(console, arguments); };
+  console.warn = function () { _seen.push(Array.prototype.join.call(arguments, ' ')); _warn.apply(console, arguments); };
+
   var mres = ScheduleAuthor.materializeZones(db, SEQUENCE_RULES,
-    { start: '2026-01-01', laborRates: {}, rates: {}, scheduleGate: ScheduleGate });
+    { start: '2026-01-01', laborRates: {}, rates: {}, scheduleGate: ScheduleGate, template: TPL });
+
+  console.log = _log; console.warn = _warn;
+  var _modelLine = _seen.filter(function (l) { return l.indexOf('§TPL_MODEL') === 0; }).pop() || '';
+  var _isCanonical = _modelLine.indexOf('model=template') >= 0;
+  // VACUOUS-aware: if the fork emitted nothing at all we cannot say which model ran, and that is
+  // an INCONCLUSIVE state, not a pass. It is reported as a FAIL because a witness that cannot see
+  // its own subject is exactly the §CRISIS this claim exists to prevent recurring.
+  check('G-COH-10 the-model-under-test-is-the-CANONICAL-template-path',
+    _isCanonical,
+    _modelLine ? _modelLine.slice(0, 120)
+               : 'INCONCLUSIVE — no §TPL_MODEL line was emitted; which model was judged is UNKNOWN');
   if (!mres.ok) {
     console.log('§W-COH SKIP G-COH-7..9 — materializeZones failed: ' + JSON.stringify(mres));
     console.log('§W-COH RESULT pass=' + pass + ' fail=' + fail);


### PR DESCRIPTION
## What this is

The 2026-08-27 user ruling makes the **template path** (`schedule_author.js` `instantiateTemplate`) the canonical 4D model, and `deriveZones` dead code (`bim-compiler prompts/4D_MODEL_INTEGRITY.md` §A banner / §L).

I traced the live path first. **The wiring is correct**: `instantiateTemplate` (`schedule_author.js:425`) → `_writeTemplateSchedule` (`:965`) persists `tasks`/`task_elements`/`task_sequences` (`:1040-1055`) → `time_machine.js buildTaskIndex()` (`:5290`) reads those same rows back (`:5341`, `:5347`) → `gantt_model.js buildTasks()` (`:96`) draws each bar at its **task** window (`:167-176`). `§TPL_REACHED` is green: all four production call sites pass `template:`.

What was wrong is that **three holes let the canonical model be swapped for the dead one silently**.

## The three holes

1. **`schedule_author.js:715` — the fork was SILENT.** A falsy `opts.template` fell through to `SG.deriveZones` with no log line. No downstream number could be attributed to a construct. Both branches now emit `§TPL_MODEL`; the legacy branch warns the schedule is off-model. (PRIMAL LAW clause 4 — a pass that cannot report it took the dead branch is not a pass.)

2. **`sw.js` — `rates/4D_template.json` was never precached.** The file that *defines* the canonical task grid was missing from `PRECACHE_ASSETS`, while `rates/sequence_rules.json` — which §I calls "a MIRROR, never executed" — was in it. Offline or on a cold SW, `_load4DTemplate()`'s fetch fails, `_4dTemplate` stays null, and the dead path runs. `_4dTemplateTried` is one-shot, so **one failed fetch drops the canonical model for the whole session.** `CACHE_VERSION` v1089 → v1090.

3. **`witness_gantt_edit_coherence.js:189` — the flagship edit witness judged the dead model.** It passed no `template:`, so all 10 claims were measured on `deriveZones`. Green over the wrong construct — PRIMAL LAW clause 2's §CRISIS case: an editor witness that never edited the canonical timeline. It now builds its fixture from the template, and **G-COH-10** asserts from the shipped `§TPL_MODEL` line that the canonical model is what was judged.

## Measured (Duplex)

| | model | grid | move cascaded | result |
|---|---|---|---|---|
| before | `§AUTHOR_ZONES` | zones=21 edges=30 | **8** | 10 pass / 0 fail |
| after | `§AUTHOR_TPL` v=1.2.0 | tasks=20 edges=29 (withinLevel=16 acrossLevels=13) | **16** | 11 pass / 0 fail |

The canonical model's *declared* edges propagate an edit to **twice as many** downstream tasks. That is a real behavioural difference no witness was seeing.

**RED CONTROL** — with `4D_template.json` moved aside: `§TPL_MODEL model=legacy-deriveZones`, G-COH-10 **FAILS** (10 pass / 1 fail, exit 1) while the other ten claims still pass. That asymmetry is exactly why this stayed invisible.

## Regression — all green

`witness_4d_template_reached` 6/0 · `witness_4d_template_instantiation` 11/0 · `witness_gantt_lock_integrity` 20/0 · `witness_tm_edit_exception` 23/0 · `witness_whatif_authored_sync` 9/9 · `witness_zone_cpm` 11/0 · `witness_gantt_edit_constraints` 18/0 · `witness_gantt_bar_identity` 6/0 · `witness_geo_support_leak` PASS.

## Not fixed here (reported, not silently expanded)

- **24 of 35** witnesses/probes that call `materializeZones` still pass no `template:` and therefore judge the dead model. Converting them is a separate pass — some may legitimately test legacy behaviour. Census is in the session report.
- `witness_zone_cpm_duplex.js:40` has a **hardcoded absolute path to a dead scratchpad dir** from an old session, so it fails on unmodified `main` too. Pre-existing, unrelated.

Spec: `bim-compiler prompts/4D_MODEL_INTEGRITY.md` §L.

🤖 Generated with [Claude Code](https://claude.com/claude-code)