### PR TITLE
fix(4d): require positive QuotaExceededError match before cache eviction

### DIFF
--- a/viewer/scene.js
+++ b/viewer/scene.js
@@ -1345,10 +1345,15 @@ async function setupScene(A) {
         // So: evict ONLY for QuotaExceededError, the one failure eviction can actually relieve.
         var _res = await _attemptWrite();
         var _ok = _res.ok;
-        if (!_ok && _res.name && _res.name !== 'QuotaExceededError') {
-          console.warn(`[S203] §CACHE_WRITE_UNFIXABLE url=${url.split('/').pop()} size=${(buf.byteLength/1024/1024).toFixed(1)}MB` +
-            ` err=${_res.err} — eviction cannot help this; cache left INTACT`);
-        } else if (!_ok) {
+        // §CACHE_EVICT_ONLY_ON_QUOTA_STRICT: require the POSITIVE match before evicting. A blank/
+        // missing name — tx.onabort firing with tx.error null, or tx.oncomplete firing with
+        // _writeOk still false (neither is provably a quota shortfall) — must default to "leave the
+        // cache intact", not fall through to eviction. The previous form
+        // (`_res.name && _res.name !== 'QuotaExceededError'`) only excluded ONE named non-quota case
+        // and let every UNNAMED failure reach the evict branch below — the same blind-evict-on-any-
+        // abort defect §CACHE_EVICT_ONLY_ON_QUOTA was written to retire, just narrowed to a smaller
+        // trigger set instead of closed.
+        if (!_ok && _res.name === 'QuotaExceededError') {
           for (var _try = 0; !_ok && _try < 4; _try++) {
             var _dropped = await A._evictOldest(cacheDb, 4);
             if (!_dropped) break;                     // nothing left to give up — stop, don't spin
@@ -1357,6 +1362,9 @@ async function setupScene(A) {
             _ok = _res.ok;
           }
           if (!_ok) console.warn(`[S203] §CACHE_EVICT_WRITE_FAIL url=${url.split('/').pop()} err=${_res.err || 'unknown'} — still failing after LRU eviction`);
+        } else if (!_ok) {
+          console.warn(`[S203] §CACHE_WRITE_UNFIXABLE url=${url.split('/').pop()} size=${(buf.byteLength/1024/1024).toFixed(1)}MB` +
+            ` err=${_res.err || '(no error name — treated as unfixable, not evicted)'} — eviction cannot help this; cache left INTACT`);
         }
       } catch(e) { console.log(`[S203] §CACHE_WRITE_ERR ${e.message}`); }
     }

--- a/viewer/sw.js
+++ b/viewer/sw.js
@@ -22,7 +22,7 @@
 // schedule_author.js is in PRECACHE_ASSETS; v1088 shipped the STAGE 3 drawer change (#1528), so this
 // separate change needs its own bump (§CRISIS LESSON 4).
 // DEPLOY: bump CACHE_VERSION on every OCI upload. Old caches are purged on activate.
-const CACHE_VERSION = 'v1092';   // bump on each deploy; per-change detail is the git commit message.
+const CACHE_VERSION = 'v1093';   // bump on each deploy; per-change detail is the git commit message.
 // v1092 (2026-08-27) §R10 (bim-compiler prompts/CPE_4D_PERF_MEM_FINDINGS.md §7, extends R1's
 // §MAXQ_STAGE_KEEP contract): the MaxQ bake's per-frame §GLOW_LENS_QUAD rebuild (viewer/effects.js)
 // now skips the dispose+rebuild when the TM-visible fixture count is unchanged since the last


### PR DESCRIPTION
## Summary
- 1d968aa (#1555) fixed the measured Hospital data-loss case (oversized write mis-treated as evictable) but left the guard inverted: it excludes one *named* non-quota failure instead of requiring the positive `QuotaExceededError` match, so any *unnamed* abort (null `tx.error`, or `tx.oncomplete` firing with `_writeOk` still false) still falls through to blind eviction.
- `LTU_AHouse_geo.db` (160.7MB) and `Terminal_geo.db` (249.2MB) both already exceed Chrome's 127MiB single-IndexedDB-value cap, so this residual path is live today, not theoretical.
- Fix: invert the guard to `_res.name === 'QuotaExceededError'` exactly — a blank/missing name now defaults to "leave the cache intact."

## Test plan
- [x] `node -c viewer/scene.js` syntax check
- [x] `sw.js` CACHE_VERSION bumped v1092→v1093 (mandatory same-PR)
- [ ] Live re-test of the original Hospital oversized-write case still passes (not re-run here — logic-only change, narrows the trigger set further, doesn't touch the already-correct named-QuotaExceededError path)

🤖 Generated with [Claude Code](https://claude.com/claude-code)