### PR TITLE
fix(4d): §S18 — the elevation patches were never uploaded to OCI, and Duplex's would have been discarded

### DIFF
--- a/buildings/patches/Duplex_extracted.db.sql
+++ b/buildings/patches/Duplex_extracted.db.sql
@@ -17,3 +17,60 @@ INSERT OR IGNORE INTO rel_aggregates (parent_guid,child_guid) VALUES ('0wkEuT1wr
 INSERT OR IGNORE INTO rel_aggregates (parent_guid,child_guid) VALUES ('0wkEuT1wr1kOyafLY4v_O1','0wkEuT1wr1kOyafLY4v_PL');
 INSERT OR IGNORE INTO rel_aggregates (parent_guid,child_guid) VALUES ('0wkEuT1wr1kOyafLY4v_O1','0wkEuT1wr1kOyafLY4v_PH');
 INSERT OR IGNORE INTO rel_aggregates (parent_guid,child_guid) VALUES ('0jf0rYHfX3RAB3bSIRjmxl','3ThA22djr8AQQ9eQMA5s7I');
+
+-- ═══ §STOREY_DATUM (2026-08-27, bim-compiler prompts/4D_MODEL_INTEGRITY.md §I.3) ═══
+-- Duplex ships with NO spatial_structure table at all, so viewer/schedule_author.js
+-- _buildScheduleElements has no declared storey datum and falls back to assigning every
+-- storey-less element (86.0% of this building, 1026/1193) to the NEAREST storey by the
+-- MEDIAN center-Z of that storey's elements -- the inference §PATHS NOT TO TAKE #7
+-- forbids, unbounded, over a pool of raw labels. These 4 rows give it the real datum.
+--
+-- NOTHING HERE IS COMPUTED. Every value is read verbatim off IfcBuildingStorey in
+-- reference/residential/Ifc2x3_Duplex_Federated.ifc (IFC2X3, metres) and is IDENTICAL in
+-- Ifc2x3_Duplex_Architecture.ifc and bim-ootb/IFC/Duplex_ARC.ifc -- three independent
+-- files, same GlobalIds, same elevations.
+--
+-- FRAME VERIFIED before shipping, not assumed: the served DB is in the SAME coordinate
+-- frame as the IFC (offset 0), confirmed by two independent exact matches against the
+-- shipped element geometry -- T/FDN's 5th-percentile base_z is -1.25, exactly the IFC
+-- datum, and Roof's median base_z is 6.00, exactly the IFC datum. (Hospital was NOT
+-- patched for the same purpose precisely because that check fails there: its source
+-- files disagree on units, mm vs ft, and its served DB carries a ~166m site offset that
+-- would have to be INFERRED. It stays INCONCLUSIVE until a real re-extraction.)
+--
+-- ⚠ CORRECTED 2026-08-27 BEFORE FIRST UPLOAD — the block above originally opened with
+-- `CREATE TABLE IF NOT EXISTS spatial_structure (... elevation REAL)`. That is green against
+-- this machine's LOCAL buildings/Duplex_extracted.db, which has NO spatial_structure table at
+-- all — the CREATE fires and the INSERTs land. It is BROKEN against the object OCI actually
+-- SERVES, which already HAS a spatial_structure table (8 compiled rows) and no elevation
+-- column: the CREATE becomes a no-op and every INSERT below throws
+-- `table spatial_structure has no column named elevation`. Because
+-- viewer/scene.js _applyPendingPatch SWALLOWS any exec failure and returns the ORIGINAL
+-- buffer, that would have silently discarded THIS ENTIRE FILE — including the working
+-- §NOGEO_COMPOSE rel_aggregates rows above — while still logging nothing but the same
+-- §S18_STOREY_MERGE_FAIL it was written to cure. Caught by scripts/probe_s18_elevation_deploy.js,
+-- which runs against the DOWNLOADED SERVED BYTES; it is invisible to any check that reads the
+-- local dev DB. Same wrong-DATA-snapshot class scripts/oci_patch_gate.js was built for.
+--
+-- So this uses the DROP+CREATE convention the other patches in this directory already use
+-- (Hospital_meta.db.sql, Terminal_meta.db.sql) — idempotent, schema-independent, safe to
+-- re-apply. The 8 existing COMPILED rows are re-inserted verbatim, read straight out of the
+-- served object (elevation NULL: they were never extracted, and their center_z is the injected
+-- mean-wall-CENTRE-z datum §K.4 flags as 0.64-3.16 m too high — NULL is correct, not a guess).
+-- viewer/lib/room_walker.js writeRooms() rewrites every STC_/RM_ row on each load anyway.
+DROP TABLE IF EXISTS spatial_structure;
+CREATE TABLE spatial_structure (guid TEXT, type TEXT, name TEXT, parent_guid TEXT,
+  object_type TEXT, predefined_type TEXT, center_x REAL, center_y REAL, center_z REAL,
+  size_x REAL, size_y REAL, size_z REAL, room_guid TEXT, elevation REAL);
+INSERT INTO spatial_structure VALUES('STC_Level_1','IfcBuildingStorey','Level 1',NULL,'COMPILED',NULL,NULL,NULL,1.6224438773874128,NULL,NULL,NULL,NULL,NULL);
+INSERT INTO spatial_structure VALUES('STC_Roof','IfcBuildingStorey','Roof',NULL,'COMPILED',NULL,NULL,NULL,6.39619200410365706,NULL,NULL,NULL,NULL,NULL);
+INSERT INTO spatial_structure VALUES('STC_T/FDN','IfcBuildingStorey','T/FDN',NULL,'COMPILED',NULL,NULL,NULL,-0.634071428571428619,NULL,NULL,NULL,NULL,NULL);
+INSERT INTO spatial_structure VALUES('RM_Level_1_1','IfcSpace','≈ Level 1 R1','STC_Level_1','COMPILED','INTERNAL',4.28659244284541962,-13.809027458058491,1.62244387738741258,7.20000000000000017,6.00000000000000177,2.56167744628844706,NULL,NULL);
+INSERT INTO spatial_structure VALUES('RM_Level_1_2','IfcSpace','≈ Level 1 R2','STC_Level_1','COMPILED','INTERNAL',4.48659244284541891,-4.00902745805849036,1.62244387738741258,7.19999999999999928,6.0,2.56167744628844706,NULL,NULL);
+INSERT INTO spatial_structure VALUES('RM_Roof_1','IfcSpace','≈ Roof R1','STC_Roof','COMPILED','INTERNAL',4.45344109776439012,-8.91126439891143462,6.39619200410365706,7.0,16.0,2.0,NULL,NULL);
+INSERT INTO spatial_structure VALUES('RM_T/FDN_1','IfcSpace','≈ T/FDN R1','STC_T/FDN','COMPILED','INTERNAL',4.45344109776439811,-12.7112643989114317,-0.634071428571428619,7.0,8.40000000000000035,2.0,NULL,NULL);
+INSERT INTO spatial_structure VALUES('RM_T/FDN_2','IfcSpace','≈ T/FDN R2','STC_T/FDN','COMPILED','INTERNAL',4.45344109776439811,-5.11126439891143125,-0.634071428571428619,7.0,8.40000000000000035,2.0,NULL,NULL);
+INSERT OR IGNORE INTO spatial_structure (guid,type,name,parent_guid,elevation) VALUES ('1xS3BCk291UvhgP2dvNsgp','IfcBuildingStorey','T/FDN','1xS3BCk291UvhgP2a6eflK',-1.25);
+INSERT OR IGNORE INTO spatial_structure (guid,type,name,parent_guid,elevation) VALUES ('1xS3BCk291UvhgP2dvNMKI','IfcBuildingStorey','Level 1','1xS3BCk291UvhgP2a6eflK',0.0);
+INSERT OR IGNORE INTO spatial_structure (guid,type,name,parent_guid,elevation) VALUES ('1xS3BCk291UvhgP2dvNMQJ','IfcBuildingStorey','Level 2','1xS3BCk291UvhgP2a6eflK',3.10000000000038);
+INSERT OR IGNORE INTO spatial_structure (guid,type,name,parent_guid,elevation) VALUES ('1xS3BCk291UvhgP2dvNtSE','IfcBuildingStorey','Roof','1xS3BCk291UvhgP2a6eflK',6.00000000000039);

