### PR TITLE
probe(4d): §TPL_CALIB_SCOPE — the calibration "fix" IS the rejected 3x revert, measured

### DIFF
--- a/scripts/probe_tpl_calibration_scope.js
+++ b/scripts/probe_tpl_calibration_scope.js
@@ -1,0 +1,173 @@
+#!/usr/bin/env node
+// probe_tpl_calibration_scope.js — §TPL_CALIB_SCOPE
+//
+// ⚠ DO NOT REMOVE — SCOPE. bim-compiler prompts/4D_GANTT_TM_REFACTOR.md §FUTURE item 2, DECISION
+// step 1 (user, 2026-08-27): "Measure the 3x calibration mismatch's real scope FIRST — across all
+// 42 tasks, not just the 7 already floored at min_days=1. This is the load-bearing unknown: if it
+// meaningfully lengthens the other 35 tasks too, the whole 369-day project total moves, which is a
+// materially bigger decision than fixing 7 short bars — STOP AND REPORT before implementing
+// broadly if so."  Read the log after every run; this probe prints only §-tagged lines.
+//
+// WITNESS CLAIM (stated before the code, Spec-First):
+//   C1. Recomputing the SHIPPED instantiateTemplate with _installSecs' basis recalibrated from
+//       28800 s (the rate table's own 8-hour crew-day) to 86400 s (the 24-hour shift priceCell
+//       actually divides by) changes N of the building's tasks' `days`, and moves totalDays from
+//       A to B. N and B are the measurement; nothing here decides whether to ship it.
+//   C2. The "recalibrate the numerator" fix and the ALREADY-REJECTED "revert shiftHours 24->8"
+//       are either the same lever or different levers. priceCell is
+//       days = ceil( secs / (shiftSecs * crews) ), so scaling secs by 3 and dividing shiftSecs by
+//       3 are algebraically identical — this probe RUNS BOTH through the shipped function and
+//       asserts task-for-task equality rather than asserting the algebra.
+//   C3. The effect is either CONFINED to the tasks currently floored at min_days=1 (the premise
+//       the fix was scoped on) or it is not. Reported as a split: floored vs non-floored.
+//
+// NON-INVENT: every input is read back from the persisted cache_4d_run.js run (elements with their
+// OWN installSecs as the shipped _installSecs computed them) and pushed through the SHIPPED
+// ScheduleAuthor.instantiateTemplate / ScheduleGate.deriveBandRanks. No duration is authored here.
+// The baseline arm is asserted against the cached run's own §AUTHOR_TPL totalDays before any
+// comparison is believed (§TPL_CALIB_BASELINE) — if the reconstruction cannot reproduce the
+// shipped number, this probe reports INCONCLUSIVE and exits non-zero rather than compare
+// (PRIMAL LAW clause 4: a witness that cannot report its own failure is not a witness).
+'use strict';
+const fs = require('fs'), path = require('path'), vm = require('vm');
+const V = path.join(__dirname, '..', 'viewer');
+const CACHE = require(path.join(__dirname, 'cache_4d_run.js'));
+
+const SG = require(path.join(V, 'schedule_gate.js')); global.ScheduleGate = SG;
+const SA = require(path.join(V, 'schedule_author.js'));
+const T = JSON.parse(fs.readFileSync(path.join(V, 'rates', '4D_template.json'), 'utf8'));
+const sb = { console: { log() {}, warn() {}, error() {} } };
+vm.createContext(sb); vm.runInContext(fs.readFileSync(path.join(V, 'rates.js'), 'utf8'), sb);
+const LR = sb.LABOR_RATES;
+const SHIFT_H = T.calendar.hours_per_shift;            // 24, the standing ruling
+const RATE_TABLE_CREW_DAY_S = 28800;                   // _installSecs' own basis (schedule_author.js:91)
+
+// Silence the shipped function's own §-logging for the ARMS only (it would print the same
+// §TPL_* lines three times per building and drown the comparison). The cached witness.log
+// already carries the real run's log verbatim — that is the primary evidence, not this.
+function quiet(fn) {
+  const l = console.log, w = console.warn;
+  console.log = function () {}; console.warn = function () {};
+  try { return fn(); } finally { console.log = l; console.warn = w; }
+}
+
+function arm(els, shiftHours, secsScale) {
+  // elements are cloned per arm so one arm cannot see another's installSecs
+  const e2 = els.map(e => ({
+    guid: e.guid, cls: e.cls, phase: e.phase, storey: e.storey, resource: e.resource,
+    base_z: e.bz, top_z: e.tz, installSecs: (e.installSecs || 0) * secsScale
+  }));
+  const bandRank = (SG.deriveBandRanks(e2, null) || {}).bandRank || {};
+  const collapse = function (st) { return SG.collapsePhase(st); };   // storeyMergeMap is null on the
+  // buildings measured here (§S18_STOREY_MERGE_FAIL: no spatial_structure) — matched, not assumed:
+  // the baseline arm's totalDays assertion below is what proves the reconstruction is faithful.
+  return quiet(() => SA.instantiateTemplate(e2, T, LR, shiftHours, bandRank, collapse, null));
+}
+
+function shippedTotalDays(log) {
+  const m = /§AUTHOR_TPL[^\n]*\btotalDays=(\d+(?:\.\d+)?)/.exec(log);
+  return m ? Number(m[1]) : null;
+}
+
+function run(bld) {
+  const c = CACHE.read(bld);
+  if (!c) { console.log('§TPL_CALIB_SCOPE bld=' + bld + ' INCONCLUSIVE — no current cache (run scripts/cache_4d_run.js ' + bld + ')'); return null; }
+  if (!c.els || !c.els.length) { console.log('§TPL_CALIB_SCOPE bld=' + bld + ' INCONCLUSIVE — cache has no elements'); return null; }
+
+  // ── arms ────────────────────────────────────────────────────────────────────────────────────
+  const base = arm(c.els, SHIFT_H, 1);                                   // shipped, as deployed
+  const recal = arm(c.els, SHIFT_H, 86400 / RATE_TABLE_CREW_DAY_S);      // C1: numerator recalibrated to the 24h shift
+  const revert = arm(c.els, RATE_TABLE_CREW_DAY_S / 3600, 1);            // C2: the rejected shiftHours 24->8 revert
+
+  // ── C-baseline: the reconstruction must reproduce the shipped run's own number ───────────────
+  const shipped = shippedTotalDays(c.log);
+  const ok = shipped != null && Math.abs(base.totalDays - shipped) < 1e-9;
+  console.log('§TPL_CALIB_BASELINE bld=' + bld + ' reconstructed=' + base.totalDays +
+    ' shippedAUTHOR_TPL=' + (shipped == null ? 'ABSENT' : shipped) + ' tasks=' + base.tasks.length +
+    ' ' + (ok ? 'MATCH' : 'MISMATCH — every number below is INCONCLUSIVE'));
+  if (!ok) return { bld: bld, ok: false };
+
+  // ── C2: same lever or two levers? task-for-task, not algebra ─────────────────────────────────
+  const rc = {}; recal.tasks.forEach(t => rc[t.id] = t);
+  let c2diff = 0;
+  revert.tasks.forEach(t => { const o = rc[t.id]; if (!o || o.days !== t.days || o.sDays !== t.sDays || o.eDays !== t.eDays) c2diff++; });
+  console.log('§TPL_CALIB_SAMELEVER bld=' + bld + ' recalibrateNumerator_vs_revertShift tasksDiffering=' +
+    c2diff + '/' + revert.tasks.length + ' totalDays ' + recal.totalDays + ' vs ' + revert.totalDays +
+    ' — ' + (c2diff === 0 && recal.totalDays === revert.totalDays
+      ? 'IDENTICAL: these are ONE lever, not two options'
+      : 'DIFFERENT: they are genuinely separate levers'));
+
+  // ── C1 + C3: per-task before/after, split by whether the task is currently at the min_days floor
+  const minDays = (T.duration_rule && T.duration_rule.min_days) || 1;
+  const bm = {}; base.tasks.forEach(t => bm[t.id] = t);
+  const rows = [];
+  recal.tasks.forEach(t => {
+    const b = bm[t.id]; if (!b) return;
+    rows.push({ id: t.id, phase: b.phase, storey: b.storey, n: b.guids.length,
+      beforeDays: b.days, afterDays: t.days, beforeCrewDays: b.crewDays, afterCrewDays: t.crewDays,
+      floored: b.days === minDays && b.crewDays < minDays, bott: b.bottleneck });
+  });
+  const floored = rows.filter(r => r.floored), nonFloored = rows.filter(r => !r.floored);
+  const changed = rows.filter(r => r.afterDays !== r.beforeDays);
+  const changedNonFloored = nonFloored.filter(r => r.afterDays !== r.beforeDays);
+  const sumB = rows.reduce((a, r) => a + r.beforeDays, 0), sumA = rows.reduce((a, r) => a + r.afterDays, 0);
+  const nfB = nonFloored.reduce((a, r) => a + r.beforeDays, 0), nfA = nonFloored.reduce((a, r) => a + r.afterDays, 0);
+
+  console.log('§TPL_CALIB_SCOPE bld=' + bld + ' tasks=' + rows.length +
+    ' totalDays ' + base.totalDays + '->' + recal.totalDays +
+    ' (x' + (recal.totalDays / base.totalDays).toFixed(2) + ')' +
+    ' tasksChanged=' + changed.length + '/' + rows.length +
+    ' sumTaskDays ' + sumB + '->' + sumA + ' (x' + (sumA / sumB).toFixed(2) + ')');
+  console.log('§TPL_CALIB_SPLIT bld=' + bld +
+    ' flooredAtMinDays=' + floored.length + ' (changed=' + floored.filter(r => r.afterDays !== r.beforeDays).length + ')' +
+    ' nonFloored=' + nonFloored.length + ' (changed=' + changedNonFloored.length + ')' +
+    ' nonFlooredSumDays ' + nfB + '->' + nfA + ' (x' + (nfB ? (nfA / nfB).toFixed(2) : 'n/a') + ')' +
+    ' — ' + (changedNonFloored.length === 0
+      ? 'CONFINED to the floored tasks'
+      : 'NOT CONFINED: ' + changedNonFloored.length + ' of the ' + nonFloored.length +
+        ' non-floored tasks lengthen too'));
+
+  // every task, sorted longest-growth first — the numbers the decision rests on
+  rows.slice().sort((a, b2) => (b2.afterDays - b2.beforeDays) - (a.afterDays - a.beforeDays)).forEach(r => {
+    console.log('§TPL_CALIB_TASK bld=' + bld + ' ' + r.id + ' phase="' + r.phase + '" level="' + r.storey +
+      '" n=' + r.n + ' days ' + r.beforeDays + '->' + r.afterDays + ' (+' + (r.afterDays - r.beforeDays) + ')' +
+      ' crewDays ' + r.beforeCrewDays.toFixed(3) + '->' + r.afterCrewDays.toFixed(3) +
+      ' bottleneck=' + r.bott + (r.floored ? ' FLOORED' : ''));
+  });
+
+  // element-weighted view: how much of the model sits in a bar that grows, and by how much
+  const elsInChanged = changed.reduce((a, r) => a + r.n, 0), elsAll = rows.reduce((a, r) => a + r.n, 0);
+  console.log('§TPL_CALIB_ELEMENTS bld=' + bld + ' elementsInGrowingBars=' + elsInChanged + '/' + elsAll +
+    ' (' + (100 * elsInChanged / elsAll).toFixed(1) + '%)');
+
+  // ── THE COMPLAINT'S OWN UNIT: a bar is "squashed" as a FRACTION OF THE DRAWN AXIS, not in days.
+  // Lengthening every task AND the project total together can leave a short bar relatively NARROWER
+  // than it started. This is the number the user's screenshot is actually about, so it is measured
+  // rather than argued: axisPct = days / totalDays.
+  const shortest = rows.slice().sort((a, b2) => a.beforeDays - b2.beforeDays).slice(0, 10);
+  let narrower = 0;
+  rows.forEach(r => {
+    if ((r.afterDays / recal.totalDays) < (r.beforeDays / base.totalDays) - 1e-12) narrower++;
+  });
+  console.log('§TPL_CALIB_AXIS_FRACTION bld=' + bld + ' tasksDrawnRELATIVELY_NARROWER_after=' + narrower +
+    '/' + rows.length + ' — ' + (narrower > rows.length / 2
+      ? 'the lever makes the SQUASHED-BAR complaint WORSE for most bars'
+      : 'most bars gain axis share'));
+  shortest.forEach(r => {
+    const pb = 100 * r.beforeDays / base.totalDays, pa = 100 * r.afterDays / recal.totalDays;
+    console.log('§TPL_CALIB_AXIS_TASK bld=' + bld + ' ' + r.id + ' n=' + r.n +
+      ' days ' + r.beforeDays + '->' + r.afterDays +
+      ' axisPct ' + pb.toFixed(3) + '%->' + pa.toFixed(3) + '% ' +
+      (pa < pb ? 'NARROWER' : pa > pb ? 'wider' : 'same'));
+  });
+  return { bld: bld, ok: true, before: base.totalDays, after: recal.totalDays,
+    changed: changed.length, changedNonFloored: changedNonFloored.length, tasks: rows.length };
+}
+
+const list = process.argv.slice(2).filter(a => a[0] !== '-');
+const out = (list.length ? list : ['Hospital', 'HHS_Office_Federated']).map(run).filter(Boolean);
+const bad = out.filter(o => !o.ok);
+console.log('§TPL_CALIB_VERDICT buildings=' + out.length + ' inconclusive=' + bad.length + ' ' +
+  out.filter(o => o.ok).map(o => o.bld + ':' + o.before + '->' + o.after +
+    '(nonFlooredChanged=' + o.changedNonFloored + ')').join(' '));
+process.exit(bad.length ? 2 : 0);

