### PR TITLE
fix(photo): step down over-boosted glossy reflection (envmap 3.0->2.0)

### DIFF
--- a/viewer/effects.js
+++ b/viewer/effects.js
@@ -2589,10 +2589,31 @@ async function setupEffects(A, renderer, scene, camera) {
       ' (start=' + PHOTO_SUN_ELEVATION_START + ' end=' + PHOTO_SUN_ELEVATION_END + ')');
   }
   A._sunArcStep = _sunArcStep;
-  var PHOTO_ENVMAP_BOOST = 3.0;   // multiply each material's existing envMapIntensity — stronger
+  var PHOTO_ENVMAP_BOOST = 2.0;   // multiply each material's existing envMapIntensity — stronger
                                    // glass/metal reflections without changing overall scene exposure
-                                   // (history: 2.2 -> 3.2 -> 4.5 -> 3.0. The 4.5 step, combined with
-                                   // the §PHOTO_ENVMAP_STALE fix below finally pointing every
+                                   // (history: 2.2 -> 3.2 -> 4.5 -> 3.0 -> 2.0. §PHOTO_REALISM_RETUNE
+                                   // (2026-08-27, PHOTOREAL_STILL_RENDER.md, this session): 3.0 was
+                                   // tuned BEFORE §MIRROR_ROOM_PROBE (2026-08-16) gave glossy/metal
+                                   // materials a real local-scene reflection on top of the sky/HDRI
+                                   // env map — with the room probe now doing part of the reflection
+                                   // work, 3.0 double-counts and reads "too bright, shiny reflection"
+                                   // (user's own words). One controlled step down (not back to the
+                                   // pre-room-probe 2.2 floor — same "single controlled increment,
+                                   // not guess-and-hope" discipline as §PHOTO_AO_EDGE's 2->4 step),
+                                   // verified live via witness_envmap_retune.js on Clinic (real,
+                                   // room-probe-applied, apples-to-apples before/after): meanBoostRatio
+                                   // 3.0000->2.0000, meanBoostedEnvMapIntensity 1.8000->1.2000 (both
+                                   // exactly track the constant, as expected); frame-level meanLuma
+                                   // 174.19->178.02, stdLuma 69.65->66.57, clippedWhiteFrac 0.00%
+                                   // unchanged — near-flat at the whole-frame level because Clinic has
+                                   // only 1 glossy/room-probe-eligible material of 7 in _matCache, so
+                                   // the material-level halo shrink is real but diluted by the rest of
+                                   // the frame. Hospital not re-verified after this same session hit a
+                                   // pre-existing CPE/Hospital environment flakiness (hang, then a
+                                   // detached-Frame puppeteer crash on retry, both unrelated to this
+                                   // diff) — see prompts/PHOTOREAL_STILL_RENDER.md §PHOTO_REALISM_RETUNE.
+                                   // (history predating this line, still true: the 4.5 step, combined
+                                   // with the §PHOTO_ENVMAP_STALE fix below finally pointing every
                                    // material at the CORRECT dusk env map, made the glint work for
                                    // the first time — but also overshot: user reported "all shadows
                                    // on building are gone." Root cause of THAT: env-map/IBL
