### PR TITLE
fix(cpe): buildup no longer bursts on the first film seconds (§CPE_BUILDUP_ONSET_BLEND)

### DIFF
--- a/viewer/cinema_maxq.js
+++ b/viewer/cinema_maxq.js
@@ -92,6 +92,26 @@
   var BUILDUP_EVEN_TEMPO = true;   // false restores §CPE_BUILDUP_WORK_PACED
   var _wpSched = null, _wpTried = false;
 
+  // ══ §CPE_BUILDUP_ONSET_BLEND (2026-08-27, CINEMA_PATH_EDITOR.md §CPE_BUILDUP_ONSET_BURST) ═════
+  // Re-raised by the user after §CPE_BUILDUP_ONSET_BURST (2026-08-13) was deprioritized, not fixed:
+  // "the movie is not reflecting the build up construction speed on the very first day... captures
+  // frames right away to days past... first few secs should take on Day 0 as most 4D rush onset."
+  // §CPE_BUILDUP_EVEN_TEMPO's day counter is still correct system-wide (kept, unchanged below) but a
+  // schedule that clusters completions early still LOOKS bursty under a pure calendar cursor —
+  // measured then: Duplex, 24.6% of the whole building already placed 5.5s into a 55s film. This is
+  // the minimal fix the prior write-up named and left unbuilt ("blend the cursor toward the
+  // already-present element-paced formula only within roughly the first ~10s of film... fading back
+  // to pure calendar-linear after") — scoped exactly to the user's own ask ("correct only the first
+  // 10 secs"), never reopening "two mechanisms compete for the whole film"
+  // (§CPE_BUILDUP_EVEN_TEMPO's own reason for retiring §CPE_BUILDUP_WORK_PACED as the default).
+  var ONSET_BLEND_SEC = 10;        // film seconds; user's own scoping, not invented
+  var _wpOnsetTried = false;       // separate one-shot arm flag — independent of _wpTried, which
+                                   // already gates BOTH the even-tempo mode-log AND the (unused
+                                   // while even-tempo is on) full-film work-pacing arm below; reusing
+                                   // it here would make _workPacingArm()'s own `_wpTried = true` first
+                                   // line silently suppress the even-tempo mode-log this same call
+                                   // still needs to print.
+
   function _workPacingArm() {
     _wpTried = true; _wpSched = null;
     if (typeof window.tmWorkSchedule !== 'function') {
@@ -112,21 +132,54 @@
     return true;
   }
 
-  // The cursor this frame should ask for. Pure function of the film fraction, so preview and bake
-  // cannot diverge and two runs of the same film ask for identical cursors.
-  function _workCursorAt(tFilm, bkState) {
+  // The cursor this frame should ask for. Pure function of (tFilm, bkState, totalSec) — `totalSec`
+  // is a per-plan constant (the film's own designed length), identical for preview and bake of the
+  // same film, so preview and bake still cannot diverge and two runs of the same film still ask for
+  // identical cursors. `totalSec` is optional (older call sites omit it) — onset blend simply stays
+  // off when it is not supplied, same DEGRADE-DON'T-DISABLE contract every other lever in this file
+  // already follows.
+  function _workCursorAt(tFilm, bkState, totalSec) {
     var t = Math.max(0, Math.min(1, tFilm));
+    var calMs = bkState.projectStart + t * (bkState.projectEnd - bkState.projectStart);
     // §CPE_BUILDUP_EVEN_TEMPO — the straight line, before any schedule is consulted. Gated ahead of
     // _workPacingArm() so an even-tempo film never even arms work pacing: arming logs a mode line
     // that would then describe a pacing that is not in force, which is exactly the kind of log that
     // costs a live debugging round-trip.
     if (BUILDUP_EVEN_TEMPO) {
+      // §CPE_BUILDUP_ONSET_BLEND — onsetU is the ONSET_BLEND_SEC window expressed as a tFilm
+      // fraction of THIS film (so "10 seconds" means the same thing on a 30s and a 300s bake),
+      // capped at half the film so a very short test/preview clip can't blend past its midpoint.
+      var onsetU = (totalSec > 0) ? Math.min(0.5, ONSET_BLEND_SEC / totalSec) : 0;
+      if (onsetU > 0 && t < onsetU) {
+        if (!_wpOnsetTried) { _wpOnsetTried = true; _workPacingArm(); }
+        if (_wpSched) {
+          var _k = Math.max(1, Math.min(_wpSched.total, Math.round(t * _wpSched.total)));
+          var elMs = _wpSched.ends[_k - 1];
+          // w: 0 at t=0 (fully element-paced, matching the burst's own true completion order) ->
+          // 1 at t=onsetU (fully calendar-linear, handing off to §CPE_BUILDUP_EVEN_TEMPO cleanly —
+          // blendedMs === calMs exactly at the handoff instant, no seam).
+          var w = t / onsetU;
+          var blendedMs = elMs + (calMs - elMs) * w;
+          if (!_wpTried) {
+            _wpTried = true;
+            console.log('§CPE_BUILDUP_PACING mode=even-calendar+onset-blend (§CPE_BUILDUP_ONSET_BLEND) ' +
+              'onsetSec=' + ONSET_BLEND_SEC + '/' + totalSec.toFixed(1) + ' onsetU=' + onsetU.toFixed(4) +
+              ' — first ' + ONSET_BLEND_SEC + 's blend toward element-paced order, fading to pure ' +
+              'calendar by t=' + onsetU.toFixed(4) + '; day counter and the rest of the film unaffected');
+          }
+          return blendedMs;
+        }
+        // Work schedule unavailable (older time_machine.js / no usable schedule) — DEGRADE to pure
+        // calendar exactly as §CPE_BUILDUP_EVEN_TEMPO always has; _workPacingArm() already logged why.
+      }
       if (!_wpTried) {
         _wpTried = true;
         console.log('§CPE_BUILDUP_PACING mode=even-calendar (§CPE_BUILDUP_EVEN_TEMPO) — every film ' +
-          'second advances the SAME number of days; dwell/tempo is the path editor\'s job (sticks + timings)');
+          'second advances the SAME number of days; dwell/tempo is the path editor\'s job (sticks + timings)' +
+          (onsetU > 0 ? ' (onset-blend window armed but no usable work schedule — see §CPE_BUILDUP_PACING arm log above)'
+                      : ' (onset-blend inactive — no totalSec passed by this caller)'));
       }
-      return bkState.projectStart + t * (bkState.projectEnd - bkState.projectStart);
+      return calMs;
     }
     if (!_wpTried) _workPacingArm();
     if (!_wpSched) return bkState.projectStart + t * (bkState.projectEnd - bkState.projectStart);
@@ -139,7 +192,7 @@
     return _wpSched.ends[k - 1];
   }
 
-  function _workPacingReset() { _wpSched = null; _wpTried = false; _fcIdx = null; }
+  function _workPacingReset() { _wpSched = null; _wpTried = false; _wpOnsetTried = false; _fcIdx = null; }
 
   // ══ §CPE_BUILDUP_TOPOUT (2026-08-02) — the ending beats dwell on the FINISHED building ═════════
   // User, on the 1761-frame Hospital bake: "the top roof solar panels never gets to be shown - it
@@ -1295,7 +1348,7 @@
           // §CPE_BUILDUP_WORK_PACED: was `projectStart + t*span` — linear in DAYS. Now linear in
           // ELEMENTS, so the building rises at an even rate regardless of how the derived 4D order
           // clusters its timestamps.
-          var _bkMs = _workCursorAt(_bkT, _bkState);
+          var _bkMs = _workCursorAt(_bkT, _bkState, nFrames / fps);
           window.tmSetCursor(_bkMs);
           // §CPE_GHOST_GROUND: same film fraction the cursor rides, so the ghost cannot drift out of
           // step with what is actually placed.

--- a/viewer/cinema_path_editor.js
+++ b/viewer/cinema_path_editor.js
@@ -1479,7 +1479,10 @@
     if (!ts.active) return null;   // conservative: never arm TM from a scrub — see block comment
     var a = A();
     var bkTn = a.buildupTAt ? a.buildupTAt(tn, s.plan) : tn;
-    var bkMs = a.buildupCursorAt ? a.buildupCursorAt(bkTn, ts)
+    // §CPE_BUILDUP_ONSET_BLEND: same durationSec the scrub's own plan was built with, so a scrub
+    // preview and the real bake agree on where the onset window ends.
+    var _totalSec = s.plan && s.plan.durationSec;
+    var bkMs = a.buildupCursorAt ? a.buildupCursorAt(bkTn, ts, _totalSec)
       : (ts.projectStart + bkTn * (ts.projectEnd - ts.projectStart));
     window.tmSetCursor(bkMs);
     // Same order as step(): readout refreshed AFTER this call's tmSetCursor, reading the cursor this
@@ -2441,18 +2444,22 @@
           // §CPE_BUILDUP_TOPOUT: the same remap the bake applies — construction completes at the
           // closing-orbit boundary, so the rehearsal's ending shows the finished building too.
           var bkTn = a.buildupTAt ? a.buildupTAt(tn, _state.plan) : tn;
+          // §CPE_BUILDUP_ONSET_BLEND: same expression §CPE_GHOST_GROUND already uses below for its
+          // own totalSec — one value, reused, so onset blend and ghost-ground fade agree on the
+          // film's length instead of each computing their own.
+          var _totalSec = _titleTotalSec || dur / 1000;
           // §GHOST_GROUND_LIVE_TRIGGER: compute the cursor ONCE and reuse it for tmSetCursor,
           // ghostGroundAt and dayCounterLiveTick — previously each call re-derived it inline
           // (harmless when they agreed, but the ghost-ground trigger now needs the EXACT same
           // cursor value tmSetCursor just used, not a separately-recomputed one).
-          var bkMs = a.buildupCursorAt ? a.buildupCursorAt(bkTn, bkPrev)
+          var bkMs = a.buildupCursorAt ? a.buildupCursorAt(bkTn, bkPrev, _totalSec)
             : (bkPrev.projectStart + bkTn * (bkPrev.projectEnd - bkPrev.projectStart));
           window.tmSetCursor(bkMs);
           // §CPE_GHOST_GROUND: the rehearsal shows what the bake will show. The fade is expressed in
           // FILM fraction, so the 10 s preview and the full bake trace the identical curve even
           // though the wall-clock speeds differ by 15x. `bkMs` is the real cursor — §GHOST_GROUND_
           // LIVE_TRIGGER compares it directly to `firstAboveMs`, never a converted fraction.
-          if (a.ghostGroundAt) a.ghostGroundAt(bkTn, _titleTotalSec || dur / 1000, bkPrev, bkMs);
+          if (a.ghostGroundAt) a.ghostGroundAt(bkTn, _totalSec, bkPrev, bkMs);
           // Same cursor the buildup was just set to — never a second, separately-interpolated clock.
           if (_dayOn && a.dayCounterLiveTick) a.dayCounterLiveTick(bkMs);
         }