--- a/buildings/patches/Duplex_extracted.db.sql.manifest.json
+++ b/buildings/patches/Duplex_extracted.db.sql.manifest.json
@@ -1,0 +1,49 @@
+{
+  "schema": "oci-patch-provenance/1",
+  "generated_at": "2026-08-27T01:13:57.436Z",
+  "bucket": "bim-ootb",
+  "engine": {
+    "worktree": "/tmp/wt-storey-oci",
+    "sha": "515b520de8a67a85d03c6651d8794fded997e3d5",
+    "behind_origin_main": 0,
+    "ahead_origin_main": 1,
+    "clean": true,
+    "dirty_paths": []
+  },
+  "served_db": {
+    "object": "buildings/Duplex_extracted.db",
+    "etag": "9d85d487-99bf-4083-9603-05a61b39248e",
+    "content-md5": "sHANmqrU2zgwa11XfgP44A==",
+    "size": "14958592",
+    "last-modified": "Fri, 05 Jun 2026 00:40:48 GMT",
+    "content-encoding": null
+  },
+  "artifact": {
+    "file": "buildings/patches/Duplex_extracted.db.sql",
+    "bytes": 7792,
+    "md5": "02f56c04c0e63bc6c919ee5d48af2b27",
+    "md5_b64": "AvVsBMDmO8bJGe5dSK8rJw==",
+    "object": "buildings/patches/Duplex_extracted.db.sql",
+    "content_type": "application/sql"
+  },
+  "target": {
+    "exists": true,
+    "etag": "a5898929-65fb-4a84-aae1-f265deff1721",
+    "size": "2057",
+    "last-modified": "Mon, 10 Aug 2026 02:59:15 GMT"
+  },
+  "verification": {
+    "cmd": "node scripts/probe_s18_elevation_deploy.js --gate-db \"$GATE_DB\"",
+    "exit": 0,
+    "tail": [
+      "§S18_DEPLOY gate-db PASS — 4 storey datums survive the room compile, 4 names -> 4 bands"
+    ]
+  },
+  "verdict": "PASS",
+  "failures": [],
+  "uploaded": {
+    "at": "2026-08-27T01:14:01.572Z",
+    "etag": "d780fe1c-c21f-4175-ad03-f1cd0e4a798a",
+    "verified": true
+  }
+}

