### PR TITLE
fix(render): transparent IFC materials were given their class's opaque METAL preset

### DIFF
--- a/viewer/streaming.js
+++ b/viewer/streaming.js
@@ -823,13 +823,33 @@ function setupStreaming(A) {
     // metals/glass stay glossy by ratio. Floor at 0.08 so nothing becomes a mirror artefact.
     var _rough = stdMat ? stdMat.rough : 0.55;
     opts.roughness = Math.max(0.08, _rough * 0.75);
-    opts.metalness = stdMat ? stdMat.metal : 0.08; // §refl: slight metal lift gives surfaces real specular response
+    // §GLASS_NOT_METAL (2026-08-30): STD_MAT is chosen by ifc_class ALONE, so an element carrying a
+    // real, transparent IFC material still got its class's OPAQUE PBR. Measured on live Clinic: the
+    // IDENTICAL IFC material `0.000,0.502,0.753,0.100` renders two different ways purely by class —
+    //   IfcWindow → metalness 0.00, envMapIntensity 0.6   (correct clear glass, 58 elements)
+    //   IfcPlate  → metalness 0.70, envMapIntensity 0.05  (STD_MAT "steel plate", 167 elements)
+    // — so 167 of Clinic's 225 glass panels rendered as metal: at metalness 0.7 the diffuse albedo is
+    // suppressed and envInt 0.05 leaves almost nothing to reflect, i.e. "loss of glass / no longer
+    // see thru" (§A), with no X-ray involved. §S265c's "trust IFC data" was only ever applied to
+    // COLOUR; alpha<1 is the IFC itself declaring the surface transparent, and in a metal/rough
+    // workflow a transparent surface is BY DEFINITION not a metal (metals are opaque). So when the
+    // element's own material says a<1, the opaque class default does not describe it — drop the
+    // metalness rather than let a steel-plate preset override real glazing.
+    opts.metalness = (a < 1.0) ? 0.0 : (stdMat ? stdMat.metal : 0.08); // §refl: slight metal lift gives surfaces real specular response
     opts.side = THREE.DoubleSide; // §S260d: IFC geometry has inconsistent normals — DoubleSide ensures pick works
     // §refl: 0.3->0.6 — more realistic reflection emphasis (global default).
     // §HOSPITAL_BLUE_TINT: per-class override (STD_MAT[...].envInt) for the small set of classes
     // whose unusually high metalness otherwise lets the sky's real, strongly-blue PMREM reflection
     // dominate the hue over their own correctly-trusted real IFC albedo — see STD_MAT comments above.
-    if (A._envMap) { opts.envMap = A._envMap; opts.envMapIntensity = (stdMat && stdMat.envInt != null) ? stdMat.envInt : 0.6; }
+    // §GLASS_NOT_METAL: the envInt overrides exist ONLY to stop a high-metalness class letting the
+    // sky's real blue PMREM reflection dominate its albedo (§HOSPITAL_BLUE_TINT / §PIPE_DUCT_BLUE_TINT
+    // above). A transparent surface has metalness 0 here, so that reason does not apply to it — and
+    // 0.05 on glass kills the reflection that makes glazing read as glass at all. Use the global 0.6.
+    if (A._envMap) {
+      opts.envMap = A._envMap;
+      opts.envMapIntensity = (a < 1.0) ? 0.6
+        : ((stdMat && stdMat.envInt != null) ? stdMat.envInt : 0.6);
+    }
     const mat = new THREE.MeshStandardMaterial(opts);
     // §PHOTO_ENVMAP_DOUBLE_BOOST_FIX (2026-08-15): effects.js's _reassertPhotoMatBoost() blindly
     // multiplies envMapIntensity x3 and tightens roughness x0.4 on every metal/glossy material
@@ -842,7 +862,12 @@ function setupStreaming(A) {
     // §TRIPLANAR: classes with a real texture set skip the fake-grain perturbation below —
     // the real photo texture takes over that job, stacking both would double-bump the normal
     // with two uncorrelated patterns.
-    var triMat = (ifcClass && TRIPLANAR_MAT[ifcClass]) ? TRIPLANAR_MAT[ifcClass] : null;
+    // §GLASS_NOT_METAL: TRIPLANAR_MAT is also class-keyed, so IfcPlate glazing was being given
+    // _TRI_METAL (`metal_color_1k.jpg`) — a brushed-metal weathering texture painted onto glass
+    // (visible in the user's own log as `§TRIPLANAR_INIT class=IfcPlate tex=…/metal_color_1k.jpg`).
+    // A transparent surface never wants an opaque material's surface-wear texture.
+    var triMat = (a < 1.0) ? null
+      : ((ifcClass && TRIPLANAR_MAT[ifcClass]) ? TRIPLANAR_MAT[ifcClass] : null);
 
     // §S277: Procedural normal perturbation — gives surface texture to flat IFC geometry.
     // Metallic surfaces (pipes, ducts, beams): fine brushed-metal grain.

--- a/viewer/sw.js
+++ b/viewer/sw.js
@@ -22,7 +22,7 @@
 // schedule_author.js is in PRECACHE_ASSETS; v1088 shipped the STAGE 3 drawer change (#1528), so this
 // separate change needs its own bump (§CRISIS LESSON 4).
 // DEPLOY: bump CACHE_VERSION on every OCI upload. Old caches are purged on activate.
-const CACHE_VERSION = 'v1105';   // bump on each deploy; per-change detail is the git commit message.
+const CACHE_VERSION = 'v1106';   // bump on each deploy; per-change detail is the git commit message.
 // v1092 (2026-08-27) §R10 (bim-compiler prompts/CPE_4D_PERF_MEM_FINDINGS.md §7, extends R1's
 // §MAXQ_STAGE_KEEP contract): the MaxQ bake's per-frame §GLOW_LENS_QUAD rebuild (viewer/effects.js)
 // now skips the dispose+rebuild when the TM-visible fixture count is unchanged since the last

--- a/viewer/tests/witness_glass_not_metal_2026-08-30.js
+++ b/viewer/tests/witness_glass_not_metal_2026-08-30.js
@@ -1,0 +1,106 @@
+// ⚠ DO NOT REMOVE — Scope guard
+// W-GLASS-NOT-METAL — prompts/LTU_TERMINAL_CLINIC_RENDER_CORRUPTION.md §X
+//
+// THE ISSUE THIS TEST EXPOSES: Clinic's curtain-wall glazing renders as steel, not glass. STD_MAT
+// and TRIPLANAR_MAT are keyed on ifc_class ALONE, so an element carrying a real transparent IFC
+// material still received its class's OPAQUE PBR preset. Clinic authors its glazing as IfcPlate,
+// whose preset is "steel plate" (metal 0.70, envInt 0.05) plus the _TRI_METAL triplanar texture.
+//
+// THE ORACLE IS IN THE BUILDING ITSELF: Clinic has the SAME IFC material `0.000,0.502,0.753,0.100`
+// on BOTH IfcWindow (58 elements) and IfcPlate (167 elements). Same rgba, same alpha, same
+// discipline — so any difference in how they render is caused by ifc_class alone, and IfcWindow
+// (metal 0.00) is the known-good rendering of that exact material. The test asserts the two agree.
+//
+// Measured on live GH Pages BEFORE the fix:
+//   0.000,0.502,0.753,0.100|IfcWindow → metalness=0    envMapIntensity=0.6  triplanar=false
+//   0.000,0.502,0.753,0.100|IfcPlate  → metalness=0.7  envMapIntensity=0.05 triplanar=true
+// i.e. 167 of Clinic's 225 glass panels (74%) rendered as metal. No X-ray involved — this is a
+// different mechanism from §B/§W's X-ray restore bug, which is separately fixed and verified.
+//
+// §-log first — READ tests/witness_glass_not_metal_2026-08-30.log before any conclusion.
+// Run:  timeout 900 node viewer/tests/witness_glass_not_metal_2026-08-30.js
+'use strict';
+const { chromium } = require(process.env.PW || (require('os').homedir() + '/bim-ootb/tests/node_modules/playwright'));
+const http = require('http'), fs = require('fs'), path = require('path');
+const ROOT = path.join(__dirname, '..', '..');
+const DATA_ROOT = '/home/red1/bim-ootb';
+const MIME = { '.html':'text/html', '.js':'text/javascript', '.json':'application/json', '.db':'application/octet-stream',
+  '.png':'image/png', '.css':'text/css', '.wasm':'application/wasm', '.bin':'application/octet-stream', '.jpg':'image/jpeg' };
+const server = http.createServer((req, res) => {
+  let p = decodeURIComponent(req.url.split('?')[0]); if (p === '/') p = '/viewer/viewer.html';
+  const send = b => { res.writeHead(200, { 'Content-Type': MIME[path.extname(p)] || 'application/octet-stream' }); res.end(b); };
+  fs.readFile(path.join(ROOT, p), (e, b) => { if (!e) return send(b);
+    fs.readFile(path.join(DATA_ROOT, p), (e2, b2) => { if (!e2) return send(b2); res.writeHead(404); res.end('404 ' + p); }); });
+});
+const log = []; let fails = 0;
+const S = m => { log.push(m); console.log(m); };
+const V = (ok, l, d) => { if (!ok) fails++; S('   ' + (ok ? '🟢' : '🔴') + ' ' + l + (d ? ' — ' + d : '')); };
+const save = () => fs.writeFileSync(path.join(__dirname, 'witness_glass_not_metal_2026-08-30.log'), log.join('\n') + '\n');
+
+(async () => {
+  await new Promise(r => server.listen(0, r));
+  const PORT = server.address().port;
+  const browser = await chromium.launch({ args: ['--js-flags=--max-old-space-size=4096'] });
+  const page = await (await browser.newContext({ viewport: { width: 1400, height: 900 } })).newPage();
+  S('── W-GLASS-NOT-METAL — witness_glass_not_metal_2026-08-30 ──');
+  S('   ISSUE: does a transparent IFC material get its class\'s OPAQUE metal preset?');
+  await page.goto('http://127.0.0.1:' + PORT + '/viewer/viewer.html?db=buildings/Clinic_extracted.db',
+    { waitUntil: 'domcontentloaded', timeout: 180000 });
+  let ready = false;
+  for (let i = 0; i < 600 && !ready; i++) { await page.waitForTimeout(1000);
+    ready = await page.evaluate(() => !!(window.APP && window.APP.streaming === false
+      && Object.keys(window.APP.guidMap || {}).length > 0)); }
+  V(ready, 'Clinic loaded and finished streaming');
+  if (!ready) { S('\n❌ ABORT'); save(); await browser.close(); server.close(); process.exit(1); }
+
+  const r = await page.evaluate(() => {
+    const A = window.APP;
+    const pick = frag => { const k = Object.keys(A._matCache || {}).filter(x => x.indexOf(frag) === 0)[0];
+      if (!k) return null; const m = A._matCache[k];
+      return { k, hex: m.color ? m.color.getHexString() : '?', op: +(m.opacity || 0).toFixed(3),
+               tr: !!m.transparent, metal: m.metalness === undefined ? null : +m.metalness.toFixed(3),
+               rough: m.roughness === undefined ? null : +m.roughness.toFixed(3),
+               envI: m.envMapIntensity === undefined ? null : +m.envMapIntensity.toFixed(3),
+               tri: !!m._triplanarShader }; };
+    const all = Object.keys(A._matCache || {}).map(k => { const m = A._matCache[k];
+      return { k, op: +(m.opacity || 0).toFixed(3), metal: m.metalness === undefined ? 0 : m.metalness,
+               tri: !!m._triplanarShader, envI: m.envMapIntensity === undefined ? null : m.envMapIntensity }; });
+    const q = s => { try { const x = A.db.exec(s); return x.length ? x[0].values : []; } catch (e) { return []; } };
+    return { win: pick('0.000,0.502,0.753,0.100|IfcWindow'),
+             plate: pick('0.000,0.502,0.753,0.100|IfcPlate'),
+             all,
+             dbCounts: q("SELECT ifc_class, COUNT(*) FROM elements_meta WHERE material_rgba='0.000,0.502,0.753,0.100' GROUP BY 1") };
+  });
+
+  S('\n   [DB] elements carrying the glass material 0.000,0.502,0.753,0.100:');
+  r.dbCounts.forEach(c => S('       ' + c[0] + ' = ' + c[1]));
+  S('   [oracle ] ' + JSON.stringify(r.win));
+  S('   [subject] ' + JSON.stringify(r.plate));
+  V(!!r.win && !!r.plate, 'both IfcWindow and IfcPlate materials exist for the SAME rgba (the oracle pair)');
+  if (!r.win || !r.plate) { S('\n❌ ABORT — oracle pair absent'); save(); await browser.close(); server.close(); process.exit(1); }
+
+  V(r.win.op === r.plate.op, 'same rgba → same opacity on both classes', r.win.op + ' vs ' + r.plate.op);
+  V(r.plate.metal === 0, 'THE BUG: IfcPlate glazing is NOT metallic (was 0.7 = STD_MAT "steel plate")',
+    'metalness=' + r.plate.metal);
+  V(r.plate.metal === r.win.metal, 'IfcPlate metalness now matches the IfcWindow oracle for the identical material',
+    r.plate.metal + ' vs oracle ' + r.win.metal);
+  V(r.plate.envI === r.win.envI, 'IfcPlate envMapIntensity matches the oracle (was 0.05 vs 0.6 — no reflection = no glass read)',
+    r.plate.envI + ' vs oracle ' + r.win.envI);
+  V(r.plate.tri === false, 'IfcPlate glazing carries no metal triplanar texture', 'triplanar=' + r.plate.tri);
+
+  // Generalisation: the rule is "a transparent surface is never a metal", not a per-class patch.
+  const trans = r.all.filter(m => m.op < 0.999);
+  const badMetal = trans.filter(m => m.metal > 0);
+  const badTri = trans.filter(m => m.tri);
+  S('\n   [general] transparent materials in the build = ' + trans.length +
+    ', metallic = ' + badMetal.length + ', triplanar = ' + badTri.length);
+  badMetal.concat(badTri).slice(0, 6).forEach(m => S('       offender ' + m.k + ' op=' + m.op + ' metal=' + m.metal + ' tri=' + m.tri));
+  V(trans.length > 0, 'the build really has transparent materials to judge (not vacuous)', 'n=' + trans.length);
+  V(badMetal.length === 0, 'no transparent material is metallic anywhere in the build', badMetal.length + ' metallic');
+  V(badTri.length === 0, 'no transparent material carries a triplanar surface-wear texture', badTri.length + ' triplanar');
+
+  S('\n── VERDICT ──');
+  S('   ' + (fails === 0 ? '🟢 W-GLASS-NOT-METAL PASS' : '🔴 W-GLASS-NOT-METAL FAIL (' + fails + ')'));
+  save(); await browser.close(); server.close();
+  process.exit(fails === 0 ? 0 : 1);
+})();


### PR DESCRIPTION
## The report

> "still not glass walls in Clinic bug is there"

The attached console log has **no X-ray toggle anywhere** — so this is *not* §B/§W's X-ray restore bug. That one is real, was fixed in #1565, and I verified it live on both GH Pages and OCI earlier today. Same visible symptom, different mechanism. I tested the wrong one first.

## Root cause

`STD_MAT` and `TRIPLANAR_MAT` are keyed on `ifc_class` **alone**, so an element carrying a real, transparent IFC material still received its class's **opaque** PBR preset. §S265c's *"trust IFC data, only NULL gets the class fallback"* was only ever applied to **colour** — roughness, metalness, envMapIntensity and the triplanar texture came from the class table unconditionally.

Clinic authors its curtain-wall glazing as `IfcPlate`, whose preset is *"steel plate"* (`metal 0.70`, `envInt 0.05`) plus the `_TRI_METAL` brushed-metal triplanar texture — visible in the user's own log:

```
§TRIPLANAR_INIT class=IfcPlate tex=textures/materials/metal_color_1k.jpg
```

**The oracle is inside the building.** Clinic puts the *same* IFC material `0.000,0.502,0.753,0.100` on both `IfcWindow` (58 elements) and `IfcPlate` (167). Measured live:

| cache key | metalness | envMapIntensity | triplanar |
|---|---|---|---|
| `…,0.100\|IfcWindow` | **0.00** | **0.6** | false |
| `…,0.100\|IfcPlate` | **0.70** | **0.05** | **true** |

Same rgba, same alpha, same discipline — the only differing input is `ifc_class`. So **167 of Clinic's 225 glass panels (74%) rendered as metal**: at metalness 0.7 the diffuse albedo is suppressed and `envInt 0.05` leaves almost nothing to reflect — exactly "loss of glass / no longer see thru".

## Fix

`alpha < 1` is the IFC itself declaring the surface transparent, and in a metal/rough workflow **a transparent surface is by definition not a metal** (metals are opaque). So when `a < 1`:

- `metalness` → 0
- `envMapIntensity` → the global 0.6 (the `envInt` overrides exist only to stop *high-metalness* classes taking the sky's blue PMREM reflection, §HOSPITAL_BLUE_TINT — that cannot apply at metalness 0)
- no triplanar surface-wear texture

One physical rule, not a per-class patch — it also clears 2 `IfcFlowTerminal` materials that were transparent-and-metallic. Roughness is deliberately left on the class value (0.225 vs the oracle's 0.08); both read as glass, and spandrel vs vision glazing differing slightly is defensible. Only the three physically-wrong properties change.

## Witness — W-GLASS-NOT-METAL

Uses that in-building oracle: the same rgba under `IfcWindow` is the known-good rendering, so the assertion is *"IfcPlate must agree with it"*.

| | before | after |
|---|---|---|
| assertions | **6/9 red** | **9/9 green** |
| subject (`IfcPlate` glass) | metal 0.7, envI 0.05, tri true | metal 0, envI 0.6, tri false |
| build-wide transparent materials | 5, of which **4 metallic / 4 triplanar** | 5, of which **0 / 0** |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012qqtWXK8Lp1DVTAMimwxdi