### PR TITLE
fix(4d): §STAIR_FLIGHT_GRID_VISIBILITY — give auditFloating the scheduler's support pool

### DIFF
--- a/viewer/schedule_gate.js
+++ b/viewer/schedule_gate.js
@@ -1121,8 +1121,19 @@
   // occurrence counts on shipped buildings are known.
   function auditFloating(elements, sched, classFilter, collectGuids, collectUnchecked) {
     var structGrid = {}, wallGrid = {}, i, c, cs, k, arr, S;
+    // §STAIR_FLIGHT_GRID_VISIBILITY, AUDIT TWIN (2026-08-27, §I.5a). This grid used to re-type
+    // `e.seq <= 4 || (e.cls === 'IfcSlab' && e.seq > 4)`, which is the scheduler's pool MINUS stair
+    // flights: IfcStairFlight carries sequence 6 (rates.js:259) so `seq<=4` is false, and the
+    // `else if` below only catches IfcWall* — so a flight landed in NEITHER grid and was invisible
+    // AS SUPPORT to this audit, while structIdxGrid (:787) and place() (:570) both admit it. That
+    // is a FALSE NEGATIVE: a target resting on a flight finds no bearing candidate, `se` stays 0,
+    // and :1204's `if (se > 0 && ...)` can never fire, so floating was UNDER-reported.
+    // The §S64 note at :1154 asserted "structGrid (p===0) ... already agrees with the gate". It did
+    // not — :787 and :1125 disagreed, 338 lines apart in one file. Now it does, because it no
+    // longer re-types the test at all: supportPool() (:1312) is the exported single definition and
+    // is verbatim the scheduler's inline pool. §I.4 — never a second copy.
     for (i = 0; i < elements.length; i++) { var e = elements[i];
-      if (e.seq <= 4 || (e.cls === 'IfcSlab' && e.seq > 4)) { cs = cellsOf(e); for (c = 0; c < cs.length; c++) (structGrid[cs[c]] = structGrid[cs[c]] || []).push(e); }
+      if (supportPool(e)) { cs = cellsOf(e); for (c = 0; c < cs.length; c++) (structGrid[cs[c]] = structGrid[cs[c]] || []).push(e); }
       else if (e.cls.indexOf('IfcWall') === 0) { cs = cellsOf(e); for (c = 0; c < cs.length; c++) (wallGrid[cs[c]] = wallGrid[cs[c]] || []).push(e); } }
     // buildingModelsSubstructure — "Gap B exemption DECIDED" (4D_SCHEDULE_PERFECTION.md 2026-08-11):
     // annotate, don't suppress. true iff ≥1 element resolves to phase==='Substructure' — seq===1 is

--- a/viewer/tests/probe_stair_flight_support_pool.js
+++ b/viewer/tests/probe_stair_flight_support_pool.js
@@ -1,0 +1,177 @@
+#!/usr/bin/env node
+// PROBE — §STAIR_POOL_AB: what does admitting IfcStairFlight to auditFloating's support grid
+// actually change? Spec: bim-compiler prompts/4D_MODEL_INTEGRITY.md §I.5a.
+//
+// ISSUE THIS PROVES OR DISPROVES. The support pool has five inline definitions. The SCHEDULER's
+// grid (schedule_gate.js:787 `P.seq<=4 || isPromotedSlab(P) || isStairFlight(P)`) admits stair
+// flights; `auditFloating`'s structurally identical grid (:1125) and time_machine.js's
+// `_buildXraySupportCache` (:3739) do not — they were never given the §STAIR_FLIGHT_GRID_VISIBILITY
+// fix of 2026-08-14. IfcStairFlight carries sequence 6 (rates.js:259), so `seq<=4` is false and the
+// `else if` only catches IfcWall*: a stair flight is invisible AS SUPPORT to the floating audit
+// while the scheduler that produced the times treats it as structure.
+//
+// DIRECTION OF THE ERROR: a target resting on a stair flight finds no bearing candidate, `se`
+// stays 0, and :1204's `if (se > 0 && ...)` can never fire. So this is a FALSE NEGATIVE — floating
+// is UNDER-reported. Fixing it should make the count go UP (or stay equal), never down.
+//
+// METHOD: run the SHIPPED auditFloating from two viewer checkouts over BYTE-IDENTICAL inputs (the
+// persisted cache, PRIMAL LAW clause 5 — the pipeline is not re-run), and diff the returned count
+// and the collected guid sets. Reports the stair-flight population so a 0-delta on a building with
+// no stair flights is called VACUOUS, never PASS.
+//
+//   VIEWER_A=<unfixed viewer> VIEWER_B=<fixed viewer> node viewer/tests/probe_stair_flight_support_pool.js [Building ...]
+'use strict';
+const path = require('path'), os = require('os');
+const ROOT = path.join(__dirname, '..', '..');
+const HOME = os.homedir();
+const VA = process.env.VIEWER_A || path.join(HOME, 'bim-ootb', 'viewer');
+const VB = process.env.VIEWER_B || path.join(ROOT, 'viewer');
+// Read the cache keyed on the UNFIXED viewer (VIEWER_A). cache_4d_run's key covers the CONTENT of
+// schedule_gate.js, so editing auditFloating invalidates every entry — but `els`/`sched` come from
+// computeSchedule/materializeZones, which this change does not touch (auditFloating feeds nothing
+// upstream of them). So the BEFORE run is the correct shared input for both sides, and taking it
+// from A's key is what makes A and B provably see byte-identical elements.
+const CACHE = require(path.join(VA, '..', 'scripts', 'cache_4d_run.js'));
+
+const SGA = require(path.join(VA, 'schedule_gate.js'));
+const SGB = require(path.join(VB, 'schedule_gate.js'));
+// contactGraph needs a ScheduleGate in scope for CELL/EPS/GAP. A and B carry identical constants
+// (this change touches a pool, not a threshold), so either serves; A is the untouched reference.
+global.ScheduleGate = SGA;
+const SS = require(path.join(VA, 'support_sweep.js'));
+
+const BUILDINGS = process.argv.slice(2).filter(a => a[0] !== '-').length
+  ? process.argv.slice(2).filter(a => a[0] !== '-')
+  : ['Duplex', 'HHS_Office_Federated', 'Hospital', 'Terminal'];
+
+// ⚠ TWO NAMING CONVENTIONS, AND GETTING THIS WRONG READS AS A CLEAN PASS.
+// The cache persists elements as `bz`/`tz` (support_sweep.js contactGraph's convention) and the
+// schedule as `{s,e}`. `auditFloating` reads `base_z`/`top_z` and `sched[guid].start/.end`. Feed it
+// the cache shape unmapped and EVERY comparison is `undefined < undefined` = false, so it returns
+// floating=0 for any input — an all-green verdict produced by judging nothing. That is precisely
+// §I.5d's observation that these two judges "receive different data shapes for the same elements",
+// biting a probe rather than production. Measured while writing this probe: unmapped, both the
+// before and after audits returned 0 on all 7 buildings AND the red control recovered 0, which is
+// what exposed it. The vacuity guard below now fails loudly instead.
+function remapEls(els) {
+  return els.map(e => Object.assign({}, e, { base_z: e.bz, top_z: e.tz }));
+}
+function remapSched(sched) {
+  const o = {};
+  for (const g of Object.keys(sched)) o[g] = { start: sched[g].s, end: sched[g].e };
+  return o;
+}
+
+// The §-log this probe must not drown in: auditFloating emits §SUPPORT_UNCHECKED per big unchecked
+// element. TEE it (never mute — PRIMAL LAW clause 3), counting rather than reprinting 63k lines.
+function quietCount(fn) {
+  const _l = console.log;
+  let n = 0;
+  console.log = function () {
+    const s = Array.prototype.map.call(arguments, String).join(' ');
+    if (s.indexOf('§SUPPORT_UNCHECKED') === 0) { n++; return; }
+    return _l.apply(console, arguments);
+  };
+  try { return { v: fn(), unchecked: n }; } finally { console.log = _l; }
+}
+
+let anyDelta = 0, rows = [];
+for (const bld of BUILDINGS) {
+  const r = CACHE.read(bld);
+  if (!r) { console.log('§STAIR_POOL CACHE_MISS ' + bld + ' — run: node scripts/cache_4d_run.js ' + bld); continue; }
+  const els = remapEls(r.els), sched = remapSched(r.sched);
+
+  // VACUITY GUARD — does auditFloating judge ANYTHING on this input? Break the schedule for every
+  // element (start everything a day before the earliest start) and demand a non-zero floating
+  // count. If a deliberately impossible schedule still audits clean, the audit is not reading these
+  // elements at all and every number below is meaningless. PRIMAL LAW clause 4: report VACUOUS,
+  // never PASS, when nothing was actually judged.
+  const t0 = Math.min.apply(null, Object.keys(sched).map(g => sched[g].start));
+  const shake = {};
+  for (const g of Object.keys(sched)) shake[g] = { start: t0 - 86400000, end: sched[g].end };
+  const shakeN = quietCount(() => SGA.auditFloating(els, shake, null, null)).v;
+  if (shakeN === 0) {
+    console.log('§STAIR_POOL ' + bld.padEnd(22) + 'VACUOUS — auditFloating returned 0 on a schedule where ' +
+      'EVERY element starts before its supports finish. It is judging nothing (field-name mismatch?); no verdict is possible.');
+    continue;
+  }
+
+  // The population that makes the verdict meaningful. A building with 0 stair flights CANNOT show
+  // a delta, so its 0 is VACUOUS, not evidence the fix is a no-op (PRIMAL LAW clause 4).
+  const flights = els.filter(e => e.cls === 'IfcStairFlight');
+  const flightSeqs = Array.from(new Set(flights.map(e => e.seq))).sort();
+
+  const gA = [], gB = [];
+  const A = quietCount(() => SGA.auditFloating(els, sched, null, gA));
+  const B = quietCount(() => SGB.auditFloating(els, sched, null, gB));
+
+  const setA = new Set(gA), setB = new Set(gB);
+  const newlySeen = gB.filter(g => !setA.has(g));      // previously-hidden floating, now visible
+  const nowClean = gA.filter(g => !setB.has(g));       // was flagged, no longer — must be 0
+  const byCls = {};
+  newlySeen.forEach(g => { const e = els.find(x => x.guid === g); const c = e ? e.cls : '?'; byCls[c] = (byCls[c] || 0) + 1; });
+
+  // BLAST RADIUS — asked of the OWNER of "does S support T" (support_sweep.js:384 contactGraph),
+  // never re-derived here. How many BEARING relations does the shipped graph assert whose support
+  // is a stair flight? That is exactly the set auditFloating's grid could not see. It is the size
+  // of the blind spot; the floating delta above is only the part that was ALSO mis-scheduled today.
+  // A zero floating delta over a non-zero blind spot means "the schedule happens to be right here",
+  // not "the pool was already correct" — those are different claims and this separates them.
+  let blind = 0, blindTargets = new Set();
+  const G = SS.contactGraph(els);
+  if (!G.ok) console.log('   §STAIR_POOL JUDGE_UNAVAILABLE — contactGraph declined, blind-spot size UNKNOWN');
+  else {
+    const EPS = SGA.EPS, GAP = SGA.GAP;
+    for (let i = 0; i < els.length; i++) {
+      const list = G.contacts[i]; if (!list) continue;
+      const T = els[i];
+      for (const j of list) {
+        const S = els[j];
+        if (S.cls !== 'IfcStairFlight') continue;
+        if (S.bz < T.bz - EPS && S.tz >= T.bz - GAP) { blind++; blindTargets.add(T.guid); }
+      }
+    }
+  }
+  console.log('   blindSpot: ' + blind + ' bearing relations carried by a stair flight, over ' +
+    blindTargets.size + ' distinct targets — invisible to auditFloating before this change');
+
+  // RED CONTROL — RECOVERED SENSITIVITY. A zero delta on today's schedule proves nothing on its
+  // own: it is equally consistent with "the pool was already right" and with "the audit still
+  // cannot see this class of violation." So MANUFACTURE the violation the blind spot hides — pull
+  // every stair-flight-supported target's start EARLIER than everything it rests on — and re-audit.
+  // The geometry and the pools stay shipped; only the SCHEDULE is perturbed, which is the input a
+  // real regression would corrupt. If B does not flag strictly more than A here, the fix did not
+  // restore the audit's ability to catch a stair-flight ordering regression, and the NO-OP above
+  // would be a scope-blind PASS (PRIMAL LAW clause 4).
+  let redA = 0, redB = 0, redRan = 0;
+  if (blindTargets.size) {
+    // t0 computed above by the vacuity guard.
+    const bad = {};
+    for (const g of Object.keys(sched)) bad[g] = { start: sched[g].start, end: sched[g].end };
+    for (const g of blindTargets) bad[g].start = t0 - 86400000;   // one day before anything begins
+    redA = quietCount(() => SGA.auditFloating(els, bad, null, null)).v;
+    redB = quietCount(() => SGB.auditFloating(els, bad, null, null)).v;
+    redRan = 1;
+    console.log('   redControl (every stair-flight-supported target started before its support): floating ' +
+      redA + ' -> ' + redB + ' (recovered ' + (redB - redA) + ' violations the old pool could not see)');
+  }
+
+  const verdict = flights.length === 0 ? 'VACUOUS' : (A.v === B.v && newlySeen.length === 0 ? 'NO-OP' : 'CHANGED');
+  console.log('§STAIR_POOL ' + bld.padEnd(22) + verdict.padEnd(9) +
+    'stairFlights=' + String(flights.length).padEnd(6) + 'seq=' + JSON.stringify(flightSeqs).padEnd(6) +
+    ' floating ' + A.v + ' -> ' + B.v + ' (delta ' + (B.v - A.v >= 0 ? '+' : '') + (B.v - A.v) + ')' +
+    ' newlyVisible=' + newlySeen.length + ' nowClean=' + nowClean.length +
+    ' unchecked ' + A.unchecked + ' -> ' + B.unchecked);
+  if (newlySeen.length) console.log('   newly-visible floating by class: ' + JSON.stringify(byCls));
+  // A FALSE NEGATIVE fix can only ADD. Anything disappearing means the pool change altered a
+  // verdict it had no business altering — report it loudly rather than averaging it away.
+  if (nowClean.length) console.log('   ⛔ UNEXPECTED — these were floating BEFORE and are not now: ' + nowClean.slice(0, 10).join(','));
+  rows.push({ bld, flights: flights.length, a: A.v, b: B.v, newly: newlySeen.length, nowClean: nowClean.length });
+  if (B.v !== A.v || newlySeen.length) anyDelta++;
+}
+
+const judged = rows.filter(r => r.flights > 0).length;
+const regress = rows.filter(r => r.nowClean > 0).length;
+console.log('§STAIR_POOL VERDICT=' + (judged === 0 ? 'INCONCLUSIVE — no building in this run has a stair flight'
+  : (regress ? 'REGRESSION on ' + regress + ' building(s)' : (anyDelta ? 'CHANGED on ' + anyDelta + '/' + judged + ' buildings with flights' : 'NO-OP across ' + judged + ' buildings with flights'))));
+process.exit(regress ? 1 : 0);

--- a/viewer/tests/witness_big_element_support_coverage.js
+++ b/viewer/tests/witness_big_element_support_coverage.js
@@ -63,6 +63,26 @@ const BLD_DIR = process.env.BLD_DIR || path.join(require('os').homedir(), 'bim-o
 // witness's own logged runs (repo convention, cf. witness_tm_geo_order_cycles.js floating=8): if
 // it moves EITHER way that is a real behavior change to examine, never to absorb silently.
 const BUILDINGS = [
+  // RE-LOCKED 2026-08-27 (§STAIR_FLIGHT_GRID_VISIBILITY audit twin, bim-compiler
+  // prompts/4D_MODEL_INTEGRITY.md §I.5a) — HHS 17->14, LTU_AHouse 626->624. Two baselines moved
+  // DOWN and, unlike §S64's rise, this is a COVERAGE GAIN, not a trade.
+  //   Cause: auditFloating's structGrid re-typed the scheduler's support pool MINUS stair flights
+  //   (IfcStairFlight is seq 6, so `seq<=4` misses it and the `else if` only catches IfcWall*), so
+  //   a flight was in NEITHER grid. It now calls the exported supportPool() — one definition, the
+  //   scheduler's own. Elements whose only candidate was a stair flight had ZERO candidates in
+  //   either pool and were therefore honest §SUPPORT_UNCHECKED findings; they now have a real one
+  //   and leave the exception set.
+  //   The exchange is exact and attributable by class, MEASURED both sides:
+  //     HHS        17->14  = IfcStairFlight 4->2, IfcSlab 5->4   (a flight resting on a flight had
+  //                          no candidate at all — the self-referential case the old pool excluded)
+  //     LTU_AHouse 626->624 = IfcWallStandardCase 355->353
+  //     Terminal / Hospital / Duplex / Clinic / JKR — class histograms BYTE-IDENTICAL, no move.
+  //   Direction check: this witness asserts `unchecked` (zero-candidate elements), which can only
+  //   FALL when a pool widens. The floating count, which this witness does not assert, moves the
+  //   other way for the same reason — +204 fleet-wide, measured in
+  //   viewer/tests/probe_stair_flight_support_pool.js. Both are the same false NEGATIVE being
+  //   repaired: the audit could not see a support the scheduler had already used.
+  //
   // Baselines RE-MEASURED 2026-08-11 (big-element follow-up, bigsup_after_fix2.log) after three
   // deliberate changes, each with its own delta reasoned below (first-run baselines in parens):
   //  (1) §HANG_NEAREST fallback (schedule_gate.js) — big pure-sink hangers (rod-suspended MEP etc.)
@@ -109,7 +129,7 @@ const BUILDINGS = [
   { file: 'Terminal_extracted.db',             name: 'Terminal', bms: true,  expectedUnchecked: 36 },   // was bms:false/279; 32->36 §S64
   { file: 'Hospital_extracted.db',             name: 'Hospital', bms: true,  expectedUnchecked: 177 },  // was 503
   { file: 'Duplex_extracted.db',               name: 'Duplex',   bms: true,  expectedUnchecked: 2 },    // was 6 — SoG override, see above
-  { file: 'HHS_Office_Federated_extracted.db', name: 'HHS',      bms: false, expectedUnchecked: 17 },   // was 21; 13->17 §S64
+  { file: 'HHS_Office_Federated_extracted.db', name: 'HHS',      bms: false, expectedUnchecked: 14 },   // was 21; 13->17 §S64; 17->14 §STAIR_FLIGHT_GRID_VISIBILITY audit twin (see below)
   { file: 'Clinic_extracted.db',               name: 'Clinic',   bms: true,  expectedUnchecked: 22 },   // count HELD, mix changed (see 3)
   // Coverage extended 2026-08-11 (chase-to-zero pass) — first witness coverage for these two; the
   // 5-building locked set above is UNTOUCHED (its 246 total stands; these rows are additive).
@@ -123,7 +143,7 @@ const BUILDINGS = [
   // member in a mutual pair never converges — measured Clinic 43k pushes/400 sweeps).
   // JKR: bms=false (zero seq-1 elements — its foundation slabs are authored plain IfcSlab at the
   // z≈84m site datum), unchecked=6, floating=81 (same steel co-planar family: CHS members/columns).
-  { file: 'LTU_AHouse_meta.db',                name: 'LTU_AHouse', bms: true,  expectedUnchecked: 626 },   // 611->626 §S64
+  { file: 'LTU_AHouse_meta.db',                name: 'LTU_AHouse', bms: true,  expectedUnchecked: 624 },   // 611->626 §S64; 626->624 §STAIR_FLIGHT_GRID_VISIBILITY audit twin (see below)
   { file: 'JKR_extracted.db',                  name: 'JKR',        bms: false, expectedUnchecked: 6 },
 ];
 

--- a/viewer/tests/witness_og_guard_bearing_bound.js
+++ b/viewer/tests/witness_og_guard_bearing_bound.js
@@ -37,6 +37,11 @@ const path = require('path');
 const vm = require('vm');
 const initSqlJs = require('/home/red1/bim-ootb/node_modules/sql.js');
 const SQLJS_DIST = '/home/red1/bim-ootb/node_modules/sql.js/dist';
+// The SHIPPED gate module, for its exported supportPool() — this witness's detection pool is the
+// production pool, asked of its owner, never re-typed here (§I.4). NOTE this is the real module;
+// the `ScheduleGate: { CELL: 4 }` stub inside the vm sandbox below (~:114) is a deliberately
+// minimal fake for the guard-under-test and is a different object.
+const ScheduleGate = require(path.join(__dirname, '..', 'schedule_gate.js'));
 const ScheduleAuthor = require(path.join(__dirname, '..', 'schedule_author.js'));
 
 let pass = 0, fail = 0;
@@ -137,7 +142,25 @@ function detectionSet(scheduled) {
   scheduled.forEach(e => {
     // §PROMOTED_CARRIER_POOL (2026-08-11): detection pool = seq<=4 ∪ promoted slabs (audit parity,
     // finding-A fix — see time_machine.js _buildXraySupportCache).
-    if (e.seq <= 4 || (e.cls === 'IfcSlab' && e.seq > 4)) cellsFor(e, e.bz, e.tz).forEach(c => (grid[c] = grid[c] || []).push(e));
+    //
+    // §STAIR_FLIGHT_GRID_VISIBILITY, JUDGE TWIN (2026-08-27, §I.5a). W-OGB-3a asserts "guard and
+    // judge are one physics" — and this line used to make that true by RE-TYPING the guard's pool,
+    // which is a weaker thing than sharing its definition: two copies of the same mistake also read
+    // as "one physics". It now asks the OWNER (schedule_gate.js supportPool), so the parity is
+    // structural. This is the SEVENTH copy of that pool found; §I.5a counted six.
+    // Widening detection can only REDUCE W-OGB-2 violations, and it stays 0 on both fixtures.
+    //
+    // ⚠ WHAT THIS UNCOVERED, DEFERRED ON PURPOSE — see §I.5a in the spec. The matching pool fix in
+    // time_machine.js `_buildXraySupportCache` is NOT in this change. Applied, it makes W-OGB-3a
+    // fail with Terminal staged=0 -> 14 (isolated by reverting only that file: 9/0 green without
+    // it, 8/1 with it). Those 14 are not a harness artifact — they are real Terminal elements that
+    // start before a stair-flight carrier finishes, and they surface because the x-ray JUDGE would
+    // then see flights as carriers while the GUARD (`_ogSupportSweep`) still repairs against WALL
+    // carriers only. So guard and judge genuinely would not be one physics for this class, and the
+    // honest fix is a decision about whether the guard must repair stair-flight carriers too — not
+    // a re-baseline of this number. Landing the x-ray half without that decision would either
+    // break this witness or bake in an asymmetry it exists to forbid.
+    if (ScheduleGate.supportPool(e)) cellsFor(e, e.bz, e.tz).forEach(c => (grid[c] = grid[c] || []).push(e));
   });
   const withBearing = {};
   scheduled.forEach(T => {


### PR DESCRIPTION
Spec: bim-compiler `prompts/4D_MODEL_INTEGRITY.md` §I.5a. Stage 2 of the §I.5 remediation (Stage 1 = #1561).

## The defect

The support pool has **seven** inline definitions (§I.5a counted six; this PR found a seventh). The **scheduler's** grid (`schedule_gate.js:787`) admits `IfcStairFlight`; `auditFloating`'s structurally identical grid (`:1125`) did not — `IfcStairFlight` is sequence 6, so `seq<=4` misses it and the `else if` only catches `IfcWall*`. **A flight landed in neither grid.**

This is the exact bug `§STAIR_FLIGHT_GRID_VISIBILITY` fixed in the scheduler on 2026-08-14. The audit twin never got it, and §S64's own comment at `:1154` asserted *"structGrid (p===0) … already agrees with the gate"* — it did not, 338 lines apart in one file.

Direction is a **false negative**: a target resting on a flight finds no bearing candidate, `se` stays 0, so `:1204`'s `if (se > 0 && …)` can never fire. Floating was **under**-reported.

## Measured — 7 buildings, over the persisted cache

| building | floating | delta | newlyVisible | nowClean | blindSpot |
|---|---|---|---|---|---|
| Duplex | 5 → 15 | **+10** | 10 | 0 | 14 |
| HHS | 231 → 246 | **+15** | 15 | 0 | 56 |
| Hospital | 172 → 172 | +0 | 0 | 0 | 5 *(1 stair flight)* |
| Terminal | 350 → 408 | **+58** | 58 | 0 | 174 |
| Clinic | 31 → 33 | **+2** | 2 | 0 | 19 |
| LTU_AHouse | 2486 → 2549 | **+63** | 63 | 0 | 397 |
| JKR | 882 → 938 | **+56** | 56 | 0 | 132 |

**+204 fleet-wide, `nowClean=0` everywhere** — strictly additive, exactly the direction a false-negative repair must move. `blindSpot` is asked of the **owner** of the support relation (`support_sweep.js` `contactGraph`): **797 bearing relations fleet-wide are carried by a stair flight** and were invisible to this audit.

## ⚠ The first measurement was VACUOUS and read as a clean NO-OP

The cache persists `bz`/`tz`; `auditFloating` reads `base_z`/`top_z`. Unmapped, every comparison is `undefined < undefined` = false — so **both** sides returned `floating=0` on all 7 buildings and the red control recovered 0. An all-green verdict produced by judging nothing.

The probe now carries a **vacuity guard**: it breaks the schedule for every element and demands a non-zero count before any verdict is issued. This is §I.5d's *"different data shapes for the same elements"* biting a probe instead of production.

## The fix

`auditFloating`'s grid calls the **exported `supportPool()`** instead of re-typing the test (§I.4 — take the relation, never recompute it). Same for `witness_og_guard_bearing_bound`, which enforced *"guard and judge are one physics"* by re-typing the pool — a claim two copies of one mistake also satisfy.

## Witnesses

| witness | before | after |
|---|---|---|
| `witness_big_element_support_coverage` | 36/0 | **36/0** (re-locked) |
| `witness_og_guard_bearing_bound` | 9/0 | **9/0** |
| `witness_gantt_lock_integrity` | 20/0 | 20/0 |
| `witness_tm_geo_order_cycles` | 6/0 | 6/0 |
| `witness_4d_template_instantiation` | 12/0 | 12/0 |

`witness_big_element_support_coverage` is a locked-baseline tripwire and **it fired**: HHS 17→14, LTU_AHouse 626→624. That is a **coverage gain**, not a regression — `unchecked` counts elements with *zero* support candidates, which can only fall when a pool widens. Attributable by class: HHS = `IfcStairFlight` 4→2 (a flight resting on a flight had no candidate at all) + `IfcSlab` 5→4; LTU = `IfcWallStandardCase` 355→353; **the other five buildings byte-identical.** Re-locked with that reasoning, per the §S64 precedent.

Pre-existing failures, **identical before and after, not caused here**: `witness_door_window_host_wall` 1/1 · `witness_midair_zero` 31/13 · `witness_4d_band_monotonic` 5/6.

## ⛔ Deliberately deferred

The §I.5a **copy 5** fix (`time_machine.js` `_buildXraySupportCache`) is **not** in this change. Applied, it makes `W-OGB-3a` fail with Terminal `staged=0 → 14` (isolated by reverting only that file: 9/0 without it, 8/1 with it).

Those 14 are **not** a harness artifact — they are real Terminal elements starting before a stair-flight carrier, surfaced because the x-ray **judge** would see flights as carriers while the **guard** (`_ogSupportSweep`) repairs against **wall** carriers only. That needs a decision about whether the guard must repair stair-flight carriers, not a re-baseline of the number.

🤖 Generated with [Claude Code](https://claude.com/claude-code)