--- a/buildings/patches/Hospital_meta.db.sql.manifest.json
+++ b/buildings/patches/Hospital_meta.db.sql.manifest.json
@@ -1,10 +1,10 @@
 {
   "schema": "oci-patch-provenance/1",
-  "generated_at": "2026-08-17T06:37:28.023Z",
+  "generated_at": "2026-08-27T01:09:13.454Z",
   "bucket": "bim-ootb",
   "engine": {
-    "worktree": "/tmp/wt-s21-hospital-data",
-    "sha": "225e0cbfe33e785554a182fec3b7f60532cfefce",
+    "worktree": "/tmp/wt-storey-oci",
+    "sha": "515b520de8a67a85d03c6651d8794fded997e3d5",
     "behind_origin_main": 0,
     "ahead_origin_main": 1,
     "clean": true,
@@ -32,7 +32,18 @@
     "size": "1382739",
     "last-modified": "Sat, 15 Aug 2026 17:27:50 GMT"
   },
-  "verification": null,
+  "verification": {
+    "cmd": "node scripts/probe_s18_elevation_deploy.js --gate-db \"$GATE_DB\"",
+    "exit": 0,
+    "tail": [
+      "§S18_DEPLOY gate-db PASS — 56 storey datums survive the room compile, 8 names -> 8 bands"
+    ]
+  },
   "verdict": "PASS",
-  "failures": []
+  "failures": [],
+  "uploaded": {
+    "at": "2026-08-27T01:09:22.527Z",
+    "etag": "3342d90b-d667-44f6-84ed-102f5b44aeea",
+    "verified": true
+  }
 }

--- a/buildings/patches/Terminal_meta.db.sql.manifest.json
+++ b/buildings/patches/Terminal_meta.db.sql.manifest.json
@@ -1,12 +1,12 @@
 {
   "schema": "oci-patch-provenance/1",
-  "generated_at": "2026-08-17T06:37:14.178Z",
+  "generated_at": "2026-08-27T01:13:30.328Z",
   "bucket": "bim-ootb",
   "engine": {
-    "worktree": "/tmp/wt-s21-terminal-data",
-    "sha": "ccc83a41ca14a01defbdee612e131408925868b7",
+    "worktree": "/tmp/wt-storey-oci",
+    "sha": "515b520de8a67a85d03c6651d8794fded997e3d5",
     "behind_origin_main": 0,
-    "ahead_origin_main": 2,
+    "ahead_origin_main": 1,
     "clean": true,
     "dirty_paths": []
   },
@@ -32,7 +32,18 @@
     "size": "569945",
     "last-modified": "Sun, 16 Aug 2026 16:59:05 GMT"
   },
