### PR TITLE
feat(cpe): §CPE_CONE_ORIENT_ADJUST — drag the POV cone to fix a bad gaze, no stick added

### DIFF
--- a/viewer/cinema_path_editor.js
+++ b/viewer/cinema_path_editor.js
@@ -55,12 +55,37 @@
   var SCRUB_PANEL_W = VF_DEFAULT_W;              // px
   // SCRUB_PANEL_GAP retired 2026-08-06 (§CPE_VF_STACK) — the bar is FUSED to B's bottom border,
   // sharing it as the divider, so there is no gap left to size.
+  // §CPE_CONE_ORIENT_ADJUST (2026-08-27) — drag the passive POV cone to correct a bad gaze without
+  // adding a stick. Spec: bim-compiler prompts/CINEMA_PATH_EDITOR.md §CPE_CONE_ORIENT_ADJUST.
+  var CONE_DEFAULT_COLOR = 0xff1744;    // the standing cone colour (unchanged, matches _syncPovMarker)
+  var CONE_FOCUS_COLOR = 0x8B5A2B;      // "brownish", per the spec's own example — a tuning knob, not fixed
+  // Rotation sensitivity — UNCONFIRMED default, same status as SCRUB_H etc. above: picked so a
+  // half-screen-width drag (~600px) turns roughly 180 deg, a comfortable full reversal in one gesture.
+  var CONE_ROTATE_RAD_PER_PX = 0.006;
+  var CONE_PITCH_CLAMP_RAD = 89 * Math.PI / 180;   // never let the drag reach straight up/down (gimbal)
+  // Envelope defaults, ARC-LENGTH in metres (spec item 5: "so behaviour scales with path geometry
+  // rather than film seconds") — FIRST-GUESS numbers, not settled with the user. ramp = short ease-in
+  // BEHIND the anchor; hold = full-strength stretch FORWARD from the anchor; decay = further ease-out
+  // past the hold. Mirrored as fallbacks in effects.js's _buildCpeCorrArc (search CPE_CONE_CORR).
+  var CPE_CONE_CORR_RAMP_M = 2;
+  var CPE_CONE_CORR_HOLD_M = 5;
+  var CPE_CONE_CORR_DECAY_M = 4;
+  // Re-dragging the cone within this world distance of an EXISTING correction's anchor UPDATES that
+  // entry in place rather than stacking a second one nearby — first-guess MVP behaviour for spec item
+  // 6 (multiple/overlapping corrections, not user-decided), flagged for review same as item 6 itself.
+  var CPE_CONE_CORR_MERGE_M = 3;
   // ══════════════════════════════════════════════════════════════════════════════════════════════
   // CPE_V changelog (2026-08-06: moved out of the console.log — the full history was printing on
   // every page load, ~4KB of text nobody was reading; kept here verbatim, nothing dropped, still
   // the first place a new session should read for "what changed and why" before the spec doc's own
   // DONE blocks, search `§CPE_SCRUB`, `§CPE_VIEWFINDER`, `§CPE_AIM_PIN`). NEWEST FIRST.
   //
+  // ── 2026-08-27 ──
+  // §CPE_CONE_ORIENT_ADJUST the passive POV cone is now interactive — click to focus (brownish tint),
+  //   drag while focused to rotate ONLY its facing (position stays scrub-driven, never draggable),
+  //   release to commit an ANCHORED gaze correction (arc-length position + corrected direction + an
+  //   asymmetric ramp/hold/decay envelope), stored on its own small list, never touching a band. See
+  //   the spec section for the full design and this session's own DONE block for measured numbers.
   // ── 2026-08-06 ──
   // §CPE_VF_PLAIN_FRAME the pixel-fit chase (§CPE_VF_FRAME_CRAFT/§CPE_VF_ALIGN_DIAG(_V2)/
   //   §CPE_VF_FRAME_DIAG/§CPE_VF_RENDER_TRACE) is retired — B is a plain fixed panel with a thin
@@ -140,7 +165,7 @@
   // §CPE_PREVIEW_DIVERGENCE plan pinned to open pose.
   // §CPE_BANDS + §CPE_SCREEN_PLANE + §CPE_PANEL_DRAG.
   // ══════════════════════════════════════════════════════════════════════════════════════════════
-  var CPE_V = 'v24';
+  var CPE_V = 'v25';
   console.log('§CPE_LOADED ' + CPE_V + ' — full changelog moved to this file\'s own comment above (search any §TAG)');
 
   var HANDLE_R = 0.30;             // metres
@@ -684,6 +709,13 @@
         return { s: o.s, r: o.r, d: { x: o.d.x, y: o.d.y, z: o.d.z },
                  a: o.a ? { x: o.a.x, y: o.a.y, z: o.a.z } : null };
       }),
+      // §CPE_CONE_ORIENT_ADJUST: rides the same override the plan, Save and the bake already consume
+      // — a deep copy, same §CPE_HOLDER_INTEGRITY treatment as bands/hose above. NOT band-indexed
+      // (spec item 4) — the cone's position is scrub-driven and may sit anywhere along the walk.
+      aimCorrections: (s.corrections || []).map(function(c) {
+        return { pos: { x: c.pos.x, y: c.pos.y, z: c.pos.z }, dir: { x: c.dir.x, y: c.dir.y, z: c.dir.z },
+                 ramp: c.ramp, hold: c.hold, decay: c.decay };
+      }),
       // §CPE_CLIP: null means the whole film; the bake remaps poseAt into [in,out] when set.
       clip: (s.clipIn > 0 || s.clipOut < 1) ? { in: s.clipIn, out: s.clipOut } : null,
       buildup: !!s.buildup,
@@ -752,6 +784,16 @@
       if (Math.abs(a.len - b.len) > 1e-6) return true;
       if (Math.abs(a.c.x - b.c.x) > 1e-6 || Math.abs(a.c.y - b.c.y) > 1e-6 || Math.abs(a.c.z - b.c.z) > 1e-6) return true;
       if (Math.abs(a.d.x - b.d.x) > 1e-6 || Math.abs(a.d.y - b.d.y) > 1e-6 || Math.abs(a.d.z - b.d.z) > 1e-6) return true;
+    }
+    // §CPE_CONE_ORIENT_ADJUST: a correction with no other edit (no hose, no clip, no band moved) must
+    // still produce an override, same "count as an edit" reasoning §CPE_STICK's own line above gives
+    // band-count changes.
+    var oc = _state.origCorrections || [];
+    if ((_state.corrections || []).length !== oc.length) return true;
+    for (var ci = 0; ci < oc.length; ci++) {
+      var ca = _state.corrections[ci], cb = oc[ci];
+      if (Math.abs(ca.pos.x - cb.pos.x) > 1e-6 || Math.abs(ca.pos.y - cb.pos.y) > 1e-6 || Math.abs(ca.pos.z - cb.pos.z) > 1e-6) return true;
+      if (Math.abs(ca.dir.x - cb.dir.x) > 1e-6 || Math.abs(ca.dir.y - cb.dir.y) > 1e-6 || Math.abs(ca.dir.z - cb.dir.z) > 1e-6) return true;
     }
     return false;
   }
@@ -962,8 +1004,17 @@
                a: o.a ? { x: o.a.x, y: o.a.y, z: o.a.z } : null };   // the world anchor rides along
     });
   }
+  // §CPE_CONE_ORIENT_ADJUST: corrections must survive undo/redo the same way bands/hose do (spec
+  // item 7 — reuse the EXISTING §CPE_UNDO stack, no new mechanism).
+  function _cloneCorrections(cs) {
+    return (cs || []).map(function(c) {
+      return { pos: { x: c.pos.x, y: c.pos.y, z: c.pos.z }, dir: { x: c.dir.x, y: c.dir.y, z: c.dir.z },
+               ramp: c.ramp, hold: c.hold, decay: c.decay };
+    });
+  }
   function _snapshot(label) {
     return { bands: _cloneBands(_state.bands), hose: _cloneHose(_state.hose),
+             corrections: _cloneCorrections(_state.corrections),
              clipIn: _state.clipIn, clipOut: _state.clipOut, label: label };
   }
   // Call BEFORE mutating, with a label naming the edit. Redo is dropped on a new edit — the standard
@@ -991,11 +1042,16 @@
     toStack.push(_snapshot(snap.label));
     _state.bands = _cloneBands(snap.bands);
     _state.hose = _cloneHose(snap.hose);
+    // §CPE_CONE_ORIENT_ADJUST: older snapshots (taken before this feature shipped, still live in a
+    // session's undo stack across a hot-reload) carry no `corrections` field — treat as empty rather
+    // than throwing, same graceful-old-record treatment §CPE_AIM_PIN's own fields already get.
+    _state.corrections = _cloneCorrections(snap.corrections || []);
     if (snap.clipIn != null) { _state.clipIn = snap.clipIn; _state.clipOut = snap.clipOut; }
     _state.staged = false;