--- a/scripts/probe_tpl_parallel_reveal.js
+++ b/scripts/probe_tpl_parallel_reveal.js
@@ -1,0 +1,172 @@
+#!/usr/bin/env node
+// probe_tpl_parallel_reveal.js — §TPL_PARALLEL_REVEAL
+//
+// ⚠ DO NOT REMOVE — SCOPE. bim-compiler prompts/4D_GANTT_TM_REFACTOR.md §FUTURE item 2, step 4
+// addendum (user, 2026-08-27): "The reveal animation must correctly show PARALLEL series, not just
+// sequential build-up within one task. When two tasks' real time-windows genuinely overlap ... their
+// elements should visibly reveal AT THE SAME TIME during movie playback, interleaved — not as if
+// only one task's animation 'has the floor' while everything else waits its turn. Verify this
+// explicitly, don't assume it falls out for free."  Read the log after every run.
+//
+// WITNESS CLAIM (Spec-First, stated before the code):
+//   P1. ABSOLUTE, NOT PER-TASK-RELATIVE. Every element's reveal timestamp is an absolute instant in
+//       the project timeline. Proven by: every element of task t lies inside t's OWN absolute window
+//       [start + t.sDays*86400000, start + t.eDays*86400000]. If reveal times were a per-task
+//       animation sequence that serialised tasks, elements of a LATER-window task would not be able
+//       to carry an EARLIER absolute timestamp than a concurrent task's — this measures exactly that.
+//   P2. PARALLEL TASKS INTERLEAVE. For two tasks whose windows genuinely intersect, element reveal
+//       timestamps inside the shared range are INTERLEAVED, not partitioned into two back-to-back
+//       blocks. TWO measures, and only the second is the verdict:
+//         (a) `alternations` = adjacent unlike-task pairs in the time-sorted union. Two back-to-back
+//             blocks give EXACTLY 1. This is the direct refutation of the serialised shape.
+//         (b) THE VERDICT — `binsBothActive`: cut the shared window into BINS equal slices and count
+//             the slices in which BOTH tasks reveal at least one element. "Reveal at the same time
+//             during playback" IS this: at every instant of the shared window, both tasks are
+//             producing elements. Requiring ALL bins is a criterion with no tuned constant in it.
+//       A ratio against a RANDOM mix (2*nA*nB/(nA+nB)) is reported as DESCRIPTIVE ONLY and is
+//       deliberately NOT a pass/fail: elements inside a task are laid out in contiguous support-order
+//       layer bands by §TPL_LAYER_ORDER, so same-task clumping is the DESIGNED behaviour, not a
+//       defect. An earlier draft of this probe scored that ratio against an invented 0.5 threshold
+//       and called a correct schedule FAIL — the mean same-task run length is printed instead so the
+//       clumping is visible as a magnitude rather than judged against a made-up bar.
+//   P3. VACUITY GUARD (PRIMAL LAW clause 4). If NO task pair's windows overlap, P2 judged an empty
+//       population — the run prints VACUOUS and exits non-zero. A 0 that means "nothing to judge"
+//       must never read as a pass.
+//
+// NON-INVENT: reads the persisted cache_4d_run.js run (element reveal times exactly as the shipped
+// materializeZones produced them, plus the shipped task grid). Nothing is re-solved or authored.
+'use strict';
+const path = require('path');
+const CACHE = require(path.join(__dirname, 'cache_4d_run.js'));
+const DAY = 86400000;
+
+function run(bld, startISO) {
+  const c = CACHE.read(bld);
+  if (!c || !c.tasks || !c.tasks.length) {
+    console.log('§TPL_PARALLEL_REVEAL bld=' + bld + ' INCONCLUSIVE — no cached task grid'); return false;
+  }
+  const base = Date.parse(startISO || '2026-01-01');
+  const sched = c.sched, tasks = c.tasks;
+
+  // ── P1: every element sits inside its own task's ABSOLUTE window ─────────────────────────────
+  let inWin = 0, outWin = 0, worstMs = 0, judged = 0;
+  tasks.forEach(t => {
+    const wS = base + t.sDays * DAY, wE = base + t.eDays * DAY;
+    t.guids.forEach(g => {
+      const s = sched[g]; if (!s) return;
+      judged++;
+      const off = s.s < wS ? wS - s.s : (s.s > wE ? s.s - wE : 0);
+      if (off > 0) { outWin++; if (off > worstMs) worstMs = off; } else inWin++;
+    });
+  });
+  console.log('§TPL_REVEAL_ABSOLUTE bld=' + bld + ' elementsInsideOwnTaskWindow=' + inWin + '/' + judged +
+    ' outside=' + outWin + ' worstOffsetDays=' + (worstMs / DAY).toFixed(3) +
+    ' — ' + (judged === 0 ? 'VACUOUS (nothing judged)'
+      : outWin === 0 ? 'PASS: reveal times are absolute project-timeline instants placed by each task\'s OWN window'
+      : 'FAIL: ' + outWin + ' element(s) reveal outside the bar that claims them'));
+
+  // ── find genuinely overlapping task pairs ────────────────────────────────────────────────────
+  const pairs = [];
+  for (let i = 0; i < tasks.length; i++) for (let j = i + 1; j < tasks.length; j++) {
+    const a = tasks[i], b = tasks[j];
+    const ov = Math.min(a.eDays, b.eDays) - Math.max(a.sDays, b.sDays);
+    if (ov > 0) pairs.push({ a: a, b: b, ov: ov, sameLevel: a.storey === b.storey });
+  }
+  const crossLevel = pairs.filter(p => !p.sameLevel);
+  console.log('§TPL_REVEAL_CONCURRENCY bld=' + bld + ' overlappingTaskPairs=' + pairs.length +
+    ' (crossLevel=' + crossLevel.length + ' sameLevel=' + pairs.filter(p => p.sameLevel).length +
+    ') of ' + (tasks.length * (tasks.length - 1) / 2) + ' pairs — sameLevel MUST stay 0 ' +
+    '(witness_4d_template_instantiation no-same-level-phase-overlap)');
+  if (!crossLevel.length) {
+    console.log('§TPL_PARALLEL_REVEAL bld=' + bld + ' VACUOUS — no two task windows intersect, so P2 judged nothing');
+    return false;
+  }
+
+  // ── P2: interleaving inside the shared range, on the widest genuine overlaps ─────────────────
+  crossLevel.sort((x, y) => y.ov - x.ov);
+  let allPass = true;
+  crossLevel.slice(0, 3).forEach(p => {
+    const s0 = Math.max(p.a.sDays, p.b.sDays) * DAY + base;
+    const e0 = Math.min(p.a.eDays, p.b.eDays) * DAY + base;
+    // An element is "revealing" over its whole [s,e] interval, not only at the instant it starts.
+    // Selecting on the start instant alone under-reports the TAIL of every support-layer band:
+    // remapSolveToTasks maps a band's solve range [glo,ghi] onto [bS,bE] where ghi is the max END,
+    // so the last element to START in a band starts strictly before bE and is still in progress
+    // after it. Measured on Hospital before this correction: 2 of 20 bins read "one task only"
+    // purely from that, on a schedule with no gap in it.
+    const pick = (t, tag) => t.guids.map(g => sched[g]).filter(s => s && s.e >= s0 && s.s <= e0)
+      .map(s => ({ t: tag, ts: s.s, te: s.e }));
+    const A = pick(p.a, 'A'), B = pick(p.b, 'B');
+    if (!A.length || !B.length) {
+      console.log('§TPL_REVEAL_INTERLEAVE bld=' + bld + ' ' + p.a.id + ' | ' + p.b.id +
+        ' VACUOUS — one side contributes no element inside the shared range (nA=' + A.length + ' nB=' + B.length + ')');
+      allPass = false; return;
+    }
+    const u = A.concat(B).sort((x, y) => x.ts - y.ts);
+    let alt = 0;
+    for (let k = 1; k < u.length; k++) if (u[k].t !== u[k - 1].t) alt++;
+    const expect = 2 * A.length * B.length / (A.length + B.length);
+    const ratio = alt / expect;                       // DESCRIPTIVE ONLY — see P2's header
+    const meanRun = u.length / Math.max(1, alt + 1);  // mean same-task run, in elements
+
+    // (b) THE VERDICT — is BOTH-active true across the whole shared window?
+    const BINS = 20, wid = (e0 - s0) / BINS;
+    let bothActive = 0, aOnly = 0, bOnly = 0, neither = 0;
+    for (let k = 0; k < BINS; k++) {
+      const lo = s0 + k * wid, hi = k === BINS - 1 ? e0 : s0 + (k + 1) * wid;
+      const inA = A.some(x => x.te >= lo && x.ts <= hi);
+      const inB = B.some(x => x.te >= lo && x.ts <= hi);
+      if (inA && inB) bothActive++; else if (inA) aOnly++; else if (inB) bOnly++; else neither++;
+    }
+    // Per-task activity, so a missing bin is ATTRIBUTED rather than blamed on serialisation. A bin
+    // with only one task active has two possible causes and they are different defects:
+    //   (i)  the tasks are serialised   — the failure this probe exists to catch;
+    //   (ii) the OTHER task has intra-task DEAD AIR — a stretch of its own window where it reveals
+    //        nothing, because remapSolveToTasks affine-maps a support layer's solve range onto a
+    //        band sized by member COUNT: a layer whose solve range is narrow relative to its band
+    //        bunches at the band's start and leaves the band's tail empty. That is §FUTURE item 2's
+    //        original "cramming" complaint, not a parallelism defect, and it must not be reported
+    //        as one. MEASURED Hospital TASK_Architecture_Envelope_Level_5: zero element starts on
+    //        days 166-168 and 173 of its own [137,180] window.
+    let aBins = 0, bBins = 0;
+    for (let k = 0; k < BINS; k++) {
+      const lo = s0 + k * wid, hi = k === BINS - 1 ? e0 : s0 + (k + 1) * wid;
+      if (A.some(x => x.te >= lo && x.ts <= hi)) aBins++;
+      if (B.some(x => x.te >= lo && x.ts <= hi)) bBins++;
+    }
+    // PARALLELISM verdict: wherever the SPARSER task is active at all, the other is active too, and
+    // the union is not two blocks. No tuned constant: the bar is min(aBins,bBins), what the data
+    // itself makes available to co-occur.
+    const ok = alt > 1 && bothActive === Math.min(aBins, bBins);
+    if (!ok) allPass = false;
+    console.log('§TPL_REVEAL_DEADAIR bld=' + bld + ' pair=' + p.a.id + '|' + p.b.id +
+      ' binsActive A=' + aBins + '/' + BINS + ' B=' + bBins + '/' + BINS + ' both=' + bothActive +
+      ' — ' + (bothActive === Math.min(aBins, bBins)
+        ? 'every slice the sparser task occupies is SHARED (no serialisation); ' +
+          (BINS - Math.min(aBins, bBins)) + ' slice(s) are intra-task dead air, §FUTURE item 2 territory'
+        : 'a slice has one task active while the other is ALSO capable of being active — genuine serialisation'));
+    const rng = arr => (Math.min.apply(null, arr.map(x => x.ts)) - base) / DAY;
+    const rngE = arr => (Math.max.apply(null, arr.map(x => x.ts)) - base) / DAY;
+    console.log('§TPL_REVEAL_INTERLEAVE bld=' + bld +
+      ' A=' + p.a.id + '[' + p.a.sDays + ',' + p.a.eDays + ']' +
+      ' B=' + p.b.id + '[' + p.b.sDays + ',' + p.b.eDays + ']' +
+      ' sharedWindowDays=[' + ((s0 - base) / DAY).toFixed(1) + ',' + ((e0 - base) / DAY).toFixed(1) + ']' +
+      ' nA=' + A.length + ' nB=' + B.length +
+      ' A_spans=[' + rng(A).toFixed(1) + ',' + rngE(A).toFixed(1) + ']' +
+      ' B_spans=[' + rng(B).toFixed(1) + ',' + rngE(B).toFixed(1) + ']' +
+      ' binsBothActive=' + bothActive + '/' + BINS + ' aOnly=' + aOnly + ' bOnly=' + bOnly + ' neither=' + neither +
+      ' alternations=' + alt + ' meanSameTaskRun=' + meanRun.toFixed(1) + 'els' +
+      ' [descriptive: vsRandomMix=' + ratio.toFixed(3) + ', clumping is §TPL_LAYER_ORDER by design]' +
+      ' — ' + (ok ? 'PASS: both tasks reveal throughout the whole shared window, interleaved'
+        : alt === 1 ? 'FAIL: exactly 2 back-to-back blocks — the tasks are SERIALISED, not parallel'
+        : 'FAIL: ' + (BINS - bothActive) + ' slice(s) of the shared window have only ONE task revealing'));
+  });
+
+  console.log('§TPL_PARALLEL_REVEAL bld=' + bld + ' ' + (outWin === 0 && allPass ? 'PASS' : 'FAIL') +
+    ' — absolute=' + (outWin === 0) + ' interleaved=' + allPass);
+  return outWin === 0 && allPass;
+}
+
+const list = process.argv.slice(2).filter(a => a[0] !== '-');
+const res = (list.length ? list : ['Hospital', 'HHS_Office_Federated']).map(b => run(b));
+process.exit(res.every(Boolean) ? 0 : 2);