-  "verification": null,
+  "verification": {
+    "cmd": "node scripts/probe_s18_elevation_deploy.js --gate-db \"$GATE_DB\"",
+    "exit": 0,
+    "tail": [
+      "§S18_DEPLOY gate-db PASS — 67 storey datums survive the room compile, 23 names -> 15 bands"
+    ]
+  },
   "verdict": "PASS",
-  "failures": []
+  "failures": [],
+  "uploaded": {
+    "at": "2026-08-27T01:13:38.625Z",
+    "etag": "a2399f72-5f2b-4843-9fcb-610302d276ff",
+    "verified": true
+  }
 }

--- a/scripts/probe_s18_elevation_deploy.js
+++ b/scripts/probe_s18_elevation_deploy.js
@@ -1,0 +1,198 @@
+#!/usr/bin/env node
+// probe_s18_elevation_deploy.js — Implementing bim-compiler prompts/4D_MODEL_INTEGRITY.md §I.3.
+//
+// ⚠ DO NOT REMOVE — SCOPE. Read the §S18_DEPLOY log after every run. ONE question, no others:
+//
+//   Does the SERVED OCI object, plus the patch this repo is about to upload for it, make
+//   viewer/schedule_author.js's §S18 query WORK — where today it throws?
+//
+// This is a DEPLOY probe, not a data probe. It is the `--verify` command for
+// scripts/oci_patch_gate.js, and it exists because the §I.3 gap turned out to be neither a
+// missing extractor fix nor missing data: the elevation patches were authored, committed, and
+// wired (viewer/scene.js A._applyPendingPatch fetches buildings/patches/<dbFile>.sql from the
+// same directory the db came from) — they were simply NEVER UPLOADED to the OCI bucket the
+// viewer actually fetches from. The repo copy and the served copy silently disagreed. Nothing
+// in the repo could see that, because nothing in the repo reads the served bytes. This does.
+//
+// It therefore runs against the DOWNLOADED SERVED BYTES, never buildings/*.db — a local
+// building DB is a dev artifact that may already carry hand-applied fixes (measured: this
+// machine's buildings/Hospital_meta.db had an elevation column the served object did not).
+//
+// WHAT IT ASSERTS, per building:
+//   1. BEFORE — the served db + served state reproduces the live failure (records it verbatim).
+//   2. AFTER  — the exact §S18 query from schedule_author.js:701 returns rows.
+//   3. SURVIVES — the elevation column and its rows are still there after viewer/lib/room_walker.js
+//      writeRooms() mutates the same table. writeRooms CREATEs spatial_structure WITHOUT an
+//      elevation column when absent (:1338) and its ADD COLUMN list omits elevation (:1342), so
+//      "the patch lands" and "the patch survives the client-side room compile" are two different
+//      claims. Only the STC_/RM_ prefixed rows are deleted, so real storey rows must persist.
+//   4. MERGES — schedule_gate.js's own deriveStoreyMergeMap() runs on the result and reports how
+//      many storey NAMES collapse into shared bands. This calls the SHIPPED function; it does not
+//      re-derive the merge (prompts/4D_MODEL_INTEGRITY.md §I OWNERSHIP TABLE — that row's owner is
+//      deriveStoreyMergeMap, and re-implementing an owned relation is this lane's recurring defect).
+//
+// VERDICTS (PRIMAL LAW clause 4 — a witness that cannot report its own failure is not a witness):
+//   PASS         — before threw / was empty, after returns rows, rows survive writeRooms.
+//   VACUOUS      — the patch applied but yielded ZERO non-null elevations. A 0 here means the
+//                  patch carries no datum, NOT that the building is fine. Never PASS.
+//   NO-OP        — the served db ALREADY answered §S18 before the patch. Nothing to deploy.
+//   FAIL         — after still throws, or rows do not survive writeRooms.
+'use strict';
+const fs = require('fs'), path = require('path'), os = require('os');
+const HOME = os.homedir();
+const initSqlJs = require(path.join(HOME, 'bim-ootb', 'node_modules', 'sql.js'));
+const SQLJS_DIST = path.join(HOME, 'bim-ootb', 'node_modules', 'sql.js', 'dist');
+const SG = require(path.join(__dirname, '..', 'viewer', 'schedule_gate.js'));
+
+// The EXACT query viewer/schedule_author.js:701 runs. Kept byte-identical on purpose: if it drifts
+// there, this probe must stop reporting PASS for a query the viewer no longer issues.
+const S18_QUERY = "SELECT type,name,elevation FROM spatial_structure WHERE type='IfcBuildingStorey' AND elevation IS NOT NULL";
+
+// Mirrors viewer/scene.js A._runSqlChunked (§PATCH_CHUNK). Statement-aware batching, not raw-line:
+// a multi-line `CREATE TABLE spatial_structure (...)` must never be cut on a chunk boundary. Node's
+// sql.js is a DIFFERENT build from the bundled browser .wasm and does not need the chunking to
+// avoid the heap crash — it is replicated anyway so this probe applies the patch the same SHAPE the
+// viewer does, rather than proving something about a code path the browser never takes.
+function runSqlChunked(db, sql) {
+  const statements = [];
+  let buf = [];
+  for (const ln of sql.split('\n')) {
+    if (!ln.trim().length) continue;
+    buf.push(ln);
+    if (/;\s*$/.test(ln)) { statements.push(buf.join('\n')); buf = []; }
+  }
+  if (buf.length) statements.push(buf.join('\n'));
+  const CHUNK = 500;
+  for (let i = 0; i < statements.length; i += CHUNK) db.run(statements.slice(i, i + CHUNK).join('\n'));
+  return statements.length;
+}
+
+// The schema mutations viewer/lib/room_walker.js writeRooms() performs on an EXISTING
+// spatial_structure (:1341-1347 ADD COLUMN list, :1349 + :1356 the idempotent compiled-row deletes).
+// Copied deliberately as the three real statements rather than by calling writeRooms(), which would
+// require compiling every room in the building to answer a question about the TABLE, not the rooms.
+function simulateWriteRoomsSchemaPass(db) {
+  for (const col of ['center_x', 'center_y', 'center_z', 'size_x', 'size_y', 'size_z', 'object_type', 'predefined_type', 'room_guid']) {
+    const type = (col.startsWith('center') || col.startsWith('size')) ? ' REAL' : ' TEXT';
+    try { db.run('ALTER TABLE spatial_structure ADD COLUMN ' + col + type); } catch (e) { /* already exists */ }
+  }
+  db.run("DELETE FROM spatial_structure WHERE type='IfcBuildingStorey' AND guid LIKE 'STC\\_%' ESCAPE '\\'");
+  db.run("DELETE FROM spatial_structure WHERE type='IfcSpace' AND guid LIKE 'RM\\_%' ESCAPE '\\'");
+}
+
+function s18(db) {
+  try {
+    const res = db.exec(S18_QUERY);
+    if (!res.length) return { ok: true, rows: [] };
+    const c = res[0].columns, tI = c.indexOf('type'), nI = c.indexOf('name'), eI = c.indexOf('elevation');
+    return { ok: true, rows: res[0].values.map(v => ({ type: v[tI], name: v[nI], elevation: v[eI] })) };
+  } catch (e) {
+    return { ok: false, err: e.message };
+  }
+}
+
+function arg(name, dflt) {
+  const i = process.argv.indexOf('--' + name);
+  return i < 0 ? dflt : process.argv[i + 1];
+}
+
+(async () => {
+  const SQL = await initSqlJs({ locateFile: f => path.join(SQLJS_DIST, f) });
+  const servedDir = arg('served-dir', process.env.SERVED_DIR);
+  const patchDir = arg('patch-dir', path.join(__dirname, '..', 'buildings', 'patches'));
+  const targets = process.argv.slice(2).filter(a => !a.startsWith('--') &&
+    !['--served-dir', '--patch-dir'].includes(process.argv[process.argv.indexOf(a) - 1]));
+
+  // --gate-db mode: scripts/oci_patch_gate.js has ALREADY downloaded the served object and applied
+  // the patch to a throwaway copy, handing it over as $GATE_DB. Assert the POST state only — there
+  // is no un-patched BEFORE left to observe.
+  //
+  // ⚠ This mode is STRICTLY WEAKER than the standalone one and must not be treated as a substitute.
+  // The gate applies the patch with `sqlite3 <db> < patch`, and the sqlite3 CLI without -bail keeps
+  // going after a failing statement. The browser does NOT: _applyPendingPatch throws out the whole
+  // buffer. So a patch that half-applies looks GREEN here and is fully DISCARDED live — which is
+  // exactly how the Duplex `CREATE TABLE IF NOT EXISTS` defect would have slipped through. Run the
+  // standalone mode (sql.js, all-or-nothing, same shape as the viewer) for that claim.
+  const gateDb = arg('gate-db');
+  if (gateDb) {
+    const db = new SQL.Database(new Uint8Array(fs.readFileSync(gateDb)));
+    const after = s18(db);
+    if (!after.ok) { console.log(`§S18_DEPLOY gate-db FAIL — §S18 still throws after the gate applied the patch: "${after.err}"`); process.exit(1); }
+    simulateWriteRoomsSchemaPass(db);
+    const survived = s18(db);
+    if (!survived.ok) { console.log(`§S18_DEPLOY gate-db FAIL — writeRooms() schema pass broke it: "${survived.err}"`); process.exit(1); }
+    if (!survived.rows.length) { console.log('§S18_DEPLOY gate-db VACUOUS — zero non-null elevations; a 0 here is not a pass'); process.exit(1); }
+    const map = SG.deriveStoreyMergeMap(survived.rows);
+    const bands = new Set(Object.keys(map).map(k => map[k])).size;
+    console.log(`§S18_DEPLOY gate-db PASS — ${survived.rows.length} storey datums survive the room compile, ${Object.keys(map).length} names -> ${bands} bands`);
+    db.close();
+    process.exit(0);
+  }
+
+  if (!servedDir || !targets.length) {
+    console.error('usage: probe_s18_elevation_deploy.js --served-dir <dir> <DbObject.db> [...]');
+    console.error('   or: probe_s18_elevation_deploy.js --gate-db "$GATE_DB"   (from oci_patch_gate.js --verify)');
+    console.error('  <DbObject.db> is the OCI object name, e.g. Hospital_meta.db; the served copy is');
+    console.error('  expected at <served-dir>/served_<DbObject.db> and the patch at <patch-dir>/<DbObject.db>.sql');
+    process.exit(2);
+  }
+
+  let anyFail = false, anyVacuous = false;
+  for (const dbObj of targets) {
+    const servedPath = path.join(servedDir, 'served_' + dbObj);
+    const patchPath = path.join(patchDir, dbObj + '.sql');
+    if (!fs.existsSync(servedPath)) { console.log(`§S18_DEPLOY ${dbObj} INCONCLUSIVE — no served copy at ${servedPath}`); anyFail = true; continue; }
+    if (!fs.existsSync(patchPath)) { console.log(`§S18_DEPLOY ${dbObj} INCONCLUSIVE — no patch at ${patchPath}`); anyFail = true; continue; }
+
+    const db = new SQL.Database(new Uint8Array(fs.readFileSync(servedPath)));
+
+    // 1. BEFORE — reproduce the live failure against the real served bytes.
+    const before = s18(db);
+    const beforeDesc = before.ok ? `returns ${before.rows.length} row(s)` : `THREW "${before.err}"`;
+    console.log(`§S18_DEPLOY ${dbObj} BEFORE ${beforeDesc}`);
+
+    // 2. AFTER — apply the patch exactly as A._applyPendingPatch would.
+    // A THROW HERE IS THE LOUDEST RESULT THIS PROBE CAN PRODUCE, not a crash. viewer/scene.js
+    // _applyPendingPatch catches every exec failure and returns the ORIGINAL buffer, so a patch
+    // whose SQL throws is not partially applied — the WHOLE FILE is silently discarded, and the
+    // only thing the user ever sees is the same §S18_STOREY_MERGE_FAIL the patch was meant to
+    // cure. Measured: the Duplex §STOREY_DATUM block opened with `CREATE TABLE IF NOT EXISTS`,
+    // which is a no-op against the served object's pre-existing elevation-less table, so every
+    // INSERT threw. Report it as FAIL and name the discarded blast radius.
+    const sql = fs.readFileSync(patchPath, 'utf8');
+    let nStmt;
+    try {
+      nStmt = runSqlChunked(db, sql);
+    } catch (e) {
+      console.log(`§S18_DEPLOY ${dbObj} FAIL — patch SQL THREW "${e.message}". _applyPendingPatch swallows this and returns the UNPATCHED buffer, so the ENTIRE ${sql.length}-byte patch would be discarded silently, not partially applied.`);
+      anyFail = true; db.close(); continue;
+    }
+    const after = s18(db);
+    if (!after.ok) { console.log(`§S18_DEPLOY ${dbObj} FAIL — after patch the query STILL throws "${after.err}"`); anyFail = true; db.close(); continue; }
+    console.log(`§S18_DEPLOY ${dbObj} AFTER  ${after.rows.length} row(s) from ${nStmt} statement(s), ${sql.length} bytes`);
+
+    // 3. SURVIVES — the client-side room compile mutates this same table afterwards.
+    simulateWriteRoomsSchemaPass(db);
+    const survived = s18(db);
+    if (!survived.ok) { console.log(`§S18_DEPLOY ${dbObj} FAIL — writeRooms() schema pass BROKE the query: "${survived.err}"`); anyFail = true; db.close(); continue; }
+    console.log(`§S18_DEPLOY ${dbObj} SURVIVES_ROOM_COMPILE ${survived.rows.length} row(s) still answer §S18`);
+
+    // 4. MERGES — the SHIPPED owner of "are two storey names one floor?".
+    const map = SG.deriveStoreyMergeMap(survived.rows);
+    const names = Object.keys(map);
+    const merged = names.filter(k => map[k] !== k).length;
+    const bands = new Set(names.map(k => map[k])).size;
+    console.log(`§S18_DEPLOY ${dbObj} MERGE names=${names.length} merged=${merged} bands=${bands}`);
+
+    // verdict
+    if (!survived.rows.length) { console.log(`§S18_DEPLOY ${dbObj} VACUOUS — patch applied but ZERO non-null elevations; a 0 here is not a pass`); anyVacuous = true; }
+    else if (before.ok && before.rows.length) { console.log(`§S18_DEPLOY ${dbObj} NO-OP — the served object already answered §S18; nothing to deploy`); }
+    else console.log(`§S18_DEPLOY ${dbObj} PASS — served object could not answer §S18, patched object can (${survived.rows.length} storey datums, ${bands} bands)`);
+
+    db.close();
+  }
+
+  const verdict = anyFail ? 'FAIL' : (anyVacuous ? 'INCONCLUSIVE' : 'PASS');
+  console.log(`§S18_DEPLOY VERDICT ${verdict}`);
+  process.exit(verdict === 'PASS' ? 0 : 1);
+})().catch(e => { console.error('§S18_DEPLOY CRASH', e); process.exit(1); });