-    _state.held = null; _state.drag = null;
+    _state.held = null; _state.drag = null; _state._coneDrag = null;
     console.log('§CPE_UNDO ' + dir + ' "' + snap.label + '" depth=' + fromStack.length +
-      ' bands=' + _state.bands.length + ' hoseOps=' + _state.hose.length);
+      ' bands=' + _state.bands.length + ' hoseOps=' + _state.hose.length +
+      ' corrections=' + _state.corrections.length);
     _histEvent((dir === 'undo' ? 'Undo: ' : 'Redo: ') + snap.label);
     _markPreviewStale();
     _refreshFlow();
@@ -1418,7 +1474,12 @@
       var env = (_state.plan && _state.plan.envelope) || 50;
       var mr = Math.max(0.3, Math.min(2.5, env / 40));   // same envelope-clamp shape as _redrawScene's tube radius
       var g = new THREE.ConeGeometry(mr, mr * 2.2, 10);
-      var m = new THREE.MeshBasicMaterial({ color: 0xff1744, transparent: true, opacity: 0.9,
+      // §CPE_CONE_ORIENT_ADJUST: focus colour is REAPPLIED below on every call (not just at creation)
+      // because _clearScene() (run by every _redrawScene()) disposes this mesh — a committed
+      // correction's own _replanFilm()/_redrawScene() pair would otherwise silently drop the user
+      // back to the default colour on a mesh they never asked to unfocus.
+      var m = new THREE.MeshBasicMaterial({ color: _state.coneFocused ? CONE_FOCUS_COLOR : CONE_DEFAULT_COLOR,
+                                            transparent: true, opacity: 0.9,
                                             depthTest: false, depthWrite: false });
       var o = new THREE.Mesh(g, m);
       o.renderOrder = 1005;   // above the path tube/handles (1002-1004) — this is the playhead itself
@@ -1427,13 +1488,21 @@
       _state.povMarker = o;
     }
     var mk = _state.povMarker;
+    var wantColor = _state.coneFocused ? CONE_FOCUS_COLOR : CONE_DEFAULT_COLOR;
+    if (mk.material && mk.material.color.getHex() !== wantColor) mk.material.color.setHex(wantColor);
+    // §CPE_CONE_ORIENT_ADJUST spec item 1: "Position is scrub-only" — always driven by `p`, even
+    // while a correction is focused/being dragged (dragging never repositions the cone).
     mk.position.set(p.x, p.y, p.z);
     // ConeGeometry's tip points +Y by default; align +Y with the gaze direction so the tip is the
-    // facing angle, not just a dot at the position.
-    var dir = new THREE.Vector3(p.tx - p.x, p.ty - p.y, p.tz - p.z);
-    if (dir.lengthSq() > 1e-9) {
-      dir.normalize();
-      mk.quaternion.setFromUnitVectors(new THREE.Vector3(0, 1, 0), dir);
+    // facing angle, not just a dot at the position. SKIPPED while a live drag is rotating the cone —
+    // `_coneDragMove` owns the orientation for that one gesture; this scrub-driven sync would
+    // otherwise fight it on the very next call (e.g. a preview-fly frame landing mid-drag).
+    if (!_state._coneDrag) {
+      var dir = new THREE.Vector3(p.tx - p.x, p.ty - p.y, p.tz - p.z);
+      if (dir.lengthSq() > 1e-9) {
+        dir.normalize();
+        mk.quaternion.setFromUnitVectors(new THREE.Vector3(0, 1, 0), dir);
+      }
     }
     if (a.markDirty) a.markDirty();
   }
@@ -2258,6 +2327,12 @@
       return { s: o.s, r: o.r, d: { x: o.d.x, y: o.d.y, z: o.d.z },
                a: o.a ? { x: o.a.x, y: o.a.y, z: o.a.z } : null };
     });
+    // §CPE_CONE_ORIENT_ADJUST: `null`/missing on any record saved before this shipped — same
+    // graceful-old-record treatment as hose/lookAt above. `origCorrections` is deliberately left
+    // untouched here, same as `origBands` above it — a LOADED plan is always treated as edited
+    // relative to the session's original open-time seed (see §CPE_PATH_NOT_PORTABLE's own comment
+    // below: it re-stages unconditionally), not a new "unedited" baseline.
+    _state.corrections = _cloneCorrections(ov.aimCorrections || []);
     _state.clipIn = ov.clip ? ov.clip.in : 0;
     _state.clipOut = ov.clip ? ov.clip.out : 1;
     _state.buildup = !!ov.buildup;
@@ -2662,6 +2737,163 @@
     return true;
   }
 
