### PR TITLE
fix(4d): the TM persist data-loss — our own LRU evictor deleted the user's edit

### DIFF
--- a/scripts/probe_tm_persist_dataloss.js
+++ b/scripts/probe_tm_persist_dataloss.js
@@ -1,0 +1,227 @@
+#!/usr/bin/env node
+// PROBE — root-cause + witness for the TM persist DATA-LOSS (bim-compiler 4D_GANTT_TM_REFACTOR.md §5b).
+//
+// SYMPTOM: persistDb() returns ok=true, logs §SCHED_PERSIST, emits no §SCHED_PERSIST_ERR — and the
+// IndexedDB 'dbs' store ends up EMPTY, the user's edit silently replaced by the pristine network copy
+// on a later reload.
+//
+// MEASURED CAUSE (this probe's own log, run 1): scene.js cachedFetch's quota-retry ladder calls
+// A._evictOldest(cacheDb, 4) on ANY transaction abort. With only 2 entries in the store, "drop the 4
+// oldest" drops EVERYTHING — including buildings/<B>_meta.db, the slot persistDb just wrote the user's
+// edit into. The abort came from the 239MB Hospital_geo.db write, and the code asserts "quota too
+// small" without ever reading tx.error (quota was 10.2GB, usage 24MB).
+//
+// This probe reproduces the loss END TO END, the way a user meets it:
+//   PHASE A  load -> activate -> edit -> persistDb        (store holds the 55MB edited blob)
+//   PHASE B  reload (same profile)                        (meta read from cache, THEN geo aborts -> evict)
+//   PHASE C  reload again                                 (store empty -> pristine refetch -> EDIT GONE)
+//
+//   node scripts/probe_tm_persist_dataloss.js <BuildingName>
+//   PUPPETEER=/abs/path/to/puppeteer  SERVE_ROOT=<repo root>  PORT=<a FREE port>
+'use strict';
+const { spawn } = require('child_process');
+const puppeteer = require(process.env.PUPPETEER || 'puppeteer');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+const PORT = Number(process.env.PORT || 8271);
+const ROOT = process.env.SERVE_ROOT || process.cwd();
+const BUILDING = process.argv[2] || 'Hospital';
+const REPEATS = Number(process.env.REPEATS || 3);
+const SETTLE = Number(process.env.SETTLE || 20000);
+const URL = `http://localhost:${PORT}/viewer/viewer.html?db=/buildings/${BUILDING}_extracted.db`;
+const PROFILE_DIR = fs.mkdtempSync(path.join(os.tmpdir(), 'tm-persist-dataloss-'));
+const CHROME = process.env.CHROME || '/home/red1/.cache/puppeteer/chrome/linux-152.0.7977.42/chrome-linux64/chrome';
+
+let pass = 0, fail = 0;
+const check = (name, cond, detail) => {
+  if (cond) { pass++; console.log('  PASS ' + name + (detail ? '  ' + detail : '')); }
+  else { fail++; console.log('  FAIL ' + name + (detail ? '  ' + detail : '')); }
+};
+const MB = n => (n / 1024 / 1024).toFixed(2) + 'MB';
+
+// ── IDB mutation spy, installed before any app script runs ──────────────────────────────────────
+function installSpy() {
+  window.__IDBSPY = [];
+  const rec = (o) => { try { window.__IDBSPY.push(o); } catch (e) {} };
+  const site = () => {
+    try {
+      return (new Error()).stack.split('\n').slice(3, 6)
+        .map(l => l.trim().replace(/^at\s+/, '').replace(/https?:\/\/[^/]+\//, '')).join(' <- ');
+    } catch (e) { return '?'; }
+  };
+  const sizeOf = v => (v && typeof v.byteLength === 'number') ? v.byteLength : -1;
+  const OSp = IDBObjectStore.prototype;
+  const oPut = OSp.put, oDel = OSp.delete, oClr = OSp.clear;
+  OSp.put = function (v, k) {
+    rec({ op: 'put', store: this.name, key: String(k), size: sizeOf(v), at: site() });
+    const r = oPut.apply(this, arguments);
+    try { r.addEventListener('error', () => rec({ op: 'put:ERR', store: this.name, key: String(k), err: (r.error && r.error.name + ':' + r.error.message) || '?' })); } catch (e) {}
+    return r;
+  };
+  OSp.delete = function (k) { rec({ op: 'DELETE', store: this.name, key: String(k), at: site() }); return oDel.apply(this, arguments); };
+  OSp.clear = function () { rec({ op: 'CLEAR', store: this.name, at: site() }); return oClr.apply(this, arguments); };
+  const DBp = IDBDatabase.prototype, oTx = DBp.transaction;
+  DBp.transaction = function (stores, mode) {
+    const tx = oTx.apply(this, arguments);
+    const at = site();
+    try {
+      tx.addEventListener('abort', () => rec({ op: 'tx:ABORT', store: String(stores), err: (tx.error && tx.error.name + ':' + tx.error.message) || '(tx.error is null)', at }));
+      tx.addEventListener('error', () => rec({ op: 'tx:ERROR', store: String(stores), err: (tx.error && tx.error.name + ':' + tx.error.message) || '?', at }));
+    } catch (e) {}
+    return tx;
+  };
+  const oDD = indexedDB.deleteDatabase.bind(indexedDB);
+  indexedDB.deleteDatabase = function (n) { rec({ op: 'DELETE_DB', store: String(n), at: site() }); return oDD(n); };
+}
+
+const snapshotFn = async () => {
+  const idb = await window.APP.openCacheDB();
+  if (!idb) return { err: 'openCacheDB null' };
+  const names = Array.from(idb.objectStoreNames);
+  const out = { version: idb.version, stores: names, dbs: [], timestamps: [] };
+  const readKeys = s => new Promise(res => { try { const tx = idb.transaction(s, 'readonly'); const rq = tx.objectStore(s).getAllKeys(); rq.onsuccess = () => res(rq.result || []); rq.onerror = () => res([]); } catch (e) { res([]); } });
+  const readSize = (s, k) => new Promise(res => { try { const tx = idb.transaction(s, 'readonly'); const rq = tx.objectStore(s).get(k); rq.onsuccess = () => { const v = rq.result; res(v && typeof v.byteLength === 'number' ? v.byteLength : -1); }; rq.onerror = () => res(-3); } catch (e) { res(-4); } });
+  for (const k of await readKeys('dbs')) out.dbs.push({ key: String(k), size: await readSize('dbs', k) });
+  if (names.indexOf('timestamps') >= 0) out.timestamps = (await readKeys('timestamps')).map(String);
+  try { const e = await navigator.storage.estimate(); out.quota = e.quota; out.usage = e.usage; } catch (e) {}
+  try { out.persisted = await navigator.storage.persisted(); } catch (e) {}
+  return out;
+};
+
+(async () => {
+  // PREFLIGHT — prove the server on PORT is OURS (concurrent sessions collide on ports; a silent
+  // bind failure once cost 300s of waiting on a window.APP.db from someone else's tree).
+  const NONCE = 'probe-' + Math.random().toString(36).slice(2) + '-' + Date.now();
+  const MARKER = path.join(ROOT, '__probe_marker.txt');
+  fs.writeFileSync(MARKER, NONCE);
+  const server = spawn('node', [__dirname + '/_fast_static_server.js', String(PORT), ROOT], { stdio: ['ignore', 'ignore', 'pipe'] });
+  let serverErr = ''; server.stderr.on('data', d => { serverErr += String(d); });
+  await new Promise(r => setTimeout(r, 1500));
+  const got = await new Promise(res => { require('http').get(`http://localhost:${PORT}/__probe_marker.txt`, r => { let b = ''; r.on('data', c => b += c); r.on('end', () => res(b)); }).on('error', e => res('ERR:' + e.message)); });
+  if (got !== NONCE) {
+    fs.rmSync(MARKER, { force: true }); server.kill();
+    console.error(`§FATAL preflight — port ${PORT} is NOT serving ${ROOT}. got=${JSON.stringify(got.slice(0, 120))}`);
+    console.error(serverErr.split('\n').slice(0, 4).join('\n') + '\n  → another session owns this port. Re-run with a free PORT=.');
+    process.exit(2);
+  }
+  console.log(`§PREFLIGHT_OK port=${PORT} root=${ROOT}`);
+  console.log(`── probe_tm_persist_dataloss — ${BUILDING} — repeats=${REPEATS} ──`);
+
+  const launch = () => puppeteer.launch({ headless: 'new', userDataDir: PROFILE_DIR, protocolTimeout: 600000, executablePath: CHROME, args: ['--no-sandbox', '--disable-dev-shm-usage', '--use-angle=swiftshader', '--enable-unsafe-swiftshader'] });
+  const openPage = async (browser, lines, errs) => {
+    const p = await browser.newPage();
+    await p.evaluateOnNewDocument(installSpy);
+    p.on('console', m => { const t = m.text(); if (t.indexOf('§') >= 0) lines.push(t); });
+    p.on('pageerror', e => errs.push(String(e).slice(0, 300)));
+    return p;
+  };
+  const showSnap = (tag, s) => {
+    console.log(`§IDBSNAP ${tag} v=${s.version} dbsEntries=${(s.dbs || []).length} quota=${s.quota ? MB(s.quota) : '?'} usage=${s.usage ? MB(s.usage) : '?'} persisted=${s.persisted}`);
+    (s.dbs || []).forEach(e => console.log(`         dbs["${e.key}"] = ${e.size >= 0 ? MB(e.size) : 'MISSING'}`));
+    console.log(`         timestamps = [${(s.timestamps || []).join(', ')}]`);
+  };
+  const dumpSpy = (tag, spy) => {
+    const interesting = spy.filter(e => /DELETE|CLEAR|ABORT|ERR/.test(e.op) || (e.op === 'put' && e.size > 1e6));
+    console.log(`§IDBSPY ${tag} total=${spy.length} interesting=${interesting.length}`);
+    interesting.forEach(e => console.log('     ' + JSON.stringify(e)));
+  };
+
+  // ══ PHASE A — load, activate, edit, persist ═══════════════════════════════════════════════════
+  let linesA = [], errsA = [];
+  const b1 = await launch();
+  const page = await openPage(b1, linesA, errsA);
+  const t0 = Date.now();
+  await page.goto(URL, { waitUntil: 'domcontentloaded', timeout: 60000 });
+  await page.waitForFunction(() => window.APP && window.APP.db, { timeout: 300000 });
+  console.log('§DATA_READY ms=' + (Date.now() - t0));
+  await new Promise(r => setTimeout(r, SETTLE));   // let the geo phase run inside the observation window
+  check('P0 no JS page error', errsA.length === 0, errsA.length ? errsA[0] : '(0)');
+
+  const spyLoad = await page.evaluate(() => window.__IDBSPY.slice());
+  dumpSpy('PHASE-A-load', spyLoad);
+  const snapT0 = await page.evaluate(snapshotFn); showSnap('A0-afterLoad', snapT0);
+
+  const actT0 = Date.now();
+  await page.evaluate(() => window.toggleTimeMachine());
+  await page.waitForFunction(() => { try { const r = window.APP.db.exec('SELECT COUNT(*) FROM tasks'); return r[0] && r[0].values[0][0] > 0; } catch (e) { return false; } }, { timeout: 120000, polling: 500 });
+  console.log('§ACTIVATE ms=' + (Date.now() - actT0));
+
+  const exp = await page.evaluate(() => { const u8 = window.APP.db.export(); return { arrLen: u8.byteLength, bufLen: u8.buffer.byteLength, offset: u8.byteOffset }; });
+  console.log('§EXPORT_SHAPE ' + JSON.stringify(exp) + ' arr=' + MB(exp.arrLen));
+  check('P1 db.export().buffer is exactly the db bytes (no wasm-heap over-read)', exp.bufLen === exp.arrLen && exp.offset === 0, JSON.stringify(exp));
+
+  const dateCol = await page.evaluate(() => { const c = (window.APP.db.exec('PRAGMA table_info(tasks)')[0] || { values: [] }).values.map(v => v[1]); return c.indexOf('schedule_start') >= 0 ? 'schedule_start' : (c.indexOf('start_date') >= 0 ? 'start_date' : null); });
+  const before = await page.evaluate(c => { const r = window.APP.db.exec('SELECT task_id, ' + c + ' FROM tasks LIMIT 1'); return r[0] ? r[0].values[0] : null; }, dateCol);
+  console.log('§TASK_BASELINE col=' + dateCol + ' row=' + JSON.stringify(before));
+
+  let lastDate = null, persistKey = null;
+  for (let i = 1; i <= REPEATS; i++) {
+    lastDate = '2026-12-' + String(10 + i).padStart(2, '0');
+    await page.evaluate((id, nd, c) => window.APP.db.run('UPDATE tasks SET ' + c + ' = ? WHERE task_id = ?', [nd, id]), before[0], lastDate, dateCol);
+    const mark = await page.evaluate(() => window.__IDBSPY.length);
+    const r = await page.evaluate(() => { const SA = window.ScheduleAuthor; const url = window.APP._dbPersistUrl || window.APP.DB_URL; return SA.persistDb(window.APP.db, url, { immediate: true }).then(ok => ({ ok, url, key: SA._cacheKeyFor(url) })); });
+    persistKey = r.key;
+    await new Promise(rr => setTimeout(rr, 1500));
+    const snap = await page.evaluate(snapshotFn);
+    const entry = (snap.dbs || []).find(e => e.key === r.key);
+    console.log(`\n§PERSIST_ROUND ${i}/${REPEATS} ok=${r.ok} key=${r.key}`);
+    showSnap('A1-afterPersist#' + i, snap);
+    dumpSpy('persist#' + i, await page.evaluate(m => window.__IDBSPY.slice(m), mark));
+    check(`P2.${i} persistDb reported ok`, r.ok === true, JSON.stringify(r));
+    check(`P3.${i} store HAS the key it just wrote, at the NEW size`, !!entry && entry.size === exp.arrLen, entry ? MB(entry.size) + ' vs export ' + MB(exp.arrLen) : 'ENTRY ABSENT');
+    check(`P4.${i} the edited slot carries a FRESH LRU timestamp (else it is evicted first)`, (snap.timestamps || []).indexOf(r.key) >= 0, 'timestamps=[' + (snap.timestamps || []).join(',') + ']');
+  }
+
+  const readback = await page.evaluate(async (key, id, col, want) => {
+    const SQL = window.APP._SQL || window.SQL || window._SQL_CACHED;
+    if (!SQL) return { err: 'no sql.js factory on window' };
+    const idb = await window.APP.openCacheDB();
+    const buf = await new Promise(res => { const tx = idb.transaction('dbs', 'readonly'); const rq = tx.objectStore('dbs').get(key); rq.onsuccess = () => res(rq.result); rq.onerror = () => res(null); });
+    if (!buf) return { err: 'no entry under key', key };
+    try { const d = new SQL.Database(new Uint8Array(buf)); const r = d.exec('SELECT ' + col + " FROM tasks WHERE task_id = '" + id.replace(/'/g, "''") + "'"); const g = r[0] ? String(r[0].values[0][0]) : null; d.close(); return { size: buf.byteLength, got: g, want, match: g === want }; }
+    catch (e) { return { err: String(e), size: buf.byteLength }; }
+  }, persistKey, before[0], dateCol, lastDate);
+  console.log('\n§READBACK ' + JSON.stringify(readback));
+  check('P5 READ-BACK — persisted blob really contains the newest edit', readback.match === true, JSON.stringify(readback));
+  await b1.close();
+
+  // ══ PHASE B — reload. meta is read from cache, THEN the geo write aborts and force-evicts. ═════
+  const runReload = async (tag) => {
+    const lines = [], errs = [];
+    const b = await launch();
+    const p = await openPage(b, lines, errs);
+    await p.goto(URL, { waitUntil: 'domcontentloaded', timeout: 60000 });
+    await p.waitForFunction(() => window.APP && window.APP.db, { timeout: 300000 });
+    await new Promise(r => setTimeout(r, SETTLE));
+    const live = await p.evaluate((id, col) => { try { const r = window.APP.db.exec('SELECT ' + col + " FROM tasks WHERE task_id = '" + id.replace(/'/g, "''") + "'"); return r[0] ? String(r[0].values[0][0]) : '(no row)'; } catch (e) { return '(no tasks table)'; } }, before[0], dateCol);
+    const snap = await p.evaluate(snapshotFn);
+    const spy = await p.evaluate(() => window.__IDBSPY.slice());
+    console.log(`\n§RELOAD ${tag} liveEditValue=${live}`);
+    showSnap(tag, snap);
+    dumpSpy(tag, spy);
+    const cl = lines.filter(l => /§CACHE_|§QUOTA|§SCHED_PERSIST|§IDB_|§PERSIST/.test(l));
+    cl.forEach(l => console.log('     ' + l));
+    await b.close();
+    return { live, snap, spy };
+  };
+
+  const B = await runReload('PHASE-B-reload1');
+  const entryB = (B.snap.dbs || []).find(e => e.key === persistKey);
+  check('P6 after ONE reload the edited slot still exists in IDB', !!entryB && entryB.size > 0,
+    entryB ? MB(entryB.size) : 'EVICTED — DATA LOSS (this is the bug)');
+
+  const C = await runReload('PHASE-C-reload2');
+  check('P7 THE USER-VISIBLE TRUTH — the edit is still there after a second reload',
+    C.live === lastDate, 'want=' + lastDate + ' got=' + C.live);
+
+  console.log('\n§SUMMARY building=' + BUILDING + ' pass=' + pass + ' fail=' + fail);
+  fs.rmSync(MARKER, { force: true });
+  server.kill();
+  try { fs.rmSync(PROFILE_DIR, { recursive: true, force: true }); } catch (e) {}
+  process.exit(fail ? 1 : 0);
+})().catch(e => {
+  console.error('§FATAL ' + e.stack);
+  try { fs.rmSync(PROFILE_DIR, { recursive: true, force: true }); } catch (e2) {}
+  process.exit(1);
+});

--- a/viewer/scene.js
+++ b/viewer/scene.js
@@ -1303,7 +1303,9 @@ async function setupScene(A) {
         // guard with objectStoreNames.contains, since listing a non-existent store in
         // db.transaction([...]) throws synchronously and would break the whole write.
         var _hasRevalStore = cacheDb.objectStoreNames.contains('revalidation');
-        // One write attempt under `key`; resolves true on success, false if the tx aborted (quota).
+        // One write attempt under `key`. Resolves { ok, name, err } — the abort REASON, not just a
+        // boolean, because only ONE class of failure (a genuine quota shortfall) can be helped by
+        // throwing other entries away. See §CACHE_EVICT_ONLY_ON_QUOTA below.
         var _attemptWrite = function() {
           return new Promise(function(resolve) {
             var _writeOk = false;
@@ -1316,27 +1318,46 @@ async function setupScene(A) {
             const req = tx.objectStore(A.CACHE_STORE).put(buf, key);
             req.onsuccess = function() { _writeOk = true; console.log(`[S203] §CACHE_WRITE_OK url=${url.split('/').pop()} size=${(buf.byteLength/1024/1024).toFixed(1)}MB`); };
             req.onerror = function() {
-              // §S260b: Quota exceeded — let the tx abort so the caller evicts LRU and retries.
               console.warn(`[S203] §CACHE_WRITE_ERR url=${url.split('/').pop()} err=${req.error}`);
             };
             tx.oncomplete = function() {
               if (!_writeOk) console.warn('[S203] §CACHE_TX_COMPLETE_BUT_NO_WRITE — data NOT persisted');
-              resolve(_writeOk);
+              resolve({ ok: _writeOk });
             };
-            tx.onabort = function() { resolve(false); };
+            // Read tx.error. The old handler discarded it and every caller then ASSUMED "quota" —
+            // which is how a non-quota abort came to be reported as `quota too small` for months.
+            tx.onabort = function() {
+              var e = tx.error;
+              resolve({ ok: false, name: e ? e.name : '', err: e ? (e.name + ': ' + e.message) : '(tx.error was null)' });
+            };
           });
         };
-        // §CACHE_EVICT_LRU_RETRY (F3): on a quota abort, drop the OLDEST entries and try again —
-        // bounded. The old code .clear()'d the entire store, so one oversized write wiped every
-        // other cached building and turned the next open of ANY of them into a fresh download.
-        var _ok = await _attemptWrite();
-        for (var _try = 0; !_ok && _try < 4; _try++) {
-          var _dropped = await A._evictOldest(cacheDb, 4);
-          if (!_dropped) break;                       // nothing left to give up — stop, don't spin
-          console.log(`[S203] §CACHE_EVICT_LRU_RETRY attempt=${_try + 1} dropped=${_dropped}`);
-          _ok = await _attemptWrite();
+        // §CACHE_EVICT_ONLY_ON_QUOTA (bim-compiler 4D_GANTT_TM_REFACTOR.md §5b) — THE DATA-LOSS FIX.
+        // This ladder used to force-evict the 4 oldest entries after ANY abort and retry, up to 4
+        // times. MEASURED on Hospital: Hospital_geo.db is 239,702,016 bytes and Chrome caps a SINGLE
+        // IndexedDB value at 133,169,152 bytes (~127MiB), so its write aborts with
+        //   UnknownError: The serialized keys and/or value are too large (size=239702104, max=133169152)
+        // — a failure NO amount of eviction can fix. The ladder ran anyway and, with only 2 entries in
+        // the store, "drop the 4 oldest" dropped EVERYTHING — including buildings/Hospital_meta.db,
+        // the slot the Time Machine had just persisted a user's Gantt edit into. persistDb had
+        // correctly reported ok=true and logged §SCHED_PERSIST; the bytes were then deleted out from
+        // under it by this loop, and the next reload silently refetched the pristine network copy.
+        // So: evict ONLY for QuotaExceededError, the one failure eviction can actually relieve.
+        var _res = await _attemptWrite();
+        var _ok = _res.ok;
+        if (!_ok && _res.name && _res.name !== 'QuotaExceededError') {
+          console.warn(`[S203] §CACHE_WRITE_UNFIXABLE url=${url.split('/').pop()} size=${(buf.byteLength/1024/1024).toFixed(1)}MB` +
+            ` err=${_res.err} — eviction cannot help this; cache left INTACT`);
+        } else if (!_ok) {
+          for (var _try = 0; !_ok && _try < 4; _try++) {
+            var _dropped = await A._evictOldest(cacheDb, 4);
+            if (!_dropped) break;                     // nothing left to give up — stop, don't spin
+            console.log(`[S203] §CACHE_EVICT_LRU_RETRY attempt=${_try + 1} dropped=${_dropped}`);
+            _res = await _attemptWrite();
+            _ok = _res.ok;
+          }
+          if (!_ok) console.warn(`[S203] §CACHE_EVICT_WRITE_FAIL url=${url.split('/').pop()} err=${_res.err || 'unknown'} — still failing after LRU eviction`);
         }
-        if (!_ok) console.warn(`[S203] §CACHE_EVICT_WRITE_FAIL url=${url.split('/').pop()} — quota too small even after LRU eviction`);
       } catch(e) { console.log(`[S203] §CACHE_WRITE_ERR ${e.message}`); }
     }
 

--- a/viewer/schedule_author.js
+++ b/viewer/schedule_author.js
@@ -2442,13 +2442,33 @@
             if (!idb || !idb.objectStoreNames.contains('dbs')) {
               console.warn('§SCHED_PERSIST_ERR no cache store url=' + url); resolve(false); return;
             }
-            var tx = idb.transaction('dbs', 'readwrite');
+            // §SCHED_PERSIST_LRU_TOUCH (bim-compiler 4D_GANTT_TM_REFACTOR.md §5b): stamp 'timestamps'
+            // in the SAME transaction as the blob. Until this, persistDb wrote 'dbs' ONLY, so an
+            // edited slot kept whatever timestamp cachedFetch left on it at first download — making
+            // the ONE entry that holds unsaved user work the OLDEST entry in the store, i.e. the
+            // FIRST thing scene.js's LRU evictor throws away. Editing your schedule literally moved
+            // your data to the front of the deletion queue (MEASURED: after three persists the
+            // Hospital meta slot still had no timestamp of its own at all).
+            var _hasTs = idb.objectStoreNames.contains('timestamps');
+            var tx = idb.transaction(_hasTs ? ['dbs', 'timestamps'] : ['dbs'], 'readwrite');
             tx.objectStore('dbs').put(buf, key);
+            if (_hasTs) tx.objectStore('timestamps').put(Date.now(), key);
             tx.oncomplete = function () {
               console.log('§SCHED_PERSIST url=' + url + ' key=' + key + ' size=' + (buf.byteLength / 1024).toFixed(0) + 'KB');
               resolve(true);
             };
             tx.onerror = function () { console.warn('§SCHED_PERSIST_ERR tx ' + (tx.error && tx.error.message)); resolve(false); };
+            // §SCHED_PERSIST_ABORT — a tx that ABORTS fires neither oncomplete nor (always) onerror.
+            // Without this handler the promise never settled: _tmPersistEdit's .then() never ran, so
+            // a failed save logged NOTHING and told the user NOTHING. Chrome aborts here for real
+            // reasons — a single IDB value over ~127MiB (a big building's meta.db can reach it) or a
+            // genuine QuotaExceededError — and each one silently discarded the user's edit.
+            tx.onabort = function () {
+              var e = tx.error;
+              console.warn('§SCHED_PERSIST_ERR abort key=' + key + ' size=' + (buf.byteLength / 1024).toFixed(0) + 'KB' +
+                ' err=' + (e ? (e.name + ': ' + e.message) : '(tx.error was null)'));
+              resolve(false);
+            };
           }).catch(function (e) { console.warn('§SCHED_PERSIST_ERR open ' + (e && e.message)); resolve(false); });
         } catch (e) { console.warn('§SCHED_PERSIST_ERR', e); resolve(false); }
       }, delay);

--- a/viewer/sw.js
+++ b/viewer/sw.js
@@ -22,7 +22,7 @@
 // schedule_author.js is in PRECACHE_ASSETS; v1088 shipped the STAGE 3 drawer change (#1528), so this
 // separate change needs its own bump (§CRISIS LESSON 4).
 // DEPLOY: bump CACHE_VERSION on every OCI upload. Old caches are purged on activate.
-const CACHE_VERSION = 'v1090';   // bump on each deploy; per-change detail is the git commit message.
+const CACHE_VERSION = 'v1091';   // bump on each deploy; per-change detail is the git commit message.
 // v1090 (2026-08-27) §TPL_MODEL: rates/4D_template.json ADDED to PRECACHE_ASSETS (it defines the
 // canonical task grid and was never precached, so offline/cold-SW silently ran the dead deriveZones
 // path), plus schedule_author.js now names which model ran at the fork. Both are precached, so

--- a/viewer/time_machine.js
+++ b/viewer/time_machine.js
@@ -6332,6 +6332,15 @@
     var persistUrl = app._dbPersistUrl || app.DB_URL;
     SA.persistDb(app.db, persistUrl, {}).then(function (ok) {
       console.log('§GANTT_EDIT_PERSIST what=' + what + ' url=' + persistUrl + ' ok=' + ok);
+      // §GANTT_EDIT_PERSIST_FAIL (bim-compiler 4D_GANTT_TM_REFACTOR.md §5b) — a save that fails must
+      // be LOUD. Before this the ok=false branch did nothing but log at info level: the edit stayed
+      // on screen, looked saved, and was gone on the next reload. persistDb now reports false for a
+      // real abort (§SCHED_PERSIST_ERR carries the reason), so say so where the user is looking.
+      if (!ok) {
+        console.warn('§GANTT_EDIT_PERSIST_FAIL what=' + what + ' url=' + persistUrl +
+          ' — edit is in memory only and will NOT survive a reload');
+        try { _tmSay('⚠ Could not save this edit — it will be lost on reload. See console (§SCHED_PERSIST_ERR).', 7000); } catch (e) {}
+      }
     });
   }
 


### PR DESCRIPTION
## The defect

`persistDb()` returned `ok=true`, logged `§SCHED_PERSIST` under the correct cache key, emitted no `§SCHED_PERSIST_ERR` — and the IndexedDB `dbs` object store ended up **empty**. The next reload silently refetched the pristine `_meta.db` and the user's Gantt edit was gone, with nothing on screen or in the log saying so.

## Root cause (measured, not assumed)

`scripts/probe_tm_persist_dataloss.js` (new) installs an IndexedDB mutation spy via `evaluateOnNewDocument` **before any app script runs**, recording every `put` / `delete` / `clear` / transaction-abort with its call site. It caught the abort the shipped code never read:

```
tx:ABORT  err="UnknownError: The serialized keys and/or value are too large
                (size=239702104 bytes, max=133169152 bytes)"
          at viewer/scene.js:1311 <- _attemptWrite (viewer/scene.js:1308)
```

`Hospital_geo.db` is **239,702,016 bytes** and Chrome caps a **single IndexedDB value at 133,169,152 bytes (~127 MiB)**. That write can never succeed, at any quota.

But `tx.onabort` was `function() { resolve(false); }` — **`tx.error` discarded**. So `cachedFetch`'s retry ladder assumed quota and ran `A._evictOldest(cacheDb, 4)` — *drop the 4 oldest entries* — for a failure no eviction could ever fix. The store held only **2** entries, so "drop the 4 oldest" dropped **everything**, including `buildings/Hospital_meta.db`: the slot the Time Machine had just persisted the edit into. It then logged `§CACHE_EVICT_WRITE_FAIL … quota too small` while `§QUOTA` reported **10,264 MB free / 24 MB used**.

**`persistDb` was never at fault.** It wrote correctly and `ok=true` was honest when it resolved. The bytes were deleted out from under it afterwards, by a different module, on a later load — which is exactly why two sessions looking inside the persist path never found it.

### Amplifier found in the same pass

`persistDb` wrote the `dbs` store **only**, never `timestamps`. An edited slot therefore kept whatever LRU timestamp `cachedFetch` left at first download — making the one entry holding unsaved user work the **oldest**, i.e. the **first** thing the evictor takes. Editing your schedule moved your data to the front of the deletion queue.

## The fix (3 files, surgical — no architecture change)

- **`viewer/scene.js`** — `_attemptWrite` resolves `{ok, name, err}` and `tx.onabort` **reads `tx.error`**. The evict-and-retry ladder runs **only for a genuine `QuotaExceededError`** (`§CACHE_EVICT_ONLY_ON_QUOTA`); any other abort logs `§CACHE_WRITE_UNFIXABLE … cache left INTACT` and deletes nothing.
- **`viewer/schedule_author.js`** — `persistDb` stamps `timestamps` in the **same transaction** as the blob (`§SCHED_PERSIST_LRU_TOUCH`), and gains the missing `tx.onabort` (`§SCHED_PERSIST_ERR abort …`). It had **none**: an aborted persist settled *no* promise, so `_tmPersistEdit`'s `.then()` never ran and a failed save logged nothing at all.
- **`viewer/time_machine.js`** — `_tmPersistEdit` on `ok=false` warns `§GANTT_EDIT_PERSIST_FAIL` and shows `⚠ Could not save this edit — it will be lost on reload`. Previously silent.

## Proof — before → after, same probe, same profile, real Hospital data

| | before | after |
|---|---|---|
| `DELETE` ops on `dbs` | **6** | **0** |
| `dbs` after persist | `[]` — **EMPTY** | `Hospital_meta.db` **54.00MB** + 2 others |
| edited slot has own LRU timestamp | ✗ | ✓ |
| read-back of persisted blob | nothing there | `match:true` |
| edit after 1 reload | evicted | present |
| **edit after 2 reloads** | **`(no tasks table)`** | **`2026-12-13`** |
| probe verdict | 9 pass / **5 fail** | **14 pass / 0 fail** |

Read-back verified across **3 sequential persists to the same key** — not a first-write-only fix.

**Regression, `scripts/probe_splitmode_persist_direct.js`:** Duplex **8/0** (whole-db), Hospital **8/0** (split). Hospital's reload now logs `§CACHE_HIT Hospital_meta.db size=55.1MB` — the edited blob.

`viewer/sw.js` `CACHE_VERSION` v1090 → **v1091** (mandatory same-PR for `scene.js`/`time_machine.js` changes).

## Known and deliberately not fixed

- `Hospital_geo.db` (228.6MB) and any single value over ~127 MiB **can never be cached in Chrome**. It now fails loudly and harmlessly instead of destructively. Chunking geo data is a separate perf question.
- Under a *genuine* `QuotaExceededError` the evictor can still delete a locally-edited slot. A hard "never evict a locally-edited key" guard needs a persistent marker (new store + version bump) — out of scope; the LRU-touch makes the edited slot the *newest* rather than the oldest, which mitigates it.

Spec: `bim-compiler prompts/4D_GANTT_TM_REFACTOR.md` §5b (updated in place to DONE with this evidence).

🤖 Generated with [Claude Code](https://claude.com/claude-code)