### PR DESCRIPTION
Implementing bim-compiler `prompts/4D_GANTT_TM_REFACTOR.md` §FUTURE item 2, DECISION **step 1** — Witness: `§TPL_CALIB_SCOPE`, `§TPL_PARALLEL_REVEAL`

**Measurement only. Zero diff to shipped viewer code** (`git diff --stat origin/main` on `viewer/` is empty) — this PR adds two probes and stops at the checkpoint the decision itself named.

## Why this stops here

§FUTURE item 2's step 1 said: *"if it meaningfully lengthens the other 35 tasks too, the whole 369-day project total moves, which is a materially bigger decision than fixing 7 short bars — STOP AND REPORT before implementing broadly if so."* It does. Measured, not assumed.

## §TPL_CALIB_SCOPE

Baseline reconstruction is asserted against the cached run's own `§AUTHOR_TPL totalDays` **before** any comparison is believed (Hospital 318 MATCH, HHS 50 MATCH); it reports INCONCLUSIVE and exits 2 if it cannot reproduce the shipped number.

| | Hospital | HHS_Office_Federated |
|---|---|---|
| totalDays before → after | **318 → 940** (×2.96) | **50 → 137** (×2.74) |
| tasks changed | 38/42 | 16/20 |
| non-floored tasks changed | **35 / 35** | **15 / 15** |
| elements in a growing bar | 63153/63182 (**100.0%**) | 6784/6839 (99.2%) |