+  // ══ §CPE_CONE_ORIENT_ADJUST — drag the POV cone to fix a bad gaze, no stick added ═══════════════
+  // Spec: bim-compiler prompts/CINEMA_PATH_EDITOR.md §CPE_CONE_ORIENT_ADJUST (2026-08-27). Makes the
+  // existing passive `_state.povMarker` cone (§CPE_POV_MARKER) interactive: click focuses it, drag
+  // while focused rotates ONLY its facing (position stays scrub-driven — spec item 1), release commits
+  // an ANCHORED correction (§CPE_CONE_ORIENT_ADJUST item 4), never a band/stick (item 8 — the whole
+  // point of this feature).
+  //
+  // ONE grab, split by what the hand does — the SAME convention §CPE_STICK vs §CPE_HOSE already
+  // established in this file ("let go without moving and you get a stick; move and you bend the
+  // pipe"): a plain click on the cone focuses it (or, if already focused, is a no-op — focus stands);
+  // a drag past CLICK_SLOP_PX live-rotates it and commits on release. This was a judgment call — the
+  // spec's own prose lists "click = focus" and "drag while focused = live edit" as two numbered
+  // steps, which could also read as two SEPARATE gestures (click once to focus, click-drag again to
+  // rotate). Combining them into one gesture reuses this file's own established split-by-movement
+  // pattern rather than inventing a second one; flagged here, not presented as user-confirmed.
+  //
+  // Hit-test is SCREEN-SPACE proximity (`_screenOf` + a pixel radius), not a THREE.Raycaster hit —
+  // same reasoning §CPE_GRAB_WYSIWYG's own comment gives for the band handles: the cone draws with
+  // depthTest:false (always visible, even through walls — see _syncPovMarker), so a depth-sorted
+  // raycast would disagree with what the user actually sees and could miss a cone that is genuinely
+  // on screen but occluded in the depth buffer.
+  // §CPE_CONE_ORIENT_ADJUST scoping note (a judgment call, not user-specified): a correction's
+  // envelope only ever affects `_beat3Pose` (the walk beat) — effects.js's own comment explains why
+  // (that is where `_pinLookAtAt`/§CPE_AIM_DEPTH already live, and it is the beat the "staring
+  // skywards" bug this feature targets actually occurs in). Outside the walk beat (dive/spin/orbit/
+  // tail) the cone's WORLD position collapses onto a fixed point per-beat (e.g. `settle` throughout
+  // the whole spin), so a correction "anchored" there would nearest-point-snap onto the walk's own
+  // s≈0/s≈1 end and silently correct the WRONG stretch — confusing, not merely inert. Gating the
+  // whole interaction to the walk window sidesteps that rather than trying to explain it in the UI.
+  function _coneInWalkWindow() {
+    var w = _walkWindow();
+    var tn = _state ? (_state.scrubTn || 0) : 0;
+    return !!w && tn > w.spin + 1e-6 && tn < w.out - 1e-6;
+  }
+  function _hitTestCone(ev) {
+    if (!_state || !_state.povMarker || !_state.povMarker.parent || !_coneInWalkWindow()) return false;
+    var mk = _state.povMarker, s = _screenOf(mk.position);
+    if (s.behind) return false;
+    var a = A();
+    var D = Math.hypot(mk.position.x - a.camera.position.x, mk.position.y - a.camera.position.y,
+                        mk.position.z - a.camera.position.z);
+    var grabPx = GRAB_PX;
+    if (D > 1e-3) {
+      var r = a.canvas.getBoundingClientRect();
+      var pxPerM = r.height / (2 * D * Math.tan(a.camera.fov * Math.PI / 360));
+      // Read the geometry back (same "read back, don't re-derive" precedent as _handleGrabPx) — the
+      // cone's own base radius, from _syncPovMarker's ConeGeometry(mr, mr*2.2, ...).
+      var geoR = (mk.geometry && mk.geometry.parameters && isFinite(mk.geometry.parameters.radius))
+        ? mk.geometry.parameters.radius : 0.5;
+      grabPx = Math.max(GRAB_PX, geoR * pxPerM + 2);
+    }
+    return Math.hypot(ev.clientX - s.x, ev.clientY - s.y) < grabPx;
+  }
+  // Pointerdown on the cone: claims the gesture, sets up the live-rotate basis (yaw/pitch derived
+  // from the cone's CURRENT displayed direction, so the drag starts from wherever the gaze is right
+  // now — auto-aim, a pin, or an earlier correction, whichever is currently shown) and focuses it
+  // immediately (spec item 2 — a plain click alone must already show the focus colour).
+  function _coneDown(ev) {
+    var mk = _state.povMarker, a = A();
+    var up = new THREE.Vector3(0, 1, 0).applyQuaternion(mk.quaternion);
+    var yaw0 = Math.atan2(up.z, up.x), pit0 = Math.atan2(up.y, Math.hypot(up.x, up.z));
+    _state._coneDrag = { sx0: ev.clientX, sy0: ev.clientY, moved: false, yaw0: yaw0, pit0: pit0, dir: null };
+    if (!_state.coneFocused) {
+      _state.coneFocused = true;
+      if (mk.material) mk.material.color.setHex(CONE_FOCUS_COLOR);
+      console.log('§CPE_CONE_FOCUS on');
+      if (a.markDirty) a.markDirty();
+    }
+  }
+  // Live rotation, gated on the file's own CLICK_SLOP_PX so a plain click never registers as a
+  // (zero-length) drag. Cheap and visual-only — no _replanFilm()/_redrawScene() during the gesture,
+  // same "land first, persisted" reasoning §CPE_DRAG_LAND_FIRST already established for band drags —
+  // just the cone mesh's own quaternion and, per spec item 3, the live viewfinder preview.
+  function _coneDragMove(ev) {
+    var d = _state._coneDrag;
+    if (!d.moved && Math.hypot(ev.clientX - d.sx0, ev.clientY - d.sy0) < CLICK_SLOP_PX) return;
+    if (!d.moved) {
+      d.moved = true;
+      // §CPE_CONE_ORIENT_ADJUST spec item 3: the preview/viewfinder auto-shows during the drag, even
+      // if the eye toggle is currently off, so the user sees the corrected framing live. OPEN
+      // QUESTION the spec left undecided — picked "stays open until the eye toggle is used" (the
+      // less-surprising default, per the spec's own recommendation) — so this only ever turns the
+      // eye ON, never back off on release.
+      if (!_state.vfOn) _toggleViewfinder(document.getElementById('cpe-vf-toggle'));
+      console.log('§CPE_CONE_DRAG start — live orientation edit, position stays scrub-driven');
+    }
+    var yaw = d.yaw0 + (ev.clientX - d.sx0) * CONE_ROTATE_RAD_PER_PX;
+    var pit = Math.max(-CONE_PITCH_CLAMP_RAD, Math.min(CONE_PITCH_CLAMP_RAD,
+      d.pit0 - (ev.clientY - d.sy0) * CONE_ROTATE_RAD_PER_PX));
+    var cp = Math.cos(pit);
+    d.dir = { x: Math.cos(yaw) * cp, y: Math.sin(pit), z: Math.sin(yaw) * cp };
+    var mk = _state.povMarker;
+    if (mk) mk.quaternion.setFromUnitVectors(new THREE.Vector3(0, 1, 0),
+      new THREE.Vector3(d.dir.x, d.dir.y, d.dir.z));
+    if (_state.vfOn && _state.vfCam && mk) {
+      _state.vfCam.position.set(mk.position.x, mk.position.y, mk.position.z);
+      _state.vfCam.lookAt(mk.position.x + d.dir.x * 20, mk.position.y + d.dir.y * 20, mk.position.z + d.dir.z * 20);
+    }
+    var a = A();
+    if (a.markDirty) a.markDirty();
+  }
+  // The actual mutation, factored out of the pointer gesture above so a witness can drive it with a
+  // KNOWN direction (deterministic — no dependency on screen-pixel drag maths), same precedent
+  // `_setPin` already established for the analogous AIM_PIN gesture.
+  function _commitConeCorrection(pos, dir) {
+    if (!_state || !pos || !dir) return false;
+    // Re-dragging near an EXISTING correction's own anchor UPDATES it in place rather than stacking a
+    // second, nearly-redundant entry — spec item 6 (multiple/overlapping corrections, not user-
+    // decided): simplest reasonable MVP, flagged for review, not presented as settled.
+    var idx = -1, bd = Infinity;
+    for (var i = 0; i < _state.corrections.length; i++) {
+      var c = _state.corrections[i];
+      var dd = Math.hypot(c.pos.x - pos.x, c.pos.y - pos.y, c.pos.z - pos.z);
+      if (dd < bd) { bd = dd; idx = i; }
+    }
+    var updating = idx >= 0 && bd < CPE_CONE_CORR_MERGE_M;
+    _undoPush(updating ? 'cone re-correct' : 'cone correction');
+    var entry = { pos: { x: pos.x, y: pos.y, z: pos.z }, dir: { x: dir.x, y: dir.y, z: dir.z },
+                  ramp: CPE_CONE_CORR_RAMP_M, hold: CPE_CONE_CORR_HOLD_M, decay: CPE_CONE_CORR_DECAY_M };
+    if (updating) _state.corrections[idx] = entry; else _state.corrections.push(entry);
+    _state.staged = false;
+    console.log('§CPE_CONE_CORRECTION ' + (updating ? 'update' : 'add') +
+      ' pos=(' + pos.x.toFixed(2) + ',' + pos.y.toFixed(2) + ',' + pos.z.toFixed(2) + ')' +
+      ' dir=(' + dir.x.toFixed(3) + ',' + dir.y.toFixed(3) + ',' + dir.z.toFixed(3) + ')' +
+      ' ramp=' + CPE_CONE_CORR_RAMP_M + 'm hold=' + CPE_CONE_CORR_HOLD_M + 'm decay=' + CPE_CONE_CORR_DECAY_M + 'm' +
+      ' count=' + _state.corrections.length + ' — anchored to path arc-length, never adds/moves a band (spec item 8)');
+    _markPreviewStale();
+    _replanFilm(); _redrawScene(); _renderRows(); _renderClock(); _syncButtons();
+    // Re-sync the cone (position + orientation) against the just-replanned pose at the current scrub
+    // position — the plan now carries the correction, so this proves (rather than assumes) the cone's
+    // own readout agrees with what the bake will actually fly.
+    if (_state.plan) _applyVFPose(_state.scrubTn || 0);
+    return true;
+  }
+  // Pointerup on the cone. A press that never moved is a plain click — focus already applied in
+  // _coneDown, nothing further to do (spec item 2). A real drag commits the correction using the
+  // cone's OWN current position (scrub-driven, never touched by this drag — spec item 1) and the
+  // final dragged direction.
+  function _coneUp() {
+    var d = _state._coneDrag;
+    _state._coneDrag = null;
+    if (!d || !d.moved) { console.log('§CPE_CONE_FOCUS click (no drag) — focus stands'); return; }
+    var mk = _state.povMarker;
+    if (mk && d.dir) _commitConeCorrection({ x: mk.position.x, y: mk.position.y, z: mk.position.z }, d.dir);
+  }
+  // Clicking anywhere OUTSIDE the cone clears focus and reverts the colour (spec item 2). Lightweight
+  // — direct material mutation + markDirty, no _redrawScene()/undo: focus is transient UI state, not
+  // authored data (see the field comment on `_state.coneFocused` in open()).
+  function _coneDefocus(why) {
+    if (!_state || !_state.coneFocused) return;
+    _state.coneFocused = false;
+    if (_state.povMarker && _state.povMarker.material) _state.povMarker.material.color.setHex(CONE_DEFAULT_COLOR);
+    console.log('§CPE_CONE_FOCUS off why=' + why);
+    var a = A();
+    if (a.markDirty) a.markDirty();
+  }
+
   function _frameBand(bi) {
     var a = A(), p = _state.bands[bi].c, clear = 6;
     try { var f = a.cinemaFan ? a.cinemaFan({ x: p.x, y: p.y, z: p.z }, 8) : null; if (f && isFinite(f.min) && f.min < 59.9) clear = f.min; } catch (e) {}
@@ -2867,6 +3099,21 @@
     var a = A(), c = a.canvas, h = {};
     h.down = function(ev) {
       if (!_state) return;
+      // ══ §CPE_CONE_ORIENT_ADJUST — checked FIRST, ahead of the handle/pipe hit-tests below, since
+      // the cone is a distinct object with its own claim on the gesture (mirrors why this sidesteps
+      // the old AIM_PIN "swallowed near-miss stick grabs" regression — see the spec section's own
+      // "chosen mechanism" paragraph: a uniquely-pickable object, not "click anywhere on the canvas").
+      if (_hitTestCone(ev)) {
+        ev.preventDefault(); ev.stopPropagation();
+        _coneDown(ev);
+        return;
+      }
+      // Not the cone. If it is currently focused, this press MIGHT be the "click outside clears
+      // focus" gesture (spec item 2) — confirmed on release (h.up), only if the pointer barely moved,
+      // same CLICK_SLOP_PX convention §CPE_AIM_PIN's own _pinCandidate uses below. Recorded WITHOUT
+      // preventDefault/stopPropagation and independently of whatever else this same gesture claims
+      // (a handle, the pipe, orbiting) — clicking a handle IS "outside the cone" too.
+      if (_state.coneFocused) _state._coneDefocusCandidate = { sx0: ev.clientX, sy0: ev.clientY };
       var hit = _hitTest(ev);
       if (!hit) {
         // §CPE_HOSE: no band handle under the cursor — try the pipe. A miss on BOTH still falls
@@ -2917,7 +3164,11 @@
       }
     };
     h.move = function(ev) {
-      if (!_state || !_state.drag) return;
+      if (!_state) return;
+      // §CPE_CONE_ORIENT_ADJUST: a claimed cone gesture owns pointermove exclusively until release —
+      // `_state.drag` is never touched by it, so the two cannot collide.
+      if (_state._coneDrag) { ev.preventDefault(); ev.stopPropagation(); _coneDragMove(ev); return; }
+      if (!_state.drag) return;
       ev.preventDefault(); ev.stopPropagation();
       var d = _state.drag;
       if (d.hose) {
@@ -3007,6 +3258,17 @@
     };
     h.up = function(ev) {
       if (!_state) return;
+      // §CPE_CONE_ORIENT_ADJUST: a claimed cone gesture resolves fully on its own and returns —
+      // it never touches `_state.drag`/`_pinCandidate`, so nothing below needs to know about it.
+      if (_state._coneDrag) { _coneUp(); return; }
+      // §CPE_CONE_ORIENT_ADJUST: "click outside the cone clears focus" (spec item 2), resolved the
+      // same way `_pinCandidate` below resolves — independently of `_state.drag`, since a genuine
+      // outside-click may not have claimed the gesture at all (e.g. empty canvas).
+      var ccd = _state._coneDefocusCandidate;
+      if (ccd) {
+        _state._coneDefocusCandidate = null;
+        if (ev && Math.hypot(ev.clientX - ccd.sx0, ev.clientY - ccd.sy0) < CLICK_SLOP_PX) _coneDefocus('clicked outside');
+      }
       // §CPE_AIM_PIN: resolved independently of `_state.drag` (which stays untouched by the
       // candidate above) — a genuine click-to-pin never claimed the gesture, so it must not be
       // gated behind "was something being dragged".
@@ -3177,7 +3439,14 @@
         controlsWere: a.controls ? a.controls.enabled : true,
         // §CPE_VIEWFINDER: OFF by default (user, 2026-08-04: "so it is not cluttered") — see the
         // eye-icon toggle in _buildPanel. `vfCam` is created lazily on first toggle-on, not here.
-        vfOn: false, vfCam: null
+        vfOn: false, vfCam: null,
+        // §CPE_CONE_ORIENT_ADJUST: adopted from an authored plan exactly like `bands` above (no
+        // reciprocal fan-out concern here — a correction is not band-indexed, so there is no
+        // seed-vs-authored distinction to make). `coneFocused`/`_coneDrag`/`_coneDefocusCandidate`
+        // are transient UI state, not authored data — never persisted, never undo-tracked.
+        corrections: _cloneCorrections(plan.aimCorrections || []),
+        origCorrections: _cloneCorrections(plan.aimCorrections || []),
+        coneFocused: false, _coneDrag: null, _coneDefocusCandidate: null, povMarker: null
       };
       console.log('§CPE_OPEN src=' + (authored ? 'authored' : 'seeded') +
         ' bands=' + _state.bands.length + ' waypoints=' + (_state.bands.length * 2) +
@@ -3518,6 +3787,17 @@
           var mk = _state.povMarker, up = new THREE.Vector3(0, 1, 0).applyQuaternion(mk.quaternion);
           return { x: mk.position.x, y: mk.position.y, z: mk.position.z,
                    dirx: up.x, diry: up.y, dirz: up.z, visible: mk.visible };
+        },
+        // §CPE_CONE_ORIENT_ADJUST witness hooks — read off the REAL mesh/state, same "product path,
+        // not a re-implementation" precedent as _probePovMarker above.
+        _probeConeFocus: function() {
+          if (!_state) return null;
+          return { focused: !!_state.coneFocused, dragging: !!_state._coneDrag,
+                   hex: (_state.povMarker && _state.povMarker.material)
+                     ? '0x' + _state.povMarker.material.color.getHex().toString(16).padStart(6, '0') : null };
+        },
+        _probeCorrections: function() {
+          return _state ? _cloneCorrections(_state.corrections) : null;
         },
         // §CPE_STICK_RED_BAR's G-RN-4c: the BAR is a separate mesh from the handles, so it needs its
         // own read-only probe or "red bar, blue dots" is asserted on half the evidence.

--- a/viewer/effects.js
+++ b/viewer/effects.js
@@ -5216,6 +5216,14 @@ async function setupEffects(A, renderer, scene, camera) {
   // pattern as _cpeHose/_cpeBands above: set from ov.reveal in A.cinemaPathPlan, read inside
   // _cinemaPathPlan's own closure, saved/restored around the call so it never leaks between plans.
   var _cpeReveal = false;
+  // §CPE_CONE_ORIENT_ADJUST (bim-compiler prompts/CINEMA_PATH_EDITOR.md, 2026-08-27) — a small list of
+  // ANCHORED gaze corrections, independent of bands: each is {pos:{x,y,z}, dir:{x,y,z}, ramp, hold,
+  // decay} (world anchor, corrected unit direction, arc-length meters for the ease-in/hold/ease-out
+  // envelope). Not band-indexed like `lookAt` — the cone's position is scrub-driven and may sit
+  // anywhere along the walk, not necessarily at a band — so this rides its OWN small array on the
+  // override, same wrapper pattern as _cpeHose/_cpeBands/_cpeReveal above: set from ov.aimCorrections
+  // in A.cinemaPathPlan, read inside _cinemaPathPlan's own closure, saved/restored around the call.
+  var _cpeCorrections = null;
   // §CPE_DISCIPLINE_REVEAL — real, measured element counts, same 3-representation enumeration
   // A.filterDiscs already uses (panels.js §NAV_FIND_002) — never an invented discipline list.
   // Outer-scope and A.-exposed (not nested inside _cinemaPathPlan) so BOTH the plan builder here AND
@@ -6397,6 +6405,92 @@ async function setupEffects(A, renderer, scene, camera) {
       return null;
     }
     A._cpePinZonesDebug = function() { if (_pinZones === null) _buildPinZones(); return _pinZones; };   // witness hook, read-only
+
+    // ══ §CPE_CONE_ORIENT_ADJUST — anchored gaze corrections (2026-08-27) ═══════════════════════════
+    // Spec: bim-compiler prompts/CINEMA_PATH_EDITOR.md §CPE_CONE_ORIENT_ADJUST. Studied `_pinLookAtAt`
+    // above before writing this: deliberately a DIFFERENT code path, not a reuse of it, because a
+    // correction's anchor is NOT band-indexed — the POV cone's position is scrub-driven and may sit
+    // anywhere along the walk, not necessarily at a band centre. Same NEAREST-POINT-ON-`flowWp`
+    // technique `_buildPinZones` uses for a band's centre, applied to each correction's own captured
+    // world anchor instead, so a correction is defined against the SAME real, hosed curve the walk is
+    // actually sampled from (never a second, unhosed notion of "where along the path this is").
+    //
+    // Unlike a pin (a look-AT POINT, recomputed fresh every frame relative to the moving camera), a
+    // correction stores a fixed captured DIRECTION — the cone's rotation at the moment the user let
+    // go — and is blended in/out by an ASYMMETRIC, ARC-LENGTH-anchored envelope (spec item 5, user's
+    // own design): a short ease-in ramp BEHIND the anchor, held at full strength FORWARD from the
+    // anchor, then eased back down over a further decay length. Ramp/hold/decay ride on EACH entry
+    // (spec item 4's own field list), copied from cinema_path_editor.js's authoring-time constants at
+    // commit time — the fallbacks below only cover a malformed/pre-this-feature record.
+    var _corrArc = null;
+    function _buildCpeCorrArc() {
+      _corrArc = [];
+      if (!_cpeCorrections || !_cpeCorrections.length || !flowWp.length) return;
+      for (var ci = 0; ci < _cpeCorrections.length; ci++) {
+        var c = _cpeCorrections[ci];
+        if (!c || !c.pos || !c.dir) continue;
+        var best = 0, bd = Infinity;
+        for (var pi = 0; pi < flowWp.length; pi++) {
+          var dx = flowWp[pi].x - c.pos.x, dy = flowWp[pi].y - c.pos.y, dz = flowWp[pi].z - c.pos.z;
+          var d = dx * dx + dy * dy + dz * dz;
+          if (d < bd) { bd = d; best = pi; }
+        }
+        var sArc = segLen[best] / totalLen;
+        // Fallbacks (2m/5m/4m) mirror cinema_path_editor.js's CPE_CONE_CORR_RAMP_M/HOLD_M/DECAY_M
+        // authoring defaults — first-guess numbers, not settled (see that file's own comment).
+        var rampM = (c.ramp != null && isFinite(c.ramp)) ? c.ramp : 2;
+        var holdM = (c.hold != null && isFinite(c.hold)) ? c.hold : 5;
+        var decayM = (c.decay != null && isFinite(c.decay)) ? c.decay : 4;
+        _corrArc.push({ s: sArc, dir: c.dir,
+          rampFrac: Math.min(0.45, rampM / Math.max(1e-3, totalLen)),
+          holdFrac: holdM / Math.max(1e-3, totalLen),
+          decayFrac: decayM / Math.max(1e-3, totalLen) });
+      }
+    }
+    // Read-only: the corrected DIRECTION and blend WEIGHT (0..1) in force at this e3, or null when no
+    // correction's window reaches this far. §CPE_CONE_ORIENT_ADJUST item 6 (multiple overlapping
+    // corrections — not user-decided): simplest reasonable MVP picked here, flagged for review — the
+    // NEAREST anchor (by |e3 - s|) wins outright where more than one window covers the same e3, no
+    // cross-correction blending.
+    function _cpeCorrectionAt(e3) {
+      if (_corrArc === null) _buildCpeCorrArc();
+      if (!_corrArc.length) return null;
+      var bestC = null, bestDist = Infinity, bestW = 0;
+      for (var i = 0; i < _corrArc.length; i++) {
+        var c = _corrArc[i];
+        var lo = c.s - c.rampFrac, hiHold = c.s + c.holdFrac, hi = hiHold + c.decayFrac;
+        if (e3 < lo - 1e-9 || e3 > hi + 1e-9) continue;
+        var w;
+        if (e3 < c.s) w = _cinemaSmoothstep((e3 - lo) / Math.max(1e-9, c.rampFrac));         // ease-in, 0->1, ends AT the anchor
+        else if (e3 <= hiHold) w = 1;                                                        // held, full strength
+        else w = 1 - _cinemaSmoothstep((e3 - hiHold) / Math.max(1e-9, c.decayFrac));         // eased back down
+        var dist = Math.abs(e3 - c.s);
+        if (bestC === null || dist < bestDist) { bestC = c; bestDist = dist; bestW = w; }
+      }
+      if (!bestC) return null;
+      return { dir: bestC.dir, w: bestW };
+    }
+    // Generic yaw/pitch-lerp direction blend — same technique _dirBlend/_cinemaGazeBlend already use
+    // in this file (short-way yaw, linear pitch), simplified to return just a unit direction (no
+    // pivot, no antipodal-reference bookkeeping — a corrected gaze and the underlying path-follow gaze
+    // are never expected to be near-antipodal, unlike the look-back beat those two already handle).
+    function _cpeCorrDirBlend(ax, ay, az, bx, by, bz, w) {
+      if (w <= 0) return { x: ax, y: ay, z: az };
+      if (w >= 1) return { x: bx, y: by, z: bz };
+      var yawA = Math.atan2(az, ax), pitA = Math.atan2(ay, Math.hypot(ax, az));
+      var yawB = Math.atan2(bz, bx), pitB = Math.atan2(by, Math.hypot(bx, bz));
+      var raw = yawB - yawA;
+      var dYaw = raw - 2 * Math.PI * Math.round(raw / (2 * Math.PI));   // short way
+      var yaw = yawA + dYaw * w, pit = pitA + (pitB - pitA) * w, cp = Math.cos(pit);
+      return { x: Math.cos(yaw) * cp, y: Math.sin(pit), z: Math.sin(yaw) * cp };
+    }
+    A._cpeCorrectionsDebug = function() { if (_corrArc === null) _buildCpeCorrArc(); return _corrArc; };   // witness hook, read-only
+    // Witness hook, read-only: samples the REAL `_beat3Pose(e3)` at an arbitrary arc-fraction —
+    // exactly the product function §CPE_CONE_ORIENT_ADJUST's envelope blend runs inside (same
+    // precedent as `A._cpePinZonesDebug` above). Lets a witness sample the corrected region's gaze
+    // SHAPE directly in the arc-fraction space the envelope is actually defined in, without needing
+    // to invert tNorm -> e3 through _evenTurnRemap/_holdMap (private to this closure).
+    A._cpeBeat3PoseDebug = function(e3) { return _beat3Pose(e3); };
     // ══ §CINEMA_GAZE_SENSE (2026-07-27) — decide the look-back's turn DIRECTION ONCE per plan.
     // _cinemaGazeBlend used to make this choice PER FRAME: if |dYaw| crossed CINEMA_TURN_ANTIPODAL_RAD
     // it switched from the short way to the +2π way. That test is a step function of the walk
@@ -7912,6 +8006,17 @@ async function setupEffects(A, renderer, scene, camera) {
           if (_aimD) { _lx = _aimD.x; _ly = _aimD.y; _lz = _aimD.z; }
         }
         }
+        // §CPE_CONE_ORIENT_ADJUST: a user-dragged correction is the LAST word on the gaze at its own
+        // arc-length window, applied AFTER the pin/depth/path-follow chain above — a judgment call,
+        // not user-confirmed: the cone shows whatever the CURRENT combined gaze is (pin included), so
+        // dragging it corrects whatever is currently there, even inside an already-pinned zone. Zero
+        // cost/no-op on every plan with no corrections authored (_cpeCorrectionAt returns null
+        // instantly once `_corrArc` is built empty).
+        var _corr = _cpeCorrectionAt(e3);
+        if (_corr && _corr.w > 0) {
+          var _cb = _cpeCorrDirBlend(_lx, _ly, _lz, _corr.dir.x, _corr.dir.y, _corr.dir.z, _corr.w);
+          _lx = _cb.x; _ly = _cb.y; _lz = _cb.z;
+        }
         // §CINEMA_BEAT_OVERLAP (2026-07-20, "no abruptness... even the path when reaching outside
         // should not be robotic abrupt stop and turn, it can play while doing both"): start blending
         // the look-at toward the pivot in the LAST CINEMA_TURN_OVERLAP fraction of the walk-out, so
@@ -8410,6 +8515,14 @@ async function setupEffects(A, renderer, scene, camera) {
                         hold: +(b.hold || 0), _stick: b._stick, _s: b._s,
                         lookAt: b.lookAt ? { x: b.lookAt.x, y: b.lookAt.y, z: b.lookAt.z } : null };
              }) : null,
