### PR TITLE
fix(open): meta.db+geo.db pair silently dropped one half

### DIFF
--- a/viewer/scene.js
+++ b/viewer/scene.js
@@ -1031,6 +1031,120 @@ async function setupScene(A) {
     return true;
   };
 
+  // Split-DB sibling of _mergeDbIntoScene — for a meta.db + geo.db pair opened as TWO separate
+  // blobs (a large/split-mode building has no single monolithic byte buffer to hand _mergeDbIntoScene).
+  // §BUG 2026-08-29: nothing called this before — split results were funnelled through the monolithic
+  // _openDbBytes/_mergeDbIntoScene path, which opens ONE SQL.Database and therefore only ever saw
+  // whichever single blob got passed in (see _openIfcFiles' old metaDb-only fallback). Same merge
+  // logic as _mergeDbIntoScene line-for-line, just META_TABLES read from srcMeta and GEO_TABLES from
+  // srcGeo instead of one shared src — _mergeTable/_georefPin are already source-agnostic, reused as-is.
+  A._mergeSplitDbIntoScene = async function(fileName, metaBytes, geoBytes) {
+    var t0 = (typeof performance !== 'undefined' && performance.now) ? performance.now() : 0;
+    var SQL = A._SQL || A.citySQL || A._citySQL;
+    if (!SQL) { console.log('§MERGE_SPLIT_FAIL reason=no_sql_factory'); if (A.status) A.status.textContent = 'Merge failed — sql.js not ready'; return false; }
+    if (!A.db) { console.log('§MERGE_SPLIT_FAIL reason=no_live_db'); return false; }
+    var srcMeta, srcGeo;
+    try { srcMeta = new SQL.Database(new Uint8Array(metaBytes)); }
+    catch (e) { console.log('§MERGE_SPLIT_FAIL reason=open_meta ' + e.message); return false; }
+    try { srcGeo = new SQL.Database(new Uint8Array(geoBytes)); }
+    catch (e) { console.log('§MERGE_SPLIT_FAIL reason=open_geo ' + e.message); try { srcMeta.close(); } catch (e2) {} return false; }
+
+    var before = Object.keys(A.buildingCentres || {});
+    var srcBlds = [];
+    try {
+      var br = srcMeta.exec('SELECT DISTINCT building FROM elements_meta');
+      if (br && br.length) srcBlds = br[0].values.map(function(v) { return v[0]; });
+    } catch (e) {}
+    console.log('§MERGE_SPLIT_START file=' + fileName + ' metaBytes=' + metaBytes.byteLength +
+      ' geoBytes=' + geoBytes.byteLength + ' srcBuildings=' + JSON.stringify(srcBlds) +
+      ' sceneBuildings=' + JSON.stringify(before));
+
+    // Frame rebase — same rule as _mergeDbIntoScene step 2, pinned off the META source
+    // (project_metadata/georef_offset_* lives with the metadata, not the geometry).
+    var pin = _georefPin(A.db), inc = _georefPin(srcMeta);
+    if (pin && inc) {
+      var dx = inc[0] - pin[0], dy = inc[1] - pin[1], dz = inc[2] - pin[2];
+      if (dx || dy || dz) {
+        try {
+          srcMeta.run('UPDATE element_transforms SET center_x = center_x + ?, center_y = center_y + ?, center_z = center_z + ?', [dx, dy, dz]);
+          console.log('§MERGE_SPLIT_GEOREF mode=rebase pin=(' + pin.join(',') + ') inc=(' + inc.join(',') + ') delta=(' + dx + ',' + dy + ',' + dz + ')');
+        } catch (e) { console.log('§MERGE_SPLIT_GEOREF mode=rebase_fail ' + e.message); }
+      } else {
+        console.log('§MERGE_SPLIT_GEOREF mode=same pin=(' + pin.join(',') + ')');
+      }
+    } else {
+      console.log('§MERGE_SPLIT_GEOREF mode=none pin=' + (pin ? '(' + pin.join(',') + ')' : 'absent') +
+        ' inc=' + (inc ? '(' + inc.join(',') + ')' : 'absent') + ' — each DB keeps its own coordinates');
+    }
+
+    // Fold tables: META_TABLES from srcMeta, GEO_TABLES from srcGeo — same _mergeTable helper, two sources.
+    var stats = {};
+    A._MERGE_META_TABLES.forEach(function(t) { var s = _mergeTable(srcMeta, A.db, t); if (s) stats[t] = s; });
+    if (A.libDb) {
+      A._MERGE_GEO_TABLES.forEach(function(t) {
+        var s = _mergeTable(srcGeo, A.libDb, t);
+        if (s) stats[t] = s;
+        else if (A.libDb !== A.db) { var s2 = _mergeTable(srcGeo, A.db, t); if (s2) stats[t] = s2; }
+      });
+    } else {
+      A._MERGE_GEO_TABLES.forEach(function(t) { var s = _mergeTable(srcGeo, A.db, t); if (s) stats[t] = s; });
+    }
+    console.log('§MERGE_SPLIT_TABLES folded=' + JSON.stringify(Object.keys(stats)) +
+      ' skipped=' + JSON.stringify(A._MERGE_META_TABLES.concat(A._MERGE_GEO_TABLES).filter(function(t) { return !stats[t]; })));
+    if (!stats.elements_meta) {
+      console.error('§MERGE_SPLIT_FAIL reason=elements_meta_not_folded — schema read failed, nothing merged');
+      try { srcMeta.close(); } catch (e) {}
+      try { srcGeo.close(); } catch (e) {}
+      if (A.status) A.status.textContent = 'Merge failed — could not read ' + fileName;
+      return false;
+    }
+    if (!stats.elements_meta.added) {
+      console.log('§MERGE_SPLIT_WARN elements_meta added=0 — nothing new (all GUIDs already present)');
+    }
+    try { srcMeta.close(); } catch (e) {}
+    try { srcGeo.close(); } catch (e) {}
+
+    A.cityBuildingDbs = A.cityBuildingDbs || {};
+    srcBlds.forEach(function(n) { A.cityBuildingDbs[n] = { db: A.db, libDb: A.libDb }; });
+
+    var env = null;
+    for (var k0 in A.buildingCentres) { if (A.buildingCentres[k0].envelope) { env = A.buildingCentres[k0].envelope; break; } }
+    var added = [];
+    try {
+      var centres = A.dbQuery('SELECT m.building, COUNT(*), AVG(t.center_x), AVG(t.center_y), AVG(t.center_z) ' +
+        'FROM elements_meta m JOIN element_transforms t ON t.guid = m.guid GROUP BY m.building');
+      for (var ci = 0; ci < centres.length; ci++) {
+        var row = centres[ci];
+        if (A.buildingCentres[row[0]]) { A.buildingCentres[row[0]].count = row[1]; continue; }
+        A.buildingCentres[row[0]] = { ix: row[2], iy: row[3], iz: row[4], count: row[1] };
+        if (env) A.buildingCentres[row[0]].envelope = env;
+        added.push(row[0]);
+      }
+    } catch (e) { console.log('§MERGE_SPLIT_CENTRES_FAIL ' + e.message); }
+    console.log('§MERGE_SPLIT_CENTRES before=' + before.length + ' after=' + Object.keys(A.buildingCentres).length +
+      ' added=' + JSON.stringify(added));
+
+    try {
+      var er = A.dbQuery('SELECT COUNT(*) FROM elements_meta');
+      A.totalElements = er.length ? er[0][0] : A.totalElements;
+      var dr = A.dbQuery('SELECT discipline, COUNT(*) FROM elements_meta GROUP BY discipline');
+      A.discCounts = {};
+      for (var di = 0; di < dr.length; di++) A.discCounts[dr[di][0]] = dr[di][1];
+    } catch (e) {}
+    if (A.updateHUD) A.updateHUD();
+    if (A.populateBuildingList) A.populateBuildingList();
+    if (A._updateFogDensity) A._updateFogDensity();
+
+    var ms = ((typeof performance !== 'undefined' && performance.now) ? performance.now() : 0) - t0;
+    console.log('§MERGE_SPLIT_DONE file=' + fileName + ' newBuildings=' + added.length +
+      ' totalElements=' + A.totalElements + ' ms=' + ms.toFixed(0));
+    if (A.status) A.status.textContent = 'Merged ' + fileName + ' — ' + added.length + ' building(s) added';
+
+    A._mergePending = (A._mergePending || []).concat(added);
+    A._mergeStreamNext();
+    return true;
+  };
+
   // Sequential drain, mirroring city.js's _cityStreamNext. Chained from the stream-complete hook in
   // streaming.js (right beside the existing City drain) — streamBuilding() handles ONE building, and
   // a real merged package (Clinic = 5 discipline buildings) has N.
