### PR TITLE
fix(4d): §I.5c — stop narrowing §TPL_LAYER_ORDER's bearing relation to the wall-pool upper bound

### DIFF
--- a/viewer/schedule_author.js
+++ b/viewer/schedule_author.js
@@ -1342,7 +1342,14 @@
           var lst = Gc.contacts[i2], b2 = [];
           if (lst) for (var q = 0; q < lst.length; q++) {
             var S2 = items[lst[q]], T2 = items[i2];
-            if (S2.bz < T2.bz - EPSl && S2.tz >= T2.bz - GAPl && S2.tz <= T2.bz + GAPl) b2.push(lst[q]);
+            // §I.5c FIX (bim-compiler 4D_MODEL_INTEGRITY.md) — this used to also require
+            // `S2.tz <= T2.bz + GAPl`, an upper bound that belongs only to auditFloating's WALL
+            // pool (§I.1 copy 3), applied here to EVERY contact. That discarded ~32% of Hospital's
+            // real bearing edges (supports whose top sits above the base they carry) from the
+            // layer pass's own graph, though it still claimed to run on "the SHIPPED contact
+            // graph's bearing relation". Now matches SupportSweep.contactGraph's own predicate
+            // (support_sweep.js `_ogSupportSweep`/`contactGraph`: no upper bound) exactly.
+            if (S2.bz < T2.bz - EPSl && S2.tz >= T2.bz - GAPl) b2.push(lst[q]);
           }
           below[i2] = b2;
         }
@@ -1403,7 +1410,9 @@
           for (var _q = 0; _q < _l2.length; _q++) {
             var _S = _it[_l2[_q]], _ss = _rm.schedule[_S.guid]; if (!_ss) continue;
             if (_taskOf[_S.guid] !== _taskOf[_T.guid]) continue;          // same task only
-            if (!(_S.bz < _T.bz - SG.EPS && _S.tz >= _T.bz - SG.GAP && _S.tz <= _T.bz + SG.GAP)) continue;
+            // §I.5c FIX — same narrowing dropped as above, so the self-check judges the SAME
+            // population the pass now actually lays out, not a pre-filtered subset of it.
+            if (!(_S.bz < _T.bz - SG.EPS && _S.tz >= _T.bz - SG.GAP)) continue;
             if (_ts.start < _ss.end - 1) _inv++;
           }
         }

--- a/viewer/tests/witness_4d_template_instantiation.js
+++ b/viewer/tests/witness_4d_template_instantiation.js
@@ -24,6 +24,10 @@ const SQLJS_DIST = path.join(HOME, 'bim-ootb', 'node_modules', 'sql.js', 'dist')
 const VIEWER_DIR = process.env.VIEWER_DIR || path.join(__dirname, '..');
 const ScheduleGate = require(path.join(VIEWER_DIR, 'schedule_gate.js'));
 global.ScheduleGate = ScheduleGate;
+// §I.5c / §I.5j(b) — without this, schedule_author.js's `global.SupportSweep` lookup misses and
+// §TPL_LAYER_ORDER logs §TPL_LAYER_ORDER_FAIL and returns null: the layer pass this witness exists
+// to judge never runs, and every invariant below was scoring a grid built in raw solve order.
+global.SupportSweep = require(path.join(VIEWER_DIR, 'support_sweep.js'));
 const ScheduleAuthor = require(path.join(VIEWER_DIR, 'schedule_author.js'));
 
 const KIT = path.join(__dirname, '..', '..', 'witness_kit');


### PR DESCRIPTION
## Summary
- `schedule_author.js`'s §TPL_LAYER_ORDER pass claimed to run on "the SHIPPED contact graph's bearing relation" but re-filtered it with `auditFloating`'s wall-pool upper bound (`S.tz <= T.bz + GAP`) applied to *every* contact — discarding ~32% of Hospital's real bearing edges. Its own self-check re-typed the same narrowed predicate, so `stillInverted` was structurally blind to what it dropped (HHS reported `0/PASS` on a run the owner's predicate scores at 138).
- Removed both narrowing clauses (`schedule_author.js:1345`, `:1412`) so the pass and its self-check use `SupportSweep.contactGraph`'s own predicate (no upper bound).
- Registered `SupportSweep` in `witness_4d_template_instantiation.js` — it never ran the layer pass at all (`§TPL_LAYER_ORDER_FAIL`, silent no-op); every prior score on this witness judged a grid built in raw solve order.

## Measured
Matches PR #1563's probe exactly: `stillInverted` Duplex 5, HHS 9, Hospital 794 (fix cures 84–93% of the real inversions). Task grid membership and `totalDays` byte-identical on all three (13/13, 50/50, 318/318) — this only reorders elements inside already-correct task windows, no schedule envelope change.

Full 72-witness headless suite: 59 green, 6 new_red — all 6 verified pre-existing on unmodified `origin/main` (isolated in a clean baseline worktree), none caused by this change.

Spec: bim-compiler `prompts/4D_MODEL_INTEGRITY.md` §I.5c, bundled into `prompts/4D_GANTT_TM_REFACTOR.md` §FUTURE item 7 stage 1 (user-approved 2026-08-27).

## Test plan
- [x] `node viewer/tests/witness_4d_template_instantiation.js` — 12/0, `stillInverted` matches PR #1563 exactly
- [x] `node viewer/tests/witness_gantt_edit_coherence.js` — 11/0, unaffected (doesn't register SupportSweep)
- [x] `node tests/run_witness_suite.js` — 59 green / 6 pre-existing red (confirmed against clean `origin/main`) / 7 known_red
- [x] Direct membership/totalDays check via `materializeZones` — unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)