### PR DESCRIPTION
Closes the `§I.3` level-relation data gap (bim-compiler `prompts/4D_MODEL_INTEGRITY.md`), which was blocking `§S18` on the whole fleet.

## It was a deploy gap, not a data gap

`§I.3` recorded *"0 of 4 shipped DBs carry `spatial_structure.elevation`"* and reads as a missing extractor fix. It is not. The data was extracted, committed and wired days earlier — `buildings/patches/Hospital_meta.db.sql` (56 real `IfcBuildingStorey` rows, 2026-08-17) and `Terminal_meta.db.sql` (67 rows) — and `viewer/scene.js` `A._applyPendingPatch` already fetches `buildings/patches/<dbFile>.sql` from the same directory the db came from.

**The patches were never uploaded to the bucket the viewer actually fetches from.**

| object | served | repo | `elevation` in served |
|---|---|---|---|
| `patches/Hospital_meta.db.sql` | 1,382,739 B | 2,592,837 B | **0 mentions** |
| `patches/Terminal_meta.db.sql` | 569,945 B | 4,723,739 B | **0 mentions** |

The repo copy and the served copy disagreed in silence, and **nothing in the repo could see it, because nothing in the repo read the served bytes.** This machine's local `buildings/Hospital_meta.db` already carried an `elevation` column the served object did not — so every local check agreed the fix was in while the fleet stayed broken. ⚠ `buildings/*.db` is a dev artifact; it is not evidence about production.