+             // §CPE_CONE_ORIENT_ADJUST rides along for the same §CPE_REOPEN_NODE reason as `bands`
+             // above: the plan is what the editor RE-OPENS from, so a dropped field would silently
+             // discard every corrected gaze on the next OK.
+             aimCorrections: _cpeCorrections ? _cpeCorrections.map(function(c) {
+               return { pos: { x: c.pos.x, y: c.pos.y, z: c.pos.z }, dir: { x: c.dir.x, y: c.dir.y, z: c.dir.z },
+                        ramp: +(c.ramp != null ? c.ramp : 2), hold: +(c.hold != null ? c.hold : 5),
+                        decay: +(c.decay != null ? c.decay : 4) };
+             }) : null,
              flownPoints: flowWp.length, pathLen: totalLen, route: outRoute, authored: outRoute === 'authored',
              sec: { dive: _useSec.dive, spin: _useSec.spin, out: _useSec.out, pullout: _useSec.pullout,
                     flyback: _useSec.flyback, reveal: _useSec.reveal, rise: _useSec.rise },
@@ -8570,7 +8683,8 @@ async function setupEffects(A, renderer, scene, camera) {
       saved.push(_cpeGet(g));
       if (ov[k] != null && isFinite(ov[k])) _cpeSet(g, ov[k]);
     }
