### PR TITLE
fix(4d): X-ray-off restore falls back to real per-material opacity (Clinic glass-loss root cause)

### DIFF
--- a/viewer/sw.js
+++ b/viewer/sw.js
@@ -22,7 +22,7 @@
 // schedule_author.js is in PRECACHE_ASSETS; v1088 shipped the STAGE 3 drawer change (#1528), so this
 // separate change needs its own bump (§CRISIS LESSON 4).
 // DEPLOY: bump CACHE_VERSION on every OCI upload. Old caches are purged on activate.
-const CACHE_VERSION = 'v1093';   // bump on each deploy; per-change detail is the git commit message.
+const CACHE_VERSION = 'v1094';   // bump on each deploy; per-change detail is the git commit message.
 // v1092 (2026-08-27) §R10 (bim-compiler prompts/CPE_4D_PERF_MEM_FINDINGS.md §7, extends R1's
 // §MAXQ_STAGE_KEEP contract): the MaxQ bake's per-frame §GLOW_LENS_QUAD rebuild (viewer/effects.js)
 // now skips the dispose+rebuild when the TM-visible fixture count is unchanged since the last

--- a/viewer/tools.js
+++ b/viewer/tools.js
@@ -319,9 +319,23 @@ function setupTools(A) {
           mat.opacity = 0.3;
           mat.side = THREE.DoubleSide;
         } else {
-          mat.transparent = mat._origTransparent !== undefined ? mat._origTransparent : false;
-          mat.opacity = mat._origOpacity !== undefined ? mat._origOpacity : 1;
-          mat.side = mat._origSide !== undefined ? mat._origSide : THREE.FrontSide;
+          // §XRAY_RESTORE_USERDATA_FIX: mat._origTransparent/_origOpacity/_origSide are only
+          // captured for materials that already existed in _matCache at the moment xray turned ON
+          // (the loop above). A material first created WHILE xray was already active
+          // (streaming.js:850 sets opacity=0.3 unconditionally at creation time, no _orig* ever
+          // recorded for it) restored here to the hardcoded default (opaque, FrontSide) instead of
+          // its real material — permanently flattening any such material transparent (e.g. glass)
+          // opaque for the rest of the session, since it then sits cached in A._matCache and is
+          // reused for every future element sharing the same cacheKey. streaming.js:848-849 already
+          // records the true per-material value in userData.origOpacity/origSide for EVERY material
+          // at creation time, xray-on-or-not — prefer that over the hardcoded default.
+          var _ud = mat.userData || {};
+          mat.transparent = mat._origTransparent !== undefined ? mat._origTransparent
+            : (_ud.origOpacity !== undefined ? _ud.origOpacity < 1.0 : false);
+          mat.opacity = mat._origOpacity !== undefined ? mat._origOpacity
+            : (_ud.origOpacity !== undefined ? _ud.origOpacity : 1);
+          mat.side = mat._origSide !== undefined ? mat._origSide
+            : (_ud.origSide !== undefined ? _ud.origSide : THREE.FrontSide);
         }
         mat.needsUpdate = true;
       }
@@ -336,9 +350,14 @@ function setupTools(A) {
           m._origSide = m.side;
           m.transparent = true; m.opacity = 0.3; m.side = THREE.DoubleSide;
         } else {
-          m.transparent = m._origTransparent !== undefined ? m._origTransparent : false;
-          m.opacity = m._origOpacity !== undefined ? m._origOpacity : 1;
-          m.side = m._origSide !== undefined ? m._origSide : THREE.FrontSide;
+          // Same §XRAY_RESTORE_USERDATA_FIX as above, applied to the scene.traverse fallback path.
+          var _mud = m.userData || {};
+          m.transparent = m._origTransparent !== undefined ? m._origTransparent
+            : (_mud.origOpacity !== undefined ? _mud.origOpacity < 1.0 : false);
+          m.opacity = m._origOpacity !== undefined ? m._origOpacity
+            : (_mud.origOpacity !== undefined ? _mud.origOpacity : 1);
+          m.side = m._origSide !== undefined ? m._origSide
+            : (_mud.origSide !== undefined ? _mud.origSide : THREE.FrontSide);
         }
         m.needsUpdate = true;
       });


### PR DESCRIPTION
## Summary
- `toggleXray()` only captures `_origOpacity`/`_origTransparent`/`_origSide` for materials already in `A._matCache` when X-ray turns ON. A material created WHILE X-ray is already active never gets those set.
- On X-ray-off, that material's opacity falls back to a hardcoded `1` (opaque) instead of its real value — permanently flattening transparent materials (glass, alpha=0.1) opaque for the rest of the session, since the material is cached and reused.
- Root cause of the reported Clinic curtain-wall glass-loss symptom, traced in `bim-compiler prompts/LTU_TERMINAL_CLINIC_RENDER_CORRUPTION.md` §B — the DB material data was verified correct throughout, this is a pure render-state bug.
- Fix: both X-ray-off restore paths fall back to `streaming.js`'s already-correct `userData.origOpacity`/`origSide` (recorded for every material, always) before the hardcoded default.

## Test plan
- [x] `node -c viewer/tools.js` syntax check
- [x] `sw.js` CACHE_VERSION bumped (this PR: v1093→v1094)
- [ ] Live re-test: toggle X-ray on mid-stream on a large building, toggle off, confirm glass stays transparent (not re-run here — no live-browser access in this session)

🤖 Generated with [Claude Code](https://claude.com/claude-code)