@@ -2604,7 +2625,7 @@ async function setupEffects(A, renderer, scene, camera) {
                                    // the `typeof m.envMapIntensity !== 'number'` check never actually
                                    // excluded plain concrete/plaster walls. Fixed by gating on
                                    // glossiness below; boost itself also dialed back one notch
-                                   // per "glint is slightly too much."
+                                   // per "glint is slightly too much.")
   var PHOTO_GLOSSY_ROUGHNESS_MAX = 0.5;  // only materials this glossy or better (glass ~0.05-0.08,
                                           // tightened/native metal ~0.3-0.5) get the envMap boost —
                                           // excludes concrete/plaster/wood (STD_MAT rough 0.6-0.95),

--- a/viewer/sw.js
+++ b/viewer/sw.js
@@ -22,7 +22,7 @@
 // schedule_author.js is in PRECACHE_ASSETS; v1088 shipped the STAGE 3 drawer change (#1528), so this
 // separate change needs its own bump (§CRISIS LESSON 4).
 // DEPLOY: bump CACHE_VERSION on every OCI upload. Old caches are purged on activate.
-const CACHE_VERSION = 'v1097';   // bump on each deploy; per-change detail is the git commit message.
+const CACHE_VERSION = 'v1098';   // bump on each deploy; per-change detail is the git commit message.
 // v1092 (2026-08-27) §R10 (bim-compiler prompts/CPE_4D_PERF_MEM_FINDINGS.md §7, extends R1's
 // §MAXQ_STAGE_KEEP contract): the MaxQ bake's per-frame §GLOW_LENS_QUAD rebuild (viewer/effects.js)
 // now skips the dispose+rebuild when the TM-visible fixture count is unchanged since the last

--- a/witness_envmap_retune.js
+++ b/witness_envmap_retune.js
@@ -1,0 +1,145 @@
+// WITNESS — §PHOTO_ENVMAP_RETUNE (2026-08-27)
+// ISSUE IT PROVES/DISPROVES: with §MIRROR_ROOM_PROBE now supplying a real local-scene reflection
+// on top of PHOTO_ENVMAP_BOOST=3.0 (a multiplier calibrated pre-room-probe, pre-§TRINORM_LINEAR,
+// when metal read near-black), are glossy materials over-bright/over-reflective (the user's "too
+// bright, shiny reflection" complaint)? Drives A.startStillRefine() (the real Alt+S entry point,
+// same as witness_envmap_stomp.js) on a real building DB, then reads back REAL numeric material
+// state (envMapIntensity, roughness, metalness) for every glossy/boosted material in A._matCache
+// plus a real canvas pixel-luminance readback (mean + bright-clip fraction as a whitewash proxy) —
+// direct numeric proof, not inference from logs or a screenshot.
+const puppeteer = require('/home/red1/bim-compiler/node_modules/puppeteer');
+const PORT = process.env.PORT || 8410;
+const BLD = process.env.BLD || 'Clinic';
+const LABEL = process.env.LABEL || 'run';
+
+process.on('unhandledRejection', function(e) { console.error('UNHANDLED_REJECTION: ' + (e && e.stack || e)); process.exit(1); });
+
+(async () => {
+  const browser = await puppeteer.launch({
+    headless: 'new',
+    args: ['--use-gl=angle', '--use-angle=swiftshader', '--no-sandbox', '--enable-unsafe-swiftshader'],
+    protocolTimeout: 300000,
+  });
+  const page = await browser.newPage();
+  await page.setViewport({ width: 960, height: 540 });
+  const logs = [];
+  page.on('console', m => logs.push(m.text()));
+  page.on('pageerror', e => logs.push('PAGEERROR ' + e.message));
+
+  console.log(`\n${'='.repeat(78)}\n§PHOTO_ENVMAP_RETUNE witness [${LABEL}] — ${BLD}\n${'='.repeat(78)}`);
+  await page.goto(`http://localhost:${PORT}/viewer/viewer.html?db=/buildings/${BLD}_extracted.db`, { waitUntil: 'domcontentloaded', timeout: 60000 });
+  await page.waitForFunction(() => window.APP && window.APP.camera && window.APP.controls &&
+    typeof window.APP.startStillRefine === 'function' && window.APP._composer, { timeout: 90000 });
+  // Wait for streaming to actually START first (it kicks off async after §DS_AUTO_START) —
+  // otherwise the settle-check below races and resolves true on `!window.APP.streaming` before
+  // any element has streamed at all (found live during this session's own building-population probe).
+  await page.waitForFunction(() => window.APP.streaming === true || (window.APP.streamQueue||[]).length > 0,
+    { timeout: 60000, polling: 250 }).catch(() => {});
+  await page.waitForFunction(() => !window.APP.streaming || (window.APP.streamIdx >= (window.APP.streamQueue||[]).length),
+    { timeout: 300000, polling: 1000 }).catch(() => {});
+  const _settleState = await page.evaluate(() => ({ streamIdx: window.APP.streamIdx, streamTotal: (window.APP.streamQueue||[]).length }));
+  console.log('--- streaming settled: ' + _settleState.streamIdx + '/' + _settleState.streamTotal + ' ---');
+
+  const matCacheCount = await page.evaluate(() => Object.keys(window.APP._matCache || {}).length);
+  console.log('matCache entries pre-stage: ' + matCacheCount);
+
+  // Fire real Alt+S staging (A.startStillRefine is the exact function keyboard.js's Alt+S calls)
+  await page.evaluate(() => { if (window.APP._stillRefineActive) window.APP.stopStillRefine(true); window.APP.startStillRefine(); });
+  await page.waitForFunction(() => window.APP._stillRefineBusy === false, { timeout: 60000, polling: 100 }).catch(() => {});
+  // §PHOTO_ENVMAP_STALE's own safety net (effects.js:4689) only pushes the room-probe texture onto
+  // materials via a 2200ms setTimeout OR the per-accumulation-frame step() loop — wait explicitly
+  // for at least one glossy material's envMap to stop pointing at the plain sky env map (A._envMap;
+  // _roomProbeRT itself is a closure-private var, not reachable from page.evaluate, so identity
+  // vs. the known sky map is the only externally-visible signal) so the pixel readback below
+  // reflects the real staged look, not a mid-swap state.
+  await page.waitForFunction(() => {
+    var cache = window.APP._matCache || {}, sky = window.APP._envMap;
+    if (!sky) return false;
+    return Object.keys(cache).some(function(k) {
+      var m = cache[k];
+      return m && m.userData && m.userData._photoRoomProbeEligible && m.envMap && m.envMap !== sky;
+    });
+  }, { timeout: 6000, polling: 200 }).catch(() => {});
+  await new Promise(res => setTimeout(res, 500));
+
+  const matStats = await page.evaluate(() => {
+    var cache = window.APP._matCache || {};
+    var glossy = [], metal = [], allBoosted = [];
+    Object.keys(cache).forEach(function(k) {
+      var m = cache[k];
+      if (!m || !m.userData) return;
+      if (m.userData._photoBoosted) allBoosted.push(m);
+      if (m.userData._photoRoomProbeEligible) {
+        glossy.push({
+          key: k,
+          envMapIntensity: m.envMapIntensity,
+          origEnvMapIntensity: m.userData._photoOrigEnvMapIntensity,
+          roughness: m.roughness,
+          origRoughness: m.userData._photoOrigRoughness,
+          metalness: m.metalness,
+          hasRoomProbeTex: !!(m.envMap && window.APP._envMap && m.envMap !== window.APP._envMap)
+        });
+      }
+    });
+    return { totalBoosted: allBoosted.length, glossyCount: glossy.length, glossy: glossy };
+  });
+
+  console.log('§MATSTATS totalBoosted=' + matStats.totalBoosted + ' glossyRoomProbeEligible=' + matStats.glossyCount);
+  var envRatios = matStats.glossy.filter(function(g){ return typeof g.origEnvMapIntensity === 'number' && g.origEnvMapIntensity > 0; })
+    .map(function(g){ return g.envMapIntensity / g.origEnvMapIntensity; });
+  var meanRatio = envRatios.length ? envRatios.reduce(function(a,b){return a+b;},0)/envRatios.length : NaN;
+  var meanEnvInt = matStats.glossy.length ? matStats.glossy.reduce(function(a,g){return a+(g.envMapIntensity||0);},0)/matStats.glossy.length : NaN;
+  var meanOrigEnvInt = matStats.glossy.length ? matStats.glossy.reduce(function(a,g){return a+(g.origEnvMapIntensity||0);},0)/matStats.glossy.length : NaN;
+  var meanRoughness = matStats.glossy.length ? matStats.glossy.reduce(function(a,g){return a+(typeof g.roughness==='number'?g.roughness:0);},0)/matStats.glossy.length : NaN;
+  var roomProbeCount = matStats.glossy.filter(function(g){return g.hasRoomProbeTex;}).length;
+  console.log('§MATSTATS meanOrigEnvMapIntensity=' + meanOrigEnvInt.toFixed(4) +
+    ' meanBoostedEnvMapIntensity=' + meanEnvInt.toFixed(4) +
+    ' meanBoostRatio=' + meanRatio.toFixed(4) +
+    ' meanRoughness=' + meanRoughness.toFixed(4) +
+    ' usingRoomProbeTex=' + roomProbeCount + '/' + matStats.glossy.length);
+
+  // Full-frame render + pixel readback — same 32x32 downsample technique as witness_envmap_stomp.js,
+  // extended with clipped-highlight fraction and stddev as a whitewash/contrast proxy.
+  const pixelStats = await page.evaluate(() => {
+    try {
+      window.APP._composer.render();
+      var SZ = 128;
+      var c = document.createElement('canvas');
+      c.width = SZ; c.height = SZ;
+      var ctx = c.getContext('2d');
+      ctx.drawImage(window.APP.renderer.domElement, 0, 0, SZ, SZ);
+      var data = ctx.getImageData(0, 0, SZ, SZ).data;
+      var n = data.length / 4, sum = 0, sumSq = 0, clipped = 0;
+      var lumas = [];
+      for (var p = 0; p < data.length; p += 4) {
+        var luma = 0.299 * data[p] + 0.587 * data[p + 1] + 0.114 * data[p + 2];
+        lumas.push(luma);
+        sum += luma; sumSq += luma * luma;
+        if (data[p] >= 250 && data[p+1] >= 250 && data[p+2] >= 250) clipped++;
+      }
+      var mean = sum / n;
+      var variance = (sumSq / n) - (mean * mean);
+      return { meanLuma: mean, stdLuma: Math.sqrt(Math.max(0, variance)), clippedFrac: clipped / n, n: n };
+    } catch (e) { return { error: String(e && e.message || e) }; }
+  });
+  console.log('§PIXELSTATS meanLuma=' + pixelStats.meanLuma.toFixed(2) +
+    ' stdLuma=' + pixelStats.stdLuma.toFixed(2) +
+    ' clippedWhiteFrac=' + (pixelStats.clippedFrac*100).toFixed(2) + '%');
+
+  await page.evaluate(() => { if (window.APP._stillRefineActive) window.APP.stopStillRefine(true); });
+
+  console.log('\n--- §MIRROR_ROOM_PROBE / §PHOTO log lines seen ---');
+  logs.filter(l => l.includes('MIRROR_ROOM_PROBE') || l.includes('PHOTO_STAGING') || l.includes('PHOTO_ENVMAP')).forEach(l => console.log(l));
+
+  console.log('\n§RESULT [' + LABEL + '] bld=' + BLD +
+    ' glossyMats=' + matStats.glossyCount +
+    ' meanBoostRatio=' + meanRatio.toFixed(4) +
+    ' meanBoostedEnvMapIntensity=' + meanEnvInt.toFixed(4) +
+    ' meanRoughness=' + meanRoughness.toFixed(4) +
+    ' meanLuma=' + pixelStats.meanLuma.toFixed(2) +
+    ' stdLuma=' + pixelStats.stdLuma.toFixed(2) +
+    ' clippedWhiteFrac=' + (pixelStats.clippedFrac*100).toFixed(2) + '%');
+
+  await browser.close();
+  process.exit(0);
+})();


### PR DESCRIPTION
## Summary
- User: "we already got things too bright, shiny reflection... shadow effects for realism" + explicit caution "not to fall off to the dark side."
- `PHOTO_ENVMAP_BOOST=3.0` was tuned before `§MIRROR_ROOM_PROBE` (2026-08-16) gave glossy/metal materials a real local reflection — now double-counts.
- One conservative step down (3.0 -> 2.0), not a final guess — same single-increment discipline `§PHOTO_AO_EDGE` already used in this file's history.

## Verification
- Clinic (the building the original "whitewash" report was on): clean before/after, room-probe-applied both runs. Material numbers track the constant exactly; frame luma slightly *up* (174→178) with *less* variance (std 70→67, less extreme highlight contrast) and zero clipping either way — not darker, less blown-out.
- Hospital: material-level change confirmed reaching the real population, but frame-level before/after hit unrelated environment flakiness (hang, then a puppeteer crash) — flagged honestly as not independently confirmed there, not claimed as passing.

## Not merged
Per the user's own caution — this is a subjective visual call, held open for live confirmation, same as this file's own `§PHOTO_AO_TUNING`/`§PHOTO_AO_EDGE` precedent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)