### Why the live log said `no such column`, not `no such table`

That detail is what made this look like a stale-extractor problem. The served `Hospital_meta.db` has no `spatial_structure` at all, and the stale served patch never mentions one — but `viewer/lib/room_walker.js` `writeRooms()` **CREATEs the table client-side without an `elevation` column** (`:1338`), and its `ADD COLUMN` list omits `elevation` (`:1342`). The client manufactures the table, then `§S18` asks it for a column it does not have. It only deletes `STC_`/`RM_` rows, so real storey rows do survive it — asserted, not assumed.

## `scripts/probe_s18_elevation_deploy.js` — the check that was missing

Runs against the **downloaded served bytes**, never `buildings/*.db`. Per building it asserts: BEFORE reproduces the live failure verbatim · AFTER answers the exact `§S18` query from `schedule_author.js:701` · the rows SURVIVE `writeRooms`' schema pass · the **shipped** `deriveStoreyMergeMap` runs on the result (the `§I` OWNERSHIP TABLE owner for that question — called, not re-derived). It reports `VACUOUS` and `NO-OP` and never a bare PASS on an empty population.

```
§S18_DEPLOY Hospital_meta.db    BEFORE THREW "no such table: spatial_structure"
§S18_DEPLOY Hospital_meta.db    AFTER 56 rows · SURVIVES_ROOM_COMPILE 56 · MERGE names=8 merged=0 bands=8   PASS
§S18_DEPLOY Terminal_meta.db    BEFORE THREW "no such column: elevation"
§S18_DEPLOY Terminal_meta.db    AFTER 67 rows · SURVIVES_ROOM_COMPILE 67 · MERGE names=23 merged=8 bands=15 PASS
§S18_DEPLOY Duplex_extracted.db BEFORE THREW "no such column: elevation"
§S18_DEPLOY Duplex_extracted.db AFTER  4 rows · SURVIVES_ROOM_COMPILE  4 · MERGE names=4 merged=0 bands=4   PASS
§S18_DEPLOY VERDICT PASS
```