-    var savedWp = _cpeWp, savedBands = _cpeBands, savedHose = _cpeHose, savedReveal = _cpeReveal;
+    var savedWp = _cpeWp, savedBands = _cpeBands, savedHose = _cpeHose, savedReveal = _cpeReveal,
+        savedCorr = _cpeCorrections;
     // §CPE_HOSE: ops ride the same override object the editor already stages and saves, so a hosed
     // path travels through Save / reload / bake by the existing seam — no second persistence path.
     _cpeHose = (ov.hose && ov.hose.length) ? ov.hose : null;
@@ -8579,12 +8693,15 @@ async function setupEffects(A, renderer, scene, camera) {
     // be ambiguous. Bands win because they carry the rigidity constraint that loose points cannot.
     if (ov.bands && ov.bands.length >= 2) { _cpeBands = ov.bands; _cpeWp = null; }
     _cpeReveal = !!ov.reveal;
+    // §CPE_CONE_ORIENT_ADJUST: same wrapper pattern as hose/reveal above — a plain array of plain
+    // correction objects, no rigidity/expansion concept like bands, so no precedence rule is needed.
+    _cpeCorrections = (ov.aimCorrections && ov.aimCorrections.length) ? ov.aimCorrections : null;
     try {
       return _cinemaPathPlan(durationSec);
     } finally {
       for (i = 0; i < _CPE_KEYS.length; i++) _cpeSet(_CPE_KEYS[i][1], saved[i]);
       _cpeWp = savedWp; _cpeBands = savedBands; _cpeHose = savedHose; _cpeSecOverride = savedSecOv;
-      _cpeReveal = savedReveal;
+      _cpeReveal = savedReveal; _cpeCorrections = savedCorr;
     }
   };
   A.cinemaPathPlanDerived = _cinemaPathPlan;   // unwrapped, for G1's byte-identity comparison

--- a/viewer/sw.js
+++ b/viewer/sw.js
@@ -22,7 +22,7 @@
 // schedule_author.js is in PRECACHE_ASSETS; v1088 shipped the STAGE 3 drawer change (#1528), so this
 // separate change needs its own bump (§CRISIS LESSON 4).
 // DEPLOY: bump CACHE_VERSION on every OCI upload. Old caches are purged on activate.