**NOT CONFINED** to the 7 tasks floored at `min_days=1`. Every non-floored task lengthens.

### The two "options" are one lever

`§TPL_CALIB_SAMELEVER`: recalibrating the numerator (`_installSecs` 28800 → 86400) and the **already-rejected** `shiftHours 24→8` revert give `tasksDiffering=0/42` and identical `totalDays` (940 vs 940; HHS 137 vs 137). `priceCell` is `days = ceil(secs / (shiftSecs × crews))`, so tripling the numerator and dividing the denominator by three cannot differ. Run through the shipped function rather than argued from algebra.

So step 2's chosen fix **is** the option rejected in the same decision as "wrong lever, would 3x every building's total and undo a standing decision."

### It also makes the reported complaint worse

`§TPL_CALIB_AXIS_FRACTION`: a bar is "squashed" as a *fraction of the drawn axis*, not in days. **26/42** Hospital bars are drawn RELATIVELY NARROWER after the change, because the project total grows faster than the short bars do:

```
TASK_Architecture_Closeup_Level_6  days 1->1  axisPct 0.314% -> 0.106%  NARROWER
TASK_Superstructure_Level_7A       days 1->2  axisPct 0.314% -> 0.213%  NARROWER
TASK_Finishes_Level_1              days 2->4  axisPct 0.629% -> 0.426%  NARROWER
```