**`deriveStoreyMergeMap` now runs** — Terminal collapses **23 storey names into 15 bands**. `§I.3` says it *"has NEVER RUN"* on any shipped building.

## ⚠ A second defect, caught by that probe and never shipped

Duplex's `§STOREY_DATUM` block (authored in **#1551**, brought here after independent verification) opened with `CREATE TABLE IF NOT EXISTS spatial_structure (… elevation REAL)`. That is green against the LOCAL `Duplex_extracted.db`, which has no such table. The **served** object **has** one, elevation-less — so the CREATE no-ops and every INSERT throws `table spatial_structure has no column named elevation`.

`_applyPendingPatch` swallows exec failures and returns the **original** buffer, so this would have **silently discarded the entire Duplex patch** — including the working `§NOGEO_COMPOSE` `rel_aggregates` rows — while still logging nothing but the `§S18_STOREY_MERGE_FAIL` it was written to cure. Rewritten to the DROP+CREATE convention `Hospital_meta.db.sql` and `Terminal_meta.db.sql` already use, re-inserting the 8 existing compiled rows verbatim from the served object.

⚠ **`oci_patch_gate.js` alone would NOT have caught this.** It applies patches with `sqlite3 <db> < patch`, and the CLI without `-bail` continues past a failing statement, so a half-applied patch reads green there and is wholly discarded live. The probe's `--gate-db` mode documents that it is strictly weaker than its standalone (sql.js, all-or-nothing) mode.

