### PR TITLE
fix(4d): §FUTURE item 2 — duration-weighted contiguous tiling closes remapSolveToTasks dead air

### DIFF
--- a/viewer/schedule_author.js
+++ b/viewer/schedule_author.js
@@ -953,10 +953,14 @@
       // violations — into the window. Support order is the only order a task's contents have.
       // Bucket the task's own members by support layer, then give each layer a CONTIGUOUS,
       // NON-OVERLAPPING band of the window sized by its member count. Inside a band the solve's
-      // relative order is preserved (affine, as before) — the crew-leveling the solve did is real
-      // and is kept. What changes is that layer n+1 cannot begin before layer n's band ends, so a
-      // beam can never precede the column carrying it. Replacing the solve outright was tried and
-      // measured WORSE (Hospital 0 -> 2 unsupported at DAY 0 HR 3): the even spread discarded the
+      // relative ORDER is preserved (each element keeps its rank by solve start) — the
+      // crew-leveling the solve did is real and is kept — but each element's WIDTH inside the band
+      // is its own duration weight, not a raw affine replay of solve magnitude (§FUTURE item 2:
+      // duration-weighted CONTIGUOUS tiling, see below — a straight affine replay left dead air at
+      // a band's tail whenever the layer's solve times were unevenly spread). What changes vs. no
+      // layering at all is that layer n+1 cannot begin before layer n's band ends, so a beam can
+      // never precede the column carrying it. Replacing the solve outright was tried and measured
+      // WORSE (Hospital 0 -> 2 unsupported at DAY 0 HR 3): the even spread discarded the
       // crew-leveling. Clamp, do not replace.
       var mine = t.guids.filter(function (x) { return solve[x]; });
       if (span <= 0) degenerate++;
@@ -973,22 +977,33 @@
         var bandW = (wE - wS) * (grp.length / Math.max(1, total));
         var bS = cursor, bE = (li === layers.length - 1) ? wE : Math.min(wE, cursor + bandW);
         if (bE <= bS) bE = bS + 1;