@@ -1073,6 +1187,40 @@ async function setupScene(A) {
     location.assign('viewer.html?db=' + encodeURIComponent(dbUrl) + '&lib=' + encodeURIComponent(dbUrl) + '&ghost=1');
   };
 
+  // Split-DB sibling of _openDbBytes — for a meta.db + geo.db pair (from a local file-pair open, or
+  // a split-mode importMultiIFC result). Mirrors _openDbBytes' merge/replace branching exactly; the
+  // only difference is TWO source blobs, cached under the _meta.db/_geo.db naming convention
+  // streaming.js's §DB_SPLIT_DETECT already expects (same convention import.js's openImported already
+  // uses successfully for split records — this extends it to the file-picker/Open door and to
+  // _openIfcFiles' split branch below, neither of which had any split-aware path before).
+  A._openSplitDbBytes = async function(fileName, metaBytes, geoBytes) {
+    var open = Object.keys(A.buildingCentres || {});
+    if (A.db && open.length) {
+      var target = (A.activeBuilding && A.buildingCentres[A.activeBuilding]) ? A.activeBuilding : open[0];
+      var choice = await A._showMergeModal(fileName, target);
+      console.log('§MERGE_CHOICE file=' + fileName + ' target=' + target + ' action=' + choice.action);
+      if (choice.action === 'merge') { await A._mergeSplitDbIntoScene(fileName, metaBytes, geoBytes); return; }
+    } else {
+      console.log('§MERGE_SKIP reason=no_building_open — replace path');
+    }
+    var key = fileName.replace(/_meta\.db$/i, '').replace(/\.(db|sqlite)$/i, '');
+    var extractedUrl = 'import://' + key + '_extracted.db/v0';
+    var metaUrl = 'import://' + key + '_meta.db/v0';
+    var geoUrl = 'import://' + key + '_geo.db/v0';
+    var cacheDb = await A.openCacheDB();
+    if (!cacheDb) { if (A.status) A.status.textContent = 'Cache unavailable'; return; }
+    await new Promise(function(resolve) {
+      var tx = cacheDb.transaction(A.CACHE_STORE, 'readwrite');
+      var store = tx.objectStore(A.CACHE_STORE);
+      store.put(metaBytes, metaUrl);
+      store.put(geoBytes, geoUrl);
+      store.put(metaBytes, extractedUrl);   // meta as primary — fast load, same as import.js's openImported
+      tx.oncomplete = resolve; tx.onerror = resolve;
+    });
+    console.log('§OPEN_DB_SPLIT cached key=' + key + ' meta=' + metaBytes.byteLength + ' geo=' + geoBytes.byteLength + ' → navigate');
+    location.assign('viewer.html?db=' + encodeURIComponent(extractedUrl) + '&lib=' + encodeURIComponent(extractedUrl) + '&ghost=1');
+  };
+
   // §SM-7.1 step 5 — source IFC in the SAME door. No new import path: route to the existing
   // A.importMultiIFC (import.js:267), take the DB it produced, feed it into the same merge/replace
   // flow. §SM-5 named the ceiling and it is measured, not theoretical: a single ~1GB+ source file