-const CACHE_VERSION = 'v1095';   // bump on each deploy; per-change detail is the git commit message.
+const CACHE_VERSION = 'v1096';   // bump on each deploy; per-change detail is the git commit message.
 // v1092 (2026-08-27) §R10 (bim-compiler prompts/CPE_4D_PERF_MEM_FINDINGS.md §7, extends R1's
 // §MAXQ_STAGE_KEEP contract): the MaxQ bake's per-frame §GLOW_LENS_QUAD rebuild (viewer/effects.js)
 // now skips the dispose+rebuild when the TM-visible fixture count is unchanged since the last

--- a/witness_cpe_cone_orient.js
+++ b/witness_cpe_cone_orient.js
@@ -1,0 +1,264 @@
+// WITNESS — §CPE_CONE_ORIENT_ADJUST: drag the passive POV cone to correct a bad gaze, no stick added.
+// Spec: bim-compiler prompts/CINEMA_PATH_EDITOR.md §CPE_CONE_ORIENT_ADJUST (2026-08-27).
+//
+// ISSUE EACH GATE PROVES OR DISPROVES:
+//   G-CONE-0   precondition — a fresh 3-band seed exists and its walk beat has a real time span, so
+//              there is a scrub position inside it to test against.
+//   G-CONE-1   before any interaction the cone is NOT focused, standing colour (0xff1744).
+//   G-CONE-2   a real click (down+up, ~zero pixels) on the cone FOCUSES it (colour -> 0x8B5A2B) and
+//              creates NO correction — click alone must never commit anything.
+//   G-CONE-3   a real click OUTSIDE the cone clears focus (colour reverts) — and, since that outside
+//              point could in principle land on the pipe/a handle, also proves it spawned no stick.
+//   G-CONE-4   a real drag (down on the cone, moved past CLICK_SLOP_PX, released) commits ONE
+//              correction with a plausible unit direction, and — the acceptance criterion this whole
+//              feature exists to satisfy — `bands.length` and every `band.c`/`band.d` are BYTE-
+//              IDENTICAL to before the drag. No band/waypoint was added or moved.
+//   G-CONE-5   the VF/preview panel auto-shows during the drag (spec item 3), even though it was
+//              never toggled on.
+//   G-CONE-6   the envelope is the ASYMMETRIC, arc-length-anchored shape spec item 5 describes:
+//              sampled via the real `_beat3Pose(e3)` product function (A._cpeBeat3PoseDebug) at the
+//              anchor, mid-hold, end-of-decay and well past decay — full strength at/through the
+//              hold, eased down by the end of decay, and materially different again once clear of
+//              the whole window (proves the taper actually decays rather than pinning forever).
+//   G-CONE-7   undo (real Ctrl+Z) removes the correction; redo (real Ctrl+Shift+Z) restores it with
+//              the same anchor/direction.
+const puppeteer = require('/home/red1/bim-compiler/node_modules/puppeteer');
+
+const PORT = process.env.PORT || 8511;
+const BUILDINGS = (process.env.BLDS || 'Duplex').split(',');
+const sleep = ms => new Promise(r => setTimeout(r, ms));
+
+async function openEditor(browser, BLD) {
+  const page = await browser.newPage();
+  await page.setViewport({ width: 1200, height: 700 });
+  const logs = [];
+  page.on('console', m => logs.push(m.text()));
+  page.on('pageerror', e => logs.push('PAGEERROR ' + e.message));
+  await page.goto(`http://localhost:${PORT}/viewer/viewer.html?db=/buildings/${BLD}_extracted.db`,
+    { waitUntil: 'domcontentloaded', timeout: 60000 });
+  await page.waitForFunction(
+    () => window.APP && window.APP.cinemaPathEditor && window.APP.startMaxQualityOrbit && window.APP._composer,
+    { timeout: 120000 });
+  await sleep(9000);
+  await page.waitForFunction(() => {
+    try { const r = window.APP.dbQuery('SELECT COUNT(*) FROM element_transforms'); return r && r[0][0] > 0; }
+    catch (e) { return false; }
+  }, { timeout: 60000, polling: 2000 });
+  await page.evaluate(() => { window.APP.startMaxQualityOrbit({ preview: false, fps: 1, editor: true }); });
+  await page.waitForSelector('#cpe-ok', { timeout: 300000 });
+  await sleep(800);
+  return { page, logs };
+}
+
+function ang(a, b) {
+  const dot = a.x * b.x + a.y * b.y + a.z * b.z;
+  const la = Math.hypot(a.x, a.y, a.z), lb = Math.hypot(b.x, b.y, b.z);
+  const c = Math.max(-1, Math.min(1, dot / (la * lb || 1)));
+  return Math.acos(c) * 180 / Math.PI;
+}
+
+// Real pointer gestures through the browser's own input pipeline — same technique
+// witness_cpe_drag.js already uses for band handles, applied here to the cone.
+async function click(page, x, y) {
+  await page.mouse.move(Math.round(x), Math.round(y));
+  await page.mouse.down();
+  await page.mouse.up();
+  await sleep(150);
+}
+async function drag(page, x0, y0, x1, y1) {
+  await page.mouse.move(Math.round(x0), Math.round(y0));
+  await page.mouse.down();
+  for (let i = 1; i <= 8; i++) await page.mouse.move(Math.round(x0 + (x1 - x0) * i / 8), Math.round(y0 + (y1 - y0) * i / 8));
+  await page.mouse.up();
+  await sleep(150);
+}
+
+async function gates(browser, BLD) {
+  const checks = [];
+  const P = (n, ok, d) => checks.push({ n, ok, d });
+  const { page, logs } = await openEditor(browser, BLD);
+
+  const setup = await page.evaluate(() => {
+    const cpe = window.APP.cinemaPathEditor;
+    const ov0 = cpe._probeOverride();
+    if (!ov0 || ov0.bands.length < 3) return null;
+    const t1 = cpe._bandTNorm(1);
+    if (t1 == null) return null;
+    cpe._scrubTo(t1);   // real product path — puts the cone at band 1's own walk position
+    const mk = cpe._probePovMarker();
+    if (!mk) return null;
+    return { nBands: ov0.bands.length, bands: ov0.bands, t1, mk };
+  });
+  if (!setup) {
+    P('G-CONE-0 a 3-band seed + walk-window scrub position + POV cone are all available (precondition)',
+      false, 'freshly-opened editor did not satisfy the precondition — inconclusive');
+    await page.close();
+    return checks;
+  }
+  P('G-CONE-0 precondition: 3-band seed, walk-window scrub target, cone exists', true,
+    `nBands=${setup.nBands} t1=${setup.t1.toFixed(3)} cone=(${setup.mk.x.toFixed(2)},${setup.mk.y.toFixed(2)},${setup.mk.z.toFixed(2)})`);
+
+  // Where the cone projects on screen right now — same THREE.Vector3.project technique
+  // witness_cpe_drag.js already uses for a band centre.
+  const proj = await page.evaluate((mk) => {
+    const A = window.APP, c = A.camera;
+    const p = new THREE.Vector3(mk.x, mk.y, mk.z);
+    const v = p.clone().project(c);
+    const r = A.canvas.getBoundingClientRect();
+    return { sx: r.left + (v.x + 1) / 2 * r.width, sy: r.top + (1 - v.y) / 2 * r.height,
+             behind: v.z > 1, rect: { left: r.left, top: r.top, width: r.width, height: r.height } };
+  }, setup.mk);
+  P('G-CONE-0b the cone projects on-screen, in front of the camera', !proj.behind,
+    `sx=${proj.sx.toFixed(0)} sy=${proj.sy.toFixed(0)} behind=${proj.behind}`);
+
+  // ── G-CONE-1: before any interaction.
+  const f0 = await page.evaluate(() => window.APP.cinemaPathEditor._probeConeFocus());
+  P('G-CONE-1 the cone is NOT focused before any interaction, standing colour',
+    f0 && f0.focused === false && f0.hex === '0xff1744', `focus=${JSON.stringify(f0)}`);
+
+  // ── G-CONE-2: a real click (no movement) on the cone.
+  const mark2 = logs.length;
+  await click(page, proj.sx, proj.sy);
+  const win2 = logs.slice(mark2);
+  const f1 = await page.evaluate(() => window.APP.cinemaPathEditor._probeConeFocus());
+  const corr1 = await page.evaluate(() => window.APP.cinemaPathEditor._probeCorrections());
+  P('G-CONE-2 a real click on the cone focuses it (colour -> 0x8b5a2b) and logs §CPE_CONE_FOCUS on',
+    f1 && f1.focused === true && f1.hex === '0x8b5a2b' && win2.some(l => l.startsWith('§CPE_CONE_FOCUS on')),
+    `focus=${JSON.stringify(f1)} logged=${win2.filter(l => l.startsWith('§CPE_CONE_FOCUS')).join(' | ')}`);
+  P('G-CONE-2b a plain click creates NO correction', corr1 && corr1.length === 0, `corrections=${corr1 ? corr1.length : 'null'}`);
+
+  // ── G-CONE-3: a real click OUTSIDE the cone — corner of the canvas, well clear of the model.
+  const mark3 = logs.length;
+  await click(page, proj.rect.left + 18, proj.rect.top + 18);
+  const win3 = logs.slice(mark3);
+  const f2 = await page.evaluate(() => window.APP.cinemaPathEditor._probeConeFocus());
+  const bands3 = await page.evaluate(() => window.APP.cinemaPathEditor._probeOverride().bands);
+  P('G-CONE-3 a real click OUTSIDE the cone clears focus (colour reverts) and logs §CPE_CONE_FOCUS off',
+    f2 && f2.focused === false && f2.hex === '0xff1744' && win3.some(l => l.startsWith('§CPE_CONE_FOCUS off')),
+    `focus=${JSON.stringify(f2)} logged=${win3.filter(l => l.startsWith('§CPE_CONE_FOCUS')).join(' | ')}`);
+  P('G-CONE-3b that outside click spawned no stick (band count unchanged)',
+    bands3.length === setup.nBands, `bands=${bands3.length} vs setup=${setup.nBands}`);
+
+  // ── G-CONE-4: a real drag — rotate the cone by a known pixel delta and release.
+  const DX = 80, DY = -40;   // yaw right ~27.5deg, pitch up ~13.7deg at CONE_ROTATE_RAD_PER_PX=0.006
+  const mark4 = logs.length;
+  await drag(page, proj.sx, proj.sy, proj.sx + DX, proj.sy + DY);
+  const win4 = logs.slice(mark4);
+  const after4 = await page.evaluate(() => ({
+    corr: window.APP.cinemaPathEditor._probeCorrections(),
+    ov: window.APP.cinemaPathEditor._probeOverride(),
+    focus: window.APP.cinemaPathEditor._probeConeFocus(),
+    vf: window.APP.cinemaPathEditor._probeVF()
+  }));
+  P('G-CONE-4 the drag committed exactly ONE correction, logged §CPE_CONE_CORRECTION add',
+    after4.corr && after4.corr.length === 1 && win4.some(l => l.startsWith('§CPE_CONE_CORRECTION add')),
+    `corrections=${after4.corr ? after4.corr.length : 'null'} logged=${win4.filter(l => l.startsWith('§CPE_CONE_CORRECTION')).join(' | ')}`);
+  const dirOk = after4.corr && after4.corr[0] && isFinite(after4.corr[0].dir.x) &&
+    Math.abs(Math.hypot(after4.corr[0].dir.x, after4.corr[0].dir.y, after4.corr[0].dir.z) - 1) < 1e-3;
+  P('G-CONE-4b the stored corrected direction is a real unit vector',
+    dirOk, `dir=${after4.corr && after4.corr[0] ? JSON.stringify(after4.corr[0].dir) : 'null'}`);
+
+  // The acceptance criterion the whole feature exists to satisfy: no band/waypoint moved.
+  const bandsAfter = after4.ov.bands;
+  let bandsIdentical = bandsAfter.length === setup.bands.length;
+  let maxDelta = 0;
+  if (bandsIdentical) {
+    for (let i = 0; i < setup.bands.length; i++) {
+      const a = setup.bands[i], b = bandsAfter[i];
+      maxDelta = Math.max(maxDelta,
+        Math.hypot(a.c.x - b.c.x, a.c.y - b.c.y, a.c.z - b.c.z),
+        Math.hypot(a.d.x - b.d.x, a.d.y - b.d.y, a.d.z - b.d.z));
+    }
+  }
+  P('G-CONE-4c bands.length and every band.c/band.d are BYTE-IDENTICAL after the cone drag — never adds/moves a band',
+    bandsIdentical && maxDelta < 1e-9,
+    `nBefore=${setup.bands.length} nAfter=${bandsAfter.length} maxDelta=${maxDelta.toExponential(2)}`);
+
+  // ── G-CONE-5: the VF panel auto-showed during the drag, even though never toggled on.
+  P('G-CONE-5 the preview/viewfinder panel auto-shows during the drag (spec item 3)',
+    after4.vf && after4.vf.on === true, `vfOn=${after4.vf ? after4.vf.on : 'null'}`);
+
+  // ── G-CONE-6: the envelope shape, sampled via the REAL _beat3Pose(e3) at known arc-fractions.
+  const shape = await page.evaluate(() => {
+    const corr = window.APP._cpeCorrectionsDebug();
+    if (!corr || !corr.length) return null;
+    const c = corr[0];
+    const at = (e3) => window.APP._cpeBeat3PoseDebug(Math.max(0, Math.min(1, e3)));
+    const dirAt = (e3) => { const p = at(e3); return { x: p.tx - p.x, y: p.ty - p.y, z: p.tz - p.z }; };
+    return {
+      s: c.s, rampFrac: c.rampFrac, holdFrac: c.holdFrac, decayFrac: c.decayFrac, corrDir: c.dir,
+      beforeRamp: dirAt(c.s - c.rampFrac - 0.05),         // well behind the ramp — untouched
+      atAnchor: dirAt(c.s),                                // ramp complete, full strength begins
+      midHold: dirAt(c.s + c.holdFrac / 2),                 // mid-hold — full strength
+      endDecay: dirAt(c.s + c.holdFrac + c.decayFrac),     // decay just finished — back to underlying
+      wellPastDecay: dirAt(c.s + c.holdFrac + c.decayFrac + 0.08)   // clear of the whole window
+    };
+  });
+  if (!shape) {
+    P('G-CONE-6 envelope shape sampled via the real _beat3Pose(e3)', false, 'A._cpeCorrectionsDebug() returned no entries — inconclusive');
+  } else {
+    const errAnchor = ang(shape.atAnchor, shape.corrDir);
+    const errMidHold = ang(shape.midHold, shape.corrDir);
+    const errEndDecay = ang(shape.endDecay, shape.corrDir);
+    const errBeforeRamp = ang(shape.beforeRamp, shape.corrDir);
+    const errPastDecay = ang(shape.wellPastDecay, shape.corrDir);
+    P('G-CONE-6a at the anchor (ramp complete) the sampled gaze matches the corrected direction (<=3deg)',
+      errAnchor <= 3, `angErr=${errAnchor.toFixed(2)}deg`);
+    P('G-CONE-6b mid-hold the sampled gaze still matches the corrected direction (<=3deg)',
+      errMidHold <= 3, `angErr=${errMidHold.toFixed(2)}deg`);
+    P('G-CONE-6c the taper actually DECAYS: well past decay, the gaze has moved measurably away from the corrected direction vs. the anchor/hold',
+      errPastDecay > errMidHold + 1, `errPastDecay=${errPastDecay.toFixed(2)}deg vs errMidHold=${errMidHold.toFixed(2)}deg (must be materially larger)`);
+    console.log(`  INFO  envelope s=${shape.s.toFixed(3)} rampFrac=${shape.rampFrac.toFixed(4)} holdFrac=${shape.holdFrac.toFixed(4)} decayFrac=${shape.decayFrac.toFixed(4)} | ` +
+      `angErr beforeRamp=${errBeforeRamp.toFixed(1)} atAnchor=${errAnchor.toFixed(1)} midHold=${errMidHold.toFixed(1)} endDecay=${errEndDecay.toFixed(1)} wellPastDecay=${errPastDecay.toFixed(1)} (deg)`);
+  }
+
+  // ── G-CONE-7: undo / redo, real Ctrl+Z / Ctrl+Shift+Z — same technique witness_cpe_undo.js uses.
+  const mark7 = logs.length;
+  await page.keyboard.down('Control'); await page.keyboard.press('KeyZ'); await page.keyboard.up('Control');
+  await sleep(200);
+  const win7 = logs.slice(mark7);
+  const afterUndo = await page.evaluate(() => ({
+    corr: window.APP.cinemaPathEditor._probeCorrections(), bands: window.APP.cinemaPathEditor._probeOverride().bands
+  }));
+  P('G-CONE-7a Ctrl+Z removes the committed correction', afterUndo.corr && afterUndo.corr.length === 0,
+    `corrections=${afterUndo.corr ? afterUndo.corr.length : 'null'} logged=${win7.filter(l => l.startsWith('§CPE_UNDO')).join(' | ')}`);
+  P('G-CONE-7b bands still untouched after undo', afterUndo.bands.length === setup.nBands, `bands=${afterUndo.bands.length}`);
+
+  const mark8 = logs.length;
+  await page.keyboard.down('Control'); await page.keyboard.down('Shift'); await page.keyboard.press('KeyZ');
+  await page.keyboard.up('Shift'); await page.keyboard.up('Control');
+  await sleep(200);
+  const win8 = logs.slice(mark8);
+  const afterRedo = await page.evaluate(() => window.APP.cinemaPathEditor._probeCorrections());
+  const redoDirErr = afterRedo && afterRedo[0] ? ang(afterRedo[0].dir, after4.corr[0].dir) : 999;
+  P('G-CONE-7c Ctrl+Shift+Z redoes the correction, same direction restored',
+    afterRedo && afterRedo.length === 1 && redoDirErr < 0.01,
+    `corrections=${afterRedo ? afterRedo.length : 'null'} dirErr=${redoDirErr.toFixed(4)}deg logged=${win8.filter(l => l.startsWith('§CPE_UNDO')).join(' | ')}`);
+
+  try { await page.evaluate(() => document.getElementById('cpe-cancel').click()); } catch (e) {}
+  console.log(`  INFO  ${logs.filter(l => /§CPE_LOADED/.test(l))[0] || '(no §CPE_LOADED)'}`);
+  checks.forEach(c => console.log(`  ${c.ok ? 'PASS' : 'FAIL'}  ${c.n}\n          ${c.d}`));
+  await page.close();
+  return checks;
+}
+
+(async () => {
+  const browser = await puppeteer.launch({
+    headless: 'new',
+    protocolTimeout: 900000,
+    args: ['--use-gl=angle', '--use-angle=swiftshader', '--no-sandbox', '--enable-unsafe-swiftshader'],
+  });
+  let allPass = true;
+  const summary = [];
+  for (const BLD of BUILDINGS) {
+    console.log(`\n${'='.repeat(78)}\n${BLD}\n${'='.repeat(78)}`);
+    const checks = await gates(browser, BLD);
+    checks.forEach(c => { if (!c.ok) allPass = false; });
+    summary.push({ BLD, pass: checks.every(c => c.ok), n: checks.filter(c => c.ok).length, t: checks.length });
+  }
+  await browser.close();
+  console.log(`\n${'='.repeat(78)}`);
+  summary.forEach(s => console.log(`${s.pass ? 'PASS' : 'FAIL'}  ${s.BLD}  (${s.n}/${s.t})`));
+  console.log(allPass ? '\nWITNESS PASS' : '\nWITNESS FAIL');
+  process.exit(allPass ? 0 : 1);
+})();