-        var glo = Infinity, ghi = -Infinity;
-        for (var q2 = 0; q2 < grp.length; q2++) {
-          var stq = solve[grp[q2]];
-          if (stq.start < glo) glo = stq.start;
-          if (stq.end > ghi) ghi = stq.end;
-        }
-        var gspan = ghi - glo, gscale = gspan > 0 ? (bE - bS) / gspan : 0;
-        var gstep = (bE - bS) / Math.max(1, grp.length);
-        for (var q3 = 0; q3 < grp.length; q3++) {
-          var gg = grp[q3], sq = solve[gg], ns2, ne2;
-          if (gspan > 0) {
-            ns2 = Math.round(bS + (sq.start - glo) * gscale);
-            ne2 = Math.round(bS + (sq.end - glo) * gscale);
-          } else {                                  // degenerate layer: deterministic even spread
-            ns2 = Math.round(bS + q3 * gstep); ne2 = Math.round(bS + (q3 + 1) * gstep);
-          }
+        // §FUTURE item 2 — duration-weighted CONTIGUOUS tiling, not raw-magnitude affine. The old
+        // code affine-mapped the layer's own solve range [glo,ghi] onto [bS,bE], which preserves
+        // the solve's ABSOLUTE spacing — so a band whose members' solve times are unevenly spread
+        // (typical: crew-levelling bunches many short elements early, one long one late) left the
+        // LATTER part of the band with zero element starts: "intra-task dead air"
+        // (§TPL_PARALLEL_REVEAL, Hospital TASK_Architecture_Envelope_Level_5 measured zero starts
+        // on days 166-168/173 of its own [137,180] window). Real crew-levelling ORDER still decides
+        // who reveals before whom (sorted by the solve's own start); what changes is that each
+        // element's share of the band is its own duration WEIGHT, not its solve-time position — so
+        // the band is tiled edge-to-edge by construction and dead air inside a populated band is
+        // structurally impossible. One rule for every band, degenerate solve-span or not — same
+        // move §TPL_LAYER_ORDER already made one level up for tasks. No duration invented: the
+        // weight is each element's own (sq.end - sq.start), the exact installSecs/crew figure the
+        // solve already computed; a zero-length solve interval floors to 1ms (equal split).
+        // Tie-break on guid (matches witness_4d_movie_binds_bars' own deterministic order for equal
+        // solveStart) — elements genuinely tied in the solve have no real "before" relationship, so
+        // any deterministic order is equally valid; matching the witness's tie-break avoids a
+        // false-positive reorder verdict on ties that are not a real order violation.
+        var ordered = grp.slice().sort(function (x, y) { return solve[x].start - solve[y].start || (x < y ? -1 : 1); });
+        var durs = ordered.map(function (g) { return Math.max(1, solve[g].end - solve[g].start); });
+        var durTotal = durs.reduce(function (a, b) { return a + b; }, 0);
+        var cum = 0;
+        for (var q3 = 0; q3 < ordered.length; q3++) {
+          var gg = ordered[q3];
+          var ns2 = Math.round(bS + (cum / durTotal) * (bE - bS));
+          cum += durs[q3];
+          var ne2 = Math.round(bS + (cum / durTotal) * (bE - bS));
           if (ne2 <= ns2) ne2 = ns2 + 1;            // never a zero-width element
           if (ne2 > bE) ne2 = Math.round(bE);
           out[gg] = { start: ns2, end: ne2 };


### PR DESCRIPTION
## Summary
Stacked on #1567 (§I.5c) — this is stage 2 of `4D_GANTT_TM_REFACTOR.md` §FUTURE item 7.

- `remapSolveToTasks` affine-mapped each support layer's own solve range onto its band, preserving absolute spacing — a layer whose members' solve times were unevenly spread left the band's tail with zero element starts ("intra-task dead air", measured on Hospital `TASK_Architecture_Envelope_Level_5`: zero starts on days 166-168/173 of its own [137,180] window).
- Replaced with duration-weighted contiguous tiling: elements keep their real solve-order rank, but each element's width inside the band is its own duration weight (the real `installSecs`/crew figure the solve already computed), not raw affine magnitude. Tiles every populated band edge-to-edge by construction — dead air becomes structurally impossible. Unifies the two previous branches (affine/even-spread) into one rule, same move `§TPL_LAYER_ORDER` already made one level up. No duration invented.
- Found and fixed a real regression against its own `witness_4d_movie_binds_bars`'s `remap-preserves-solve-order` invariant in the same pass: needed the same guid tie-break the witness uses for elements tied on `solveStart` (the old affine map collapsed ties to equal `playStart`; duration-weighted tiling must break ties deterministically to avoid dead air, and needed to match the witness's own convention to avoid a false reorder verdict).

## Measured
Dead-air slices in the 3 widest cross-level overlapping pairs per building (Hospital/HHS/Duplex) dropped to 0/20 everywhere (was 3-4/20). Task grid membership and `totalDays` unchanged on all three (42/67/318, 20/30/50, 20/29/13).

## ⚠ Separate finding, flagged not fixed
Full-suite sweep surfaced `witness_day0_integrity.js` newly red. Isolated: it reproduces the **exact same** verdict (`claims=13 PASS=4 FAIL=5 INCONCLUSIVE=4`) on unmodified `origin/main` with a freshly-built cache — a real, pre-existing DAY-0 integrity regression unrelated to this PR or #1567 (bim-compiler `PROGRESS.md`'s "14 PASS/0 FAIL/2 INCONCLUSIVE" headline is stale against current `origin/main`). Out of scope here; flagged in the bim-compiler doc commit for whoever owns that lane next.

## Test plan
- [x] `scripts/probe_tpl_parallel_reveal.js` — dead-air 0/20 on all 3 buildings' widest overlaps (was 3-4/20)
- [x] `witness_4d_template_instantiation.js` — 12/0, task grid unchanged
- [x] `witness_4d_movie_binds_bars.js` — 7/0 (found+fixed the tie-break regression)
- [x] `witness_gantt_edit_coherence.js` — 11/0, unaffected
- [x] `tests/run_witness_suite.js` — 58 green / 7 new_red, all 7 verified pre-existing against a clean `origin/main` baseline

🤖 Generated with [Claude Code](https://claude.com/claude-code)