@@ -1089,6 +1237,16 @@ async function setupScene(A) {
     console.log('§OPEN_IFC files=' + files.length + ' names=' + Array.prototype.map.call(files, function(f){ return f.name; }).join(','));
     var out = await A.importMultiIFC(files);
     if (!out || !out.record) { console.log('§OPEN_IFC_FAIL reason=no_record_returned'); return; }
+    // §BUG 2026-08-29: a split-mode result (large building, e.g. LTU_AHouse 8-file merge) carries
+    // metaDb+geoDb as SEPARATE blobs — this used to take metaDb alone (`extractedDb || metaDb`) and
+    // silently drop geoDb, opening a metadata-only DB with zero mesh geometry. Route split results
+    // through _openSplitDbBytes instead, which keeps both halves.
+    if (out.split && out.record.metaDb && out.record.geoDb) {
+      console.log('§OPEN_IFC_DB building=' + out.buildingName + ' meta=' + out.record.metaDb.byteLength +
+        ' geo=' + out.record.geoDb.byteLength + ' split=true');
+      await A._openSplitDbBytes(out.buildingName + '_meta.db', new Uint8Array(out.record.metaDb), new Uint8Array(out.record.geoDb));
+      return;
+    }
     var bytes = out.record.extractedDb || out.record.metaDb;
     if (!bytes) { console.log('§OPEN_IFC_FAIL reason=no_db_bytes split=' + !!out.record.metaDb); return; }
     console.log('§OPEN_IFC_DB building=' + out.buildingName + ' bytes=' + bytes.byteLength + ' split=' + !!out.split);
@@ -1105,6 +1263,19 @@ async function setupScene(A) {
         for (var pi = 0; pi < picks.length; pi++) fsaFiles.push(await picks[pi].getFile());
         console.log('§OPEN_PICK mode=fsa n=' + fsaFiles.length + ' name=' + fsaFiles[0].name + ' bytes=' + fsaFiles[0].size);
         if (/\.ifc$/i.test(fsaFiles[0].name)) { await A._openIfcFiles(fsaFiles); return; }
+        // §BUG 2026-08-29: selecting a meta.db + geo.db pair together used to silently drop everything
+        // past fsaFiles[0] — picker return order isn't guaranteed alphabetical-by-role, so "geo.db"
+        // (no elements_meta at all) could load ALONE while meta.db (the actual data) was discarded.
+        // Detect the pair by name first, before falling into the single-file path.
+        var metaFile = fsaFiles.filter(function(f) { return /_meta\.db$/i.test(f.name); })[0];
+        var geoFile = fsaFiles.filter(function(f) { return /_geo\.db$/i.test(f.name); })[0];
+        if (fsaFiles.length >= 2 && metaFile && geoFile) {
+          console.log('§OPEN_PICK_SPLIT meta=' + metaFile.name + ' geo=' + geoFile.name);
+          var metaBuf = new Uint8Array(await metaFile.arrayBuffer());
+          var geoBuf = new Uint8Array(await geoFile.arrayBuffer());
+          await A._openSplitDbBytes(metaFile.name, metaBuf, geoBuf);
+          return;
+        }
         var buf = await fsaFiles[0].arrayBuffer();
         await A._openDbBytes(fsaFiles[0].name, new Uint8Array(buf));
         return;
@@ -1117,7 +1288,19 @@ async function setupScene(A) {
       var file = input.files[0];
       console.log('§OPEN_PICK mode=input n=' + input.files.length + ' name=' + file.name + ' bytes=' + file.size);
       if (/\.ifc$/i.test(file.name)) { await A._openIfcFiles(input.files); }
-      else { var buf = await file.arrayBuffer(); await A._openDbBytes(file.name, new Uint8Array(buf)); }
+      else {
+        var files2 = Array.prototype.slice.call(input.files);
+        var metaFile2 = files2.filter(function(f) { return /_meta\.db$/i.test(f.name); })[0];
+        var geoFile2 = files2.filter(function(f) { return /_geo\.db$/i.test(f.name); })[0];
+        if (files2.length >= 2 && metaFile2 && geoFile2) {
+          console.log('§OPEN_PICK_SPLIT mode=input meta=' + metaFile2.name + ' geo=' + geoFile2.name);
+          var metaBuf2 = new Uint8Array(await metaFile2.arrayBuffer());
+          var geoBuf2 = new Uint8Array(await geoFile2.arrayBuffer());
+          await A._openSplitDbBytes(metaFile2.name, metaBuf2, geoBuf2);
+        } else {
+          var buf2 = await file.arrayBuffer(); await A._openDbBytes(file.name, new Uint8Array(buf2));
+        }
+      }
       if (input.parentNode) document.body.removeChild(input);
     });
     document.body.appendChild(input); input.click();

--- a/viewer/sw.js
+++ b/viewer/sw.js
@@ -22,7 +22,7 @@
 // schedule_author.js is in PRECACHE_ASSETS; v1088 shipped the STAGE 3 drawer change (#1528), so this
 // separate change needs its own bump (§CRISIS LESSON 4).
 // DEPLOY: bump CACHE_VERSION on every OCI upload. Old caches are purged on activate.
-const CACHE_VERSION = 'v1098';   // bump on each deploy; per-change detail is the git commit message.
+const CACHE_VERSION = 'v1099';   // bump on each deploy; per-change detail is the git commit message.
 // v1092 (2026-08-27) §R10 (bim-compiler prompts/CPE_4D_PERF_MEM_FINDINGS.md §7, extends R1's
 // §MAXQ_STAGE_KEEP contract): the MaxQ bake's per-frame §GLOW_LENS_QUAD rebuild (viewer/effects.js)
 // now skips the dispose+rebuild when the TM-visible fixture count is unchanged since the last

--- a/viewer/tests/witness_open_split_db_pair_2026-08-29.js
+++ b/viewer/tests/witness_open_split_db_pair_2026-08-29.js
@@ -1,0 +1,182 @@
+// ⚠ DO NOT REMOVE — Scope guard
+// W-OPEN-SPLIT-PAIR — prompts/LTU_TERMINAL_CLINIC_RENDER_CORRUPTION.md §R follow-up
+//
+// THE ISSUE THIS TEST EXPOSES: the "Open" door (A.openModelDb) let a user multi-select a meta.db +
+// geo.db pair (exactly what a browser download of a split-mode import produces), but the code only
+// ever read the FIRST file — file-picker order isn't guaranteed, so "geo.db" (no elements_meta table
+// at all) could load ALONE while "meta.db" (the real data) was silently discarded. Separately,
+// _openIfcFiles took a split-mode importMultiIFC() result's metaDb and dropped its geoDb entirely,
+// so even the in-app "drop IFC while a building is open" merge path lost all mesh geometry for large
+// (split) buildings. Both symptoms reproduced live: §DB_SPLIT_DETECT meta=...geo.db geo=...geo.db
+// (same file twice), §CENTRES_RESULT rows=0 (geo.db alone has no elements_meta).
+//
+// Fix: A._openSplitDbBytes / A._mergeSplitDbIntoScene — split-aware siblings of the existing,
+// already-witnessed A._openDbBytes / A._mergeDbIntoScene (W-SCENE-MERGE), reusing the same
+// _mergeTable/_georefPin helpers with TWO sources (meta, geo) instead of one.
+//
+// PHASE A  Nothing open, select meta.db+geo.db together → real elements load (not 0), real geo mesh
+//          data cached under the correct _meta.db/_geo.db sibling URLs §DB_SPLIT_DETECT expects.
+// PHASE B  A building (Clinic) already open, select the SAME split pair → merge modal → Merge →
+//          building added to the LIVE scene, no navigation, both meta AND geo tables folded in.
+//
+// §-log first — READ tests/witness_open_split_db_pair_2026-08-29.log before any conclusion.
+// Run:  timeout 300 node viewer/tests/witness_open_split_db_pair_2026-08-29.js
+'use strict';
+const { chromium } = require(process.env.PW || (require('os').homedir() + '/bim-ootb/tests/node_modules/playwright'));
+const http = require('http'), fs = require('fs'), path = require('path');
+
+const ROOT = path.join(__dirname, '..', '..');
+const DATA_ROOT = '/home/red1/bim-ootb';
+const SCRATCH = '/tmp/claude-1000/-home-red1-bim-compiler/f18d6fef-97cb-4266-802e-ce981b8dd210/scratchpad/split_test';
+const CLINIC = path.join(DATA_ROOT, 'buildings', 'Clinic_extracted.db');
+const META = path.join(SCRATCH, 'Duplex_meta.db');
+const GEO = path.join(SCRATCH, 'Duplex_geo.db');
+const MIME = { '.html': 'text/html', '.js': 'text/javascript', '.json': 'application/json',
+  '.db': 'application/octet-stream', '.png': 'image/png', '.css': 'text/css', '.wasm': 'application/wasm',
+  '.bin': 'application/octet-stream' };
+const server = http.createServer((req, res) => {
+  let p = decodeURIComponent(req.url.split('?')[0]); if (p === '/') p = '/viewer/viewer.html';
+  const send = (buf) => { res.writeHead(200, { 'Content-Type': MIME[path.extname(p)] || 'application/octet-stream' }); res.end(buf); };
+  fs.readFile(path.join(ROOT, p), (e, buf) => {
+    if (!e) return send(buf);
+    fs.readFile(path.join(DATA_ROOT, p), (e2, buf2) => {
+      if (!e2) return send(buf2);
+      res.writeHead(404); res.end('404 ' + p);
+    });
+  });
+});
+
+const log = [];
+let fails = 0;
+function S(m) { log.push(m); console.log(m); }
+function verdict(ok, label, detail) { if (!ok) fails++; S('   ' + (ok ? '🟢' : '🔴') + ' ' + label + (detail ? ' — ' + detail : '')); }
+function save() { fs.writeFileSync(path.join(__dirname, 'witness_open_split_db_pair_2026-08-29.log'), log.join('\n') + '\n'); }
+
+async function waitReady(page, secs) {
+  let ready = false;
+  for (let i = 0; i < (secs || 120) && !ready; i++) {
+    await page.waitForTimeout(1000);
+    try {
+      ready = await page.evaluate(() => !!(window.APP && window.APP.guidMap
+        && Object.keys(window.APP.guidMap).length > 0 && window.APP.streaming === false));
+    } catch (e) {}
+  }
+  return ready;
+}
+
+function snap(page) {
+  return page.evaluate(() => {
+    const A = window.APP;
+    const q = (sql) => { try { const r = A.db.exec(sql); return r.length ? r[0].values : []; } catch (e) { return []; } };
+    return {
+      href: location.href,
+      centres: Object.keys(A.buildingCentres || {}),
+      guidMap: Object.keys(A.guidMap || {}).length,
+      totalElements: A.totalElements,
+      metaCount: (q('SELECT COUNT(*) FROM elements_meta')[0] || [null])[0],
+    };
+  });
+}
+
+// Same real-user path as W-SCENE-MERGE: FSA removed → hidden <input multiple> → Playwright answers
+// the chooser with an ARRAY of files (both meta.db and geo.db at once, exactly a real multi-select).
+async function openFiles(page, filePaths) {
+  await page.evaluate(() => { try { delete window.showOpenFilePicker; } catch (e) { window.showOpenFilePicker = undefined; } });
+  const [chooser] = await Promise.all([
+    page.waitForEvent('filechooser', { timeout: 30000 }),
+    page.evaluate(() => { window.APP.openModelDb(); }),
+  ]);
+  await chooser.setFiles(filePaths);
+}
+
+(async () => {
+  await new Promise(r => server.listen(0, r));
+  const PORT = server.address().port;
+  const browser = await chromium.launch({ args: ['--js-flags=--max-old-space-size=4096'] });
+  const ctx = await browser.newContext({ viewport: { width: 1400, height: 900 } });
+  const page = await ctx.newPage();
+  const cons = [];
+  page.on('console', m => cons.push(m.text()));
+  page.on('pageerror', e => cons.push('PAGEERROR ' + e.message));
+  const grep = (needle) => cons.filter(l => l.indexOf(needle) >= 0);
+
+  S('── W-OPEN-SPLIT-PAIR — witness_open_split_db_pair_2026-08-29 ──');
+  S('   ISSUE: does selecting meta.db+geo.db together actually load/merge BOTH halves?');
+
+  // ══ PHASE A ══ replace path — select the split pair, force "New" if a default building is already
+  // auto-loaded (a blank viewer.html isn't guaranteed empty state; same "Esc = New" pattern
+  // W-SCENE-MERGE's own Phase 3 already relies on) ══════════════════════════════════════════════
+  S('\n── PHASE A: select Duplex_meta.db + Duplex_geo.db together (replace path) ──');
+  await page.goto('http://127.0.0.1:' + PORT + '/viewer/viewer.html', { waitUntil: 'networkidle' });
+  await waitReady(page, 30);   // let any default auto-load settle before touching the picker
+  cons.length = 0;
+  await openFiles(page, [META, GEO]);
+  try {
+    await page.waitForSelector('#merge-modal', { state: 'visible', timeout: 5000 });
+    S('     [note] a building was already open (auto-loaded default) — clicking New to force replace');
+    await page.click('#merge-new-btn');
+  } catch (e) { /* no modal — nothing was open, straight replace, as originally expected */ }
+  const readyA = await waitReady(page, 90);
+  verdict(readyA, 'split pair loaded + streaming complete (not stuck/blank)');
+  if (!readyA) {
+    S('   [console tail] ' + cons.slice(-40).join('\n     '));
+    S('\n❌ ABORT — Phase A never became ready'); save(); await browser.close(); server.close(); process.exit(1);
+  }
+  const pickLine = grep('§OPEN_PICK_SPLIT')[0];
+  verdict(!!pickLine, 'the picker detected the pair by name (not silently using file[0] alone)', pickLine || 'no §OPEN_PICK_SPLIT');
+  const splitDetect = grep('§DB_SPLIT_DETECT')[0] || '';
+  verdict(/found=true/.test(splitDetect), 'streaming.js confirmed real split mode (both halves present)', splitDetect || 'no §DB_SPLIT_DETECT line');
+  verdict(!/meta=.*geo\.db.*geo=.*geo\.db/.test(splitDetect), 'meta URL and geo URL are DIFFERENT files (the original bug: both pointed at geo.db)', splitDetect);
+  const snapA = await snap(page);
+  verdict(snapA.metaCount === 1193, 'real element count loaded from META (not 0 — the original bug loaded geo.db alone, which has no elements_meta)', 'metaCount=' + snapA.metaCount);
+  verdict(snapA.guidMap > 0, 'geometry actually streamed (guidMap has real pickable elements)', 'guidMap=' + snapA.guidMap);
+  S('     [state] Phase A: href=' + snapA.href + ' centres=' + JSON.stringify(snapA.centres) + ' metaCount=' + snapA.metaCount + ' guidMap=' + snapA.guidMap);
+S('     [console tail 15] ' + cons.slice(-15).join('\n' + '       '));
+
+  // ══ PHASE B ══ Clinic already open, select the split pair → MERGE into the live scene ══════════
+  S('\n── PHASE B: Clinic loaded, then Open→Merge the same Duplex split pair ──');
+  await page.goto('http://127.0.0.1:' + PORT + '/viewer/viewer.html?db=buildings/Clinic_extracted.db', { waitUntil: 'networkidle' });
+  const readyB0 = await waitReady(page, 120);
+  verdict(readyB0, 'building Clinic loaded + streaming complete (Phase B setup)');
+  if (!readyB0) { S('\n❌ ABORT — Clinic never became ready'); save(); await browser.close(); server.close(); process.exit(1); }
+  await page.evaluate(() => { window.__mergeEpoch = 'E' + Date.now(); });
+  const beforeB = await snap(page);
+  S('     [state] before: centres=' + JSON.stringify(beforeB.centres) + ' metaCount=' + beforeB.metaCount);
+
+  cons.length = 0;
+  await openFiles(page, [META, GEO]);
+  await page.waitForSelector('#merge-modal', { state: 'visible', timeout: 30000 });
+  const promptLine = grep('§MERGE_PROMPT')[0];
+  verdict(!!promptLine, 'merge prompt shown instead of silently replacing the live scene', promptLine || 'no §MERGE_PROMPT');
+  await page.click('#merge-btn');
+  let mergeDone = null;
+  for (let i = 0; i < 120 && !mergeDone; i++) { await page.waitForTimeout(1000); mergeDone = grep('§MERGE_SPLIT_DONE')[0]; }
+  S('     [console] ' + (grep('§MERGE_SPLIT_START')[0] || 'no §MERGE_SPLIT_START'));
+  S('     [console] ' + (grep('§MERGE_SPLIT_TABLES')[0] || 'no §MERGE_SPLIT_TABLES'));
+  grep('§MERGE_SPLIT_FAIL').forEach(l => S('     [console] ' + l));
+  verdict(!!mergeDone, '§MERGE_SPLIT_DONE emitted (the new split-aware merge path actually ran)', mergeDone || 'never');
+  verdict(!grep('§MERGE_SPLIT_FAIL').length, 'no §MERGE_SPLIT_FAIL', 'fails=' + grep('§MERGE_SPLIT_FAIL').length);
+  if (!mergeDone) { S('\n❌ ABORT — split merge never completed'); S('   last console: ' + cons.slice(-25).join('\n     ')); save(); await browser.close(); server.close(); process.exit(1); }
+
+  const tablesLine = grep('§MERGE_SPLIT_TABLES')[0] || '';
+  verdict(/"elements_meta"/.test(tablesLine), 'META tables folded from the meta.db source (not lost)', tablesLine);
+  verdict(/"component_geometries"/.test(tablesLine), 'GEO tables folded from the geo.db source — THIS is the exact thing the old code dropped', tablesLine);
+
+  let settled = false;
+  for (let i = 0; i < 300 && !settled; i++) {
+    await page.waitForTimeout(1000);
+    settled = await page.evaluate(() => !!(window.APP && window.APP.streaming === false
+      && (!window.APP._mergePending || window.APP._mergePending.length === 0)));
+  }
+  const afterB = await snap(page);
+  verdict(settled, 'merged building finished streaming');
+  verdict(afterB.href.split('#')[0] === beforeB.href.split('#')[0], 'no page navigation (real merge, not a replace)', afterB.href);
+  verdict(afterB.centres.length > beforeB.centres.length, 'new building really joined the live scene', 'before=' + beforeB.centres.length + ' after=' + afterB.centres.length + ' ' + JSON.stringify(afterB.centres));
+  verdict(afterB.metaCount > beforeB.metaCount, 'element count grew by the merged building (data really landed, not just the prompt)', 'before=' + beforeB.metaCount + ' after=' + afterB.metaCount);
+
+  S('\n── VERDICT ──');
+  S('   ' + (fails === 0 ? '🟢 W-OPEN-SPLIT-PAIR PASS' : '🔴 W-OPEN-SPLIT-PAIR FAIL (' + fails + ' failed assertion(s))'));
+  save();
+  await browser.close(); server.close();
+  process.exit(fails === 0 ? 0 : 1);
+})();


### PR DESCRIPTION
## Summary
- `A.openModelDb()` let you multi-select files but only ever read the first one — selecting a `meta.db`+`geo.db` pair together could load geo.db alone (no `elements_meta`) while meta.db was silently discarded. Reproduced live: `§DB_SPLIT_DETECT meta=...geo.db geo=...geo.db` (same file twice), `§CENTRES_RESULT rows=0`.
- `_openIfcFiles` took a split-mode `importMultiIFC()` result's `metaDb` and dropped `geoDb` entirely, so the in-app "drop IFC while a building is open" path lost all mesh geometry for large (split) buildings.
- Added `A._openSplitDbBytes` / `A._mergeSplitDbIntoScene` — split-aware siblings of the existing `A._openDbBytes` / `A._mergeDbIntoScene` (W-SCENE-MERGE), reusing the same `_mergeTable`/`_georefPin` helpers with two sources instead of one. Wired into `openModelDb`'s file-picker (FSA + `<input>` fallback) and into `_openIfcFiles`' split branch.
- `sw.js` CACHE_VERSION v1098→v1099 (same-PR, `viewer/scene.js` changed).

## Test plan
- [x] New witness `viewer/tests/witness_open_split_db_pair_2026-08-29.js` (W-OPEN-SPLIT-PAIR) — both phases PASS: replace path loads real data (not 0, not geo-only), merge path folds both meta AND geo tables into a live scene, no navigation.
- [x] Existing `witness_scene_merge_2026-07-30.js` (W-SCENE-MERGE) re-run against this branch — same 3 pre-existing failures as on a clean `origin/main` baseline (unrelated Duplex/Clinic `normals`-column schema mismatch), confirming zero regression.

🤖 Generated with [Claude Code](https://claude.com/claude-code)