### PR DESCRIPTION
## Summary
- The auto-authored Alt+C camera path occasionally "stares skywards"/at a wall when disturbed (already-diagnosed §CPE_AIM_DEPTH omnidirectional search) — until now the only lever to fix it was adding a stick, which moves WHERE the camera is, not just where it LOOKS ("we ended up with more sticks when the intent was just cam adjustment").
- Makes the existing passive POV cone (§CPE_POV_MARKER, the red gizmo shown during scrub/preview) interactive: **click** it to focus (colour → a brownish tint, `0x8B5A2B`), **drag** while focused to rotate ONLY its facing (position stays scrub-driven, never draggable), **release** to commit an ANCHORED gaze correction.
- A correction is its own small list on the plan — arc-length anchor position + corrected direction + an asymmetric ramp/hold/decay envelope — round-tripped through save/reopen the same way bands already are. **Never adds or moves a band/waypoint** (the acceptance criterion this whole feature exists to satisfy).
- Spec: `bim-compiler prompts/CINEMA_PATH_EDITOR.md` §CPE_CONE_ORIENT_ADJUST (supersedes the §CPE_PREVIEW_TACKBACK_PIN "re-enable AIM_PIN's click trigger" direction recorded just above it — that trigger stays exactly as disabled/commented-out as before, untouched by this PR).