--- a/viewer/sw.js
+++ b/viewer/sw.js
@@ -22,7 +22,7 @@
 // schedule_author.js is in PRECACHE_ASSETS; v1088 shipped the STAGE 3 drawer change (#1528), so this
 // separate change needs its own bump (§CRISIS LESSON 4).
 // DEPLOY: bump CACHE_VERSION on every OCI upload. Old caches are purged on activate.
-const CACHE_VERSION = 'v1094';   // bump on each deploy; per-change detail is the git commit message.
+const CACHE_VERSION = 'v1095';   // bump on each deploy; per-change detail is the git commit message.
 // v1092 (2026-08-27) §R10 (bim-compiler prompts/CPE_4D_PERF_MEM_FINDINGS.md §7, extends R1's
 // §MAXQ_STAGE_KEEP contract): the MaxQ bake's per-frame §GLOW_LENS_QUAD rebuild (viewer/effects.js)
 // now skips the dispose+rebuild when the TM-visible fixture count is unchanged since the last

--- a/witness_cpe_buildup_onset_blend.js
+++ b/witness_cpe_buildup_onset_blend.js
@@ -1,0 +1,263 @@
+// WITNESS — §CPE_BUILDUP_ONSET_BLEND. The buildup must not burst on the very first film-seconds.
+// Spec: bim-compiler prompts/CINEMA_PATH_EDITOR.md §CPE_BUILDUP_ONSET_BURST.
+//
+// USER REPORT, re-raised 2026-08-27 (§CPE_BUILDUP_ONSET_BURST was measured 2026-08-13, then
+// deprioritized unfixed): "the movie is not reflecting the build up construction speed on the very
+// first day. IT captures frames right away to days past and thus the movie jumps without
+// appreciating the first hour. First few secs should take on Day 0 as most 4D rush onset."
+//
+// WHAT THIS PROVES OR DISPROVES — cinema_maxq.js `_workCursorAt` now takes an optional 3rd arg
+// `totalSec` (the film's own designed length). When supplied, the first ONSET_BLEND_SEC (=10) film
+// seconds blend the cursor toward the element-paced order (§CPE_BUILDUP_WORK_PACED, otherwise
+// retired), fading linearly back to pure calendar by the end of that window. §CPE_BUILDUP_EVEN_TEMPO
+// itself — the day counter's straight line — must stay exactly correct for the REST of the film and
+// at the handoff instant; only the onset window may deviate, and only toward less burst, never more.
+//
+//   G-ONSET-1  BURST REDUCED — with the SAME real Duplex schedule, cumulative placed% at real
+//              film-second marks inside the onset window is closer to time-proportional with the
+//              blend than without it (the §CPE_BUILDUP_ONSET_BURST measurement, re-run before/after).
+//   G-ONSET-2  HANDOFF SEAMLESS — blended cursor(t) == pure-calendar cursor(t) at t==onsetU exactly
+//              (no visible jump/cut at the moment the blend hands off).
+//   G-ONSET-3  PAST-ONSET UNCHANGED — for t in [onsetU, 1], cursor(t) is byte-identical (within fp
+//              tolerance) to the pure calendar-linear line — §CPE_BUILDUP_EVEN_TEMPO's own
+//              guarantee, untouched outside the onset window.
+//   G-ONSET-4  DEGRADE — callers that omit totalSec (older cached copies, or a call site never
+//              updated) get byte-identical pure calendar-linear across the WHOLE film, same as
+//              before this change existed. Also proves the pre-existing witness_cpe_buildup_tempo.js
+//              (which calls buildupCursorAt with 2 args) is unaffected by this change.
+//   G-ONSET-5  GHOST-GROUND INTERACTION — replays REAL per-frame conditions through the onset-blend-
+//              enabled 3-arg buildupCursorAt (the same call cinema_maxq.js's bake loop now makes),
+//              and confirms the ground opacity floor still holds on every frame until the REAL
+//              (post-blend) cursor actually crosses firstAboveMs — i.e. the onset blend does not
+//              reintroduce the §GHOST_GROUND_LIVE_TRIGGER two-clocks bug class the prior write-up
+//              flagged as the specific risk of this change.
+//
+// EVIDENCE DISCIPLINE: sampled off the REAL exposed APP.buildupCursorAt/ghostGroundAt against the
+// REAL armed Time Machine schedule — never a screenshot, never "looks smoother" — CLAUDE.md
+// FUNDAMENTAL LAW.
+const puppeteer = require('/home/red1/bim-compiler/node_modules/puppeteer');
+
+const PORT = process.env.PORT || 8471;
+const BUILDINGS = (process.env.BLDS || 'Duplex').split(',');
+const ONSET_SEC = 10;
+const sleep = ms => new Promise(r => setTimeout(r, ms));
+const DAY = 86400000;
+
+async function openArmed(browser, BLD) {
+  const page = await browser.newPage();
+  const cdp = await page.createCDPSession();
+  await cdp.send('Network.enable');
+  await cdp.send('Network.setBypassServiceWorker', { bypass: true });
+  await page.setViewport({ width: 1200, height: 700 });
+  const logs = [];
+  page.on('console', m => logs.push(m.text()));
+  page.on('pageerror', e => logs.push('PAGEERROR ' + e.message));
+  await page.goto(`http://localhost:${PORT}/viewer/viewer.html?db=/buildings/${BLD}_extracted.db`,
+    { waitUntil: 'domcontentloaded', timeout: 60000 });
+  await page.waitForFunction(
+    () => window.APP && window.APP.buildupCursorAt && window.APP.ghostGroundArm && window.APP.dbQuery,
+    { timeout: 120000 });
+  await sleep(9000);
+  await page.waitForFunction(() => {
+    try { const r = window.APP.dbQuery('SELECT COUNT(*) FROM element_transforms'); return r && r[0][0] > 0; }
+    catch (e) { return false; }
+  }, { timeout: 60000, polling: 2000 });
+  return { page, logs };
+}
+
+async function gates(browser, BLD) {
+  const checks = [];
+  const P = (n, ok, d) => { checks.push({ n, ok, d }); };
+  const { page, logs } = await openArmed(browser, BLD);
+
+  const res = await page.evaluate(async (ONSET_SEC) => {
+    const A = window.APP;
+    if (typeof window.tmGenerateTimeline === 'function') { try { window.tmGenerateTimeline(); } catch (e) {} }
+    let ok = false;
+    try { ok = await window.tmActivateForBake(); } catch (e) { return { err: 'tmActivateForBake: ' + e.message }; }
+    if (!ok) return { err: 'tmActivateForBake returned false — no ops for this building' };
+    const bk = window.tmFollowTimeline();
+    if (!bk) return { err: 'no timeline to follow' };
+    if (typeof A.buildupCursorAt !== 'function') return { err: 'APP.buildupCursorAt missing' };
+    if (typeof A.buildupPacingReset === 'function') A.buildupPacingReset();
+
+    const out = { projectStart: bk.projectStart, projectEnd: bk.projectEnd, ops: bk.ops };
+    const span = bk.projectEnd - bk.projectStart;
+
+    // A real film length, same shape as a real bake (Duplex bakes land near ~55s in the recorded
+    // history this witness's spec section cites).
+    const TOTAL_SEC = 55;
+    const onsetU = Math.min(0.5, ONSET_SEC / TOTAL_SEC);
+    out.totalSec = TOTAL_SEC; out.onsetU = onsetU;
+
+    // ── G-ONSET-1 data: cumulative placed% at fixed real-seconds marks across the onset window,
+    // WITH the blend (3-arg) vs WITHOUT it (2-arg, i.e. pure calendar — the pre-fix behavior).
+    if (typeof A.buildupPacingReset === 'function') A.buildupPacingReset();
+    const marks = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10].map(s => s / TOTAL_SEC);
+    const placedAt = (ms) => (typeof window.tmPlacedCount === 'function') ? window.tmPlacedCount(ms) : null;
+    out.withBlend = marks.map(t => {
+      const ms = A.buildupCursorAt(t, bk, TOTAL_SEC);
+      const p = placedAt(ms);
+      return { sec: +(t * TOTAL_SEC).toFixed(1), ms: Math.round(ms), placed: p, frac: p != null && bk.ops ? p / bk.ops : null };
+    });
+    if (typeof A.buildupPacingReset === 'function') A.buildupPacingReset();
+    out.withoutBlend = marks.map(t => {
+      const ms = A.buildupCursorAt(t, bk);   // 2-arg — degrade path, pure calendar
+      const p = placedAt(ms);
+      return { sec: +(t * TOTAL_SEC).toFixed(1), ms: Math.round(ms), placed: p, frac: p != null && bk.ops ? p / bk.ops : null };
+    });
+
+    // ── G-ONSET-2 / G-ONSET-3: the full curve, dense sampling, with the blend armed.
+    if (typeof A.buildupPacingReset === 'function') A.buildupPacingReset();
+    const N = 200;
+    out.curve = [];
+    for (let i = 0; i <= N; i++) {
+      const t = i / N;
+      out.curve.push({ t: +t.toFixed(4), ms: A.buildupCursorAt(t, bk, TOTAL_SEC) });
+    }
+    out.pacingLogTail = window.__pacingLogTail || null;
+
+    // ── G-ONSET-5: ghost-ground interaction, real per-frame replay with the 3-arg cursor.
+    let ggOut = null;
+    if (A.ground && A.groundIfcZ != null && typeof window.tmGroundSchedule === 'function' &&
+        A.ghostGroundArm && A.ghostGroundAt && A.ghostGroundRestore) {
+      const sched = window.tmGroundSchedule(A.groundIfcZ);
+      if (sched && sched.aboveTotal && sched.belowTotal && sched.firstAboveMs != null) {
+        A.ground.visible = false;
+        if (typeof A.buildupPacingReset === 'function') A.buildupPacingReset();
+        const armed = A.ghostGroundArm(bk);
+        A.ground.visible = true;
+        const NF = 400;
+        const frames = [];
+        let realFireFrame = null;
+        for (let i = 0; i <= NF; i++) {
+          const tFrac = i / NF;
+          const cursorMs = A.buildupCursorAt(tFrac, bk, TOTAL_SEC);
+          const o = A.ghostGroundAt(tFrac, TOTAL_SEC, bk, cursorMs);
+          if (realFireFrame == null && cursorMs >= sched.firstAboveMs) realFireFrame = i;
+          frames.push({ i, t: +tFrac.toFixed(4), cursorMs: Math.round(cursorMs), o: o == null ? null : +o.toFixed(4) });
+        }
+        A.ghostGroundRestore();
+        ggOut = { armed, firstAboveMs: sched.firstAboveMs, realFireFrame, frames };
+      } else {
+        ggOut = { skip: 'no above+below split on this building (nothing to ghost)' };
+      }
+    } else {
+      ggOut = { skip: 'ghost-ground API or groundIfcZ unavailable on this build' };
+    }
+    out.groundOut = ggOut;
+
+    try { window.tmRestoreDerivedOrder(); } catch (e) {}
+    return out;
+  }, ONSET_SEC);
+
+  if (res.err) {
+    P('G-ONSET-0 the buildup schedule is readable', false, res.err);
+    await page.close();
+    return checks;
+  }
+
+  const span = res.projectEnd - res.projectStart;
+
+  // ── G-ONSET-1. The 10s mark (index 9) sits exactly ON onsetU (10/55) — the blend fades to w=1
+  // there BY CONSTRUCTION (that's G-ONSET-2's own handoff proof), so it trivially agrees with the
+  // unblended series and proves nothing about burst reduction. The real evidence is strictly INSIDE
+  // the window (marks 1s..9s) where the two paths actually diverge.
+  const interior = res.withBlend.slice(0, 9).map((m, i) => {
+    const expFrac = res.withBlend[i].sec / res.totalSec;
+    const wErr = m.frac == null ? null : Math.abs(m.frac - expFrac);
+    const woErr = res.withoutBlend[i].frac == null ? null : Math.abs(res.withoutBlend[i].frac - expFrac);
+    return { sec: m.sec, wErr, woErr };
+  });
+  const sumW = interior.reduce((a, x) => a + (x.wErr || 0), 0);
+  const sumWo = interior.reduce((a, x) => a + (x.woErr || 0), 0);
+  P('G-ONSET-1 burst reduced — summed deviation from time-proportional placed%, across the 1s..9s marks strictly inside the onset window, is smaller WITH the blend',
+    interior.every(x => x.wErr != null && x.woErr != null) && sumW < sumWo,
+    `summed abs error vs time-proportional over marks 1..9s: WITHOUT=${(sumWo * 100).toFixed(1)}pt  WITH=${(sumW * 100).toFixed(1)}pt  ` +
+    `(lower is less bursty; ${(100 * (1 - sumW / sumWo)).toFixed(0)}% reduction)  ` +
+    `per-mark %placed WITHOUT=[${res.withoutBlend.slice(0, 9).map(m => m.frac == null ? '-' : (m.frac * 100).toFixed(1)).join(',')}]  ` +
+    `WITH=[${res.withBlend.slice(0, 9).map(m => m.frac == null ? '-' : (m.frac * 100).toFixed(1)).join(',')}]  ` +
+    `(10s mark omitted from this metric — it sits exactly on onsetU and trivially agrees by construction, see G-ONSET-2)`);
+
+  // ── G-ONSET-2: handoff at t=onsetU
+  const at = res.curve.find(c => Math.abs(c.t - res.onsetU) < 1 / 200 + 1e-9) || {};
+  const calAtOnsetU = res.projectStart + res.onsetU * span;
+  const handoffGapDays = at.ms != null ? Math.abs(at.ms - calAtOnsetU) / DAY : null;
+  P('G-ONSET-2 handoff at t=onsetU is seamless — blended cursor matches pure-calendar within one sample step',
+    handoffGapDays != null && handoffGapDays <= 0.02 * (span / DAY),
+    `onsetU=${res.onsetU.toFixed(4)}  nearestSampleT=${at.t}  cursorMs=${at.ms == null ? 'n/a' : Math.round(at.ms)}  ` +
+    `pureCalendarMs=${Math.round(calAtOnsetU)}  gap=${handoffGapDays == null ? 'n/a' : handoffGapDays.toFixed(2) + 'd'} ` +
+    `(tol ${(0.02 * span / DAY).toFixed(2)}d = 2% of ${(span / DAY).toFixed(0)}d span)`);
+
+  // ── G-ONSET-3: past onset, curve == pure calendar line
+  let worst = 0, worstAt = 0;
+  const past = res.curve.filter(c => c.t >= res.onsetU);
+  past.forEach(c => {
+    const dev = Math.abs(c.ms - (res.projectStart + c.t * span));
+    if (dev > worst) { worst = dev; worstAt = c.t; }
+  });
+  P('G-ONSET-3 past the onset window the cursor is byte-identical to pure calendar-linear (§CPE_BUILDUP_EVEN_TEMPO unchanged)',
+    past.length > 0 && worst <= 0.005 * span,
+    `${past.length} samples in [${res.onsetU.toFixed(3)}, 1]  maxDeviation=${(worst / DAY).toFixed(2)}d = ${(100 * worst / span).toFixed(3)}% of span (tol 0.5%) at t=${worstAt.toFixed(3)}`);
+
+  // ── G-ONSET-4: degrade path (2-arg call) is untouched pure calendar across the WHOLE onset window
+  const degradeWorst = res.withoutBlend.every((m, i) => {
+    const t = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10][i] / res.totalSec;
+    const expect = res.projectStart + t * span;
+    return Math.abs(m.ms - expect) <= 1; // ms rounding only
+  });
+  P('G-ONSET-4 degrade — omitting totalSec (2-arg call) stays byte-identical pure calendar-linear across the whole film',
+    degradeWorst,
+    `withoutBlend series ms vs pure-calendar expectation, all within 1ms: ${degradeWorst}`);
+
+  // ── G-ONSET-5: ghost-ground interaction
+  const go = res.groundOut || {};
+  if (go.skip) {
+    P('G-ONSET-5 ghost-ground onset interaction — INCONCLUSIVE, feature not applicable on this building',
+      true, go.skip);
+  } else {
+    const frames = go.frames || [];
+    const nf = go.realFireFrame;
+    const preFire = nf == null ? [] : frames.slice(0, nf);
+    const floorHeld = preFire.every(f => f.o != null && Math.abs(f.o - 0.22) < 1e-6);
+    let monotoneAfter = true;
+    for (let i = 1; i < frames.length; i++) {
+      if (frames[i].o != null && frames[i - 1].o != null && frames[i].o < frames[i - 1].o - 1e-9) monotoneAfter = false;
+    }
+    P('G-ONSET-5 onset blend does not reopen §GHOST_GROUND_LIVE_TRIGGER — opacity floor holds until the REAL (post-blend) cursor crosses firstAboveMs, then rises monotonically',
+      go.armed === true && nf != null && floorHeld && monotoneAfter,
+      `armed=${go.armed}  firstAboveMs=${go.firstAboveMs}  realFireFrame=${nf}/${frames.length ? frames.length - 1 : '?'} ` +
+      `(t=${nf == null ? 'n/a' : frames[nf].t}, cursorMs=${nf == null ? 'n/a' : frames[nf].cursorMs})  ` +
+      `${preFire.length} frames before fire, all pinned at 0.22: ${floorHeld}  monotoneAfter=${monotoneAfter}`);
+  }
+
+  const pacing = logs.filter(l => l.indexOf('§CPE_BUILDUP_PACING') >= 0);
+  const onsetLine = logs.filter(l => l.indexOf('§CPE_BUILDUP_ONSET_BLEND') >= 0 || l.indexOf('onset-blend') >= 0);
+  P('G-ONSET-6 the mode line names the onset blend so a live bake log is self-explaining',
+    pacing.some(l => l.indexOf('onset-blend') >= 0 || l.indexOf('ONSET_BLEND') >= 0),
+    pacing.slice(-3).join(' | ') || '(no §CPE_BUILDUP_PACING line at all)');
+
+  await page.close();
+  return checks;
+}
+
+(async () => {
+  const browser = await puppeteer.launch({
+    headless: 'new',
+    protocolTimeout: 900000,
+    args: ['--use-gl=angle', '--use-angle=swiftshader', '--no-sandbox', '--enable-unsafe-swiftshader'],
+  });
+  let allPass = true;
+  const summary = [];
+  for (const BLD of BUILDINGS) {
+    console.log(`\n${'='.repeat(78)}\n${BLD}\n${'='.repeat(78)}`);
+    const checks = await gates(browser, BLD);
+    checks.forEach(c => { if (!c.ok) allPass = false; console.log(`  ${c.ok ? 'PASS' : 'FAIL'}  ${c.n}\n          ${c.d}`); });
+    summary.push({ BLD, pass: checks.every(c => c.ok), n: checks.filter(c => c.ok).length, t: checks.length });
+  }
+  await browser.close();
+  console.log(`\n${'='.repeat(78)}`);
+  summary.forEach(s => console.log(`${s.pass ? 'PASS' : 'FAIL'}  ${s.BLD}  (${s.n}/${s.t})`));
+  console.log(allPass ? '\nWITNESS PASS' : '\nWITNESS FAIL');
+  process.exit(allPass ? 0 : 1);
+})();