4 of the 7 floored tasks do not grow at all (their crewDays stay under 1.0 even at the 8h basis), confirming the prior session's prediction.

## §TPL_PARALLEL_REVEAL (step 4 addendum)

- **Absolute, not per-task-relative**: 63182/63182 Hospital elements reveal inside their own task's `[sDays,eDays]` window, worst offset **0.000 days**. `remapSolveToTasks` computes `wS = base + t.sDays*86400000` per task independently, so overlapping windows overlap by construction.
- **Overlapping tasks interleave**: Hospital has 44 cross-level overlapping task pairs (same-level 0, as `no-same-level-phase-overlap` requires). On the three widest overlaps, alternations = 949 / 684 / 1009 where a serialised pair gives exactly **1**; mean same-task run 5.7–9.1 elements out of thousands.
- Residual one-task slices are **attributed, not blamed on serialisation**: they are intra-task dead air. `TASK_Architecture_Envelope_Level_5` has zero element starts on days 166–168 and 173 of its own [137,180] window — that is §FUTURE item 2's own cramming complaint, caused by `remapSolveToTasks` affine-mapping a support layer's narrow solve range onto a band sized by member *count*.

An earlier draft of this probe scored interleaving against an invented `ratio > 0.5` threshold and called a correct schedule FAIL; that threshold is removed and the random-mix ratio is now printed as descriptive only, since same-task clumping is `§TPL_LAYER_ORDER` working as designed.

## Invariant

`witness_4d_template_instantiation.js` — **pass=11 fail=0 ran=82** before AND after, `no-same-level-phase-overlap` PASS. Unchanged by construction: no shipped code was touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)