### PR TITLE
fix(4d): §BUILDING_SCOPE_FLOOR — a scope:"building" phase now gates every level

### DIFF
--- a/viewer/schedule_author.js
+++ b/viewer/schedule_author.js
@@ -483,11 +483,14 @@
     var byId = {};
     T.phases.forEach(function (p) { byId[p.id] = p; });
 
-    var tasks = [], edges = [], reports = [], taskAt = {}, totalDays = 0;
+    var tasks = [], edges = [], reports = [], taskAt = {}, totalDays = 0, buildingScopeTask = {};
     levels.forEach(function (lv, li) {
       var prevOnLevel = null;   // for the BRIDGED within-level chain (_empty_phase_rule)
       var cursor = 0;
       T.phases.forEach(function (p) {
+        // The within_level edge naming THIS phase as successor — computed once per phase, reused
+        // below both for the prevOnLevel chain and for the building-scope floor.
+        var wl = (T.dependencies.within_level || []).filter(function (ed) { return ed.succ === p.id; })[0];
         // _edge_scope_rule: a building-scope phase instantiates ONCE, on the lowest level. But its
         // ELEMENTS must all come with it — an element of a building-scope phase that happens to sit
         // on an upper storey belongs to that single task, it is not dropped. Silently losing it is
@@ -523,6 +526,20 @@
             if (need > start) start = need;
           }
         }
+        // §BUILDING_SCOPE_FLOOR (2026-08-27) — a scope:"building" phase (e.g. Substructure)
+        // instantiates exactly ONE task (line ~498), filed under whichever level sorts first. The
+        // ordinary within_level edge below only ever reaches THAT one level's chain, because
+        // prevOnLevel resets to null at the top of every level's own loop — every OTHER level's
+        // first phase never sees it. Not a Terminal-specific patch: this reads the template's own
+        // declared within_level/scope fields, so it applies to whatever phase is scope:"building",
+        // on any building. Measured on Terminal before this fix: the task graph was 5 disconnected
+        // chains, only 5/77 tasks reachable from Substructure (bim-compiler
+        // 4D_GANTT_TM_REFACTOR.md §FUTURE — live-log investigation, 2026-08-27).
+        var bTask = wl && byId[wl.pred] && byId[wl.pred].scope === 'building' ? buildingScopeTask[wl.pred] : null;
+        if (bTask && bTask !== prevOnLevel) {
+          var needB = bTask.eDays + (wl.lag_days || 0);
+          if (needB > start) start = needB;
+        }
         var t = {
           id: 'TASK_' + _slug(p.name) + '_' + _slug(lv),
           phase: p.name, storey: lv, level: li, phaseId: p.id,
@@ -530,13 +547,20 @@
           crewDays: pr.crewDays, bottleneck: pr.bottleneck, guids: c.guids
         };
         tasks.push(t); taskAt[k] = t;
+        if (p.scope === 'building') buildingScopeTask[p.id] = t;
         if (t.eDays > totalDays) totalDays = t.eDays;
         cursor = t.eDays;
         // within_level edge, from the last phase that ACTUALLY instantiated on this level.
         if (prevOnLevel) {
-          var wl = (T.dependencies.within_level || []).filter(function (ed) { return ed.succ === p.id; })[0];
           edges.push({ predId: prevOnLevel.id, succId: t.id, type: (wl && wl.type) || 'FS',
                        lagDays: wl ? (wl.lag_days || 0) : 0, kind: 'within_level' });
+        }
+        // §BUILDING_SCOPE_FLOOR edge — see comment above. Skipped when prevOnLevel already IS the
+        // building-scope task (the one level it's naturally co-located with): the edge above
+        // already covers that case, and this would just be a duplicate of the same constraint.
+        if (bTask && bTask !== prevOnLevel) {
+          edges.push({ predId: bTask.id, succId: t.id, type: wl.type || 'FS',
+                       lagDays: wl.lag_days || 0, kind: 'building_scope' });
         }
         if (ladder[p.id] && li > 0) {
           var b2 = taskAt[p.name + '||' + levels[li - 1]];


### PR DESCRIPTION
## Summary
Stacked on #1568 (which is stacked on #1567). Not part of the original §FUTURE item 7 plan — surfaced from a live-log investigation this session: *"why does Terminal substructure not finish first before anything else?"*

`instantiateTemplate` files a `scope:"building"` phase's (Substructure) single task under whichever level sorts first by elevation, then only wires its `within_level` FS edge via `prevOnLevel` — which resets to null at the top of every OTHER level's own loop. So the edge only reaches the one level the task happens to land on. Every other level's own first phase starts completely unconstrained.

**Fix:** for every phase on every level, if its declared `within_level` predecessor has `scope:"building"`, apply that predecessor's FS floor (and a real edge) regardless of which level the building-scope task is filed under — reads the template's own declared fields, nothing building-specific, generalizes to any IFC model. Skipped where the ordinary edge already covers it (no duplicate constraint). Purely additive — never removes or weakens a constraint.

## Measured (full 7-building fleet, before → after)
| building | reachable from Substructure | totalDays |
|---|---|---|
| Clinic | 35/35 (already clean) → 35/35 | 111→111, 0 tasks moved |
| Duplex | 17/20 → **20/20** | 13→13 |
| HHS | no Substructure (legit) → unaffected | 50→50 |
| Hospital | 42/42 (already clean) → 42/42 | 318→318, 0 tasks moved |
| JKR | 39/67 → **66/67** | 56→55 |
| LTU_AHouse | 62/62 (already clean) → 62/62 | 788→788, 0 tasks moved |
| Terminal | 5/77 → **75/77** | 97→97 (2 previously-day-0 orphan tasks, 492 elements, now correctly gated at day 2/4) |

Buildings already correctly connected are byte-identical — verified **per-task** sDays/eDays, not just aggregate totalDays (0/139 tasks differing across Clinic+Hospital+LTU+HHS).

**Residual, named not fixed:** Terminal (21 members) and JKR (199 members) each still have one orphaned root — same failure class, different shape: a level whose local phase-chain starts mid-sequence (skips straight to e.g. Architecture Envelope with no local Superstructure). Needs a further generalization (search back through lower levels for the nearest instance of the declared predecessor phase) — a separate, more debatable design decision, deliberately not folded in here.

## Test plan
- [x] Fleet-wide reachability/totalDays measurement, before and after (see above)
- [x] `witness_4d_template_instantiation.js` — 12/0
- [x] `witness_gantt_edit_coherence.js` — 11/0
- [x] `tests/run_witness_suite.js` — 59 green / 6 new_red, all 6 previously verified pre-existing (see #1567/#1568)

🤖 Generated with [Claude Code](https://claude.com/claude-code)