### PR DESCRIPTION
## Summary
- Alt+C movies were skipping past Day 0 in the opening seconds because the calendar-linear buildup cursor lets a schedule's early-clustered completions burst visually (measured 2026-08-13: 24.6% of Duplex already built 5.5s into a 55s film).
- `_workCursorAt` now blends toward the already-present element-paced order for the first 10 film-seconds, fading to pure calendar-linear by the end of that window — day counter and rest of film unaffected.
- Scoped exactly to `prompts/CINEMA_PATH_EDITOR.md` §CPE_BUILDUP_ONSET_BURST per user confirmation; does not touch the separate, already-blocked Gantt bar-width lane.

## Test plan
- [x] `node --check` on all 3 changed viewer files
- [x] New `witness_cpe_buildup_onset_blend.js` — 12/12 green on Duplex + Hospital (burst reduced 34-35%, handoff seamless, day-counter unchanged past onset, degrade path unchanged, ghost-ground interaction specifically replayed and confirmed clean)
- [x] `witness_cpe_ghost_ground.js` re-run unmodified — 30/30 green (Duplex + Hospital), confirms the old 2-arg call pattern is untouched
- [x] `witness_cpe_buildup_tempo.js` re-run — Duplex 3/3 green (confirms degrade path byte-identical); Hospital run hit a pre-existing CPE-editor-UI open timeout unrelated to this diff (unchanged code path), not chased further given Duplex + the new witness's own Hospital pass already cover the actual cursor math

🤖 Generated with [Claude Code](https://claude.com/claude-code)