### PR TITLE
fix(merge): merged IFC lost its geometry on save — geo fold died on a table-name mismatch

### DIFF
--- a/scripts/make_merge_roundtrip_fixtures.py
+++ b/scripts/make_merge_roundtrip_fixtures.py
@@ -1,0 +1,92 @@
+# Builds three fixture DBs for W-MERGE-GEO-FOLD, all EXTRACTED from the real shipped
+# LTU_AHouse DBs + the verbatim import_db_builder.js schema. Nothing invented.
+import sqlite3, os, shutil, sys
+SRC_META = '/home/red1/bim-ootb/buildings/LTU_AHouse_meta.db'
+SRC_GEO  = '/home/red1/bim-ootb/buildings/LTU_AHouse_geo.db'
+OUT = sys.argv[1]
+os.makedirs(OUT, exist_ok=True)
+N_KEEP = 300          # scene-side ("LTU minus ARC") element sample
+N_ARC  = 120          # incoming import sample
+
+src_m = sqlite3.connect(SRC_META); src_g = sqlite3.connect(SRC_GEO)
+
+# Scene side: take N_KEEP non-ARC elements that HAVE geometry, and N_ARC ARC elements to play
+# the role of the "intentionally left out" discipline.
+keep = src_m.execute("""SELECT m.guid FROM elements_meta m JOIN element_instances i ON i.guid=m.guid
+                        WHERE m.discipline<>'ARC' AND i.geometry_hash IS NOT NULL LIMIT ?""", (N_KEEP,)).fetchall()
+arc  = src_m.execute("""SELECT m.guid FROM elements_meta m JOIN element_instances i ON i.guid=m.guid
+                        WHERE m.discipline='ARC'  AND i.geometry_hash IS NOT NULL LIMIT ?""", (N_ARC,)).fetchall()
+keep = [r[0] for r in keep]; arc = [r[0] for r in arc]
+assert len(keep) == N_KEEP and len(arc) == N_ARC, (len(keep), len(arc))
+
+def ddl(conn, t):
+    r = conn.execute("SELECT sql FROM sqlite_master WHERE type='table' AND name=?", (t,)).fetchone()
+    return r[0] if r else None
+
+# ── 1. LTUish_meta.db — real server schema (elements_meta has NO `building` column) ──
+p = os.path.join(OUT, 'LTUish_meta.db')
+if os.path.exists(p): os.remove(p)
+dm = sqlite3.connect(p)
+for t in ('elements_meta', 'element_transforms', 'element_instances', 'project_metadata'):
+    d = ddl(src_m, t)
+    if d: dm.execute(d)
+ph = ','.join('?' * len(keep))
+for t in ('elements_meta', 'element_transforms', 'element_instances'):
+    cols = [c[1] for c in src_m.execute('PRAGMA table_info(%s)' % t)]
+    rows = src_m.execute('SELECT * FROM %s WHERE guid IN (%s)' % (t, ph), keep).fetchall()
+    dm.executemany('INSERT INTO %s VALUES (%s)' % (t, ','.join('?' * len(cols))), rows)
+dm.executemany('INSERT INTO project_metadata VALUES (?,?)',
+               src_m.execute('SELECT key, value FROM project_metadata').fetchall())
+dm.commit()
+mcols = [c[1] for c in dm.execute('PRAGMA table_info(elements_meta)')]
+assert 'building' not in mcols, 'fixture must reproduce the real no-building-column shape'
+
+# ── 2. LTUish_geo.db — real geo schema: base_geometries (NOT component_geometries) ──
+p = os.path.join(OUT, 'LTUish_geo.db')
+if os.path.exists(p): os.remove(p)
+dg = sqlite3.connect(p)
+dg.execute(ddl(src_g, 'base_geometries'))
+hashes = [r[0] for r in dm.execute('SELECT DISTINCT geometry_hash FROM element_instances WHERE geometry_hash IS NOT NULL')]
+gph = ','.join('?' * len(hashes))
+grows = src_g.execute('SELECT * FROM base_geometries WHERE geometry_hash IN (%s)' % gph, hashes).fetchall()
+dg.executemany('INSERT INTO base_geometries VALUES (?,?,?,?,?)', grows)
+dg.commit()
+
+# ── 3. ARCimport.db — VERBATIM import_db_builder.js schema (component_geometries + `building`) ──
+p = os.path.join(OUT, 'ARCimport.db')
+if os.path.exists(p): os.remove(p)
+da = sqlite3.connect(p)
+da.execute('CREATE TABLE project_metadata (key TEXT PRIMARY KEY, value TEXT)')
+da.execute('CREATE TABLE elements_meta (guid TEXT PRIMARY KEY, ifc_class TEXT, element_name TEXT, storey TEXT, discipline TEXT, material_name TEXT, material_rgba TEXT, building TEXT)')
+da.execute('CREATE TABLE element_transforms (guid TEXT PRIMARY KEY, center_x REAL, center_y REAL, center_z REAL, rotation_x REAL, rotation_y REAL, rotation_z REAL, bbox_x REAL, bbox_y REAL, bbox_z REAL)')
+da.execute('CREATE TABLE element_instances (guid TEXT PRIMARY KEY, geometry_hash TEXT)')
+da.execute('CREATE TABLE component_geometries (geometry_hash TEXT PRIMARY KEY, vertices BLOB, faces BLOB, normals BLOB, building TEXT)')
+da.execute('CREATE TABLE bom_tree (parent_guid TEXT NOT NULL, child_guid TEXT NOT NULL, rel_type TEXT NOT NULL, PRIMARY KEY (parent_guid, child_guid))')
+BLD = 'LTU_AHouse_ARC'
+aph = ','.join('?' * len(arc))
+for guid, ic, en, st, di, mn, mr in src_m.execute(
+        'SELECT guid, ifc_class, element_name, storey, discipline, material_name, material_rgba '
+        'FROM elements_meta WHERE guid IN (%s)' % aph, arc):
+    da.execute('INSERT INTO elements_meta VALUES (?,?,?,?,?,?,?,?)', (guid, ic, en, st, di, mn, mr, BLD))
+da.executemany('INSERT INTO element_transforms VALUES (?,?,?,?,?,?,?,?,?,?)',
+               src_m.execute('SELECT * FROM element_transforms WHERE guid IN (%s)' % aph, arc).fetchall())
+da.executemany('INSERT INTO element_instances VALUES (?,?)',
+               src_m.execute('SELECT guid, geometry_hash FROM element_instances WHERE guid IN (%s)' % aph, arc).fetchall())
+ah = [r[0] for r in da.execute('SELECT DISTINCT geometry_hash FROM element_instances WHERE geometry_hash IS NOT NULL')]
+ahp = ','.join('?' * len(ah))
+for gh, v, f, vc, fc in src_g.execute('SELECT * FROM base_geometries WHERE geometry_hash IN (%s)' % ahp, ah):
+    da.execute('INSERT INTO component_geometries VALUES (?,?,?,?,?)', (gh, v, f, None, BLD))
+da.executemany('INSERT INTO project_metadata VALUES (?,?)',
+               src_m.execute('SELECT key, value FROM project_metadata').fetchall())
+da.commit()
+
+print('§FX meta_elements=%d meta_hasBuildingCol=%s' % (
+    dm.execute('SELECT COUNT(*) FROM elements_meta').fetchone()[0], 'building' in mcols))
+print('§FX geo_base_geometries=%d  (component_geometries absent: %s)' % (
+    dg.execute('SELECT COUNT(*) FROM base_geometries').fetchone()[0],
+    dg.execute("SELECT COUNT(*) FROM sqlite_master WHERE name='component_geometries'").fetchone()[0] == 0))
+print('§FX arc_elements=%d arc_component_geometries=%d arc_hasBuildingCol=True' % (
+    da.execute('SELECT COUNT(*) FROM elements_meta').fetchone()[0],
+    da.execute('SELECT COUNT(*) FROM component_geometries').fetchone()[0]))
+print('§FX guid_overlap_scene_vs_arc=%d (must be 0)' % len(set(keep) & set(arc)))
+for c in (dm, dg, da, src_m, src_g): c.close()