## What's built
- **effects.js**: a new `_cpeCorrections` plan field (same wrapper pattern `A.cinemaPathPlan` already uses for `_cpeBands`/`_cpeHose`/`_cpeReveal`). Each correction's world anchor is resolved to an arc-fraction via the SAME nearest-point-on-`flowWp` technique `_buildPinZones` already uses for bands — not a reuse of the pin mechanism itself (a correction isn't band-indexed), but studied and deliberately kept as a separate code path so the two don't fight or duplicate taper math. Checked inside `_beat3Pose`, after the existing pin/§CPE_AIM_DEPTH chain — a judgment call (flagged in the spec file, see below) that a cone correction is the last word on the gaze at its own window, even inside an already-pinned zone.
- **cinema_path_editor.js**: cone hit-test/focus/drag/commit wired into the existing `h.down`/`h.move`/`h.up` pointer pipeline. Hit-test is screen-space proximity (`_screenOf` + a pixel radius), NOT a `THREE.Raycaster` hit — same reasoning `_handleGrabPx`'s own comment gives for band handles: the cone draws with `depthTest:false`, so a raycast would disagree with what's actually visible. One grab, split by movement (click = focus, drag past `CLICK_SLOP_PX` = rotate+commit) — the same convention §CPE_STICK vs §CPE_HOSE already established in this file. Corrections thread through `_buildOverride`/`_isEdited`/undo-redo (`_undoPush` before every commit, reusing the EXISTING `§CPE_UNDO` stack per spec item 7)/`_pathsApply`/`open()`, the same seam bands/hose already ride.
- Interaction is gated to the walk beat's own time window (`_walkWindow()`) — outside it the cone's world position collapses onto a fixed per-beat point (e.g. `settle` throughout the whole spin), so a correction "anchored" there would silently snap onto the wrong end of the walk. Not user-specified; flagged in the spec-file update as a judgment call.

## Open questions flagged for review (none silently settled)
1. **VF panel auto-show on release**: spec left "auto-hide again, or stays open" undecided — built as "stays open until the eye toggle is used" (least-surprising default, per the spec's own recommendation).
2. **Envelope constants**: `CPE_CONE_CORR_RAMP_M=2` / `HOLD_M=5` / `DECAY_M=4` (arc-length metres) are first-guess defaults, not settled with the user — named, commented, tunable.
3. **Click vs. click-then-drag as one gesture**: the spec's prose lists "click = focus" and "drag while focused = live edit" as two numbered steps; built as ONE grab split by movement (reusing this file's own §CPE_STICK/§CPE_HOSE precedent) rather than requiring two separate clicks — a judgment call, not confirmed.
4. **Overlapping corrections**: not user-decided — simplest MVP picked (nearest anchor wins outright, no cross-correction blending), same "re-dragging near an existing anchor updates it in place" MVP for the merge-distance question.
5. **Correction vs. an existing pin at the same spot**: a correction is applied AFTER the pin/depth chain, so it can override even a pinned zone's gaze — not confirmed with the user.

All five are also written into the spec file's own dated update (`prompts/CINEMA_PATH_EDITOR.md` §CPE_CONE_ORIENT_ADJUST), matching this project's "not yet decided / flagged for review" house style.

## Test plan
- [x] `node --check` on both changed viewer files
- [x] New `witness_cpe_cone_orient.js` — **17/17 PASS (Duplex)**, real click/drag pointer events (not synthetic hooks) through `THREE.Vector3.project`-computed screen coordinates, same technique `witness_cpe_drag.js` already uses for band handles:
  - click focuses (colour + log), creates no correction; click outside clears focus and spawns no stick
  - a real drag commits exactly one correction with a real unit direction
  - **`bands.length` and every `band.c`/`band.d` are byte-identical before/after the drag** (maxDelta=0) — the core acceptance criterion
  - the VF/preview panel auto-shows during the drag even though never toggled on
  - the envelope shape sampled via the real `_beat3Pose(e3)` product function (new `A._cpeBeat3PoseDebug` witness hook): 0.00° error at the anchor and through mid-hold, materially larger error well past the decay window (147.85° vs 0.00°) — the taper actually decays, doesn't pin forever
  - real Ctrl+Z removes the correction, real Ctrl+Shift+Z redoes it (bands untouched throughout)
  - Hospital timed out opening the editor in this environment (>9 min, twice) — this matches a **pre-existing, already-documented** environment limitation in this exact repo (see PR #1570's own test plan: "Hospital run hit a pre-existing CPE-editor-UI open timeout unrelated to this diff"). Duplex-only is consistent with several sibling witnesses' own defaults (`witness_cpe_click_slop.js`, `witness_cpe_scrub_viewfinder.js`, `witness_cpe_aim_pin.js`).
- [x] Regression suite re-run unmodified — **90/92 across 9 files**:
  - `witness_cpe_buildup_tempo.js` 3/3, `witness_cpe_ghost_ground.js` 15/15, `witness_cpe_aim_pin.js` 7/7, `witness_cpe_drag.js` 8/8 (Duplex+Terminal), `witness_cpe_undo.js` 12/12 (Duplex+Terminal), `witness_cpe_pov_marker.js` 6/6, `witness_cpe_click_slop.js` 6/6, `witness_cpe_scrub_viewfinder.js` 33/33 — all clean
  - `witness_cinema_bands.js`: Duplex 4/6 (B5/B7 fail — sharp-corner/LOS gates), Terminal 6/6. **Confirmed pre-existing via `git stash` baseline diff**: re-ran the identical witness against pristine `origin/main` with this PR's changes stashed away — byte-identical failure numbers (band1 aimErr=171.8°, peak=84.6°/frame at t=0.157) with or without this change. Not a regression.
- [x] `sw.js` `CACHE_VERSION` v1095 → v1096 (cinema_path_editor.js/effects.js both changed and are in PRECACHE_ASSETS)
- [x] Grep-confirmed the disabled §CPE_AIM_PIN click trigger (`cinema_path_editor.js` ~line 3018, `// if (ev && ...) _tryPinClick(...)`) is untouched by this diff — out of scope per the dispatch

Not merging/auto-merging — leaving open for review of the interaction and the open questions above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)