### PR TITLE
feat(4d): persist task grid in cache + reveal-spread histogram probe

### DIFF
--- a/scripts/cache_4d_run.js
+++ b/scripts/cache_4d_run.js
@@ -42,12 +42,12 @@ function dbKey(file) {
 }
 function dirFor(bld) { return path.join(ROOT, bld, codeKey() + '_' + dbKey(path.join(BLD, bld + '_extracted.db'))); }
 
-// read(bld) — what every downstream probe should call. Returns {els, sched, log, dir} or null.
+// read(bld) — what every downstream probe should call. Returns {els, sched, tasks, log, dir} or null.
 function read(bld) {
   const d = dirFor(bld);
   if (!fs.existsSync(path.join(d, 'run.json'))) return null;
   const j = JSON.parse(fs.readFileSync(path.join(d, 'run.json'), 'utf8'));
-  return { els: j.els, sched: j.sched, storeys: j.storeys || null, log: fs.readFileSync(path.join(d, 'witness.log'), 'utf8'), dir: d };
+  return { els: j.els, sched: j.sched, storeys: j.storeys || null, tasks: j.tasks || null, log: fs.readFileSync(path.join(d, 'witness.log'), 'utf8'), dir: d };
 }
 
 function build(bld, force) {
@@ -75,7 +75,7 @@ function build(bld, force) {
       // TEE, not suppress: the §-log is the evidence, so it goes to the file AND to the terminal.
       console.log = function () { const s = Array.prototype.join.call(arguments, ' '); lines.push(s); _l(s); };
       console.warn = function () { const s = Array.prototype.join.call(arguments, ' '); lines.push(s); _w(s); };
-      let els = null, sched = null, storeys = null, err = null;
+      let els = null, sched = null, storeys = null, tasks = null, err = null;
       try {
         const db = new SQL.Database(new Uint8Array(fs.readFileSync(file)));
         const base = { start: '2026-01-01', laborRates: sb.LABOR_RATES, rates: sb.RATES,
@@ -87,6 +87,11 @@ function build(bld, force) {
           x0: e.x0, x1: e.x1, y0: e.y0, y1: e.y1, bz: e.base_z, tz: e.top_z }));
         const res = SA.materializeZones(db, sb.SEQUENCE_RULES, base);
         sched = res && res.displaySchedule;
+        // task grid (id, window, member guids) — needed to compute reveal-time-within-task-window,
+        // 4D_GANTT_TM_REFACTOR.md §FUTURE item 2. Not derivable from els/sched alone: the task_id a
+        // guid belongs to only exists on `res.tasks` (in-memory here, never written back to the db).
+        if (res && res.tasks) tasks = res.tasks.map(t => ({ id: t.id, sDays: t.sDays, eDays: t.eDays,
+          phase: t.phase, storey: t.storey, guids: t.guids }));
         // The IFC's OWN declared spatial structure, persisted alongside the run so a witness can
         // compare "storeys the model declares" against "bands the schedule invents" without a
         // tolerance constant anywhere. Absent on some shipped DBs (Duplex/Hospital have no
@@ -107,7 +112,7 @@ function build(bld, force) {
       fs.mkdirSync(d, { recursive: true });
       fs.writeFileSync(path.join(d, 'witness.log'), lines.join('\n') + '\n');
       fs.writeFileSync(path.join(d, 'run.json'), JSON.stringify({ bld: bld, builtAt: new Date().toISOString(),
-        codeKey: codeKey(), els: els, sched: flat, storeys: storeys }));
+        codeKey: codeKey(), els: els, sched: flat, storeys: storeys, tasks: tasks }));
       console.log('§CACHE_BUILT ' + bld + ' n=' + els.length + ' scheduled=' + Object.keys(flat).length +
         ' logLines=' + lines.length + ' declaredStoreys=' + (storeys ? storeys.length : 'ABSENT') + ' -> ' + d);
       return read(bld);