--- a/viewer/scene.js
+++ b/viewer/scene.js
@@ -887,7 +887,31 @@ async function setupScene(A) {
   // A._libHasNormals (streaming.js:868) honest after a merge.
   function _mergeTable(src, dst, table) {
     var sCols = _mergeCols(src, table), dCols = _mergeCols(dst, table);
-    if (!sCols || !dCols) return null;
+    if (!sCols) return null;
+    // §MERGE_CREATE 2026-08-30 — "fold only when the table exists on BOTH sides" silently threw away
+    // every incoming geometry BLOB whenever the two sides name that table differently: a server
+    // split geo.db carries `base_geometries`, a client-side IFC import carries
+    // `component_geometries` (import_db_builder.js:66). Neither name was ever on both sides, so
+    // _MERGE_GEO_TABLES folded NOTHING and the merged building saved with no geometry at all
+    // (W-MERGE-SAVE-ROUNDTRIP). The readers already accept either name (streaming.js:1162,1212), so
+    // materialising the source's own table in the destination is what makes the fold lossless.
+    // Only ever reached for the fixed _MERGE_META_TABLES/_MERGE_GEO_TABLES whitelist.
+    if (!dCols) {
+      var ddl = null;
+      try {
+        var dr = src.exec("SELECT sql FROM sqlite_master WHERE type='table' AND name='" +
+          table.replace(/'/g, "''") + "'");
+        if (dr && dr.length && dr[0].values.length) ddl = dr[0].values[0][0];
+      } catch (e) {}
+      if (!ddl) return null;
+      try { dst.run(ddl); } catch (e) {
+        console.warn('§MERGE_CREATE_FAIL table=' + table + ' ' + e.message); return null;
+      }
+      dCols = _mergeCols(dst, table);
+      if (!dCols) return null;
+      console.log('§MERGE_CREATE table=' + table + ' cols=' + dCols.length +
+        ' — destination had no such table, created from source schema');
+    }
     var cols = dCols.filter(function(c) { return sCols.indexOf(c) >= 0; });
     if (!cols.length) return null;
     var q = cols.map(function(c) { return '"' + c + '"'; }).join(',');
@@ -909,6 +933,51 @@ async function setupScene(A) {
       ' after=' + after + ' added=' + added + ' dup=' + dup + ' errs=' + errs +
       ' cols=' + cols.length + '/src' + sCols.length + '/dst' + dCols.length);
     return { src: srcRows, before: before, after: after, added: added, dup: dup, errs: errs };
+  }
+
+  // §MERGE_BLDCOL 2026-08-30 — LTU_AHouse_meta.db's elements_meta has NO `building` column
+  // (streaming.js:26-31, CPE_4D_PERF_MEM_FINDINGS §R6). Two consequences, both live bugs:
+  //   1. _mergeTable's destination-driven column intersection DROPS the incoming building name, so
+  //      a merged DB cannot say which rows are the new building.
+  //   2. the `GROUP BY m.building` centres query below throws (§HELPERS_QUERY_ERR), gets swallowed
+  //      by dbQuery, and leaves added=[] — the merged building is never registered, never streams.
+  // Add the column once, backfilling existing rows with the label the scene is ALREADY using for
+  // them (read off buildingCentres — extracted from live state, never invented), so both the live
+  // scene and every DB saved from it can name both buildings.
+  function _ensureBuildingCol(dst, src) {
+    var sCols = _mergeCols(src, 'elements_meta'), dCols = _mergeCols(dst, 'elements_meta');
+    if (!sCols || !dCols) return false;
+    if (dCols.indexOf('building') >= 0) return true;
+    if (sCols.indexOf('building') < 0) return false;   // neither side has it — nothing to preserve
+    var keys = Object.keys(A.buildingCentres || {});
+    var label = (keys.length === 1) ? keys[0]
+      : (A._singleBuildingName ? A._singleBuildingName() : 'building');
+    try {
+      dst.run('ALTER TABLE elements_meta ADD COLUMN building TEXT');
+      dst.run('UPDATE elements_meta SET building = ? WHERE building IS NULL', [label]);
+      var n = 0;
+      try { n = dst.exec("SELECT COUNT(*) FROM elements_meta WHERE building = ?", [label])[0].values[0][0]; } catch (e) {}
+      // streaming.js probes this ONCE and caches — a stale `false` would keep every m.building
+      // query on the single-building fallback for the rest of the session.
+      A._buildingCol = true;
+      console.log('§MERGE_BLDCOL added=building backfill="' + label + '" rows=' + n);
+      return true;
+    } catch (e) { console.warn('§MERGE_BLDCOL_FAIL ' + e.message); return false; }
+  }
+
+  // The centres re-query both merge paths run in their step 6. Mirrors streaming.js:2501's
+  // _hasBuildingCol guard, which the merge copies were written without.
+  function _mergeCentresRows() {
+    var ok = A._hasBuildingCol ? A._hasBuildingCol(A.db) : true;
+    if (ok) {
+      return A.dbQuery('SELECT m.building, COUNT(*), AVG(t.center_x), AVG(t.center_y), AVG(t.center_z) ' +
+        'FROM elements_meta m JOIN element_transforms t ON t.guid = m.guid GROUP BY m.building');
+    }
+    var label = (A._singleBuildingName ? A._singleBuildingName() : 'building');
+    console.log('§MERGE_CENTRES_FALLBACK no building column — one building, one centre name="' + label + '"');
+    return A.dbQuery("SELECT '" + label.replace(/'/g, "''") + "', COUNT(*), " +
+      'AVG(t.center_x), AVG(t.center_y), AVG(t.center_z) ' +
+      'FROM elements_meta m JOIN element_transforms t ON t.guid = m.guid');
   }
 
   function _georefPin(db) {
@@ -965,6 +1034,7 @@ async function setupScene(A) {
 
     // ── §SM-7.1 step 3: fold the tables
     var stats = {};
+    _ensureBuildingCol(A.db, src);
     A._MERGE_META_TABLES.forEach(function(t) { var s = _mergeTable(src, A.db, t); if (s) stats[t] = s; });
     if (A.libDb) {
       A._MERGE_GEO_TABLES.forEach(function(t) {
@@ -972,6 +1042,10 @@ async function setupScene(A) {
         if (s) stats[t] = s;
         else if (A.libDb !== A.db) { var s2 = _mergeTable(src, A.db, t); if (s2) stats[t] = s2; }
       });
+    } else {
+      // A.libDb is null in several streaming modes (streaming.js:2302,2479). Without this branch the
+      // geometry fold was skipped outright — the split sibling below always had it, this one didn't.
+      A._MERGE_GEO_TABLES.forEach(function(t) { var s = _mergeTable(src, A.db, t); if (s) stats[t] = s; });
     }
     console.log('§MERGE_TABLES folded=' + JSON.stringify(Object.keys(stats)) +
       ' skipped=' + JSON.stringify(A._MERGE_META_TABLES.concat(A._MERGE_GEO_TABLES).filter(function(t){ return !stats[t]; })));
@@ -996,8 +1070,7 @@ async function setupScene(A) {
     for (var k0 in A.buildingCentres) { if (A.buildingCentres[k0].envelope) { env = A.buildingCentres[k0].envelope; break; } }
     var added = [];
     try {
-      var centres = A.dbQuery('SELECT m.building, COUNT(*), AVG(t.center_x), AVG(t.center_y), AVG(t.center_z) ' +
-        'FROM elements_meta m JOIN element_transforms t ON t.guid = m.guid GROUP BY m.building');
+      var centres = _mergeCentresRows();
       for (var ci = 0; ci < centres.length; ci++) {
         var row = centres[ci];
         if (A.buildingCentres[row[0]]) { A.buildingCentres[row[0]].count = row[1]; continue; }
@@ -1079,6 +1152,7 @@ async function setupScene(A) {
 
     // Fold tables: META_TABLES from srcMeta, GEO_TABLES from srcGeo — same _mergeTable helper, two sources.
     var stats = {};
+    _ensureBuildingCol(A.db, srcMeta);
     A._MERGE_META_TABLES.forEach(function(t) { var s = _mergeTable(srcMeta, A.db, t); if (s) stats[t] = s; });
     if (A.libDb) {
       A._MERGE_GEO_TABLES.forEach(function(t) {
@@ -1111,8 +1185,7 @@ async function setupScene(A) {
     for (var k0 in A.buildingCentres) { if (A.buildingCentres[k0].envelope) { env = A.buildingCentres[k0].envelope; break; } }
     var added = [];
     try {
-      var centres = A.dbQuery('SELECT m.building, COUNT(*), AVG(t.center_x), AVG(t.center_y), AVG(t.center_z) ' +
-        'FROM elements_meta m JOIN element_transforms t ON t.guid = m.guid GROUP BY m.building');
+      var centres = _mergeCentresRows();
       for (var ci = 0; ci < centres.length; ci++) {
         var row = centres[ci];
         if (A.buildingCentres[row[0]]) { A.buildingCentres[row[0]].count = row[1]; continue; }

--- a/viewer/sw.js
+++ b/viewer/sw.js
@@ -22,7 +22,7 @@
 // schedule_author.js is in PRECACHE_ASSETS; v1088 shipped the STAGE 3 drawer change (#1528), so this
 // separate change needs its own bump (§CRISIS LESSON 4).
 // DEPLOY: bump CACHE_VERSION on every OCI upload. Old caches are purged on activate.
-const CACHE_VERSION = 'v1099';   // bump on each deploy; per-change detail is the git commit message.
+const CACHE_VERSION = 'v1100';   // bump on each deploy; per-change detail is the git commit message.
 // v1092 (2026-08-27) §R10 (bim-compiler prompts/CPE_4D_PERF_MEM_FINDINGS.md §7, extends R1's
 // §MAXQ_STAGE_KEEP contract): the MaxQ bake's per-frame §GLOW_LENS_QUAD rebuild (viewer/effects.js)
 // now skips the dispose+rebuild when the TM-visible fixture count is unchanged since the last

--- a/viewer/tests/witness_merge_save_roundtrip_2026-08-30.js
+++ b/viewer/tests/witness_merge_save_roundtrip_2026-08-30.js
@@ -1,0 +1,244 @@
+// ⚠ DO NOT REMOVE — Scope guard
+// W-MERGE-SAVE-ROUNDTRIP — prompts/LTU_TERMINAL_CLINIC_RENDER_CORRUPTION.md §U
+//
+// THE ISSUE THIS TEST EXPOSES (user report, 2026-08-30, verbatim): "Can open the meta/geo DBs and
+// then add another IFC in this case ARC which was intentionally left out to test LTU. But when
+// saving the merged one, which is extracted DB and reopening, it still does not has the merged ARC."
+//
+// Three defects in ONE chain, all reproduced here on REAL LTU_AHouse data shapes:
+//   1. GEO FOLD DIES ON A TABLE-NAME MISMATCH. _mergeTable() only folds a table present on BOTH
+//      sides. The scene's geo.db carries `base_geometries`; a client-side IFC import carries
+//      `component_geometries` (import_db_builder.js:66). Neither name exists on both sides, so the
+//      incoming geometry is folded NOWHERE — silently, visible only as §MERGE_TABLES skipped=[...].
+//   2. THE CENTRES QUERY IS UNGUARDED. _mergeDbIntoScene/_mergeSplitDbIntoScene hardcode
+//      `GROUP BY m.building`, but LTU_AHouse_meta.db's elements_meta HAS NO `building` COLUMN
+//      (streaming.js:26-31 / CPE_4D_PERF_MEM_FINDINGS §R6 already measured this). The query throws,
+//      is swallowed, added=[] — so the merged building is never registered and never streams.
+//   3. `building` IS DISCARDED ON THE WAY IN. _mergeTable's destination-driven column intersection
+//      drops the source's `building` value when the destination lacks the column, so even a
+//      successful merge cannot say which rows are the new building.
+//
+// PHASE A  Open LTUish_meta.db + LTUish_geo.db as a split pair (the "LTU minus ARC" scene).
+// PHASE B  Merge ARCimport.db (verbatim import_db_builder.js schema) — assert geometry ACTUALLY
+//          folds and the new building registers.
+// PHASE C  THE USER'S ACTUAL COMPLAINT: A._exportBuildingDb() → reopen those exact bytes → assert
+//          the ARC elements AND their resolvable geometry survive the round-trip.
+//
+// §-log first — READ tests/witness_merge_save_roundtrip_2026-08-30.log before any conclusion.
+// Fixtures are built by scripts/make_merge_roundtrip_fixtures.py, EXTRACTED from the real shipped
+// buildings/LTU_AHouse_{meta,geo}.db — no invented rows, no invented schema.
+// Run:  timeout 600 node viewer/tests/witness_merge_save_roundtrip_2026-08-30.js
+'use strict';
+const { chromium } = require(process.env.PW || (require('os').homedir() + '/bim-ootb/tests/node_modules/playwright'));
+const http = require('http'), fs = require('fs'), path = require('path');
+
+const ROOT = path.join(__dirname, '..', '..');
+const DATA_ROOT = '/home/red1/bim-ootb';
+const FX = process.env.FX || '/tmp/claude-1000/-home-red1-bim-compiler/44cdbb2b-5d15-48a2-a387-baa2b66d404a/scratchpad/fx';
+const META = path.join(FX, 'LTUish_meta.db');
+const GEO  = path.join(FX, 'LTUish_geo.db');
+const ARC  = path.join(FX, 'ARCimport.db');
+const ARC_BUILDING = 'LTU_AHouse_ARC';
+const MIME = { '.html': 'text/html', '.js': 'text/javascript', '.json': 'application/json',
+  '.db': 'application/octet-stream', '.png': 'image/png', '.css': 'text/css', '.wasm': 'application/wasm',
+  '.bin': 'application/octet-stream' };
+const server = http.createServer((req, res) => {
+  let p = decodeURIComponent(req.url.split('?')[0]); if (p === '/') p = '/viewer/viewer.html';
+  const send = (buf) => { res.writeHead(200, { 'Content-Type': MIME[path.extname(p)] || 'application/octet-stream' }); res.end(buf); };
+  fs.readFile(path.join(ROOT, p), (e, buf) => {
+    if (!e) return send(buf);
+    fs.readFile(path.join(DATA_ROOT, p), (e2, buf2) => {
+      if (!e2) return send(buf2);
+      res.writeHead(404); res.end('404 ' + p);
+    });
+  });
+});
+
+const log = [];
+let fails = 0;
+function S(m) { log.push(m); console.log(m); }
+function verdict(ok, label, detail) { if (!ok) fails++; S('   ' + (ok ? '🟢' : '🔴') + ' ' + label + (detail ? ' — ' + detail : '')); }
+function save() { fs.writeFileSync(path.join(__dirname, 'witness_merge_save_roundtrip_2026-08-30.log'), log.join('\n') + '\n'); }
+
+async function waitReady(page, secs) {
+  let ready = false;
+  for (let i = 0; i < (secs || 120) && !ready; i++) {
+    await page.waitForTimeout(1000);
+    try {
+      ready = await page.evaluate(() => !!(window.APP && window.APP.guidMap
+        && Object.keys(window.APP.guidMap).length > 0 && window.APP.streaming === false));
+    } catch (e) {}
+  }
+  return ready;
+}
+
+async function openFiles(page, filePaths) {
+  await page.evaluate(() => { try { delete window.showOpenFilePicker; } catch (e) { window.showOpenFilePicker = undefined; } });
+  const [chooser] = await Promise.all([
+    page.waitForEvent('filechooser', { timeout: 30000 }),
+    page.evaluate(() => { window.APP.openModelDb(); }),
+  ]);
+  await chooser.setFiles(filePaths);
+}
+
+(async () => {
+  for (const f of [META, GEO, ARC]) {
+    if (!fs.existsSync(f)) { S('❌ missing fixture ' + f + ' — run scripts/make_merge_roundtrip_fixtures.py first'); save(); process.exit(1); }
+  }
+  await new Promise(r => server.listen(0, r));
+  const PORT = server.address().port;
+  const browser = await chromium.launch({ args: ['--js-flags=--max-old-space-size=4096'] });
+  const ctx = await browser.newContext({ viewport: { width: 1400, height: 900 } });
+  const page = await ctx.newPage();
+  const cons = [];
+  page.on('console', m => cons.push(m.text()));
+  page.on('pageerror', e => cons.push('PAGEERROR ' + e.message));
+  const grep = (needle) => cons.filter(l => l.indexOf(needle) >= 0);
+
+  S('── W-MERGE-SAVE-ROUNDTRIP — witness_merge_save_roundtrip_2026-08-30 ──');
+  S('   ISSUE: merge an IFC into an open split-DB scene, SAVE, REOPEN — does the merged building survive?');
+
+  // ══ PHASE A — open the "LTU minus ARC" split pair ═══════════════════════════════════════════
+  S('\n── PHASE A: open LTUish_meta.db + LTUish_geo.db (split pair, elements_meta has NO `building` column) ──');
+  await page.goto('http://127.0.0.1:' + PORT + '/viewer/viewer.html', { waitUntil: 'networkidle' });
+  await waitReady(page, 30);
+  cons.length = 0;
+  await openFiles(page, [META, GEO]);
+  try {
+    await page.waitForSelector('#merge-modal', { state: 'visible', timeout: 5000 });
+    S('     [note] a default building was auto-loaded — clicking New to force replace');
+    await page.click('#merge-new-btn');
+  } catch (e) { /* nothing open — straight replace */ }
+  const readyA = await waitReady(page, 90);
+  verdict(readyA, 'split pair loaded + streaming complete');
+  if (!readyA) {
+    S('   [console tail] ' + cons.slice(-40).join('\n     '));
+    S('\n❌ ABORT — Phase A never became ready'); save(); await browser.close(); server.close(); process.exit(1);
+  }
+  const stateA = await page.evaluate(() => {
+    const A = window.APP;
+    const q = (db, sql) => { try { const r = db.exec(sql); return r.length ? r[0].values[0][0] : null; } catch (e) { return null; } };
+    const tbls = (db) => { try { const r = db.exec("SELECT name FROM sqlite_master WHERE type='table'"); return r.length ? r[0].values.map(v => v[0]) : []; } catch (e) { return []; } };
+    return {
+      metaCount: q(A.db, 'SELECT COUNT(*) FROM elements_meta'),
+      hasBuildingCol: !!(A._hasBuildingCol && A._hasBuildingCol(A.db)),
+      libIsDb: A.libDb === A.db,
+      dbTables: tbls(A.db),
+      libTables: A.libDb ? tbls(A.libDb) : null,
+      centres: Object.keys(A.buildingCentres || {}),
+    };
+  });
+  verdict(stateA.metaCount === 300, 'scene loaded the 300 non-ARC elements from META', 'metaCount=' + stateA.metaCount);
+  verdict(stateA.hasBuildingCol === false, 'fixture faithfully reproduces LTU: elements_meta has NO `building` column', 'hasBuildingCol=' + stateA.hasBuildingCol);
+  verdict(stateA.libTables && stateA.libTables.indexOf('base_geometries') >= 0, 'scene geometry lives in `base_geometries` (server split shape)', 'libTables=' + JSON.stringify(stateA.libTables));
+  S('     [state] centres=' + JSON.stringify(stateA.centres) + ' libIsDb=' + stateA.libIsDb);
+
+  // ══ PHASE B — merge the import-shaped ARC DB ════════════════════════════════════════════════
+  S('\n── PHASE B: Open→Merge ARCimport.db (import_db_builder.js shape: component_geometries + `building`) ──');
+  cons.length = 0;
+  await openFiles(page, [ARC]);
+  await page.waitForSelector('#merge-modal', { state: 'visible', timeout: 30000 });
+  await page.click('#merge-btn');
+  let mergeDone = null;
+  for (let i = 0; i < 120 && !mergeDone; i++) { await page.waitForTimeout(1000); mergeDone = grep('§MERGE_DONE')[0]; }
+  S('     [console] ' + (grep('§MERGE_START')[0] || 'no §MERGE_START'));
+  const tablesLine = grep('§MERGE_TABLES')[0] || '';
+  S('     [console] ' + (tablesLine || 'no §MERGE_TABLES'));
+  grep('§MERGE_ROWS').forEach(l => S('     [console] ' + l));
+  S('     [console] ' + (grep('§MERGE_CENTRES')[0] || 'no §MERGE_CENTRES'));
+  grep('§MERGE_CENTRES_FAIL').forEach(l => S('     [console] ' + l));
+  verdict(!!mergeDone, '§MERGE_DONE emitted', mergeDone || 'never');
+  if (!mergeDone) { S('\n❌ ABORT — merge never completed'); S('   ' + cons.slice(-25).join('\n     ')); save(); await browser.close(); server.close(); process.exit(1); }
+
+  // DEFECT 1 — the geometry fold
+  // ⚠ must match inside folded=[...] ONLY — the first cut of this matched the whole line and so
+  // went GREEN while `component_geometries` sat in skipped=[...], i.e. while the defect was live.
+  const foldedArr = (tablesLine.match(/folded=(\[[^\]]*\])/) || [])[1] || '[]';
+  verdict(/"component_geometries"/.test(foldedArr),
+    'DEFECT 1: incoming `component_geometries` is in folded=[...] (old code left it in skipped=[...])', 'folded=' + foldedArr);
+  // DEFECT 2 — the centres query
+  // dbQuery swallows the throw internally, so §MERGE_CENTRES_FAIL never fires — the honest signal
+  // that the `GROUP BY m.building` query died is §HELPERS_QUERY_ERR (+ the added=[] below).
+  const bldErr = cons.filter(l => /HELPERS_QUERY_ERR|no such column: m\.building/.test(l));
+  verdict(!bldErr.length,
+    'DEFECT 2: the centres query did not blow up on a DB with no `building` column',
+    bldErr[0] || 'no m.building query error');
+  const centresLine = grep('§MERGE_CENTRES')[0] || '';
+  verdict(centresLine.indexOf(ARC_BUILDING) >= 0,
+    'DEFECT 2: the merged building was actually REGISTERED as a new centre', centresLine);
+
+  const stateB = await page.evaluate((BLD) => {
+    const A = window.APP;
+    const q = (db, sql) => { try { const r = db.exec(sql); return r.length ? r[0].values[0][0] : null; } catch (e) { return 'ERR'; } };
+    const geoRows = (db) => {
+      if (!db) return null;
+      let n = 0;
+      for (const t of ['component_geometries', 'base_geometries']) {
+        const v = q(db, 'SELECT COUNT(*) FROM "' + t + '"');
+        if (typeof v === 'number') n += v;
+      }
+      return n;
+    };
+    return {
+      metaCount: q(A.db, 'SELECT COUNT(*) FROM elements_meta'),
+      arcRows: q(A.db, "SELECT COUNT(*) FROM elements_meta WHERE building='" + BLD + "'"),
+      hasBuildingCol: !!(A._hasBuildingCol && A._hasBuildingCol(A.db)),
+      dbGeo: geoRows(A.db), libGeo: geoRows(A.libDb),
+      centres: Object.keys(A.buildingCentres || {}),
+    };
+  }, ARC_BUILDING);
+  verdict(stateB.metaCount === 420, 'all 120 ARC elements folded into elements_meta', 'metaCount=' + stateB.metaCount + ' (expected 420)');
+  // DEFECT 3 — the building label
+  verdict(stateB.arcRows === 120,
+    'DEFECT 3: merged rows kept their `building` value (destination gained the column)', 'arcRows=' + stateB.arcRows);
+  verdict((stateB.libGeo || 0) + (stateB.dbGeo || 0) >= 237 + 45,
+    'DEFECT 1: live scene now holds BOTH geometry sets', 'dbGeo=' + stateB.dbGeo + ' libGeo=' + stateB.libGeo + ' (expected >= 282)');
+  S('     [state] centres=' + JSON.stringify(stateB.centres));
+
+  // ══ PHASE C — THE USER'S COMPLAINT: save, then reopen ══════════════════════════════════════
+  S('\n── PHASE C: A._exportBuildingDb() → reopen those exact bytes (the "save and reopen" the user reported broken) ──');
+  const roundTrip = await page.evaluate((BLD) => {
+    const A = window.APP;
+    const bytes = A._exportBuildingDb();
+    if (!bytes) return { err: 'export returned null' };
+    const SQL = A._SQL || A.citySQL || A._citySQL;
+    const re = new SQL.Database(new Uint8Array(bytes));
+    const q = (sql) => { try { const r = re.exec(sql); return r.length ? r[0].values : []; } catch (e) { return [['ERR:' + e.message]]; } };
+    const one = (sql) => { const v = q(sql); return v.length ? v[0][0] : null; };
+    const tables = (q("SELECT name FROM sqlite_master WHERE type='table'") || []).map(v => v[0]);
+    const geoTables = tables.filter(t => t === 'component_geometries' || t === 'base_geometries');
+    // Every geometry_hash reachable in the reopened DB, across BOTH geometry table names.
+    const hashUnion = geoTables.map(t => 'SELECT geometry_hash FROM "' + t + '"').join(' UNION ');
+    const out = {
+      bytes: bytes.byteLength, tables: tables, geoTables: geoTables,
+      metaCount: one('SELECT COUNT(*) FROM elements_meta'),
+      arcMeta: one("SELECT COUNT(*) FROM elements_meta WHERE building='" + BLD + "'"),
+      arcRenderable: hashUnion ? one(
+        "SELECT COUNT(*) FROM elements_meta m JOIN element_instances i ON i.guid=m.guid " +
+        "WHERE m.building='" + BLD + "' AND i.geometry_hash IN (" + hashUnion + ")") : 0,
+      sceneRenderable: hashUnion ? one(
+        "SELECT COUNT(*) FROM elements_meta m JOIN element_instances i ON i.guid=m.guid " +
+        "WHERE m.building<>'" + BLD + "' AND i.geometry_hash IN (" + hashUnion + ")") : 0,
+    };
+    re.close();
+    return out;
+  }, ARC_BUILDING);
+  if (roundTrip.err) {
+    verdict(false, 'export produced bytes', roundTrip.err);
+  } else {
+    S('     [saved] bytes=' + roundTrip.bytes + ' geoTables=' + JSON.stringify(roundTrip.geoTables));
+    S('     [saved] tables=' + JSON.stringify(roundTrip.tables));
+    verdict(roundTrip.metaCount === 420, 'reopened DB has all 420 elements (300 scene + 120 ARC)', 'metaCount=' + roundTrip.metaCount);
+    verdict(roundTrip.arcMeta === 120, 'reopened DB still knows which 120 rows are the merged ARC building', 'arcMeta=' + roundTrip.arcMeta);
+    verdict(roundTrip.arcRenderable === 120,
+      'THE USER\'S BUG: every merged ARC element resolves to real geometry in the SAVED file', 'arcRenderable=' + roundTrip.arcRenderable + '/120');
+    verdict(roundTrip.sceneRenderable === 300,
+      'the ORIGINAL scene geometry also survived the save (no regression on the half that already worked)', 'sceneRenderable=' + roundTrip.sceneRenderable + '/300');
+  }
+
+  S('\n── VERDICT ──');
+  S('   ' + (fails === 0 ? '🟢 W-MERGE-SAVE-ROUNDTRIP PASS' : '🔴 W-MERGE-SAVE-ROUNDTRIP FAIL (' + fails + ' failed assertion(s))'));
+  save();
+  await browser.close(); server.close();
+  process.exit(fails === 0 ? 0 : 1);
+})();


### PR DESCRIPTION
## The report

> "Can open the meta/geo DBs and then add another IFC in this case ARC which was intentionally left out to test LTU. But when saving the merged one, which is extracted DB and reopening, it still does not has the merged ARC in the whole."

Reproduced, root-caused, fixed, witnessed.

## Three defects in one chain

**1. The geometry fold never ran — table-name mismatch.**
`_mergeTable()` folded a table only when it existed on **both** sides. The scene's split `geo.db` carries `base_geometries`; a client-side IFC import carries `component_geometries` (`import_db_builder.js:66`). Neither name is on both sides, so every incoming geometry BLOB was dropped — silently, visible only as `§MERGE_TABLES skipped=[...,"component_geometries","base_geometries"]`. The saved DB then held the merged `elements_meta`/`element_instances` rows with geometry hashes resolving to nothing.

Fix: when the destination has no such table, create it from the source's own DDL and fold into it (`§MERGE_CREATE`). Readers already accept either name (`streaming.js:1162,1212`). Same helper fix also recovers `bom_tree`, which was dropping identically.

**2. The centres query threw and was swallowed.**
Both merge paths hardcoded `GROUP BY m.building`, but `LTU_AHouse_meta.db`'s `elements_meta` has **no `building` column** (`streaming.js:26-31`, `CPE_4D_PERF_MEM_FINDINGS §R6` measured this). `dbQuery` ate the error → `added=[]` → the merged building was never registered and never streamed.

Fix: route both through `_mergeCentresRows()`, mirroring `streaming.js:2501`'s existing `_hasBuildingCol` guard that the merge copies were written without.

**3. `building` was discarded on the way in.**
`_mergeTable`'s destination-driven column intersection dropped the source's building name when the destination lacked the column. Fix: `_ensureBuildingCol()` adds it once, backfilling existing rows with the label the scene is already using (read off `buildingCentres` — extracted, not invented), and invalidates streaming.js's cached `_buildingCol` probe (`§MERGE_BLDCOL`).

**Also:** `_mergeDbIntoScene` skipped the geometry fold outright when `A.libDb` was null (`streaming.js:2302,2479` set it null in several modes) — its split sibling always had that `else` branch, this one did not.

## Witness — W-MERGE-SAVE-ROUNDTRIP

`viewer/tests/witness_merge_save_roundtrip_2026-08-30.js` walks the user's exact path: open split pair → merge an import-shaped DB → `A._exportBuildingDb()` → reopen those bytes. Fixtures are **extracted** from the real shipped `buildings/LTU_AHouse_{meta,geo}.db` (`scripts/make_merge_roundtrip_fixtures.py`) — no invented rows or schema.

| | before | after |
|---|---|---|
| assertions | **6/14 red** | **14/14 green** |
| `§MERGE_TABLES folded=` | `elements_meta, element_transforms, element_instances` | `…, bom_tree, component_geometries` |
| `§MERGE_CENTRES` | `added=[]` | `added=["LTU_AHouse_ARC"]` |
| saved file | 483,328 B, `geoTables=["base_geometries"]` | 860,160 B, `geoTables=["base_geometries","component_geometries"]` |
| after reopen | `arcRenderable=ERR: no such column` | `arcRenderable=120/120`, `sceneRenderable=300/300` |

Two assertions in the first cut of the witness went green while the defect was live (one matched `component_geometries` anywhere on the line, including `skipped=[...]`); both were re-anchored before the fix was written.

## Regression

- **W-OPEN-SPLIT-PAIR — PASS.**
- **W-SCENE-MERGE** fails the same 3 assertions (CLAIM 8, 8b, 6b) with identical detail strings on this branch **and** on clean `origin/main` `141c1c5` — pre-existing, unchanged.
- `tests/audit_specs.js`'s one violation (`38-sh-dx-2d-runtime.spec.js`) is in a file this branch does not touch.

`viewer/sw.js` CACHE_VERSION v1099 → v1100 (`scene.js` is precached).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012qqtWXK8Lp1DVTAMimwxdi