### PR TITLE
fix(cpe): §CPE_PIE_HOLD — the pie holds the last real crew instead of vanishing

### DIFF
--- a/viewer/cinema_maxq.js
+++ b/viewer/cinema_maxq.js
@@ -778,7 +778,8 @@
         console.warn('§CPE_RESOURCE_PANEL_ERR draw: ' + eRp.message + ' — panel skipped, frames continue'); }
     }
     if (statInfo && statInfo.shown && A.bigStatsCompositeOntoCanvas) try {
-      A.bigStatsCompositeOntoCanvas(ctx, w, h, statInfo.shown, 1, statInfo.pos, _stackY);
+      // §CPE_PIE_HOLD — statInfo.held is the composition the pie holds beside the card.
+      A.bigStatsCompositeOntoCanvas(ctx, w, h, statInfo.shown, 1, statInfo.pos, _stackY, statInfo.held);
     } catch (eBs) {
       if (!A._bsDrawErrLogged) { A._bsDrawErrLogged = true;
         console.warn('§CPE_BIG_STATS_ERR draw: ' + eBs.message + ' — card skipped, frames continue'); }
@@ -1378,6 +1379,7 @@
       // Rides the same Label ON checkbox and refuses honestly when there is no schedule to read.
       try {
         if (_roomTitle && A.resourcePanelAt && typeof window.tmOpsSnapshot === 'function' && _bkState) {
+          A._resHoldFrames = 0; A._resHoldLogged = false;   // §CPE_PIE_HOLD counts are per-bake
           _resOps = window.tmOpsSnapshot();
           console.log('§CPE_RESOURCE_PANEL ' + (_resOps && _resOps.length
             ? ('on ops=' + _resOps.length + ' rates=' + (!!(window.LABOR_RATES)) + ' pos=' + _ovPos)
@@ -1567,15 +1569,23 @@
         // honestly empty) the same slot revolves big headline numbers instead. The switch is the
         // pie's OWN emptiness, not a hardcoded film fraction — a building whose work runs to the
         // last frame keeps the pie the whole way, with no second opinion about when topout was.
-        var _resInfo = null, _statInfo = null;
-        if (_resOps && _bkState && A.resourcePanelAt) {
-          var _ri = A.resourcePanelAt(_bkMs, _resOps, _bkState.projectStart, _bkState.projectEnd);
-          if (_ri) _resInfo = { info: _ri, pos: _ovPos };
+        // §CPE_PIE_HOLD (user, 2026-08-30): "make the pie part not to disappear but hold when there
+        // is silent info." resourcePanelHoldAt returns today's real composition while trades work,
+        // and the most recent REAL one (held=true, dimmed, captioned with its day) once they stop —
+        // so the pie keeps its column through the whole reveal and the card revolves beside it.
+        var _resInfo = null, _statInfo = null, _holdInfo = null;
+        if (_resOps && _bkState && A.resourcePanelHoldAt) {
+          _holdInfo = A.resourcePanelHoldAt(_bkMs, _resOps, _bkState.projectStart, _bkState.projectEnd);
         }
-        if (!_resInfo && _bigCards && A.bigStatsAt) {
+        if (_holdInfo && !_holdInfo.held) {
+          _resInfo = { info: _holdInfo, pos: _ovPos };        // trades are working: pie + trade list
+        } else if (_bigCards && A.bigStatsAt) {
           var _si = A.bigStatsAt(_bigCards, i / fps);
-          if (_si) _statInfo = { shown: _si, pos: _ovPos };
+          if (_si) _statInfo = { shown: _si, pos: _ovPos, held: _holdInfo };   // held pie + card
         }
+        // No cards could be built from this building's sources — hold the pie rather than leave the
+        // slot empty, which is the disappearance the user reported.
+        if (!_resInfo && !_statInfo && _holdInfo) _resInfo = { info: _holdInfo, pos: _ovPos };
         var blob = await _captureFrame(w, h, _titleInfo, _dayInfo, _ovInfo, _resInfo, _statInfo);
         // §MAXQ_IDB_SALVAGE (2026-07-25, real user repro on Hospital AND HHS_Office — both mid-bake,
         // ~100+ frames in): a backgrounded/throttled tab can have Chrome force-close this run's IDB
@@ -1659,6 +1669,14 @@
       // user into normal navigation. plan=null is the explicit "force restore" signal.
       try { if (A.cpeRevealApplyVisual) A.cpeRevealApplyVisual(null, 0); } catch (eRV) {}
       _workPacingReset();
+      // §CPE_PIE_HOLD — say how much of the film the pie HELD a past composition rather than
+      // showing today's. A bake where this equals framesDone means no day was ever staffed and the
+      // whole panel was a hold: that is a schedule problem, not a HUD one, and must be visible.
+      console.log('§CPE_PIE_HOLD heldFrames=' + (A._resHoldFrames || 0) + '/' + framesDone +
+        (framesDone ? ' (' + Math.round((A._resHoldFrames || 0) / framesDone * 100) + '% of the film)' : '') +
+        ((A._resHoldFrames || 0) === 0 ? ' — trades were active for every frame, the pie was never held'
+          : ((A._resHoldFrames || 0) >= framesDone ? ' ⚠ NO frame had a live crew — the pie held throughout'
+             : ' — pie holds the last real crew through the silent tail')));
       // ══ §MAXQ_QUALITY — the run states its own health, ALWAYS, before anything is stitched.
       // The defect this exists for is a film that looks complete and plays fine while its last
       // seconds are visually dead. A degraded bake must never finish quietly: `unconverged` is the

--- a/viewer/cpe_resource_panel.js
+++ b/viewer/cpe_resource_panel.js
@@ -27,6 +27,9 @@
 function setupCpeResourcePanel(A) {
   var POS = { tr: 1, tl: 1, br: 1, bl: 1 };
   var MS_PER_DAY = 86400000;
+  // §CPE_PIE_HOLD — how far a HELD composition (one from a past day) is dimmed. It stays
+  // legible, but a viewer can see at a glance that it is not today's crew.
+  var HELD_DIM = 0.60;
 
   // Trade colours — distinct hues, readable small. Keyed on the resource ids rates.js already uses.
   var TRADE_COLOR = {
@@ -97,6 +100,60 @@ function setupCpeResourcePanel(A) {
     return { rows: rows, totalHeads: total, progress: elapsed,
              dayKey: Math.floor((cursorMs - projectStartMs) / MS_PER_DAY),
              ratesPresent: !!LR };
+  };
+
+  // ══ §CPE_PIE_HOLD (2026-08-30, user ruling) ══════════════════════════════════════════════════
+  // User: "make the pie part not to disappear but hold when there is silent info."
+  //
+  // MEASURED FIRST (persisted ~/.cache/bim4d task windows, no probe launched): Hospital 318 days,
+  // Clinic 111, Terminal 97, HHS 50, Duplex 13 — **ZERO** days with no task active on any of them.
+  // So the silence is not a mid-programme gap; it is the post-§CPE_BUILDUP_TOPOUT half (topoutU=0.524
+  // on the user's own Hospital bake), where no trade is active and the pie vanished entirely.
+  //
+  // This layers a HOLD on top of resourcePanelAt WITHOUT changing it — that function stays the pure
+  // live-day truth its witness gates, so "who is on site today" and "who was on site last" can never
+  // be confused in the log. Pure: no module state, no carried-forward numbers. The held composition
+  // is the REAL composition of the most recent staffed day, recomputed by the same arithmetic at
+  // that day's cursor — nothing averaged, decayed or extrapolated.
+  //   • progress stays LIVE — elapsed programme fraction is still true after topout, so the ring
+  //     keeps filling on the real cursor while the wedges hold.
+  //   • held=true + heldDayKey travel with the info so the panel can dim it and print the day it is
+  //     from. A held pie is a claim about a PAST day and must say so.
+  //   • nothing staffed yet at this cursor -> null. No fabricated composition, ever.
+  A.resourcePanelHoldAt = function (cursorMs, ops, projectStartMs, projectEndMs) {
+    var live = A.resourcePanelAt(cursorMs, ops, projectStartMs, projectEndMs);
+    var todayKey = Math.floor((cursorMs - projectStartMs) / MS_PER_DAY);
+    if (live) { live.held = false; live.heldDayKey = todayKey; live.heldDays = 0; return live; }
+    if (!ops || !ops.length || !(projectEndMs > projectStartMs)) return null;
+    // Most recent staffed activity at or before this cursor's day. Same prefix scan the live path
+    // uses (ops are sorted by start_ts), so a held frame costs no more than a live one.
+    var dayEnd = projectStartMs + (todayKey + 1) * MS_PER_DAY;
+    var lastEnd = -Infinity, i, o, e;
+    for (i = 0; i < ops.length; i++) {
+      o = ops[i];
+      if (o.s >= dayEnd) break;
+      if (!o.r) continue;
+      e = (o.e == null ? o.s : o.e);
+      if (e > lastEnd) lastEnd = e;
+    }
+    if (!isFinite(lastEnd)) return null;      // nothing has ever been staffed before now
+    // The day containing that end HAD that op running, so this recomputation cannot come back empty
+    // for the reason the live call did — but if it somehow does, refuse rather than draw a blank ring.
+    var held = A.resourcePanelAt(Math.min(lastEnd, dayEnd - 1), ops, projectStartMs, projectEndMs);
+    if (!held) return null;
+    held.held = true;
+    held.heldDayKey = held.dayKey;
+    held.heldDays = todayKey - held.dayKey;
+    held.dayKey = todayKey;
+    held.progress = Math.max(0, Math.min(1, (cursorMs - projectStartMs) / (projectEndMs - projectStartMs)));
+    if (!A._resHoldLogged) {
+      A._resHoldLogged = true;
+      console.log('§CPE_RESOURCE_HOLD first hold at day=' + (todayKey + 1) + ' holding day=' +
+        (held.heldDayKey + 1) + ' (' + held.heldDays + ' days back) heads=' + held.totalHeads +
+        ' trades=' + held.rows.length + ' — pie holds, ring stays live');
+    }
+    A._resHoldFrames = (A._resHoldFrames || 0) + 1;
+    return held;
   };
 
   // Sun azimuth from the REAL scene light, so the cylinder's highlight and its dropped shadow fall
@@ -209,24 +266,69 @@ function setupCpeResourcePanel(A) {
     return { card: cards[idx], idx: idx, n: cards.length, opacity: Math.max(0, fade) };
   };
 
-  A.bigStatsCompositeOntoCanvas = function (ctx, w, h, shown, opacity, pos, stackY) {
-    if (!ctx || !shown || !shown.card || !(opacity > 0)) return;
-    var c = shown.card;
+  // ── The panel BOX. §CPE_PIE_HOLD: both modes call this, so the slot cannot change size, corner or
+  // stack position when the content inside it swaps from the trade list to a revolving stat card.
+  function _box(w, h, pos, stackY) {
     var bw = Math.round(h * 0.36), bh = Math.round(h * 0.24);
     var margin = Math.round(h * 0.028);
     var at = (pos && POS[pos]) ? pos : 'tr';
     var sy = stackY || 0;
-    var x = (at === 'tl' || at === 'bl') ? margin : w - margin - bw;
-    var y = (at === 'bl' || at === 'br') ? h - margin - bh - sy : margin + sy;
-    var rad = Math.round(bh * 0.09);
+    return { bw: bw, bh: bh, rad: Math.round(bh * 0.09),
+             x: (at === 'tl' || at === 'bl') ? margin : w - margin - bw,
+             y: (at === 'bl' || at === 'br') ? h - margin - bh - sy : margin + sy };
+  }
+
+  // ── Frosted plate. Cheap only HERE: _captureFrame has already drawn the rendered frame into this
+  // context, so the pixels behind the panel exist and can be blurred back over themselves. ONE
+  // implementation for both modes — the plate must not change tone as the content swaps.
+  function _plate(ctx, B) {
+    var glass = _glass(ctx, B.x, B.y, B.bw, B.bh, B.rad);
+    _round(ctx, B.x, B.y, B.bw, B.bh, B.rad);
+    ctx.fillStyle = glass ? 'rgba(0,0,0,0.28)' : 'rgba(0,0,0,0.45)';
+    ctx.fill();
+    _round(ctx, B.x, B.y, B.bw, B.bh, B.rad);
+    ctx.strokeStyle = 'rgba(255,255,255,0.20)'; ctx.lineWidth = 1; ctx.stroke();
+  }
+
+  // ── The pie + ring are static for a whole calendar day, so they are rendered once into an
+  // offscreen canvas and blitted. The user's own instruction: "yes reprint if no change".
+  // Cached across BOTH modes, so a held pie costs nothing extra for the whole reveal.
+  var _pieKey = null, _pieCanvas = null;
+  function _pie(ctx, B, info) {
+    var lit = A.resourcePanelLightDir();
+    var key = (info.held ? 'H' : 'L') +
+              (info.heldDayKey == null ? info.dayKey : info.heldDayKey) +
+              '|' + B.bw + 'x' + B.bh + '|' + info.rows.length + '|' + info.totalHeads +
+              '|' + info.progress.toFixed(3) + '|' + lit.x.toFixed(2) + ',' + lit.y.toFixed(2);
+    if (_pieKey !== key || !_pieCanvas) { _pieCanvas = _pieBitmap(B.bw, B.bh, info, lit); _pieKey = key; }
+    if (!_pieCanvas) return;
+    ctx.save();
+    _round(ctx, B.x, B.y, B.bw, B.bh, B.rad); ctx.clip();
+    ctx.drawImage(_pieCanvas, B.x, B.y);
+    ctx.restore();
+  }
+
+  // §CPE_BIG_STATS + §CPE_PIE_HOLD. `heldInfo` (optional) is the composition the pie holds while the
+  // cards revolve — pass what A.resourcePanelHoldAt returned. With it, the pie keeps its column and
+  // the card takes the content column; without it the card falls back to the full width it had
+  // before the hold existed, so an older caller still renders correctly.
+  A.bigStatsCompositeOntoCanvas = function (ctx, w, h, shown, opacity, pos, stackY, heldInfo) {
+    if (!ctx || !shown || !shown.card || !(opacity > 0)) return;
+    var c = shown.card;
+    var B = _box(w, h, pos, stackY);
+    var bw = B.bw, bh = B.bh, x = B.x, y = B.y, rad = B.rad;
     ctx.save();
     ctx.globalAlpha = Math.min(1, opacity);
-    var glass = _glass(ctx, x, y, bw, bh, rad);
-    _round(ctx, x, y, bw, bh, rad);
-    ctx.fillStyle = glass ? 'rgba(0,0,0,0.30)' : 'rgba(0,0,0,0.45)';
-    ctx.fill();
-    _round(ctx, x, y, bw, bh, rad);
-    ctx.strokeStyle = 'rgba(255,255,255,0.20)'; ctx.lineWidth = 1; ctx.stroke();
+    _plate(ctx, B);
+
+    // The pie does NOT leave when the trades do — it holds the last real composition in exactly the
+    // place it occupied all through the build, dimmed and captioned with the day it is from.
+    var G = _geom(bw, bh);
+    var colX = x + Math.round(bh * 0.13), colW = bw - Math.round(bh * 0.13) * 2;
+    if (heldInfo && heldInfo.rows && heldInfo.rows.length && heldInfo.totalHeads > 0) {
+      _pie(ctx, B, heldInfo);
+      colX = x + G.lx; colW = G.availW;
+    }
 
     ctx.save();
     _round(ctx, x, y, bw, bh, rad); ctx.clip();
@@ -235,23 +337,23 @@ function setupCpeResourcePanel(A) {
     var F = 'BlinkMacSystemFont,"Segoe UI",Roboto,-apple-system,sans-serif';
     // THE NUMBER — as large as will fit, because the whole point is grasping it at a glance.
     var big = Math.round(bh * 0.42), tw;
-    do { ctx.font = '800 ' + big + 'px ' + F; tw = ctx.measureText(c.big).width; if (tw <= bw - pad * 2) break; big -= 2; }
+    do { ctx.font = '800 ' + big + 'px ' + F; tw = ctx.measureText(c.big).width; if (tw <= colW) break; big -= 2; }
     while (big > 14);
     ctx.textBaseline = 'alphabetic'; ctx.textAlign = 'left';
     ctx.fillStyle = '#fff';
     var baseY = y + pad + big * 0.86;
-    ctx.fillText(c.big, x + pad, baseY);
+    ctx.fillText(c.big, colX, baseY);
     ctx.font = '600 ' + Math.round(bh * 0.105) + 'px ' + F;
     ctx.fillStyle = 'rgba(255,255,255,0.88)';
-    ctx.fillText(_fit(ctx, c.label, bw - pad * 2), x + pad, baseY + Math.round(bh * 0.17));
+    ctx.fillText(_fit(ctx, c.label, colW), colX, baseY + Math.round(bh * 0.17));
     if (c.sub) {
       ctx.font = '500 ' + Math.round(bh * 0.085) + 'px ' + F;
       ctx.fillStyle = 'rgba(255,255,255,0.60)';
-      ctx.fillText(_fit(ctx, c.sub, bw - pad * 2), x + pad, baseY + Math.round(bh * 0.30));
+      ctx.fillText(_fit(ctx, c.sub, colW), colX, baseY + Math.round(bh * 0.30));
     }
     // dots: which of the revolving cards this is, so a viewer knows more are coming
     var dr = Math.max(2, Math.round(bh * 0.016)), gap = dr * 3, i2;
-    var dx = x + pad, dy = y + bh - pad * 0.7;
+    var dx = colX, dy = y + bh - pad * 0.7;
     for (i2 = 0; i2 < shown.n; i2++) {
       ctx.beginPath(); ctx.arc(dx + i2 * gap, dy, dr, 0, Math.PI * 2);
       ctx.fillStyle = (i2 === shown.idx) ? 'rgba(255,255,255,0.85)' : 'rgba(255,255,255,0.28)';
@@ -278,90 +380,58 @@ function setupCpeResourcePanel(A) {
     } catch (e) { return false; }
   }
 
-  var _cacheKey = null, _cacheCanvas = null;
-
   // ── The ONLY place the panel is drawn, so live preview and baked video cannot disagree.
+  // Same box, same plate, same pie column as the stat-card mode — only the content column differs.
   A.resourcePanelCompositeOntoCanvas = function (ctx, w, h, info, opacity, pos, stackY) {
     if (!ctx || !info || !(opacity > 0)) return;
-    var bw = Math.round(h * 0.36), bh = Math.round(h * 0.24);
-    var margin = Math.round(h * 0.028);
-    var at = (pos && POS[pos]) ? pos : 'tr';
-    var sy = stackY || 0;
-    var x = (at === 'tl' || at === 'bl') ? margin : w - margin - bw;
-    var y = (at === 'bl' || at === 'br') ? h - margin - bh - sy : margin + sy;
-    var rad = Math.round(bh * 0.09);
-
+    var B = _box(w, h, pos, stackY);
     ctx.save();
     ctx.globalAlpha = Math.min(1, opacity);
-
-    // ── Frosted glass. Cheap only HERE: _captureFrame has already drawn the rendered frame into
-    // this context, so the pixels behind the panel exist and can be blurred back over themselves.
-    var glass = false;
-    try {
-      if (typeof ctx.filter === 'string' && typeof document !== 'undefined' && document.createElement) {
-        var tmp = document.createElement('canvas');
-        tmp.width = bw; tmp.height = bh;
-        tmp.getContext('2d').drawImage(ctx.canvas, x, y, bw, bh, 0, 0, bw, bh);
-        ctx.save();
-        _round(ctx, x, y, bw, bh, rad); ctx.clip();
-        ctx.filter = 'blur(9px)';
-        ctx.drawImage(tmp, x - 9, y - 9, bw + 18, bh + 18);   // overscan: no dark halo at the edge
-        ctx.filter = 'none';
-        ctx.restore();
-        glass = true;
-      }
-    } catch (e) { glass = false; }
-    _round(ctx, x, y, bw, bh, rad);
-    ctx.fillStyle = glass ? 'rgba(0,0,0,0.28)' : 'rgba(0,0,0,0.45)';
-    ctx.fill();
-    _round(ctx, x, y, bw, bh, rad);
-    ctx.strokeStyle = 'rgba(255,255,255,0.20)'; ctx.lineWidth = 1; ctx.stroke();
-
-    // ── The pie + ring are static for a whole calendar day, so they are rendered once into an
-    // offscreen canvas and blitted. The user's own instruction: "yes reprint if no change".
-    var lit = A.resourcePanelLightDir();
-    var key = info.dayKey + '|' + bw + 'x' + bh + '|' + info.rows.length + '|' +
-              info.progress.toFixed(3) + '|' + lit.x.toFixed(2) + ',' + lit.y.toFixed(2);
-    if (_cacheKey !== key || !_cacheCanvas) {
-      _cacheCanvas = _renderPanel(bw, bh, info, lit);
-      _cacheKey = key;
-    }
-    if (_cacheCanvas) {
-      ctx.save();
-      _round(ctx, x, y, bw, bh, rad); ctx.clip();
-      ctx.drawImage(_cacheCanvas, x, y);
-      ctx.restore();
-    }
+    _plate(ctx, B);
+    _pie(ctx, B, info);
+    ctx.save();
+    _round(ctx, B.x, B.y, B.bw, B.bh, B.rad); ctx.clip();
+    ctx.translate(B.x, B.y);
+    _drawList(ctx, B.bw, B.bh, info);
+    ctx.restore();
     ctx.restore();
   };
 
-  function _renderPanel(bw, bh, info, lit) {
+  // §CPE_PIE_HOLD — ONE panel, ONE geometry, in BOTH modes: [ pie + ring ] | [ content ].
+  // The pie's position is computed here and nowhere else, so the trade list and the revolving stat
+  // card sit in exactly the same column and the pie cannot move or vanish between them.
+  // §CPE_RESOURCE_PANEL_LAYOUT (2026-08-30, found by rendering a real frame, not by reading): the
+  // pie was sized from panel HEIGHT and the list took whatever was left over — which at 216x187 was
+  // 3.5 PIXELS. Trade names rendered as one letter each and "36 on site" was clipped mid-word. The
+  // content column's width is RESERVED FIRST and the pie fits into the remainder, so the text can
+  // never be squeezed out no matter how the panel is proportioned. Widened again after a real baked
+  // frame showed "Conc...", "Steel...", "Pipefit..." all truncating.
+  function _geom(bw, bh) {
+    var pad = Math.round(bh * 0.10);
+    var listW = Math.max(Math.round(bw * 0.56), 110);
+    var pieW = bw - listW - Math.round(pad * 1.4);
+    var R = Math.max(10, Math.min(pieW / 2 / 1.22, (bh - pad * 2) / 2 * 0.82));
+    return { pad: pad, listW: listW, pieW: pieW, cx: pad + pieW / 2, cy: bh / 2,
+             R: R, RY: R * 0.52, depth: Math.max(4, R * 0.30),
+             lx: bw - listW, availW: listW - pad };
+  }
+
+  // The pie + ring ONLY, on a transparent bitmap — cached and shared by both panel modes.
+  // When info.held is true the wedges are dimmed and the day they are from is printed under them:
+  // a held pie is a claim about a PAST day and must say so on screen (§CPE_PIE_HOLD rule 2).
+  // The ring is NOT dimmed — elapsed programme fraction is still live and true after topout.
+  function _pieBitmap(bw, bh, info, lit) {
     var c = document.createElement('canvas');
     c.width = bw; c.height = bh;
     var g = c.getContext('2d');
-    // §CPE_RESOURCE_PANEL_LAYOUT (2026-08-30, found by rendering a real frame, not by reading): the
-    // pie was sized from panel HEIGHT and the list took whatever was left over — which at 216x187
-    // was 3.5 PIXELS. Trade names rendered as one letter each and "36 on site" was clipped mid-word.
-    // The list's width is now RESERVED FIRST and the pie fits into the remainder, so the text column
-    // can never be squeezed out no matter how the panel is proportioned.
-    var pad = Math.round(bh * 0.10);
-    // §CPE_RESOURCE_PANEL_LAYOUT — widened after a real baked frame showed "Conc...", "Steel...",
-    // "Pipefit..." all truncating. A trade name a client cannot read is the same failure as a
-    // placeholder storey: the card is there but says nothing. The pie takes the remainder.
-    var listW = Math.max(Math.round(bw * 0.56), 110);
-    var pieW = bw - listW - Math.round(pad * 1.4);
-    var cy = bh / 2;
-    var R = Math.max(10, Math.min(pieW / 2 / 1.22, (bh - pad * 2) / 2 * 0.82));
-    var cx = pad + pieW / 2;
-    var RY = R * 0.52;                 // squashed = the cylinder seen at an angle
-    var depth = Math.max(4, R * 0.30); // extruded skirt height
+    var G = _geom(bw, bh);
+    var cx = G.cx, cy = G.cy, R = G.R, RY = G.RY, depth = G.depth;
 
     // ══ 1. Progress ring — the outer perimeter. The elapsed arc is solid; the balance is an EMPTY
     // GLASS CYLINDER (the user's phrase): a translucent wall with a rim highlight, so the remainder
     // reads as "still to build" rather than as chart background.
     var ringR = R * 1.20, ringRY = RY * 1.20, ringW = Math.max(3, R * 0.13);
     var a0 = -Math.PI / 2, a1 = a0 + info.progress * Math.PI * 2;
-    // glass shell, full circle first
     g.save();
     g.lineWidth = ringW;
     g.strokeStyle = 'rgba(255,255,255,0.13)';
@@ -371,7 +441,6 @@ function setupCpeResourcePanel(A) {
     g.strokeStyle = 'rgba(255,255,255,0.22)'; g.lineWidth = 1;
     _ellipseArc(g, cx, cy, ringR, ringRY, 0, Math.PI * 2); g.stroke();
     g.restore();
-    // filled portion — skirt then top, so the fill reads as a solid wall inside the glass
     if (info.progress > 0.001) {
       g.save();
       g.lineWidth = ringW;
@@ -386,6 +455,8 @@ function setupCpeResourcePanel(A) {
     // face, then a specular arc on the sun side. Standard 2D cylinder construction — and at this
     // size it reads more solid than a real lit mesh would, because the scene's own lighting is
     // near-uniform (the §TRIPLANAR_NORMAL lesson: 4.3% under flat light).
+    g.save();
+    if (info.held) g.globalAlpha = HELD_DIM;
     var acc = -Math.PI / 2, i, row, frac, col;
     for (i = 0; i < info.rows.length; i++) {
       row = info.rows[i];
@@ -406,21 +477,37 @@ function setupCpeResourcePanel(A) {
       acc += frac * Math.PI * 2;
     }
     // specular arc on the sun side of the top face
-    g.save();
     g.strokeStyle = 'rgba(255,255,255,0.30)'; g.lineWidth = Math.max(1, R * 0.06);
     var sa = Math.atan2(lit.y, lit.x);
     _ellipseArc(g, cx, cy, R * 0.88, RY * 0.88, sa - 0.55, sa + 0.55); g.stroke();
     g.restore();
 
-    // ══ 3. Avatar + qty rows. The staffage PNGs already vendored are office/street people
-    // (sitting formal, walking with shopping) — wrong for a trade, so the figure is drawn: a
-    // hard-hat silhouette tinted per trade. Zero assets, crisp at any export size.
-    var lx = bw - listW;
-    var availW = listW - pad;
+    // ══ 3. The held caption. Only drawn when the composition is NOT today's.
+    if (info.held) {
+      var fs = Math.max(8, Math.round(bh * 0.062));
+      g.font = '600 ' + fs + 'px -apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,sans-serif';
+      g.textAlign = 'center'; g.textBaseline = 'middle';
+      g.fillStyle = 'rgba(255,255,255,0.62)';
+      g.fillText('day ' + ((info.heldDayKey || 0) + 1), cx,
+                 Math.min(bh - fs * 0.8, cy + ringRY + depth + fs * 1.05));
+      g.textAlign = 'left';
+    }
+    return c;
+  }
+
+  // ══ 4. Avatar + qty rows, drawn live into the panel's own space (translated by the caller).
+  // The staffage PNGs already vendored are office/street people (sitting formal, walking with
+  // shopping) — wrong for a trade, so the figure is drawn: a hard-hat silhouette tinted per trade.
+  // Zero assets, crisp at any export size.
+  function _drawList(g, bw, bh, info) {
+    var G = _geom(bw, bh), pad = G.pad, lx = G.lx, availW = G.availW;
     var fs = Math.max(9, Math.round(bh * 0.085));
     var rowH = Math.round(fs * 1.55);
     var maxRows = Math.max(1, Math.floor((bh - pad * 2 - fs * 1.4) / rowH));
-    g.textBaseline = 'middle';
+    var i, row, col;
+    g.save();
+    if (info.held) g.globalAlpha = HELD_DIM;
+    g.textAlign = 'left'; g.textBaseline = 'middle';
     g.font = '700 ' + Math.round(fs * 1.15) + 'px -apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,sans-serif';
     g.fillStyle = '#fff';
     g.fillText(info.totalHeads + ' on site', lx, pad + fs * 0.7);
@@ -443,7 +530,7 @@ function setupCpeResourcePanel(A) {
       g.fillStyle = 'rgba(255,255,255,0.55)';
       g.fillText('+' + (info.rows.length - maxRows) + ' more', lx + fs * 1.05, ry);
     }
-    return c;
+    g.restore();
   }
 
   // A hard-hat worker silhouette — helmet, head, shoulders. Deliberately simple: it must read at

--- a/viewer/sw.js
+++ b/viewer/sw.js
@@ -22,7 +22,7 @@
 // schedule_author.js is in PRECACHE_ASSETS; v1088 shipped the STAGE 3 drawer change (#1528), so this
 // separate change needs its own bump (§CRISIS LESSON 4).
 // DEPLOY: bump CACHE_VERSION on every OCI upload. Old caches are purged on activate.
-const CACHE_VERSION = 'v1107';   // bump on each deploy; per-change detail is the git commit message.
+const CACHE_VERSION = 'v1108';   // bump on each deploy; per-change detail is the git commit message.
 // v1092 (2026-08-27) §R10 (bim-compiler prompts/CPE_4D_PERF_MEM_FINDINGS.md §7, extends R1's
 // §MAXQ_STAGE_KEEP contract): the MaxQ bake's per-frame §GLOW_LENS_QUAD rebuild (viewer/effects.js)
 // now skips the dispose+rebuild when the TM-visible fixture count is unchanged since the last

--- a/witness_cpe_resource_hold.js
+++ b/witness_cpe_resource_hold.js
@@ -1,0 +1,141 @@
+// WITNESS — §CPE_PIE_HOLD (bim-compiler prompts/CINEMA_PATH_EDITOR.md §CPE_PIE_HOLD).
+//
+// ISSUE IT PROVES/DISPROVES: the composition pie DISAPPEARED for the whole silent tail of a bake
+// (after §CPE_BUILDUP_TOPOUT no trade is active, resourcePanelAt correctly returns null, and the
+// panel's entire left column vanished while a full-width stat card took the slot). User, 2026-08-30:
+// "make the pie part not to disappear but hold when there is silent info."
+//
+// Does the hold (a) return TODAY's real composition while trades work, (b) hold the REAL composition
+// of the last staffed day once they stop — not a re-derivation, not an average, not a decay,
+// (c) keep the progress ring LIVE while the wedges hold, (d) REFUSE when nothing has ever been
+// staffed rather than fabricating one, and (e) actually draw the pie in BOTH panel modes?
+//
+// (b) and (d) are the load-bearing ones: a held pie is a claim about a PAST day, so it must be that
+// day's real numbers and it must never be invented.
+//
+// Runs in NODE — the hold is pure arithmetic over an ops array, so no browser is launched. That is
+// deliberate: the user's standing warning is that twelve puppeteer Chromes competed with a real bake
+// and it had to be aborted. This witness costs a page-load of nothing.
+const fs = require('fs'), path = require('path'), vm = require('vm');
+
+// ── a recording 2D context: counts draw calls the way witness_big_stats.js does in the browser
+function mkCtx(w, h) {
+  const rec = { fills: 0, strokes: 0, images: 0, texts: [] };
+  const ctx = {
+    canvas: { width: w, height: h }, filter: 'none', font: '', fillStyle: '', strokeStyle: '',
+    lineWidth: 1, globalAlpha: 1, textAlign: 'left', textBaseline: 'alphabetic', _rec: rec,
+    save() {}, restore() {}, translate() {}, clip() {}, beginPath() {}, closePath() {},
+    moveTo() {}, lineTo() {}, arc() {}, arcTo() {}, ellipse() {}, roundRect() {},
+    fill() { rec.fills++; }, stroke() { rec.strokes++; },
+    drawImage() { rec.images++; }, fillText(t) { rec.texts.push(String(t)); },
+    measureText(t) { return { width: String(t).length * 6 }; }
+  };
+  return ctx;
+}
+const sandbox = { console, Math, Date, JSON, parseInt, isFinite, Infinity };
+sandbox.window = sandbox;
+// Offscreen canvases matter here: the pie is rendered into one and BLITTED, so its wedge fills and
+// its caption land on the offscreen recorder, never on the panel's own context. A witness that only
+// counted fills on the visible context would score a pie that never drew as a pass.
+let OFFSCREEN = [];
+sandbox.document = { createElement: () => { const c = { width: 0, height: 0 };
+  c.getContext = () => { const x = mkCtx(c.width, c.height); OFFSCREEN.push(x); return x; }; return c; } };
+vm.createContext(sandbox);
+vm.runInContext(fs.readFileSync(path.join(__dirname, 'viewer/cpe_resource_panel.js'), 'utf8'), sandbox);
+vm.runInContext(fs.readFileSync(path.join(__dirname, 'viewer/rates.js'), 'utf8'), sandbox);
+
+const A = { sun: { position: { x: -0.6, y: 1, z: -0.8 } } };
+sandbox.APP = A;
+sandbox.setupCpeResourcePanel(A);
+if (!sandbox.LABOR_RATES) { console.log('INCONCLUSIVE — rates.js exposed no LABOR_RATES; nothing was judged.'); process.exit(1); }
+
+// ── synthetic programme, shaped like the measured real ones (gap-free build, silent tail after
+// topout). Every op carries a trade rates.js knows, so the arithmetic under test is the real one.
+const D = 86400000, PS = Date.UTC(2026, 0, 5), DAYS = 60, TOPOUT = 30;
+const ops = [];
+function add(dayFrom, dayTo, trade, n) {
+  for (let k = 0; k < n; k++) ops.push({ s: PS + dayFrom * D + 3600000, e: PS + dayTo * D + 3600000, r: trade });
+}
+add(0, 9, 'CONCRETE_GANG', 40);
+add(4, 14, 'STEEL_ERECTOR', 25);
+add(10, 19, 'MASON', 18);
+add(15, TOPOUT - 1, 'HVAC_TECH', 12);
+add(18, TOPOUT - 1, 'PLUMBER', 9);
+// an UNSTAFFED day inside the programme: real ops, no trade on them (this is what an unassigned
+// schedule looks like — the panel must hold, not blank)
+for (let k = 0; k < 30; k++) ops.push({ s: PS + 12 * D, e: PS + 12 * D + 3600000, r: null });
+ops.sort((a, b) => a.s - b.s);
+const PE = PS + DAYS * D;
+const at = (d) => PS + d * D + 12 * 3600000;
+
+const live = A.resourcePanelHoldAt(at(6), ops, PS, PE);
+const rawLive = A.resourcePanelAt(at(6), ops, PS, PE);
+const lastStaffed = A.resourcePanelAt(at(TOPOUT - 1), ops, PS, PE);
+const rawSilent = A.resourcePanelAt(at(45), ops, PS, PE);
+const held = A.resourcePanelHoldAt(at(45), ops, PS, PE);
+const before = A.resourcePanelHoldAt(PS - 3 * D, ops, PS, PE);
+// mid-programme unstaffed day: build a programme whose day 12 has ONLY resource-less ops
+const gapOps = ops.filter(o => !(o.r && o.s <= PS + 12 * D + D && (o.e == null ? o.s : o.e) >= PS + 12 * D));
+gapOps.sort((a, b) => a.s - b.s);
+const rawGap = A.resourcePanelAt(at(12), gapOps, PS, PE);
+const gapHeld = A.resourcePanelHoldAt(at(12), gapOps, PS, PE);
+
+const sig = (info) => info ? info.rows.map(r => r.trade + ':' + r.heads).sort().join(',') : null;
+
+// ── draw: does the pie reach the canvas in BOTH modes?
+const W = 1852, H = 960;
+const off = () => OFFSCREEN.reduce((a, x) => ({ fills: a.fills + x._rec.fills, strokes: a.strokes + x._rec.strokes,
+                                                texts: a.texts.concat(x._rec.texts) }), { fills: 0, strokes: 0, texts: [] });
+OFFSCREEN = []; const c1 = mkCtx(W, H);
+A.resourcePanelCompositeOntoCanvas(c1, W, H, held, 1, 'tr', 60);
+const o1 = off();
+const card = { card: { big: '63,182', label: 'elements coordinated', src: 'elements_meta' }, idx: 0, n: 5, opacity: 1 };
+OFFSCREEN = []; const c2 = mkCtx(W, H); A.bigStatsCompositeOntoCanvas(c2, W, H, card, 1, 'tr', 60, held);
+const o2 = off();
+OFFSCREEN = []; const c3 = mkCtx(W, H); A.bigStatsCompositeOntoCanvas(c3, W, H, card, 1, 'tr', 60, null);
+const o3 = off();
+const capHeld = o1.texts.concat(o2.texts).concat(c1._rec.texts).concat(c2._rec.texts);
+
+console.log('='.repeat(84) + '\n§CPE_PIE_HOLD witness — synthetic programme, ' + DAYS +
+  ' days, topout day ' + TOPOUT + ', ' + ops.length + ' ops\n' + '='.repeat(84));
+console.log('  live  day 7  : ' + JSON.stringify(sig(live)) + '  heads=' + (live && live.totalHeads) + ' held=' + (live && live.held));
+console.log('  last staffed : day ' + (lastStaffed && lastStaffed.dayKey + 1) + '  ' + JSON.stringify(sig(lastStaffed)));
+console.log('  silent day 46: raw=' + (rawSilent === null ? 'null' : 'NON-NULL') +
+  '  hold=' + JSON.stringify(sig(held)) + '  held=' + (held && held.held) +
+  ' heldDay=' + (held && held.heldDayKey + 1) + ' back=' + (held && held.heldDays) + 'd');
+console.log('  ring on hold : progress=' + (held && held.progress.toFixed(4)) +
+  '  cursor=' + ((at(45) - PS) / (PE - PS)).toFixed(4) +
+  '  heldDayProgress=' + (lastStaffed && lastStaffed.progress.toFixed(4)));
+console.log('  before start : ' + (before === null ? 'null (refused)' : 'FABRICATED ' + JSON.stringify(sig(before))));
+console.log('  mid gap d13  : raw=' + (rawGap === null ? 'null' : 'NON-NULL') + '  hold=' + JSON.stringify(sig(gapHeld)) +
+  ' heldDay=' + (gapHeld && gapHeld.heldDayKey + 1));
+console.log('  draw: resource panel blits=' + c1._rec.images + ' offscreen wedgeFills=' + o1.fills +
+  ' | stats+held blits=' + c2._rec.images + ' cardFills=' + c2._rec.fills +
+  ' | stats alone blits=' + c3._rec.images + ' cardFills=' + c3._rec.fills);
+console.log('  captions seen: ' + JSON.stringify(capHeld.filter(t => /^day /.test(t))));
+
+const G = [
+  ['G-HOLD-1  a staffed day returns the LIVE composition (held=false), identical to resourcePanelAt',
+    !!live && live.held === false && sig(live) === sig(rawLive) && live.totalHeads > 0],
+  ['G-HOLD-2  a silent day HOLDS the last staffed day\'s REAL rows (not a re-derivation)',
+    !!held && held.held === true && sig(held) === sig(lastStaffed) &&
+    held.totalHeads === lastStaffed.totalHeads && held.heldDayKey === lastStaffed.dayKey],
+  ['G-HOLD-3  the ring stays LIVE on a held frame (cursor progress, not the held day\'s)',
+    !!held && Math.abs(held.progress - (at(45) - PS) / (PE - PS)) < 1e-9 &&
+    Math.abs(held.progress - lastStaffed.progress) > 0.01],
+  ['G-HOLD-4  nothing staffed yet -> null, no fabricated composition', before === null],
+  ['G-HOLD-5  an unstaffed day INSIDE the programme holds the PREVIOUS staffed day',
+    rawGap === null && !!gapHeld && gapHeld.held === true && gapHeld.heldDayKey < 12 && gapHeld.totalHeads > 0],
+  ['G-HOLD-6  resourcePanelAt itself still returns null on a silent day (live contract intact)',
+    rawSilent === null],
+  ['G-HOLD-7  the pie really DRAWS in both modes — wedges filled, and the stats panel blits one more layer than without it',
+    o1.fills > 0 && c1._rec.images > 0 && c2._rec.images > c3._rec.images && c3._rec.fills > 0],
+  ['G-HOLD-8  a held pie is captioned with the day it is from (a past day must say so)',
+    capHeld.some(t => t === 'day ' + (lastStaffed.dayKey + 1))],
+  ['G-HOLD-9  the pie bitmap is cached ACROSS both modes — the second panel re-blits, never re-renders',
+    o2.fills === 0 && c2._rec.images > 0]
+];
+let pass = 0;
+G.forEach(([n, v]) => { console.log('  ' + (v ? 'PASS' : 'FAIL') + '  ' + n); if (v) pass++; });
+console.log('\n  ' + pass + '/' + G.length + ' — ' + (pass === G.length ? 'PASS' : 'FAIL'));
+process.exit(pass === G.length ? 0 : 1);


### PR DESCRIPTION
**User, 2026-08-30:** *"make the pie part not to disappear but hold when there is silent info."*

## Measured first — the silence is not a gap
From the persisted `~/.cache/bim4d` task windows (no probe launched, no bake disturbed):

| building | tasks | programme days | days with NO task active |
|---|---|---|---|
| Hospital | 42 | 318 | **0** |
| Clinic | 35 | 111 | **0** |
| Terminal | 77 | 97 | **0** |
| HHS_Office_Federated | 20 | 50 | **0** |
| Duplex | 20 | 13 | **0** |

Every programme is gap-free, so the silence is the post-`§CPE_BUILDUP_TOPOUT` half (`topoutU=0.524` on the user's own Hospital bake): no trade is active, `resourcePanelAt` correctly returns `null`, and the panel's whole left column disappeared while a full-width stat card took the slot.

## What changed
**ONE panel, ONE geometry, both modes: `[ pie + ring ] | [ content ]`.** The pie keeps its column for the whole film; only the right column swaps between the live trade list and the revolving `§CPE_BIG_STATS` card.

- the held composition is the **real** composition of the most recent staffed day, recomputed by the same arithmetic at that day's cursor — nothing averaged, decayed, or carried forward
- dimmed to 0.60 and **captioned with the day it is from** — a held pie is a claim about a PAST day and must say so
- **the progress ring stays live** — elapsed programme fraction is still true after topout
- nothing staffed yet at this cursor → `null`, panel omitted, never a fabricated composition
- `A.resourcePanelAt` is **unchanged** — still the pure live-day truth its witness gates; the hold is a separate pure function on top

New `§CPE_PIE_HOLD` line at bake end reports `heldFrames/framesDone`, and flags the case where NO frame had a live crew (a schedule problem, not a HUD one).

## Witness — `witness_cpe_resource_hold.js`, 9/9 PASS
Runs in **node**, no browser: the hold is pure arithmetic, and the standing warning is that twelve puppeteer Chromes competed with a real bake and it had to be aborted.

```
  live  day 7  : "CONCRETE_GANG:18,STEEL_ERECTOR:12"  heads=30 held=false
  last staffed : day 30  "HVAC_TECH:4,PLUMBER:4"
  silent day 46: raw=null  hold="HVAC_TECH:4,PLUMBER:4"  held=true heldDay=30 back=16d
  ring on hold : progress=0.7583  cursor=0.7583  heldDayProgress=0.4917
  before start : null (refused)
  mid gap d13  : raw=null  hold="CONCRETE_GANG:18" heldDay=10
  draw: resource panel blits=2 offscreen wedgeFills=4 | stats+held blits=2 | stats alone blits=1
  captions seen: ["day 30"]
  9/9 — PASS
```

G-HOLD-2 (holds the last staffed day's REAL rows, not a re-derivation) and G-HOLD-4 (refuses rather than fabricating) are the load-bearing ones. G-HOLD-7 counts fills on the **offscreen** pie bitmap — a witness that only counted the visible context would have scored a pie that never drew as a pass. G-HOLD-9 proves the bitmap is cached across both modes, so a held pie costs one blit per frame.

eslint `no-undef`: 3 messages before, 3 after (pre-existing `VideoEncoder`/`VideoFrame`), none new. `sw.js` CACHE_VERSION v1107 → v1108.

Spec: bim-compiler `prompts/CINEMA_PATH_EDITOR.md` §CPE_PIE_HOLD

🤖 Generated with [Claude Code](https://claude.com/claude-code)