### PR TITLE
feat(4d): §TPL_LEVEL_AXIS — task grid can use LevelDeriver, flag-gated OFF

### DIFF
--- a/viewer/schedule_author.js
+++ b/viewer/schedule_author.js
@@ -422,16 +422,32 @@
   //   { id, phase, storey, level, sDays, eDays, days, guids, crewDays, bottleneck }
   // and an edge is { predId, succId, type, lagDays, kind } — kind 'within_level' | 'across_levels'.
   // EVERY edge's lag comes from the TEMPLATE, never from the dates it constrains.
-  function instantiateTemplate(elements, T, laborRates, shiftHours, bandRank, collapse) {
+  // §TPL_LEVEL_AXIS (2026-08-27) — `levelAxis` is the OPT-IN vertical-axis override. Omit it and
+  // this function behaves EXACTLY as before: the level key is collapse(e.storey) and the level order
+  // is `bandRank`. Supply { keyOf, rankOf } and the grid is keyed/ordered by that instead.
+  // WHY IT EXISTS: e.storey reaching this function has already been rewritten by
+  // _buildScheduleElements's assignStoreyByZ (line ~342), which replaces EVERY '_UNKNOWN' storey
+  // with the nearest real storey NAME by median centre-Z — so deriveBandRanks's own '_UNKNOWN'
+  // exclusion (schedule_gate.js:350) can never fire on this path: the bucket it guards is empty by
+  // the time it looks. LevelDeriver (viewer/lib/level_deriver.js) answers the same question from the
+  // FROZEN DB instead and is not exposed to that rewrite (see _deriverLevelAxis's header for the
+  // read-path proof). Default stays the old path until the swap is deliberately flipped.
+  function instantiateTemplate(elements, T, laborRates, shiftHours, bandRank, collapse, levelAxis) {
     laborRates = laborRates || {};
     var shiftSecs = (shiftHours > 0 ? shiftHours : (T.calendar && T.calendar.hours_per_shift) || 24) * 3600;
     var minDays = (T.duration_rule && T.duration_rule.min_days) || 1;
     collapse = collapse || function (x) { return x; };
+    // Resolved ONCE. With levelAxis absent both of these are literally the expressions that were
+    // inline here before, so the flag-off path is unchanged by construction, not by inspection.
+    var keyOf = (levelAxis && levelAxis.keyOf) || function (el) { return collapse(el.storey); };
+    var rankOf = (levelAxis && levelAxis.rankOf) || function (k) {
+      return (bandRank && bandRank[k] != null) ? bandRank[k] : 1e9;
+    };
 
     // (phase, storey) -> { secs per trade, guids }
     var cell = {}, storeySeen = {};
     for (var i = 0; i < elements.length; i++) {
-      var e = elements[i], st = collapse(e.storey), ph = e.phase || '_UNPHASED';
+      var e = elements[i], st = keyOf(e), ph = e.phase || '_UNPHASED';
       storeySeen[st] = 1;
       var k = ph + '||' + st, c = cell[k] || (cell[k] = { secs: {}, guids: [] });
       var tr = (e.resource && e.resource !== '_DEFAULT') ? e.resource : '_DEFAULT';
@@ -441,8 +457,7 @@
     // levels bottom-up. bandRank is the SAME rank deriveBandRanks gives the movie, so "the level
     // below" means the same thing here as it does in the solver's own band gate.
     var levels = Object.keys(storeySeen).sort(function (a, b) {
-      var ra = bandRank && bandRank[a] != null ? bandRank[a] : 1e9;
-      var rb = bandRank && bandRank[b] != null ? bandRank[b] : 1e9;
+      var ra = rankOf(a), rb = rankOf(b);
       return ra - rb || (a < b ? -1 : a > b ? 1 : 0);
     });
 
@@ -974,6 +989,215 @@
     return { schedule: out, mapped: mapped, degenerateTasks: degenerate };
   }
 
+  // ══ §TPL_LEVEL_AXIS — the LevelDeriver vertical axis for the task grid (2026-08-27) ═══════════
+  // Implementing bim-compiler prompts/4D_MODEL_INTEGRITY.md §I.3 — Witness: §TPL_LEVEL_DISAGREE
+  //
+  // THE READ-PATH PROOF (verified 2026-08-27, the reason this swap REMOVES the defect instead of
+  // relocating it). assignStoreyByZ (line ~342) is a PURE LOCAL function: it returns a string that
+  // is stored only into the in-memory element literal's `storey:` field (line ~368). It issues no
+  // db.run and no UPDATE — `elements_meta.storey` on disk is never touched by it (the only writers
+  // of that column repo-wide are wizard_storeys.js, i.e. a deliberate user authoring act, and the
+  // importers). LevelDeriver.readLookups reads `SELECT guid, storey FROM elements_meta` STRAIGHT
+  // FROM THE FROZEN DB (level_deriver.js:67) and LevelDeriver.levelFor consumes only guid/base_z/
+  // top_z off the element object — it never reads el.storey. So the '_UNKNOWN' guard at
+  // level_deriver.js:178 sees the UNREWRITTEN value and actually fires, where the structurally
+  // identical guard in deriveBandRanks (schedule_gate.js:350) is dead code on this path.
+  //
+  // Returns { keyOf, rankOf, stats } for instantiateTemplate, or null (caller keeps the OLD path —
+  // never a silent half-swap).
+  function _deriverLevelAxis(db, elements, collapse, storeyMergeMap, label) {
+    var LD = (global && global.LevelDeriver) ||
+             (typeof globalThis !== 'undefined' && globalThis.LevelDeriver) ||
+             (typeof window !== 'undefined' && window.LevelDeriver) || null;
+    // NODE ONLY: the browser already loads lib/level_deriver.js via a <script> tag (viewer.html
+    // ~line 940) so LD is on window there. Under node a witness/probe that never required it would
+    // otherwise get a SILENT fallback to the old axis — which is exactly how the first flag-on run
+    // of the shipped witnesses came back byte-identical and looked like "no change" (2026-08-27).
+    // Resolving it here makes the module self-sufficient instead of trusting every caller to know.
+    if ((!LD || !LD.readLookups) && typeof require === 'function' && typeof __dirname !== 'undefined') {
+      try { LD = require(__dirname + '/lib/level_deriver.js'); } catch (e) {
+        console.log('§TPL_LEVEL_AXIS_REQUIRE_FAIL ' + ((e && e.message) || e));
+      }
+    }
+    if (!LD || !LD.readLookups) {
+      console.log('§TPL_LEVEL_AXIS_UNAVAILABLE label=' + label + ' — LevelDeriver not loaded; the task ' +
+        'grid STAYS on collapse(e.storey). Reported, not silently degraded (§S32.4 stop-and-report).');
+      return null;
+    }
+    var L = LD.readLookups(db);
+    var G = LD.buildGrid(L, elements);
+    G.medGap = LD.medianGap(G.grid);
+
+    // grid index -> a REAL declared storey name where that grid line carries one (so the Gantt keeps
+    // human floor names), else 'L<idx>' — location_axis.js's own convention for a derived level.
+    // Names are collapse()'d and merge-mapped exactly like the old axis, so a level the two axes
+    // AGREE on carries byte-identical text and the disagreement count below measures real
+    // disagreement, not a renaming.
+    var nameAt = {}, taken = {}, keyAt = {};
+    Object.keys(L.storeyNameCenterZ).forEach(function (nm) {
+      var z = L.storeyNameCenterZ[nm];
+      if (!isFinite(z) || !G.grid.length) return;
+      var i = LD.nearestIdx(G.grid, z);
+      if (Math.abs(G.grid[i] - z) > 1e-6) return;          // that name is not on this grid line
+      var c = collapse(nm);
+      if (storeyMergeMap && storeyMergeMap[c]) c = storeyMergeMap[c];
+      (nameAt[i] = nameAt[i] || []).push(c);
+    });
+    var collided = [];
+    Object.keys(nameAt).map(Number).sort(function (a, b) { return a - b; }).forEach(function (i) {
+      var cands = nameAt[i].slice().sort();
+      for (var q = 0; q < cands.length; q++) {
+        if (taken[cands[q]] == null) { keyAt[i] = cands[q]; taken[cands[q]] = i; break; }
+      }
+      // Every candidate name already belongs to a LOWER grid line — an ambiguous storey NAME sitting
+      // at two elevations (LevelDeriver reports these as ambiguousNames; measured 0 on this fleet).
+      // Keep the two levels DISTINCT rather than silently folding two floors into one task row.
+      if (keyAt[i] == null) { keyAt[i] = 'L' + i; collided.push(i + '<-' + cands.join('/')); }
+    });
+    function keyForIdx(idx) {
+      if (idx == null || idx < 0) return '_UNKNOWN';
+      return keyAt[idx] != null ? keyAt[idx] : 'L' + idx;
+    }
+
+    var idxOf = {}, keyByGuid = {}, tier = { T1: 0, T2: 0, T3: 0, T4: 0 }, overridden = 0;
+    var votes = {};
+    for (var i2 = 0; i2 < elements.length; i2++) {
+      var el = elements[i2];
+      var r = LD.levelFor(el, L.rawStorey[el.guid], L, G);
+      tier[r.tier] = (tier[r.tier] || 0) + 1;
+      if (r.overridden) overridden++;
+      var ix = (r.idx == null ? -1 : r.idx);
+      idxOf[el.guid] = ix;
+      // NAME VOTE (only used for grid lines that spatial_structure did not name — below). The vote
+      // is cast from the RAW DB storey, never e.storey, so a name assignStoreyByZ invented cannot
+      // win it. An element with no declared storey abstains; it has no name to contribute.
+      var rs0 = L.rawStorey[el.guid];
+      if (ix >= 0 && rs0 && rs0 !== '_UNKNOWN' && !/^unknown$/i.test(String(rs0))) {
+        var cn = collapse(rs0);
+        if (storeyMergeMap && storeyMergeMap[cn]) cn = storeyMergeMap[cn];
+        (votes[ix] = votes[ix] || {})[cn] = ((votes[ix] || {})[cn] || 0) + 1;
+      }
+    }
+    // §S34.1 measured: some buildings (Duplex, LTU_AHouse) carry storey NAMES on elements but no
+    // IfcBuildingStorey.Elevation at all, so buildGrid falls back to a uniform grid and the loop
+    // above named nothing. Rather than show the user "L0/L1/L2/L3" where the model plainly says
+    // "T/FDN / Level 1 / Level 2 / Roof", label each unnamed grid line with the MOST COMMON declared
+    // name among the elements that geometrically land on it. The level's IDENTITY stays geometric —
+    // this only supplies its LABEL, and the label is extracted from the data, never invented.
+    var voted = [];
+    Object.keys(votes).map(Number).sort(function (a, b) { return a - b; }).forEach(function (ix2) {
+      if (keyAt[ix2] != null) return;                       // spatial_structure already named it
+      var v = votes[ix2];
+      var best = Object.keys(v).sort(function (a, b) { return v[b] - v[a] || (a < b ? -1 : 1); })
+        .filter(function (nm) { return taken[nm] == null; })[0];
+      if (best == null) return;                             // every candidate belongs to a lower line
+      keyAt[ix2] = best; taken[best] = ix2;
+      voted.push(ix2 + '="' + best + '"(' + v[best] + '/' + Object.keys(v).reduce(function (s, k) { return s + v[k]; }, 0) + ')');
+    });
+    if (voted.length) console.log('§TPL_LEVEL_AXIS_NAMEVOTE label=' + label +
+      ' gridLines spatial_structure did not name, labelled by plurality of the RAW declared storey of ' +
+      'the elements on them: ' + voted.join(' '));
+    // re-key now that late names exist
+    for (var i4 = 0; i4 < elements.length; i4++) keyByGuid[elements[i4].guid] = keyForIdx(idxOf[elements[i4].guid]);
+    // rank = the grid index itself. The grid is the DECLARED floor lines in ascending order, so the
+    // index IS the floor order — no median-of-element-z election is needed to recover it (that
+    // election is what §BIMEYES measured as manufacturing band inversions).
+    var rank = {};
+    Object.keys(keyAt).forEach(function (i3) { rank[keyAt[i3]] = Number(i3); });
+
+    console.log('§TPL_LEVEL_AXIS label=' + label + ' source=LevelDeriver gridSource=' + G.source +
+      ' k=' + G.grid.length + ' levels=' + JSON.stringify(Object.keys(rank).sort(function (a, b) { return rank[a] - rank[b]; })) +
+      ' T1=' + tier.T1 + ' T2=' + tier.T2 + ' T3=' + tier.T3 + ' T4=' + tier.T4 +
+      ' geometryOverrides=' + overridden +
+      ' ambiguousNames=' + L.ambiguousNames.length +
+      ' nameCollisions=' + (collided.length ? JSON.stringify(collided) : '0'));
+    if (tier.T4) console.log('§TPL_LEVEL_AXIS_T4 label=' + label + ' n=' + tier.T4 +
+      ' elements have non-finite geometry and NO declared storey — they key to _UNKNOWN and sort LAST. ' +
+      'Counted, never defaulted onto a real floor (that defaulting is the defect this swap removes).');
+
+    return {
+      keyOf: function (el) { var k = keyByGuid[el.guid]; return k != null ? k : '_UNKNOWN'; },
+      rankOf: function (k) { return rank[k] != null ? rank[k] : 1e9; },
+      stats: { grid: G.grid, gridSource: G.source, tier: tier, overridden: overridden,
+               rank: rank, keyByGuid: keyByGuid, rawStorey: L.rawStorey }
+    };
+  }
+
+  // §TPL_LEVEL_DISAGREE — measure the two axes SIDE BY SIDE before trusting either (step 3 of the
+  // 2026-08-27 task; the §STATUS instrument rule: a swap that is not measured is a guess). Prints
+  // every element whose OLD key (collapse(assignStoreyByZ(...))) differs from the NEW one, bucketed,
+  // plus the share of those whose RAW db storey was absent/_UNKNOWN — i.e. the ones assignStoreyByZ
+  // FABRICATED a floor for. That last number is the direct tie to the measured fabrication rates.
+  function _logLevelDisagreement(elements, collapse, axis, label) {
+    if (!axis) return null;
+    var raw = axis.stats.rawStorey || {};
+    var n = elements.length, dis = 0, fabricated = 0, fabAndDisagree = 0;
+    var pairs = {}, samples = [];
+    for (var i = 0; i < n; i++) {
+      var e = elements[i];
+      var oldK = collapse(e.storey), newK = axis.keyOf(e);
+      var rs = raw[e.guid];
+      var wasFab = !rs || rs === '_UNKNOWN' || /^unknown$/i.test(String(rs));
+      if (wasFab) fabricated++;
+      if (oldK === newK) continue;
+      dis++;
+      if (wasFab) fabAndDisagree++;
+      var pk = oldK + ' -> ' + newK;
+      pairs[pk] = (pairs[pk] || 0) + 1;
+      if (samples.length < 12) samples.push({ guid: e.guid, cls: e.cls, rawStorey: rs == null ? null : rs,
+        old: oldK, 'new': newK, base_z: Number((e.base_z).toFixed(3)) });
+    }
+    // ⚠ THE RAW `disagree` COUNT OVERSTATES THE CHANGE AND MUST NOT BE THE HEADLINE. When a building
+    // has no IfcBuildingStorey.Elevation the derived grid lines get their labels from a plurality
+    // vote, so a level can come out correctly grouped but differently NAMED — and then every element
+    // on it counts as "disagreeing" purely because the text changed. Measured on Duplex before this
+    // split existed: 100.00% raw, of which only 9.56% was a real regrouping.
+    // STRUCTURAL disagreement is the honest number: map each OLD level to the NEW level that most of
+    // its elements went to, then count only the elements that did NOT follow their own level's
+    // plurality. That is invariant under relabeling and is what actually changes the task grid.
+    var domOf = {}, byOld = {};
+    for (var i5 = 0; i5 < n; i5++) {
+      var e5 = elements[i5], o5 = collapse(e5.storey), n5 = axis.keyOf(e5);
+      (byOld[o5] = byOld[o5] || {})[n5] = ((byOld[o5] || {})[n5] || 0) + 1;
+    }
+    Object.keys(byOld).forEach(function (o) {
+      var v = byOld[o];
+      domOf[o] = Object.keys(v).sort(function (a, b) { return v[b] - v[a] || (a < b ? -1 : 1); })[0];
+    });
+    var structural = 0, structFab = 0;
+    for (var i6 = 0; i6 < n; i6++) {
+      var e6 = elements[i6], o6 = collapse(e6.storey);
+      if (axis.keyOf(e6) === domOf[o6]) continue;
+      structural++;
+      var rs6 = raw[e6.guid];
+      if (!rs6 || rs6 === '_UNKNOWN' || /^unknown$/i.test(String(rs6))) structFab++;
+    }
+    var relabelOnly = dis - structural;
+
+    var pct = function (a) { return (100 * a / (n || 1)).toFixed(2) + '%'; };
+    var top = Object.keys(pairs).sort(function (a, b) { return pairs[b] - pairs[a]; }).slice(0, 12)
+      .reduce(function (o, k) { o[k] = pairs[k]; return o; }, {});
+    console.log('§TPL_LEVEL_DISAGREE label=' + label + ' n=' + n +
+      ' STRUCTURAL=' + structural + ' (' + pct(structural) + ' — elements that actually change level GROUP; this is the headline)' +
+      ' relabelOnly=' + relabelOnly + ' (' + pct(relabelOnly) + ' — same group, different level NAME)' +
+      ' rawKeyDiff=' + dis + ' (' + pct(dis) + ')' +
+      ' rawStoreyMissing=' + fabricated + ' (' + pct(fabricated) + ' — assignStoreyByZ INVENTED a floor name for these)' +
+      ' structuralAmongFabricated=' + structFab + '/' + fabricated +
+      ' structuralAmongDeclared=' + (structural - structFab) + '/' + (n - fabricated) +
+      ' distinctPairs=' + Object.keys(pairs).length);
+    console.log('§TPL_LEVEL_DISAGREE_MAP label=' + label + ' dominantOldToNew=' + JSON.stringify(domOf));
+    console.log('§TPL_LEVEL_DISAGREE_PAIRS label=' + label + ' ' + JSON.stringify(top));
+    samples.forEach(function (s) {
+      console.log('§TPL_LEVEL_DISAGREE_EG label=' + label + ' guid=' + s.guid + ' cls=' + s.cls +
+        ' rawDbStorey=' + JSON.stringify(s.rawStorey) + ' old="' + s.old + '" new="' + s['new'] + '" base_z=' + s.base_z);
+    });
+    if (structural === 0) console.log('§TPL_LEVEL_DISAGREE_VACUOUS label=' + label +
+      ' — no element changes level GROUP on this building (relabelOnly=' + relabelOnly + '). It cannot ' +
+      'tell the swap apart structurally; a 0 here is NOT evidence the swap is correct elsewhere (§S32.4 vacuity rule).');
+    return { n: n, disagree: dis, structural: structural, relabelOnly: relabelOnly,
+             fabricated: fabricated, fabAndDisagree: fabAndDisagree, structFab: structFab, pairs: pairs };
+  }
+
   // _writeTemplateSchedule — the §TEMPLATE_INSTANTIATE write path. Same tables, same schedule_id,
   // same idempotent rebuild as the legacy grouping path; the difference is WHERE the numbers come
   // from: task windows from 4D_template.json's duration_rule, task_sequences from its dependencies.
@@ -986,7 +1210,33 @@
       var c = SG.collapsePhase(st);
       return (storeyMergeMap && storeyMergeMap[c]) || c;
     }
-    var inst = instantiateTemplate(elements, T, laborRates, opts.shiftHours, bandRank, collapse);
+    // §TPL_LEVEL_AXIS opt-in. `opts.levelSource === 'deriver'` swaps the task grid's vertical axis
+    // to LevelDeriver; anything else (including absent) keeps the proven collapse(e.storey)/bandRank
+    // path byte-for-byte. `opts.levelProbe` measures the two axes against each other WITHOUT
+    // swapping — so the disagreement rate can be read off a shipped-behaviour run.
+    // TPL_LEVEL_SOURCE / TPL_LEVEL_PROBE env overrides exist so the SHIPPED witnesses can be run
+    // flag-on without forking them (node harness only — `process` is absent in the browser, so the
+    // live viewer can only ever be switched by an explicit opts.levelSource).
+    var _env = (typeof process !== 'undefined' && process && process.env) ? process.env : {};
+    var _srcOpt = opts.levelSource || _env.TPL_LEVEL_SOURCE || null;
+    var _wantAxis = (_srcOpt === 'deriver');
+    var _wantProbe = _wantAxis || !!opts.levelProbe || _env.TPL_LEVEL_PROBE === '1';
+    var _axis = null;
+    if (_wantProbe) {
+      _axis = _deriverLevelAxis(db, elements, collapse, storeyMergeMap, opts.label || 'building');
+      _logLevelDisagreement(elements, collapse, _axis, opts.label || 'building');
+    }
+    if (_wantAxis && !_axis) {
+      // Asked for the new axis, could not build it. Do NOT quietly serve the old one under the new
+      // name — say so, then fall back to the proven path.
+      console.log('§TPL_LEVEL_SOURCE requested=deriver effective=storey — FELL BACK (axis unavailable)');
+    }
+    var _useAxis = _wantAxis ? _axis : null;
+    // Emitted only when something was actually asked for, so a default run's §-log stays byte-for-byte
+    // what it was before this change (the flag-off identity the witnesses check).
+    if (_wantProbe) console.log('§TPL_LEVEL_SOURCE requested=' + (_srcOpt || 'storey') +
+      ' effective=' + (_useAxis ? 'deriver' : 'storey') + ' probe=on');
+    var inst = instantiateTemplate(elements, T, laborRates, opts.shiftHours, bandRank, collapse, _useAxis);
     if (!inst.tasks.length) { console.log('§AUTHOR_TPL_FAIL reason=no_tasks'); return { ok: false, reason: 'no_tasks' }; }
 
     // Absence is REPORTED, never silent — 4D_template.json's own instantiation rule, and the
@@ -2492,6 +2742,10 @@
     materializeZones: materializeZones,
     _buildScheduleElements: _buildScheduleElements,
     instantiateTemplate: instantiateTemplate,
+    // §TPL_LEVEL_AXIS — exported so the axis and its disagreement measurement are testable on their
+    // own, without having to drive a whole materializeZones write to see them.
+    _deriverLevelAxis: _deriverLevelAxis,
+    _logLevelDisagreement: _logLevelDisagreement,
     remapSolveToTasks: remapSolveToTasks,
     scheduleContiguous: scheduleContiguous,
     activeSchedule: activeSchedule,

--- a/viewer/tests/probe_tpl_level_axis.js
+++ b/viewer/tests/probe_tpl_level_axis.js
@@ -1,0 +1,125 @@
+#!/usr/bin/env node
+// probe_tpl_level_axis.js — §TPL_LEVEL_AXIS / §TPL_LEVEL_DISAGREE
+// Implementing bim-compiler prompts/4D_MODEL_INTEGRITY.md §I.3
+//
+// ISSUE IT PROVES OR DISPROVES: the task grid keys its levels on `collapse(e.storey)`, where
+// `e.storey` has already been rewritten by _buildScheduleElements's assignStoreyByZ — every element
+// whose DB storey is absent/'_UNKNOWN' is given the nearest REAL storey NAME by median centre-Z.
+// LevelDeriver answers the same question from the frozen DB and is not exposed to that rewrite.
+// This probe MEASURES how far apart the two answers actually are, per building, instead of assuming
+// the swap helps. It is a probe, not a witness: it asserts nothing, it reports numbers.
+//   node viewer/tests/probe_tpl_level_axis.js [Building ...]
+// Default buildings: Duplex, HHS_Office_Federated, Hospital (the three the instantiation witness uses).
+'use strict';
+const fs = require('fs');
+const path = require('path');
+const vm = require('vm');
+const os = require('os');
+
+const VIEWER_DIR = process.env.VIEWER_DIR || path.join(__dirname, '..');
+const BLD_DIR = process.env.BLD_DIR || path.join(os.homedir(), 'bim-ootb', 'buildings');
+const SQLJS_DIST = path.join(os.homedir(), 'bim-ootb', 'node_modules', 'sql.js', 'dist');
+const initSqlJs = require(path.join(SQLJS_DIST, 'sql-wasm.js'));
+
+const ScheduleGate = require(path.join(VIEWER_DIR, 'schedule_gate.js'));
+// LevelDeriver self-registers on globalThis; schedule_author resolves it from there at call time.
+globalThis.LevelDeriver = require(path.join(VIEWER_DIR, 'lib', 'level_deriver.js'));
+const ScheduleAuthor = require(path.join(VIEWER_DIR, 'schedule_author.js'));
+
+const T = JSON.parse(fs.readFileSync(path.join(VIEWER_DIR, 'rates', '4D_template.json'), 'utf8'));
+const START = '2026-01-01';
+const BUILDINGS = process.argv.slice(2).length ? process.argv.slice(2)
+  : ['Duplex', 'HHS_Office_Federated', 'Hospital'];
+
+function executedRules() {
+  const sb = { console: { log() {}, warn() {}, error() {} } };
+  vm.createContext(sb);
+  vm.runInContext(fs.readFileSync(path.join(VIEWER_DIR, 'rates.js'), 'utf8'), sb);
+  return sb;
+}
+
+// Run materializeZones on a FRESH copy of the db (it writes tasks), capturing the §-log.
+function run(SQL, file, R, extraOpts) {
+  const db = new SQL.Database(new Uint8Array(fs.readFileSync(file)));
+  const _l = console.log, _w = console.warn;
+  const logs = [];
+  console.log = (...a) => { logs.push(a.join(' ')); };
+  console.warn = () => {};
+  let res;
+  try {
+    res = ScheduleAuthor.materializeZones(db, R.SEQUENCE_RULES, Object.assign({
+      start: START, laborRates: R.LABOR_RATES, rates: R.RATES,
+      nameOverrides: R.SEQUENCE_NAME_OVERRIDES, defaultRule: R.SEQUENCE_DEFAULT,
+      scheduleGate: ScheduleGate, shiftHours: T.calendar.hours_per_shift, template: T
+    }, extraOpts || {}));
+  } finally { console.log = _l; console.warn = _w; }
+  const q = s => { try { const r = db.exec(s); return r.length ? r[0].values : []; } catch (e) { return []; } };
+  const tasks = q("SELECT task_id,name,schedule_start,schedule_finish FROM tasks WHERE schedule_id='SCH_AUTHORED' AND is_summary=0");
+  const te = q('SELECT task_id,guid FROM task_elements');
+  db.close();
+  return { res, logs, tasks, te };
+}
+
+(async () => {
+  const SQL = await initSqlJs({ locateFile: f => path.join(SQLJS_DIST, f) });
+  const R = executedRules();
+  const summary = [];
+
+  for (const bld of BUILDINGS) {
+    const file = path.join(BLD_DIR, bld + '_extracted.db');
+    if (!fs.existsSync(file)) { console.log('§PROBE_SKIP ' + bld + ' (no ' + file + ')'); continue; }
+    console.log('\n════════ ' + bld + ' ════════');
+
+    // A — OLD axis + probe on: shipped behaviour, plus the side-by-side measurement.
+    const A = run(SQL, file, R, { levelProbe: true, label: bld });
+    A.logs.filter(s => /^§TPL_LEVEL/.test(s)).forEach(s => console.log('  ' + s));
+
+    // B — NEW axis: the swap actually applied.
+    const B = run(SQL, file, R, { levelSource: 'deriver', label: bld });
+
+    const dis = (A.logs.find(s => s.indexOf('§TPL_LEVEL_DISAGREE label=') === 0) || '');
+    const m = /STRUCTURAL=(\d+) \(([\d.]+)%/.exec(dis);
+    const mr = /relabelOnly=(\d+) \(([\d.]+)%/.exec(dis);
+    const mf = /rawStoreyMissing=(\d+) \(([\d.]+)%/.exec(dis);
+
+    const levelsOf = r => {
+      const s = new Set();
+      r.tasks.forEach(([, name]) => { const d = name.indexOf(' — '); if (d > 0) s.add(name.slice(d + 3)); });
+      return [...s];
+    };
+    const row = {
+      building: bld,
+      elements: Number((/ n=(\d+) /.exec(dis) || [])[1] || 0),
+      structural: m ? Number(m[1]) : null,
+      structuralPct: m ? m[2] : null,
+      relabelOnly: mr ? Number(mr[1]) : null,
+      fabricated: mf ? Number(mf[1]) : null,
+      fabricatedPct: mf ? mf[2] : null,
+      tasksOld: A.tasks.length, tasksNew: B.tasks.length,
+      levelsOld: levelsOf(A).length, levelsNew: levelsOf(B).length,
+      totalDaysOld: A.res && A.res.totalDays, totalDaysNew: B.res && B.res.totalDays,
+      assignedOld: new Set(A.te.map(r2 => r2[1])).size,
+      assignedNew: new Set(B.te.map(r2 => r2[1])).size
+    };
+    summary.push(row);
+    console.log('  §PROBE_AXIS_EFFECT ' + bld +
+      ' tasks ' + row.tasksOld + '->' + row.tasksNew +
+      ' levels ' + row.levelsOld + '->' + row.levelsNew +
+      ' totalDays ' + row.totalDaysOld + '->' + row.totalDaysNew +
+      ' elementsAssigned ' + row.assignedOld + '->' + row.assignedNew);
+    console.log('  §PROBE_LEVELS_OLD ' + bld + ' ' + JSON.stringify(levelsOf(A).sort()));
+    console.log('  §PROBE_LEVELS_NEW ' + bld + ' ' + JSON.stringify(levelsOf(B).sort()));
+  }
+
+  console.log('\n════════ SUMMARY ════════');
+  console.log('§PROBE_TPL_LEVEL_AXIS ' + JSON.stringify(summary, null, 2));
+  summary.forEach(r => {
+    console.log('§PROBE_ROW ' + r.building +
+      ' n=' + r.elements +
+      ' STRUCTURAL=' + r.structural + ' (' + r.structuralPct + '%)' +
+      ' relabelOnly=' + r.relabelOnly +
+      ' fabricatedByAssignStoreyByZ=' + r.fabricated + ' (' + r.fabricatedPct + '%)' +
+      ' tasks=' + r.tasksOld + '->' + r.tasksNew +
+      ' assigned=' + r.assignedOld + '->' + r.assignedNew);
+  });
+})();


### PR DESCRIPTION
## The defect

`instantiateTemplate` keys its level grid on `collapse(e.storey)`. That `e.storey` has already been rewritten by `_buildScheduleElements`'s `assignStoreyByZ` (`schedule_author.js:342`), which hands **every** element with an absent/`_UNKNOWN` storey the nearest REAL storey NAME by median centre-Z. `deriveBandRanks`'s own `_UNKNOWN` exclusion (`schedule_gate.js:350`) is therefore **dead code on this path** — the bucket it guards is already empty when it looks.

## Step 1 — does `LevelDeriver` depend on the corrupted field? **No. Verified in code.**

- `assignStoreyByZ` is a **pure local function**. Its result is stored only into the in-memory element literal's `storey:` field (`:368`). It issues **no `db.run`/`UPDATE`** — `elements_meta.storey` on disk is never touched (only `wizard_storeys.js`, a deliberate user act, and the importers write it).
- `LevelDeriver.readLookups` reads `SELECT guid, storey FROM elements_meta` **straight from the frozen DB** (`level_deriver.js:67`); `levelFor` consumes only `guid`/`base_z`/`top_z` — **it never reads `el.storey`**.
- So the `_UNKNOWN` guard at `level_deriver.js:178` sees the **unrewritten** value and actually fires.

**The swap removes the exposure; it does not relocate it.**

## Step 3 — measured, not assumed (`§TPL_LEVEL_DISAGREE`)

| building | n | fabricated by `assignStoreyByZ` | **STRUCTURAL** | tasks | grid source |
|---|---|---|---|---|---|
| Duplex | 1,119 | 976 (**87.22%**) | 107 (**9.56%**) | 20 → 20 | `uniform3m` :warning: |
| HHS_Office_Federated | 6,839 | 2,120 (**31.00%**) | 533 (**7.79%**) | 20 → 17 | `declared` k=3 :white_check_mark: |
| Hospital | 63,182 | 9,457 (**14.97%**) | 25,198 (**39.88%**) | 42 → 68 | `uniform3m` :warning: |

The fabrication column **independently reproduces** the 87.0 / 30.8 / 14.9% figures. But **fabrication does not predict disagreement** — Duplex is 87% fabricated and only 9.6% structurally different; Hospital is 15% fabricated and 39.9% different. `assignStoreyByZ`'s nearest-median-Z guess usually lands on the same floor the geometry does; the divergence comes from the **grid**, not the guess.

:warning: **Report STRUCTURAL, never the raw key diff.** Raw diff counts an element as disagreeing when only the level's *name* changed. Duplex first measured **100.00%** raw where the real regrouping was **9.56%**. Both are logged; STRUCTURAL is the headline.

## Step 4 — witnesses

| witness | flag OFF | flag ON |
|---|---|---|
| `witness_4d_template_instantiation` | **byte-identical** to `origin/main`, 11/11, `ran=82` | 11/11, `ran=105` |
| `witness_4d_template` | **byte-identical**, 29/29 | 29/29 |
| `witness_4d_template_reached` | **byte-identical**, 6/6 | 6/6 |

Flag-off identity was proven by `git stash`-ing this diff, re-running, and `diff`-ing the logs — zero bytes differ.

:warning: **Flag-ON green is SCOPE-BLIND.** These invariants judge crew-legality, ladder monotonicity and coverage — **none judges whether the level PARTITION is correct**, which is exactly what flipping would damage on Hospital. Green here is not permission to flip.

## Step 6 — flag NOT flipped. The blocker is data, upstream of this code.

`Duplex_extracted.db` and `Hospital_extracted.db` have **no `spatial_structure` table at all** (`PRAGMA table_info` returns empty); only HHS carries storey `center_z`. With no declared floor lines `buildGrid` falls back to a **uniform 3.0 m grid** — Hospital's 8 real storeys become 16 occupied levels, the task grid inflates 42 → 68, and labels degrade to synthetic `L3/L5/L8/…` won on absurd margins (`§TPL_LEVEL_AXIS_NAMEVOTE`: grid line 4 labelled `"Level 6"` on **2 votes out of 5,676**).

This is the gap `bim-compiler d0b226dce` (§STOREY_DATUM — write `IfcBuildingStorey.Elevation`, *"which was never extracted"*) just fixed **at the extractor** — the shipped DBs have not been re-extracted since. Flip only after they are, then re-run the probe to confirm `gridSource=declared` fleetwide.

**No `gen_version` bump** (`_GANTT_CACHE_VERSION = 37`, `time_machine.js:8260`) while the flag is off — shipped output is proven byte-identical. **Flipping later REQUIRES the bump** or users keep a stale schedule built on the old partition.

## Notable fixes found while building this

- **Silent-fallback trap:** the first flag-on witness run came back byte-identical and looked like "no change". Cause: the witnesses never `require` `level_deriver.js`, so the axis silently fell back to the old path. `schedule_author` now resolves it itself under node (browser unaffected — `viewer.html` already script-tags it).
- **Level naming:** without a label rule Duplex's floors rendered `L0..L3`. Derived grid lines that `spatial_structure` did not name are now labelled by **plurality of the RAW declared storey** of the elements on them — extracted from data, never invented, and cast from the uncorrupted DB value so a fabricated name cannot win the vote.

## Follow-up (named, not chased)

`time_machine.js:3687` and `:4563` carry their own copies of `assignStoreyByZ` feeding the movie/x-ray element builders. Same fabrication, different consumers — out of scope for this slice.

Spec: `bim-compiler` §I ownership table + new `§I.3a` (`976b41ea8`).