## Provenance — nothing here is computed

Hospital's elevations are unit-resolved **per `IfcProject`** across its 7 discipline IFCs: the **SPR sprinkler file declares `FOOT`** where the other six declare `MILLI.METRE`, so its Level 2/3/4/5 land at **6.096 / 10.9728 / 15.8496 / 20.7264 m** beside the mm files' 6 / 11 / 16 / 21 — 0.096 m apart, and correctly merged under `GAP`. Duplex's four are identical across three independent source files. Verified against `internal/UNMERGED/` and `~/Projects/bim-compiler/DAGCompiler/lib/input/IFC/UNMERGED/`.

## Deployed

All three uploaded through `scripts/oci_patch_gate.js --upload` (engine clean, 0 behind `origin/main`), each `§GATE_VERDICT UPLOAD_VERIFIED` with a fetch-back check; manifests committed.

## Not done here, deliberately

- **`opts.levelSource='deriver'` (#1556) is NOT flipped.** This PR only removes the data blocker that `§I.3a` cites as the reason it is off. Whether LevelDeriver's higher tiers activate correctly on real declared storeys is a separate verification.
- **`HHS_Office_Federated` stays OPEN.** It has `spatial_structure` with 3 storeys and populated `center_z` (`size_z = 0`, a placement point) but no `elevation` column and no patch adding one, so `§S18` still throws for it. `elevation := center_z` is plausible but is a **derivation, not an extraction** — closing it honestly means reading HHS's own source IFCs. Not guessed.
- **Overlaps #1551**, which carries the same Duplex block in its pre-corrected form. That PR should drop its copy of `buildings/patches/Duplex_extracted.db.sql` — the version here is the one verified against served bytes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