--- a/scripts/probe_tpl_reveal_spread.js
+++ b/scripts/probe_tpl_reveal_spread.js
@@ -1,0 +1,56 @@
+#!/usr/bin/env node
+// probe_tpl_reveal_spread.js — 4D_GANTT_TM_REFACTOR.md §FUTURE item 2, the RED/before measurement
+// ⚠ DO NOT REMOVE — SCOPE. Spec-First (CLAUDE.md): measure the CURRENT distribution before any code
+// change. Reads the persisted cache (bim-ootb/scripts/cache_4d_run.js) — never re-invokes the
+// pipeline. Question: for a task spanning [task_sDays, task_eDays], where does each of its elements'
+// reveal timestamp (displaySchedule[guid].s, from §TPL_MOVIE_BINDS_BARS) fall inside that window,
+// normalized to [0,1]? A histogram skewed toward 0 is "crammed at the start"; a flat histogram is
+// "spread across the bar" (the fixed shape).
+'use strict';
+const path = require('path');
+const CACHE = require(path.join(__dirname, 'cache_4d_run.js'));
+
+const bld = process.argv[2] || 'Hospital';
+const run = CACHE.read(bld);
+if (!run) { console.log('§TPL_REVEAL_SPREAD_FAIL bld=' + bld + ' — no cache, run: node scripts/cache_4d_run.js ' + bld); process.exit(1); }
+if (!run.tasks) { console.log('§TPL_REVEAL_SPREAD_FAIL bld=' + bld + ' — cache has no tasks field, rebuild with --force'); process.exit(1); }
+
+const BUCKETS = 10;
+const hist = new Array(BUCKETS).fill(0);
+let n = 0, skipped = 0;
+const base = Date.parse('2026-01-01');
+const perTask = [];
+
+for (const t of run.tasks) {
+  const wS = base + t.sDays * 86400000, wE = base + t.eDays * 86400000;
+  const wSpan = wE - wS;
+  const tHist = new Array(BUCKETS).fill(0);
+  let tN = 0;
+  for (const g of t.guids) {
+    const sc = run.sched[g];
+    if (!sc) { skipped++; continue; }
+    let pos = wSpan > 0 ? (sc.s - wS) / wSpan : 0;
+    if (pos < 0) pos = 0; if (pos > 1) pos = 1;
+    let b = Math.floor(pos * BUCKETS); if (b >= BUCKETS) b = BUCKETS - 1;
+    hist[b]++; n++;
+    tHist[b]++; tN++;
+  }
+  if (tN) perTask.push({ id: t.id, n: tN, days: t.eDays - t.sDays,
+    firstDecilePct: 100 * tHist[0] / tN });
+}
+
+perTask.sort((a, b) => b.firstDecilePct - a.firstDecilePct);
+console.log('§TPL_REVEAL_SPREAD_WORST bld=' + bld + ' top5-by-firstDecilePct=' +
+  JSON.stringify(perTask.slice(0, 5)));
+
+const pct = hist.map(c => (100 * c / n).toFixed(1));
+console.log('§TPL_REVEAL_SPREAD bld=' + bld + ' tasks=' + run.tasks.length + ' n=' + n + ' skipped=' + skipped +
+  ' decileCounts=[' + hist.join(',') + '] decilePct=[' + pct.join(',') + ']' +
+  ' — decile 0 = first 10% of the task own window, decile 9 = last 10%; a flat 10.0 each = uniform spread');
+
+// Simple skew signal: share of elements landing in the FIRST decile vs a uniform-spread expectation
+// of 10%. This is the number item 2's "crammed at the start" claim is actually about.
+const first = parseFloat(pct[0]);
+console.log('§TPL_REVEAL_SPREAD_SKEW bld=' + bld + ' firstDecilePct=' + first.toFixed(1) +
+  ' uniformExpected=10.0 ratio=' + (first / 10).toFixed(2) + 'x' +
+  (first > 20 ? ' — CRAMMED (>2x uniform)' : first > 12 ? ' — mild skew' : ' — roughly uniform'));


### PR DESCRIPTION
## Summary
- `cache_4d_run.js` now also persists `res.tasks` (task_id, window days, member guids) into `run.json` — previously discarded, needed to answer "where inside its task does each element reveal."
- `probe_tpl_reveal_spread.js` — read-only probe over the cache, buckets each element's reveal time into deciles of its own task's window. This is the red/before measurement `4D_GANTT_TM_REFACTOR.md §FUTURE` item 2 asks for before any display-authoring code change.

No pipeline/schedule_author.js/production behavior change — cache format extension + a new diagnostic script only.

## Test plan
- [x] `node scripts/cache_4d_run.js --force Hospital` rebuilt cleanly, `§CACHE_BUILT` line unchanged shape
- [x] `node scripts/probe_tpl_reveal_spread.js Hospital` — n=63182/63182, 0 skipped