### PR TITLE
perf(cinema): §R10 — MaxQ bake skips the lens-quad rebuild when nothing changed

### DIFF
--- a/viewer/effects.js
+++ b/viewer/effects.js
@@ -4060,8 +4060,19 @@ async function setupEffects(A, renderer, scene, camera) {
     // emissive left on would follow the user back into navigation.
     if (A._bloomPass) A._bloomPass.enabled = false;
     _emberOff();
-    // §GLOW_LENS_QUAD: the fitted lens quad is still-only — always tear it down here.
-    _glowLensOff();
+    // §GLOW_LENS_QUAD: still-only content — always tear down on a REAL exit (!keepStaging). A
+    // bake-frame cancel (keepStaging=true) skips the dispose+rebuild when something is already
+    // staged AND the TM-visible fixture count is unchanged since the last stage — unlike the round
+    // sprite (camera-dependent eye-offset) and §NIGHT_STILL_LIGHTS (camera-frustum-dependent), the
+    // quad's geometry (position/size/yaw) is built ONLY from fixture world data + the TM-visibility
+    // gate, never from A.camera — an unchanged visible set means an unchanged quad, byte-identical
+    // to what is already staged. §R10, CPE_4D_PERF_MEM_FINDINGS.md §7.
+    if (keepStaging && (_glowLensMeshRect || _glowLensMeshRound) &&
+        _glowVisibleFixtureCount(A._tmIsVisible) === _glowLensStagedCount) {
+      console.log('§GLOW_LENS_QUAD skip (count unchanged ' + _glowLensStagedCount + ')');
+    } else {
+      _glowLensOff();
+    }
     // §GLOW_SPRITE_NAV_OFF (2026-08-07): the round sprite no longer restages for nav — live
     // navigation runs on the real point lights only now (see tools.js toggleNightMode). Still
     // torn down unconditionally so it can never survive into navigation.
@@ -4414,14 +4425,21 @@ async function setupEffects(A, renderer, scene, camera) {
   // placed fixtures grows tick by tick — rebuild the (small, ≤~1200-point) cloud only when that
   // count actually changes, not on every tick. isVisible === null (TM inactive) always matches
   // "everything" and is a no-op restage the first time it's seen after a buildup ends.
+  // §R10 (CPE_4D_PERF_MEM_FINDINGS.md §7): shared with the lens quad's own bake-frame skip-gate
+  // below — same predicate, one owner, so the two mechanisms can never disagree on "how many
+  // fixtures are visible right now."
+  function _glowVisibleFixtureCount(isVisible) {
+    var allPos = A._nightFixtureWorldPositions ? A._nightFixtureWorldPositions() : [];
+    var n = 0;
+    for (var _gi = 0; _gi < allPos.length; _gi++) {
+      if (allPos[_gi].__guid == null || !isVisible || isVisible(allPos[_gi].__guid)) n++;
+    }
+    return n;
+  }
   if (typeof A._tmVisSubscribe === 'function') {
     A._tmVisSubscribe(function(isVisible) {
       if (!_glowPoints || !A._nightMode) return;
-      var allPos = A._nightFixtureWorldPositions ? A._nightFixtureWorldPositions() : [];
-      var n = 0;
-      for (var _gi = 0; _gi < allPos.length; _gi++) {
-        if (allPos[_gi].__guid == null || !isVisible || isVisible(allPos[_gi].__guid)) n++;
-      }
+      var n = _glowVisibleFixtureCount(isVisible);
       if (n === _glowStagedCount) return;
       _glowOff();
       _glowOn();
@@ -4477,6 +4495,7 @@ async function setupEffects(A, renderer, scene, camera) {
   // rather than a single one-size-fits-all shape.
   var GLOW_LENS_ROUND_ASPECT = 1.25;
   var _glowLensMeshRect = null, _glowLensMeshRound = null;
+  var _glowLensStagedCount = -1;   // §R10 — fixture count the CURRENT quads were built with
   function _glowLensOn() {
     if (_glowLensMeshRect || _glowLensMeshRound) return;
     if (typeof A._nightFixtureWorldPositions !== 'function') return;
@@ -4488,6 +4507,9 @@ async function setupEffects(A, renderer, scene, camera) {
     // startStillRefine) staged every fixture's quad from frame 1, ignoring the 4D schedule. Same
     // predicate, same guid-null passthrough for the synthetic per-storey/tier-3 fallback.
     pos = pos.filter(function(p) { return p.__guid == null || A._tmIsVisible(p.__guid); });
+    // §R10 — recorded BEFORE the zero-check, same placement _glowStagedCount uses above, so a
+    // teardown-time comparison sees "0 visible" as a real, stable count rather than "unset".
+    _glowLensStagedCount = pos.length;
     if (!pos.length) { console.log('§GLOW_LENS_QUAD_GATE 0 fixtures placed yet — nothing to light'); return; }
     var geo = new THREE.PlaneGeometry(1, 1);
     var matRect = new THREE.MeshBasicMaterial({

--- a/viewer/sw.js
+++ b/viewer/sw.js
@@ -22,7 +22,14 @@
 // schedule_author.js is in PRECACHE_ASSETS; v1088 shipped the STAGE 3 drawer change (#1528), so this
 // separate change needs its own bump (§CRISIS LESSON 4).
 // DEPLOY: bump CACHE_VERSION on every OCI upload. Old caches are purged on activate.
-const CACHE_VERSION = 'v1091';   // bump on each deploy; per-change detail is the git commit message.
+const CACHE_VERSION = 'v1092';   // bump on each deploy; per-change detail is the git commit message.
+// v1092 (2026-08-27) §R10 (bim-compiler prompts/CPE_4D_PERF_MEM_FINDINGS.md §7, extends R1's
+// §MAXQ_STAGE_KEEP contract): the MaxQ bake's per-frame §GLOW_LENS_QUAD rebuild (viewer/effects.js)
+// now skips the dispose+rebuild when the TM-visible fixture count is unchanged since the last
+// stage — its geometry never reads A.camera, unlike the round glow sprite and §NIGHT_STILL_LIGHTS
+// (both untouched, both correctly camera-dependent). effects.js?v=26->27, both in PRECACHE_ASSETS.
+// Witness: witness_glow_lens_stage_keep.js, 7/7 PASS (Duplex A/B: baseline 29 stage/remove cycles
+// in 28 frames -> fix 2 stages + 27 skips, last-frame rect/round counts byte-identical both sides).
 // v1090 (2026-08-27) §TPL_MODEL: rates/4D_template.json ADDED to PRECACHE_ASSETS (it defines the
 // canonical task grid and was never precached, so offline/cold-SW silently ran the dead deriveZones
 // path), plus schedule_author.js now names which model ran at the fork. Both are precached, so

--- a/viewer/viewer.html
+++ b/viewer/viewer.html
@@ -822,7 +822,7 @@ html.bim-embedded, html.bim-embedded body { background: #0b0b0b; }
 <script src="qrcode.min.js?v=1" onerror="console.warn('§LOAD_FAIL qrcode.min.js — QR sharing disabled')"></script>
 <script src="config.js?v=4" onerror="console.warn('§LOAD_FAIL config.js')"></script>
 <script src="db_resolve.js?v=2" onerror="console.warn('§LOAD_FAIL db_resolve.js')"></script>
-<script src="effects.js?v=26" onerror="console.warn('§LOAD_FAIL effects.js')"></script>
+<script src="effects.js?v=27" onerror="console.warn('§LOAD_FAIL effects.js')"></script>
 <script src="effects_gi_poc.js?v=3" onerror="console.warn('§LOAD_FAIL effects_gi_poc.js')"></script>
 <script src="lib/mp4_mux.js?v=1" onerror="console.warn('§LOAD_FAIL mp4_mux.js — MaxQ falls back to webm')"></script>
 <script src="cinema_path_editor.js?v=15" onerror="console.warn('§LOAD_FAIL cinema_path_editor.js — Alt+C path editing disabled')"></script>

--- a/witness_glow_lens_stage_keep.js
+++ b/witness_glow_lens_stage_keep.js
@@ -1,0 +1,138 @@
+#!/usr/bin/env node
+// WITNESS — §R10 (bim-compiler prompts/CPE_4D_PERF_MEM_FINDINGS.md §7, extends R1's §MAXQ_STAGE_KEEP
+// contract to the lens quad).
+//
+// ISSUE: the MaxQ bake tore down and rebuilt §GLOW_LENS_QUAD's InstancedMesh (rect+round) from
+// scratch EVERY frame, even though the quad's geometry is built purely from fixture world data +
+// the TM-visibility gate — never from A.camera — so an unchanged visible-fixture count means an
+// unchanged quad. The fix skips the dispose+rebuild when keepStaging is true, something is already
+// staged, and the TM-visible fixture count hasn't moved since the last stage.
+//
+// GATES (run with BASE=origin/main for the RED side, FIX=this worktree):
+//   G-BAKE-COMPLETES   both bakes finish, zero page errors.
+//   G-LENS-POPULATION  baseline actually stages the lens quad at least once — if this is 0 the
+//                      whole witness is VACUOUS (§CRISIS-class per WITNESS_INTERFACE_FRAMEWORK.md
+//                      §4) and every other gate below means nothing.
+//   G-LENS-CHURN-RED   baseline (unpatched) stages the quad on close to EVERY frame — the RED case
+//                      this fix targets must actually reproduce, or the A/B proves nothing.
+//   G-LENS-SKIP-FIRES  fix logs at least one "§GLOW_LENS_QUAD skip (count unchanged N)" line, and
+//                      its total staged-count is far below baseline's — the skip actually engages.
+//   G-LENS-FINAL-EQ    the LAST "staged rect=R round=Rd" line on each side reports the identical
+//                      rect/round counts — the skip changed the cost, not the final answer.
+//   G-LENS-TEARDOWN    a real end-of-bake exit (keepStaging=false) still removes the quad on the
+//                      fix side — "§GLOW_LENS_QUAD removed" appears after the last MAXQ_FRAME line,
+//                      so still-only content still never survives into navigation.
+//   G-PERF             informational: frames captured, wall ms/frame both sides.
+//
+// PRECONDITIONS: BASE_PORT serves shipped origin/main (bim-ootb main, up to date), FIX_PORT serves
+// this worktree. Duplex_extracted.db symlinked into both buildings/ dirs.
+const puppeteer = require('/home/red1/bim-compiler/node_modules/puppeteer');
+const BLD = 'Duplex';
+const FIX_PORT = process.env.FIX_PORT || 8561;
+const BASE_PORT = process.env.BASE_PORT || 8399;
+const sleep = ms => new Promise(r => setTimeout(r, ms));
+
+async function waitForLog(logs, re, timeoutMs) {
+  const t0 = Date.now();
+  for (;;) {
+    const hit = logs.find(l => re.test(l));
+    if (hit) return hit;
+    if (Date.now() - t0 > timeoutMs) return null;
+    await sleep(300);
+  }
+}
+
+// Same real user path R1's witness_maxq_stage_keep.js drives: open editor -> click OK -> bake
+// continues WITH buildup (default-on) -> run to §MAXQ_DONE/§MAXQ_WEBM. fps=1 keeps frame count small.
+async function bake(browser, port, logs, errs) {
+  const page = await browser.newPage();
+  await page.setViewport({ width: 1200, height: 700 });
+  page.on('console', m => logs.push(m.text()));
+  page.on('pageerror', e => { errs.push(e.message); logs.push('PAGEERROR ' + e.message); });
+  await page.goto(`http://localhost:${port}/viewer/viewer.html?db=/buildings/${BLD}_extracted.db`,
+    { waitUntil: 'domcontentloaded', timeout: 60000 });
+  await page.waitForFunction(
+    () => window.APP && window.APP.cinemaPathPlan && window.APP.cinemaPathEditor &&
+          window.APP.startMaxQualityOrbit && window.APP._composer,
+    { timeout: 120000 });
+  await sleep(9000);
+  await page.waitForFunction(() => {
+    try { const r = window.APP.dbQuery('SELECT COUNT(*) FROM element_transforms'); return r && r[0][0] > 0; }
+    catch (e) { return false; }
+  }, { timeout: 60000, polling: 2000 });
+  await page.evaluate(() => { window.APP.startMaxQualityOrbit({ preview: false, fps: 1, editor: true, forceWebm: true }); });
+  await page.waitForSelector('#cpe-ok', { timeout: 300000 });
+  await sleep(1500);
+  const t0 = Date.now();
+  await page.evaluate(() => { document.getElementById('cpe-ok').click(); });
+  const done = await waitForLog(logs, /§MAXQ_(DONE|WEBM|MP4)\b/, 1200000);
+  const wallMs = Date.now() - t0;
+  await page.close();
+  return { done, wallMs };
+}
+
+function tally(logs) {
+  const frames = logs.filter(l => /§MAXQ_FRAME i=/.test(l)).length;
+  const staged = logs.filter(l => /§GLOW_LENS_QUAD staged rect=/.test(l));
+  const removed = logs.filter(l => /§GLOW_LENS_QUAD removed/.test(l)).length;
+  const skip = logs.filter(l => /§GLOW_LENS_QUAD skip \(count unchanged/.test(l)).length;
+  const lastStaged = staged.length ? staged[staged.length - 1] : null;
+  const lastStagedMatch = lastStaged ? lastStaged.match(/rect=(\d+) round=(\d+)/) : null;
+  // Find the index of the LAST §MAXQ_FRAME line vs the LAST "removed" line, to confirm end-of-bake
+  // teardown happens AFTER the frame loop, not mid-bake.
+  const lastFrameIdx = logs.map((l, i) => /§MAXQ_FRAME i=/.test(l) ? i : -1).filter(i => i >= 0).pop();
+  const lastRemovedIdx = logs.map((l, i) => /§GLOW_LENS_QUAD removed/.test(l) ? i : -1).filter(i => i >= 0).pop();
+  return {
+    frames, staged: staged.length, removed, skip,
+    lastRectRound: lastStagedMatch ? { rect: +lastStagedMatch[1], round: +lastStagedMatch[2] } : null,
+    teardownAfterLastFrame: lastFrameIdx !== undefined && lastRemovedIdx !== undefined && lastRemovedIdx > lastFrameIdx
+  };
+}
+
+(async () => {
+  const browser = await puppeteer.launch({
+    headless: 'new', protocolTimeout: 1200000,
+    args: ['--no-sandbox', '--disable-dev-shm-usage', '--use-gl=angle', '--use-angle=swiftshader',
+      '--enable-unsafe-swiftshader']
+  });
+  const checks = [];
+  const P = (n, ok, d) => { checks.push({ n, ok, d }); console.log((ok ? 'PASS ' : 'FAIL ') + n + ' — ' + d); };
+  try {
+    const bLogs = [], bErrs = [];
+    const b = await bake(browser, BASE_PORT, bLogs, bErrs);
+    const bt = tally(bLogs);
+    console.log('§WITNESS_BASELINE done=' + !!b.done + ' frames=' + bt.frames + ' wallMs=' + b.wallMs +
+      ' lensStaged=' + bt.staged + ' lensRemoved=' + bt.removed + ' lensSkip=' + bt.skip);
+
+    const fLogs = [], fErrs = [];
+    const f = await bake(browser, FIX_PORT, fLogs, fErrs);
+    const ft = tally(fLogs);
+    console.log('§WITNESS_FIX done=' + !!f.done + ' frames=' + ft.frames + ' wallMs=' + f.wallMs +
+      ' lensStaged=' + ft.staged + ' lensRemoved=' + ft.removed + ' lensSkip=' + ft.skip);
+
+    P('G-BAKE-COMPLETES', !!b.done && !!f.done && bErrs.length === 0 && fErrs.length === 0,
+      `baseline=${b.done ? 'done' : 'TIMEOUT'} fix=${f.done ? 'done' : 'TIMEOUT'} pageerrors=${bErrs.length}/${fErrs.length}`);
+    P('G-LENS-POPULATION', bt.staged > 0,
+      bt.staged > 0 ? `baseline staged ${bt.staged} times — real population, not vacuous`
+                    : 'VACUOUS — baseline never staged the lens quad; Duplex may have no qualifying fixtures for this witness');
+    P('G-LENS-CHURN-RED', bt.staged >= bt.frames - 2,
+      `baseline lensStaged=${bt.staged} frames=${bt.frames} — the RED case (stage-every-frame) must actually reproduce`);
+    P('G-LENS-SKIP-FIRES', ft.skip > 0 && ft.staged < bt.staged,
+      `fix lensSkip=${ft.skip} lensStaged=${ft.staged} vs baseline lensStaged=${bt.staged}`);
+    P('G-LENS-FINAL-EQ',
+      !!bt.lastRectRound && !!ft.lastRectRound &&
+      bt.lastRectRound.rect === ft.lastRectRound.rect && bt.lastRectRound.round === ft.lastRectRound.round,
+      `baseline last=${JSON.stringify(bt.lastRectRound)} fix last=${JSON.stringify(ft.lastRectRound)}`);
+    P('G-LENS-TEARDOWN', ft.teardownAfterLastFrame,
+      `fix: last §GLOW_LENS_QUAD removed occurs after the last §MAXQ_FRAME line = ${ft.teardownAfterLastFrame}`);
+    P('G-PERF', true,
+      `informational: baseline ${Math.round(b.wallMs / Math.max(1, bt.frames))}ms/frame vs fix ${Math.round(f.wallMs / Math.max(1, ft.frames))}ms/frame (Duplex, swiftshader — direction only, GPU-blind)`);
+  } catch (e) {
+    P('G-INFRA', false, e.message);
+  } finally {
+    const pass = checks.filter(c => c.ok).length;
+    console.log(`\n§GLOW_LENS_STAGE_KEEP WITNESS ${pass}/${checks.length} PASS`);
+    await browser.close();
+    process.exit(pass === checks.length ? 0 : 1);
+  }
+})();


### PR DESCRIPTION
## Summary
- `§GLOW_LENS_QUAD` was disposed+rebuilt every MaxQ bake frame despite its geometry never depending on camera pose — only on the TM-visible fixture set. Extends R1's `keepStaging` contract (`§MAXQ_STAGE_KEEP`, #1307) to skip the rebuild when that count hasn't moved since the last stage.
- Round glow sprite and `§NIGHT_STILL_LIGHTS` are untouched — both genuinely camera-dependent (eye-offset nudge / frustum culling), correctly recompute every pose.
- `sw.js` `CACHE_VERSION` v1091→v1092, `effects.js?v=26→27` (both precached).

Spec: bim-compiler `prompts/CPE_4D_PERF_MEM_FINDINGS.md` §7.

## Test plan
- [x] `witness_glow_lens_stage_keep.js` — two-source A/B (shipped `origin/main` vs. this branch), 7/7 PASS
  - baseline reproduces the churn: 29 stage/remove cycles over 28 Duplex bake frames
  - fix: 2 stages + 27 skips
  - last-frame `rect=`/`round=` instance counts byte-identical baseline vs. fix (quality unchanged, not inferred)
  - end-of-bake real teardown still fires (invariant intact)
- [ ] Real-GPU `§MAXQ_FRAME` before/after on a bigger building (Hospital/Terminal) — swiftshader wall-clock in the witness is GPU-blind, direction-only, per this repo's own standing rule

🤖 Generated with [Claude Code](https://claude.com/claude-code)