### PR TITLE
fix(4d): §TPL_MODEL — both branches on one stream, and stop the witness muting the failure one

### DIFF
--- a/viewer/schedule_author.js
+++ b/viewer/schedule_author.js
@@ -736,6 +736,17 @@
     // number was unattributable to a construct, and `witness_gantt_edit_coherence` passed 10/0
     // while judging the legacy path (its materializeZones call passes no `template:`).
     // PRIMAL LAW clause 4: a pass that cannot report that it took the dead branch is not a pass.
+    //
+    // ⚠ BOTH BRANCHES LOG ON console.log, AND THAT IS LOAD-BEARING (§I.5j(b), fixed 2026-08-27).
+    // The dead branch used to emit on console.warn while the canonical one used console.log. Every
+    // §-collecting witness in this repo filters the LOG stream, and
+    // witness_4d_template_instantiation.js additionally installed `console.warn = () => {}` — so
+    // the one line that says "the dead model ran" was emitted and then deleted before any collector
+    // saw it. MEASURED before the fix (viewer/tests/probe_tpl_model_stream.js, Duplex):
+    // canonical-branch-visible=YES, legacy-branch-visible=NO, on a run where the legacy branch
+    // provably executed. A §-tag was not enough: which STREAM a line used decided whether the
+    // witness could see it. Do not "restore" the warn stream for emphasis — emphasis that a witness
+    // cannot read is not observability, it is decoration (PRIMAL LAW clause 3).
     if (opts.template) {
       var _tv = (opts.template.meta && opts.template.meta.version) || '?';
       console.log('§TPL_MODEL model=template v=' + _tv +
@@ -743,7 +754,7 @@
       return _writeTemplateSchedule(db, elements, schedule, opts, SG,
         storeyMergeMap, laborRates, schedId, start, _displayAuthored);
     }
-    console.warn('§TPL_MODEL model=legacy-deriveZones — ⛔ the CANONICAL template path did NOT ' +
+    console.log('§TPL_MODEL model=legacy-deriveZones — ⛔ the CANONICAL template path did NOT ' +
       'run (opts.template absent). Phases become an ENVELOPE over what the elements did, and an ' +
       'envelope cannot constrain what drew it. Every number from this schedule is off-model.');
 

--- a/viewer/tests/probe_tpl_model_stream.js
+++ b/viewer/tests/probe_tpl_model_stream.js
@@ -1,0 +1,100 @@
+#!/usr/bin/env node
+// PROBE — §TPL_MODEL_STREAM: can a witness that wraps the console actually SEE the fork take the
+// dead branch? Spec: bim-compiler prompts/4D_MODEL_INTEGRITY.md §I.5j(b).
+//
+// ISSUE THIS PROVES OR DISPROVES. `materializeZones` names which model ran on two different
+// streams — the canonical branch on console.log, the legacy-deriveZones branch on console.warn —
+// and witness_4d_template_instantiation.js installs `console.warn = () => {}`. So the witness built
+// to catch a silent fallback to the dead model is STRUCTURALLY BLIND to it: the line is emitted and
+// then deleted before the collector sees it. PRIMAL LAW clause 4 — a witness that cannot report its
+// own failure case is not a witness.
+//
+// METHOD. Force the legacy branch (call materializeZones with NO `template:`) under the EXACT
+// console wrapper the witness installs, and report whether a §TPL_MODEL line reached the collector.
+// Run it against an unfixed viewer to reproduce the blindness, and against a fixed one to see it
+// lift. Both branches are exercised so the probe cannot pass by never firing the fork.
+//
+//   VIEWER_DIR=<viewer> node viewer/tests/probe_tpl_model_stream.js
+'use strict';
+const fs = require('fs');
+const path = require('path');
+const vm = require('vm');
+const HOME = require('os').homedir();
+const initSqlJs = require(path.join(HOME, 'bim-ootb', 'node_modules', 'sql.js'));
+const SQLJS_DIST = path.join(HOME, 'bim-ootb', 'node_modules', 'sql.js', 'dist');
+const VIEWER_DIR = process.env.VIEWER_DIR || path.join(__dirname, '..');
+const ScheduleGate = require(path.join(VIEWER_DIR, 'schedule_gate.js'));
+global.ScheduleGate = ScheduleGate;
+const ScheduleAuthor = require(path.join(VIEWER_DIR, 'schedule_author.js'));
+const BLD_DIR = process.env.BLD_DIR || path.join(HOME, 'bim-ootb', 'buildings');
+const BLD = process.argv[2] || 'Duplex';
+
+function executedRules() {
+  const sb = { console: { log() {}, warn() {}, error() {} } };
+  vm.createContext(sb);
+  vm.runInContext(fs.readFileSync(path.join(VIEWER_DIR, 'rates.js'), 'utf8'), sb);
+  return sb;
+}
+const T = JSON.parse(fs.readFileSync(path.join(VIEWER_DIR, 'rates', '4D_template.json'), 'utf8'));
+
+// The wrapper witness_4d_template_instantiation.js:62-63 installs, reproduced VERBATIM. If this
+// probe invented a friendlier wrapper it would prove nothing about the shipped witness.
+function runUnderWitnessWrapper(db, R, withTemplate) {
+  const logs = [];
+  const _l = console.log, _w = console.warn;
+  console.log = (...a) => { const s = a.join(' '); if (s.indexOf('§TPL_') === 0 || s.indexOf('§AUTHOR_TPL') === 0) logs.push(s); };
+  console.warn = () => {};
+  const base = {
+    start: '2026-01-01', laborRates: R.LABOR_RATES, rates: R.RATES,
+    nameOverrides: R.SEQUENCE_NAME_OVERRIDES, defaultRule: R.SEQUENCE_DEFAULT,
+    scheduleGate: ScheduleGate, shiftHours: T.calendar.hours_per_shift
+  };
+  let res;
+  try {
+    res = ScheduleAuthor.materializeZones(db, R.SEQUENCE_RULES,
+      withTemplate ? Object.assign({}, base, { template: T }) : base);
+  } finally { console.log = _l; console.warn = _w; }
+  return { logs, res };
+}
+
+(async () => {
+  const SQL = await initSqlJs({ locateFile: f => path.join(SQLJS_DIST, f) });
+  const R = executedRules();
+  const file = path.join(BLD_DIR, BLD + '_extracted.db');
+  if (!fs.existsSync(file)) { console.log('§TPL_STREAM INCONCLUSIVE — no db ' + file); process.exit(2); }
+
+  const buf = new Uint8Array(fs.readFileSync(file));
+  let fail = 0;
+  const modelLine = ls => ls.filter(l => l.indexOf('§TPL_MODEL') === 0).pop() || '';
+
+  // ---- CASE A: the CANONICAL branch. Must be visible today (it already is) ----
+  const dbA = new SQL.Database(buf.slice());
+  const A = runUnderWitnessWrapper(dbA, R, true);
+  dbA.close();
+  const lineA = modelLine(A.logs);
+  const okA = lineA.indexOf('model=template') >= 0;
+  console.log('§TPL_STREAM canonical-branch-visible=' + (okA ? 'YES' : 'NO') + ' line=' + (lineA ? '"' + lineA.slice(0, 70) + '"' : '<NONE>'));
+  if (!okA) fail++;
+
+  // ---- CASE B: the DEAD branch. THE POINT OF THIS PROBE ----
+  // Not a synthetic stub: this is materializeZones' real fallback, reached the way live UI reaches
+  // it (schedule_author_ui.js:288, `window._4dTemplate` null → no `template:` passed).
+  const dbB = new SQL.Database(buf.slice());
+  const B = runUnderWitnessWrapper(dbB, R, false);
+  dbB.close();
+  const lineB = modelLine(B.logs);
+  const okB = lineB.indexOf('model=legacy-deriveZones') >= 0;
+  console.log('§TPL_STREAM legacy-branch-visible=' + (okB ? 'YES' : 'NO') + ' line=' + (lineB ? '"' + lineB.slice(0, 70) + '"' : '<NONE>'));
+  if (!okB) fail++;
+
+  // A probe that never fired the fork would report YES/NO on an empty population. Prove the dead
+  // branch actually RAN, independently of the console, by checking it produced a schedule.
+  const ranB = !!(B.res && B.res.ok);
+  console.log('§TPL_STREAM legacy-branch-actually-ran=' + (ranB ? 'YES' : 'NO') +
+    ' — if NO, the visibility verdict above is VACUOUS');
+  if (!ranB) { console.log('§TPL_STREAM VERDICT=INCONCLUSIVE — the dead branch never executed'); process.exit(2); }
+
+  console.log('§TPL_STREAM ' + BLD + ' VERDICT=' + (fail ? 'BLIND fail=' + fail : 'VISIBLE') +
+    ' — the shipped witness wrapper ' + (fail ? 'CANNOT' : 'can') + ' see which model ran on both branches');
+  process.exit(fail ? 1 : 0);
+})();

--- a/viewer/tests/witness_4d_template_instantiation.js
+++ b/viewer/tests/witness_4d_template_instantiation.js
@@ -45,6 +45,10 @@ function executedRules() {
 }
 const T = JSON.parse(fs.readFileSync(path.join(VIEWER_DIR, 'rates', '4D_template.json'), 'utf8'));
 const dayOf = iso => Math.round((Date.parse(iso) - Date.parse(START)) / 86400000);
+// The SHIPPED attribution line, read — never re-derived from the fact that we passed `template:`.
+// §I: "assume the canonical model ran because the code *can* pass template:" is the named `never`.
+const modelOf = logs => (logs.filter(l => l.indexOf('§TPL_MODEL') === 0).pop() || '')
+  .replace(/^§TPL_MODEL\s*/, '').slice(0, 80);
 
 (async () => {
   const SQL = await initSqlJs({ locateFile: f => path.join(SQLJS_DIST, f) });
@@ -57,10 +61,18 @@ const dayOf = iso => Math.round((Date.parse(iso) - Date.parse(START)) / 86400000
     const file = path.join(BLD_DIR, bld + '_extracted.db');
     if (!fs.existsSync(file)) { console.log('§4DTI_SKIP ' + bld); continue; }
     const db = new SQL.Database(new Uint8Array(fs.readFileSync(file)));
+    // §I.5j(b) — TEE, NEVER MUTE. This wrapper used to be `console.warn = () => {}`, which deleted
+    // the one line that says the DEAD model ran (§TPL_MODEL model=legacy-deriveZones was emitted on
+    // warn while the canonical branch used log), plus §TPL_ZERO_MINUTE and §CLASS_UNMATCHED on every
+    // run. So the witness written to catch a silent fallback to the dead model was structurally
+    // blind to it — PRIMAL LAW clause 3 and 4. Both streams are now collected AND forwarded; the
+    // shape is witness_gantt_edit_coherence.js:203-204's. Measured cost of forwarding: the pipeline
+    // emits 25 lines per building and every one of them is §-tagged, so there is no noise to hide.
     const _l = console.log, _w = console.warn;
     const logs = [];
-    console.log = (...a) => { const s = a.join(' '); if (s.indexOf('§TPL_') === 0 || s.indexOf('§AUTHOR_TPL') === 0) logs.push(s); };
-    console.warn = () => {};
+    const keep = s => (s.indexOf('§TPL_') === 0 || s.indexOf('§AUTHOR_TPL') === 0) && logs.push(s);
+    console.log = (...a) => { keep(a.join(' ')); return _l.apply(console, a); };
+    console.warn = (...a) => { keep(a.join(' ')); return _w.apply(console, a); };
     const res = ScheduleAuthor.materializeZones(db, R.SEQUENCE_RULES, {
       start: START, laborRates: R.LABOR_RATES, rates: R.RATES,
       nameOverrides: R.SEQUENCE_NAME_OVERRIDES, defaultRule: R.SEQUENCE_DEFAULT,
@@ -123,6 +135,7 @@ const dayOf = iso => Math.round((Date.parse(iso) - Date.parse(START)) / 86400000
       ' distinctLags=' + JSON.stringify(Array.from(new Set(seqRows.map(r => r[3])))));
     logs.filter(l => l.indexOf('§TPL_PHASE_ABSENT') === 0 || l.indexOf('§TPL_PHASE_COVERAGE') === 0)
       .forEach(l => console.log('   ' + l));
+    console.log('§4DTI_MODEL ' + bld + ' ' + (modelOf(logs) || 'ABSENT — which model produced this grid is UNKNOWN'));
     db.close();
   }
 
@@ -147,6 +160,17 @@ const dayOf = iso => Math.round((Date.parse(iso) - Date.parse(START)) / 86400000
     .invariant('every-element-lands-in-a-task', () => perBuilding.every(b => INV.everyElementLandsInATask(b.els.length, b.te)))
     // Absence is REPORTED, never silent — the §S67 HOP1/HOP3 defect.
     .invariant('absence-is-reported', () => perBuilding.every(b => b.logs.some(l => l.indexOf('§TPL_PHASE_COVERAGE') === 0)))
+    // §I.5j(b) — WHICH MODEL DID THIS WITNESS ACTUALLY JUDGE? Every invariant above is scored on a
+    // task grid; none of them asks which of the two models EMITTED that grid, and until the stream
+    // fix above the answer was unreadable here by construction. An absent line is judged FAIL, not
+    // pass: "no attribution" is INCONCLUSIVE, and PRIMAL LAW clause 4 forbids scoring INCONCLUSIVE
+    // as green. Same claim as witness_gantt_edit_coherence's G-COH-10, on the generation path.
+    .invariant('the-CANONICAL-template-model-ran', () => perBuilding.every(b => {
+      const m = modelOf(b.logs);
+      if (!m) { console.log('§4DTI_MODEL_FAIL ' + b.bld + ' INCONCLUSIVE — no §TPL_MODEL line was emitted'); return false; }
+      if (m.indexOf('model=template') !== 0) { console.log('§4DTI_MODEL_FAIL ' + b.bld + ' judged the DEAD model: ' + m); return false; }
+      return true;
+    }))
     .redControl(rs => rs.map((r, i) => i ? r : Object.assign({}, r, { endDay: r.startDay })))
     .run();
 })();


### PR DESCRIPTION
Spec: bim-compiler `prompts/4D_MODEL_INTEGRITY.md` §I.5j(b). PRIMAL LAW clause 3 + 4.
Stage 1 of a 5-stage §I.5 remediation. Visibility only — **no scheduling behavior changes.**

## The defect

`materializeZones` names which of the two models ran on **two different streams**:

| branch | line | stream |
|---|---|---|
| canonical | `schedule_author.js:741` `§TPL_MODEL model=template` | `console.log` |
| dead model | `schedule_author.js:746` `§TPL_MODEL model=legacy-deriveZones` | `console.warn` |

…and `witness_4d_template_instantiation.js:63` installed `console.warn = () => {}`.

So the witness built to catch a silent fallback to the dead model **could not, by construction, ever see it happen.** The line was emitted and then deleted before the collector read it. A `§`-tag was not enough: which STREAM a line used decided whether a witness could see it.

## Measured, before and after

`viewer/tests/probe_tpl_model_stream.js` (new) reproduces the shipped witness wrapper **verbatim** and forces the dead branch the way live UI reaches it (`schedule_author_ui.js:288`, `window._4dTemplate` null → no `template:` passed):

| | canonical visible | legacy visible | verdict |
|---|---|---|---|
| **BEFORE** | YES | **NO** | `BLIND fail=1` (exit 1) |
| **AFTER** | YES | **YES** | `VISIBLE` (exit 0) |

The probe separately asserts `legacy-branch-actually-ran=YES` from the returned schedule, so the verdict cannot be VACUOUS — the dead branch really executed on the run that was blind to it.

## The fix, two halves

1. **`schedule_author.js:746` `warn` → `log`.** Both branches on one stream. Every `§`-collecting witness in this repo filters the LOG stream; `§S18_STOREY_MERGE_FAIL` and `§AUTHOR_ZONES_FAIL` already use `log`. Emphasis a witness cannot read is not observability.
2. **`witness_4d_template_instantiation.js` — TEE, never mute.** Both streams collected AND forwarded, the shape `witness_gantt_edit_coherence.js:203-204` already uses. Measured cost of forwarding: 25 lines per building, every one `§`-tagged, **zero non-`§` noise** — there was nothing to hide.

New invariant **`the-CANONICAL-template-model-ran`** reads the shipped `§TPL_MODEL` line rather than assuming the canonical model ran because the code passes `template:` (§I's named `never`). **Absence is judged FAIL, not pass** — INCONCLUSIVE scored green is the §CRISIS this exists to prevent.

## Witness results

| witness | before | after |
|---|---|---|
| `witness_4d_template_instantiation` | pass=11 fail=0 ran=82 | **pass=12 fail=0 ran=82** |
| `witness_gantt_edit_coherence` | — | pass=11 fail=0 |
| `witness_zone_display_authoring` | — | pass=18 fail=0 |
| `witness_crosstask_judge_parity` | — | pass=20 fail=0 |

**RED CONTROL** — force the legacy branch by dropping `template:`: `FAIL the-CANONICAL-template-model-ran` + `§4DTI_MODEL_FAIL Duplex judged the DEAD model`, exit 1. The new invariant fails on the broken case; it is not a tautology.

## Surfaced by the un-muting — previously invisible on every run, NOT fixed here

```
§TPL_LAYER_ORDER_FAIL SupportSweep not loaded — task interiors stay in solve order
§TPL_LAYER_SELFCHECK applied=0 moved=0/63182 stillInverted=0 FAIL pass did not run
```

The layer-order pass **never runs in this node harness at all.** Recorded for the §I.5c slice (Stage 3) rather than chased here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)