### PR TITLE
feat(cpe): §CPE_STATS_TAIL — two rounds, and only the Reveal round revolves

### DIFF
--- a/viewer/cinema_maxq.js
+++ b/viewer/cinema_maxq.js
@@ -1044,6 +1044,8 @@
     // only the camera head is projected per frame. Rides the Label ON checkbox: the user's ruling
     // was "It is user's choice as its the Label ON option", so it needs no toggle of its own.
     var _ovPath = null, _ovPos = 'tl', _resOps = null, _bigCards = null;
+    // §CPE_STATS_TAIL — the Reveal 2nd round's film fraction, read off the plan's own topout.
+    var _revealU = null;
     var _dayPos = 'tr';
     function _tFilm(tNorm) { return _clip ? _clip.in + tNorm * (_clip.out - _clip.in) : tNorm; }
     function poseAt(tNorm) {
@@ -1314,6 +1316,7 @@
           if (!_bkState) { console.warn('§CPE_BUILDUP_SKIP reason=no timeline to follow — baking without the buildup'); _buildup = false; }
           if (_bkState) {
             var _top = _buildupTopoutU(plan);
+            _revealU = _top.u;   // §CPE_STATS_TAIL — where the Reveal 2nd round starts
             console.log('§CPE_BUILDUP_TOPOUT topoutU=' + _top.u.toFixed(3) + ' src=' + _top.src +
               ' — construction completes at the closing-orbit boundary; the pull-back shows the' +
               ' topping-out and the orbit circles the FINISHED building (solar-panel lesson 2026-08-02)');
@@ -1380,6 +1383,7 @@
       try {
         if (_roomTitle && A.resourcePanelAt && typeof window.tmOpsSnapshot === 'function' && _bkState) {
           A._resHoldFrames = 0; A._resHoldLogged = false;   // §CPE_PIE_HOLD counts are per-bake
+          A._statTailFrames = 0; A._statTailLogged = false; // §CPE_STATS_TAIL, same
           _resOps = window.tmOpsSnapshot();
           console.log('§CPE_RESOURCE_PANEL ' + (_resOps && _resOps.length
             ? ('on ops=' + _resOps.length + ' rates=' + (!!(window.LABOR_RATES)) + ' pos=' + _ovPos)
@@ -1569,23 +1573,43 @@
         // honestly empty) the same slot revolves big headline numbers instead. The switch is the
         // pie's OWN emptiness, not a hardcoded film fraction — a building whose work runs to the
         // last frame keeps the pie the whole way, with no second opinion about when topout was.
-        // §CPE_PIE_HOLD (user, 2026-08-30): "make the pie part not to disappear but hold when there
-        // is silent info." resourcePanelHoldAt returns today's real composition while trades work,
-        // and the most recent REAL one (held=true, dimmed, captioned with its day) once they stop —
-        // so the pie keeps its column through the whole reveal and the card revolves beside it.
+        // §CPE_PIE_HOLD + §CPE_STATS_TAIL — TWO ROUNDS, and the user's ruling is that they behave
+        // differently (2026-08-30): "In the first round, if nothing is added, that last info holds
+        // and wait till a new one arrives, not intersperse" … "[the highlights] should all be in
+        // play during the 'Reveal' 2nd round."
+        //   ROUND 1 (buildup, u < topoutU): the panel is the schedule and NOTHING rotates. If the
+        //     day has no staffed op the last real composition HOLDS until a new one arrives.
+        //   ROUND 2 (the Reveal, u >= topoutU): the schedule has topped out and the counter is
+        //     pinned — MEASURED at ≈125 s of the user's 229.8 s Hospital film — so the whole set of
+        //     highlights revolves here, with the roster as one of the slots so nothing is lost.
+        // The boundary is the plan's own topout (§CPE_BUILDUP_TOPOUT), not a new constant. With no
+        // plan beats to read it degrades to "the ops can no longer change" — DEGRADE, DON'T DISABLE.
         var _resInfo = null, _statInfo = null, _holdInfo = null;
         if (_resOps && _bkState && A.resourcePanelHoldAt) {
           _holdInfo = A.resourcePanelHoldAt(_bkMs, _resOps, _bkState.projectStart, _bkState.projectEnd);
         }
-        if (_holdInfo && !_holdInfo.held) {
-          _resInfo = { info: _holdInfo, pos: _ovPos };        // trades are working: pie + trade list
-        } else if (_bigCards && A.bigStatsAt) {
-          var _si = A.bigStatsAt(_bigCards, i / fps);
-          if (_si) _statInfo = { shown: _si, pos: _ovPos, held: _holdInfo };   // held pie + card
+        var _inReveal = (_revealU != null)
+          ? (nFrames > 1 ? (i / (nFrames - 1)) >= _revealU : false)
+          : !!(_resOps && _bkState && A.resourcePanelFrozenAt &&
+               A.resourcePanelFrozenAt(_bkMs, _resOps, _bkState.projectStart, _bkState.projectEnd));
+        if (!_inReveal) {
+          if (_holdInfo) _resInfo = { info: _holdInfo, pos: _ovPos };   // round 1: hold, never rotate
+        } else if (A.tailPanelAt) {
+          var _si = A.tailPanelAt(_bigCards, i / fps, _holdInfo);
+          if (_si) {
+            _statInfo = { shown: _si, pos: _ovPos, held: _holdInfo };
+            A._statTailFrames = (A._statTailFrames || 0) + 1;
+            if (!A._statTailLogged) {
+              A._statTailLogged = true;
+              console.log('§CPE_STATS_TAIL reveal round entered at frame ' + i + '/' + nFrames +
+                ' u=' + (nFrames > 1 ? (i / (nFrames - 1)).toFixed(3) : '1.000') +
+                ' boundary=' + (_revealU != null ? 'topoutU ' + _revealU.toFixed(3) : 'ops-frozen (no plan beats)') +
+                ' slots=' + _si.n + ' (roster' + (_bigCards ? ' + ' + _bigCards.length + ' cards' : ', NO cards built') + ')');
+            }
+          } else if (_holdInfo) {
+            _resInfo = { info: _holdInfo, pos: _ovPos };   // nothing to revolve — hold, never blank
+          }
         }
-        // No cards could be built from this building's sources — hold the pie rather than leave the
-        // slot empty, which is the disappearance the user reported.
-        if (!_resInfo && !_statInfo && _holdInfo) _resInfo = { info: _holdInfo, pos: _ovPos };
         var blob = await _captureFrame(w, h, _titleInfo, _dayInfo, _ovInfo, _resInfo, _statInfo);
         // §MAXQ_IDB_SALVAGE (2026-07-25, real user repro on Hospital AND HHS_Office — both mid-bake,
         // ~100+ frames in): a backgrounded/throttled tab can have Chrome force-close this run's IDB
@@ -1677,6 +1701,13 @@
         ((A._resHoldFrames || 0) === 0 ? ' — trades were active for every frame, the pie was never held'
           : ((A._resHoldFrames || 0) >= framesDone ? ' ⚠ NO frame had a live crew — the pie held throughout'
              : ' — pie holds the last real crew through the silent tail')));
+      // §CPE_STATS_TAIL — how much of the film the Reveal round reclaimed. 0 on a bake whose plan
+      // has no topout AND whose ops never freeze: that is the case where the dead tail stays dead.
+      console.log('§CPE_STATS_TAIL revolvedFrames=' + (A._statTailFrames || 0) + '/' + framesDone +
+        (framesDone ? ' (' + Math.round((A._statTailFrames || 0) / framesDone * 100) + '% of the film)' : '') +
+        ((A._statTailFrames || 0) === 0
+          ? ' — the Reveal round never revolved: no topout on the plan and the ops never froze'
+          : ' — highlights in play for the whole Reveal round, roster included'));
       // ══ §MAXQ_QUALITY — the run states its own health, ALWAYS, before anything is stitched.
       // The defect this exists for is a film that looks complete and plays fine while its last
       // seconds are visually dead. A degraded bake must never finish quietly: `unconverged` is the

--- a/viewer/cpe_resource_panel.js
+++ b/viewer/cpe_resource_panel.js
@@ -156,6 +156,40 @@ function setupCpeResourcePanel(A) {
     return held;
   };
 
+  // ══ §CPE_STATS_TAIL (2026-08-30, user ruling) ═══════════════════════════════════════════════
+  // User, on BIM_MaxQ_Hospital_1788092317604.mp4: "there is ample unused timing to display more
+  // info after Finishes."
+  //
+  // MEASURED on that mp4: the day counter's digits stop changing at u≈0.45 (Day 315/315) and the
+  // pie shows one static trade — 4 on site, Finisher ×4 — for the remaining ≈125 s. Over HALF the
+  // film. §CPE_BIG_STATS could not reach it because its handover trigger is "the pie is honestly
+  // empty", and on this schedule Finisher ops run to the last day so the pie is never empty.
+  //
+  // The right test is not emptiness, it is whether the schedule CAN still change. Frozen ⟺ no op
+  // boundary — a start or an end — remains between this cursor and the end of the film. Then the
+  // composition is fixed for every frame that follows and the column is showing a number that will
+  // never move again. resourcePanelAt returning null is a SPECIAL CASE of this, so §CPE_PIE_HOLD is
+  // subsumed, not replaced. Read off the ops array only: never a film fraction, never a topout
+  // constant. A building whose work runs to the last frame never freezes and keeps its trade list.
+  // Boundaries are compared against the END OF THE CURSOR'S DAY, not the instant: the panel is a
+  // per-day readout, so an op that starts or ends later TODAY changes nothing about what any
+  // following frame will show. This also covers the real shape — the buildup parks the cursor on the
+  // final day for the whole reveal, with the last trade still running on it (MEASURED: Hospital
+  // 315/315 with Finisher ×4 from u≈0.45 to the last frame).
+  A.resourcePanelFrozenAt = function (cursorMs, ops, projectStartMs, projectEndMs) {
+    if (!ops || !ops.length || !(projectEndMs > projectStartMs)) return false;
+    var dayEnd = projectStartMs + (Math.floor((cursorMs - projectStartMs) / MS_PER_DAY) + 1) * MS_PER_DAY;
+    var i, o, e;
+    for (i = 0; i < ops.length; i++) {
+      o = ops[i];
+      if (!o.r) continue;
+      if (o.s > dayEnd && o.s <= projectEndMs) return false;        // a trade still starts ahead
+      e = (o.e == null ? o.s : o.e);
+      if (e > dayEnd && e <= projectEndMs) return false;            // a trade still finishes ahead
+    }
+    return true;
+  };
+
   // Sun azimuth from the REAL scene light, so the cylinder's highlight and its dropped shadow fall
   // on the same side as every shadow in the frame behind it — and track the Alt+C noon->dusk arc.
   // Returns a 2D unit direction in panel space, or a sane default when there is no sun to read.
@@ -312,8 +346,23 @@ function setupCpeResourcePanel(A) {
   // cards revolve — pass what A.resourcePanelHoldAt returned. With it, the pie keeps its column and
   // the card takes the content column; without it the card falls back to the full width it had
   // before the hold existed, so an older caller still renders correctly.
+  // §CPE_STATS_TAIL — the tail rotation is [ roster ] + cards, so the trade list with its avatars
+  // and ×N is ONE of the revolving slots rather than being replaced by them. Nothing the panel used
+  // to say is lost to the cards; the dead half of the film just gains everything else.
+  A.tailPanelAt = function (cards, filmSec, info) {
+    var nCards = cards ? cards.length : 0;
+    var hasRoster = !!(info && info.rows && info.rows.length);
+    var n = nCards + (hasRoster ? 1 : 0);
+    if (!n) return null;
+    var idx = Math.floor(filmSec / CARD_SECONDS) % n;
+    var u = (filmSec % CARD_SECONDS) / CARD_SECONDS;
+    var fade = Math.max(0, Math.min(1, Math.min(u, 1 - u) / 0.12));
+    if (hasRoster && idx === 0) return { roster: info, idx: idx, n: n, opacity: fade };
+    return { card: cards[idx - (hasRoster ? 1 : 0)], idx: idx, n: n, opacity: fade };
+  };
+
   A.bigStatsCompositeOntoCanvas = function (ctx, w, h, shown, opacity, pos, stackY, heldInfo) {
-    if (!ctx || !shown || !shown.card || !(opacity > 0)) return;
+    if (!ctx || !shown || !(shown.card || shown.roster) || !(opacity > 0)) return;
     var c = shown.card;
     var B = _box(w, h, pos, stackY);
     var bw = B.bw, bh = B.bh, x = B.x, y = B.y, rad = B.rad;
@@ -334,6 +383,14 @@ function setupCpeResourcePanel(A) {
     _round(ctx, x, y, bw, bh, rad); ctx.clip();
     ctx.globalAlpha = Math.min(1, opacity) * shown.opacity;   // the card itself fades, the plate does not
     var pad = Math.round(bh * 0.13);
+    // §CPE_STATS_TAIL — the roster slot draws the real trade list, not a number, so the avatars and
+    // the ×N counts stay in the rotation instead of being replaced by the cards.
+    if (shown.roster) {
+      ctx.save(); ctx.translate(x, y); _drawList(ctx, bw, bh, shown.roster); ctx.restore();
+      _dots(ctx, x + G.lx, y + bh - pad * 0.7, bh, shown);
+      ctx.restore(); ctx.restore();
+      return;
+    }
     var F = 'BlinkMacSystemFont,"Segoe UI",Roboto,-apple-system,sans-serif';
     // THE NUMBER — as large as will fit, because the whole point is grasping it at a glance.
     var big = Math.round(bh * 0.42), tw;
@@ -351,17 +408,20 @@ function setupCpeResourcePanel(A) {
       ctx.fillStyle = 'rgba(255,255,255,0.60)';
       ctx.fillText(_fit(ctx, c.sub, colW), colX, baseY + Math.round(bh * 0.30));
     }
-    // dots: which of the revolving cards this is, so a viewer knows more are coming
+    _dots(ctx, colX, y + bh - pad * 0.7, bh, shown);
+    ctx.restore();
+    ctx.restore();
+  };
+
+  // dots: which of the revolving slots this is, so a viewer knows more are coming
+  function _dots(ctx, dx, dy, bh, shown) {
     var dr = Math.max(2, Math.round(bh * 0.016)), gap = dr * 3, i2;
-    var dx = colX, dy = y + bh - pad * 0.7;
     for (i2 = 0; i2 < shown.n; i2++) {
       ctx.beginPath(); ctx.arc(dx + i2 * gap, dy, dr, 0, Math.PI * 2);
       ctx.fillStyle = (i2 === shown.idx) ? 'rgba(255,255,255,0.85)' : 'rgba(255,255,255,0.28)';
       ctx.fill();
     }
-    ctx.restore();
-    ctx.restore();
-  };
+  }
 
   // shared frosted-glass backdrop — one implementation for both panel modes
   function _glass(ctx, x, y, bw, bh, rad) {

--- a/viewer/sw.js
+++ b/viewer/sw.js
@@ -22,7 +22,7 @@
 // schedule_author.js is in PRECACHE_ASSETS; v1088 shipped the STAGE 3 drawer change (#1528), so this
 // separate change needs its own bump (§CRISIS LESSON 4).
 // DEPLOY: bump CACHE_VERSION on every OCI upload. Old caches are purged on activate.
-const CACHE_VERSION = 'v1109';   // bump on each deploy; per-change detail is the git commit message.
+const CACHE_VERSION = 'v1110';   // bump on each deploy; per-change detail is the git commit message.
 // v1092 (2026-08-27) §R10 (bim-compiler prompts/CPE_4D_PERF_MEM_FINDINGS.md §7, extends R1's
 // §MAXQ_STAGE_KEEP contract): the MaxQ bake's per-frame §GLOW_LENS_QUAD rebuild (viewer/effects.js)
 // now skips the dispose+rebuild when the TM-visible fixture count is unchanged since the last

--- a/witness_cpe_resource_hold.js
+++ b/witness_cpe_resource_hold.js
@@ -1,4 +1,4 @@
-// WITNESS — §CPE_PIE_HOLD (bim-compiler prompts/CINEMA_PATH_EDITOR.md §CPE_PIE_HOLD).
+// WITNESS — §CPE_PIE_HOLD + §CPE_STATS_TAIL (bim-compiler prompts/CINEMA_PATH_EDITOR.md).
 //
 // ISSUE IT PROVES/DISPROVES: the composition pie DISAPPEARED for the whole silent tail of a bake
 // (after §CPE_BUILDUP_TOPOUT no trade is active, resourcePanelAt correctly returns null, and the
@@ -82,6 +82,36 @@ const gapHeld = A.resourcePanelHoldAt(at(12), gapOps, PS, PE);
 
 const sig = (info) => info ? info.rows.map(r => r.trade + ':' + r.heads).sort().join(',') : null;
 
+// ── §CPE_STATS_TAIL. ISSUE IT PROVES/DISPROVES: on the user's own Hospital bake the day counter
+// pinned at 315/315 from u≈0.45 and the pie showed one static trade (Finisher ×4) for the remaining
+// ≈125 s of a 229.8 s film — over HALF the film with nothing new on screen. §CPE_BIG_STATS could
+// not reach it: its trigger was "the pie is honestly empty", and Finisher ops run to the last day so
+// the pie is never empty. User's ruling: round 1 HOLDS and never intersperses; every highlight
+// belongs in the Reveal 2nd round.
+const frozenMid = A.resourcePanelFrozenAt(at(20), ops, PS, PE);      // trades still start/end ahead
+const frozenTail = A.resourcePanelFrozenAt(at(45), ops, PS, PE);     // past every boundary
+// the Hospital shape: staffed to the very last day, so the pie is NEVER empty but IS frozen
+// Finisher runs to the LAST day and the cursor parks there, exactly as the bake's buildup remap
+// leaves it (MEASURED: Day 315/315 with Finisher ×4 for the last ~125 s of the user's film).
+const hOps = ops.filter(o => o.r).concat(
+  Array.from({ length: 12 }, () => ({ s: PS + (DAYS - 6) * D, e: PE, r: 'FINISHER' })));
+hOps.sort((a, b) => a.s - b.s);
+const hLive = A.resourcePanelAt(at(DAYS - 1), hOps, PS, PE);
+const hFrozen = A.resourcePanelFrozenAt(at(DAYS - 1), hOps, PS, PE);
+const cards = [{ big: '63,182', label: 'elements coordinated', src: 'elements_meta' },
+               { big: '8', label: 'levels', src: 'elements_meta.storey' },
+               { big: '315', label: 'day programme', src: 'bake _bkState' }];
+const seenSlots = new Set(); let rosterSlots = 0, cardSlots = 0, faded = false;
+for (let t = 0; t < (cards.length + 1) * 4.5; t += 0.25) {
+  const sh = A.tailPanelAt(cards, t, hLive);
+  if (!sh) continue;
+  seenSlots.add(sh.idx);
+  if (sh.roster) rosterSlots++; else cardSlots++;
+  if (sh.opacity < 0.99) faded = true;
+}
+const rotN = A.tailPanelAt(cards, 0, hLive);
+const noCards = A.tailPanelAt(null, 0, hLive);      // cards unbuildable -> roster still revolves
+
 // ── draw: does the pie reach the canvas in BOTH modes?
 const W = 1852, H = 960;
 const off = () => OFFSCREEN.reduce((a, x) => ({ fills: a.fills + x._rec.fills, strokes: a.strokes + x._rec.strokes,
@@ -94,6 +124,11 @@ OFFSCREEN = []; const c2 = mkCtx(W, H); A.bigStatsCompositeOntoCanvas(c2, W, H, 
 const o2 = off();
 OFFSCREEN = []; const c3 = mkCtx(W, H); A.bigStatsCompositeOntoCanvas(c3, W, H, card, 1, 'tr', 60, null);
 const o3 = off();
+// the roster slot must draw the LIST (avatars + ×N), not a number
+OFFSCREEN = []; const c4 = mkCtx(W, H);
+A.bigStatsCompositeOntoCanvas(c4, W, H, A.tailPanelAt(cards, 0, hLive), 1, 'tr', 60, hLive);
+const o4 = off();
+const rosterTexts = c4._rec.texts.concat(o4.texts);
 const capHeld = o1.texts.concat(o2.texts).concat(c1._rec.texts).concat(c2._rec.texts);
 
 console.log('='.repeat(84) + '\n§CPE_PIE_HOLD witness — synthetic programme, ' + DAYS +
@@ -113,6 +148,13 @@ console.log('  draw: resource panel blits=' + c1._rec.images + ' offscreen wedge
   ' | stats+held blits=' + c2._rec.images + ' cardFills=' + c2._rec.fills +
   ' | stats alone blits=' + c3._rec.images + ' cardFills=' + c3._rec.fills);
 console.log('  captions seen: ' + JSON.stringify(capHeld.filter(t => /^day /.test(t))));
+console.log('  frozen: mid-programme=' + frozenMid + '  past-every-boundary=' + frozenTail +
+  '  |  Hospital shape (staffed to the last day): pieEmpty=' + (hLive === null) + ' frozen=' + hFrozen +
+  ' rows=' + JSON.stringify(sig(hLive)));
+console.log('  rotation: slots=' + (rotN && rotN.n) + ' (1 roster + ' + cards.length + ' cards)  reached=' +
+  seenSlots.size + '  rosterHits=' + rosterSlots + ' cardHits=' + cardSlots + ' fades=' + faded +
+  '  noCardsFallback=' + (noCards ? 'roster n=' + noCards.n : 'null'));
+console.log('  roster slot draws: ' + JSON.stringify(rosterTexts.filter(t => /on site|×/.test(t))));
 
 const G = [
   ['G-HOLD-1  a staffed day returns the LIVE composition (held=false), identical to resourcePanelAt',
@@ -133,7 +175,20 @@ const G = [
   ['G-HOLD-8  a held pie is captioned with the day it is from (a past day must say so)',
     capHeld.some(t => t === 'day ' + (lastStaffed.dayKey + 1))],
   ['G-HOLD-9  the pie bitmap is cached ACROSS both modes — the second panel re-blits, never re-renders',
-    o2.fills === 0 && c2._rec.images > 0]
+    o2.fills === 0 && c2._rec.images > 0],
+  ['G-TAIL-1  a cursor with a later op boundary is NOT frozen (round 1 keeps the trade list)',
+    frozenMid === false],
+  ['G-TAIL-2  staffed to the LAST day -> pie NOT empty yet IS frozen (the Hospital case the cards could not reach)',
+    hLive !== null && hLive.totalHeads > 0 && hFrozen === true],
+  ['G-TAIL-3  the empty-pie case still reports frozen (§CPE_PIE_HOLD subsumed, not regressed)',
+    frozenTail === true],
+  ['G-TAIL-4  the rotation reaches every slot, roster included, and fades',
+    !!rotN && rotN.n === cards.length + 1 && seenSlots.size === cards.length + 1 &&
+    rosterSlots > 0 && cardSlots > 0 && faded === true],
+  ['G-TAIL-5  the roster slot draws the trade LIST (avatars + ×N), not a number',
+    rosterTexts.some(t => /on site$/.test(t)) && rosterTexts.some(t => /^×\d+$/.test(t))],
+  ['G-TAIL-6  no cards buildable -> the roster still revolves rather than the panel going blank',
+    !!noCards && noCards.n === 1 && !!noCards.roster]
 ];
 let pass = 0;
 G.forEach(([n, v]) => { console.log('  ' + (v ? 'PASS' : 'FAIL') + '  ' + n); if (v) pass++; });


### PR DESCRIPTION
**User, 2026-08-30, on `BIM_MaxQ_Hospital_1788092317604.mp4`:** *"there is ample unused timing to display more info after Finishes"* … *"the in betweens highlights are in the wrong spots. They should all be in play during the 'Reveal' 2nd round. In the first round, if nothing is added, that last info holds and wait till a new one arrives, not intersperse."*

## Measured on that exact mp4
3,447 frames · 15 fps · 229.8 s · 1852×960 · h264 · 145 MB · **no audio stream**.

- The day counter's digits **stop changing at u≈0.45** (`Day 315 / 315`). XOR against the final frame's digit mask drops from ~250 px to ~50 px (compression noise) at sample 27 of 60 and never rises again.
- The pie shows **one static trade for that whole tail** — `4 on site · Finisher ×4`, ~5,100 palette-matched wedge px in all 22 samples from u=0.35 to u=0.99.
- **≈125 s of a 229.8 s film had nothing new on screen.**

## Why the cards never appeared
`§CPE_BIG_STATS`'s handover trigger was *"the pie is honestly empty"*. On this schedule Finisher ops run to the last day, so the pie is **never** empty and the cards were structurally unreachable. Right about the symptom, wrong about the test.

## The two-round rule
- **Round 1 (buildup, u < topoutU)** — the schedule, and **nothing rotates**. A day with no staffed op **holds** the last real composition until a new one arrives (§CPE_PIE_HOLD). No interspersing.
- **Round 2 (the Reveal, u ≥ topoutU)** — every highlight is in play, revolving, with the **roster as one of the slots** so the trade list with its avatars and ×N is never lost to the cards.

The boundary is the plan's own `§CPE_BUILDUP_TOPOUT`, not a new constant. With no plan beats to read it degrades to `resourcePanelFrozenAt` — *no op boundary remains after the end of this cursor's **day***, so the composition is fixed for every following frame. Day granularity is what makes the real shape work: the buildup parks the cursor on the final day with the last trade still running on it, which is non-empty **and** frozen at once.

## Witness — `witness_cpe_resource_hold.js`, 15/15 PASS (node, no browser)
```
  frozen: mid-programme=false  past-every-boundary=true
          Hospital shape (staffed to the last day): pieEmpty=false frozen=true rows="FINISHER:4"
  rotation: slots=4 (1 roster + 3 cards)  reached=4  rosterHits=18 cardHits=54 fades=true
            noCardsFallback=roster n=1
  roster slot draws: ["4 on site","×4"]
  15/15 — PASS
```
G-TAIL-2 is the load-bearing one: staffed to the last day → pie **not** empty yet **is** frozen, the exact Hospital case the cards could not reach. G-TAIL-5 proves the roster slot draws the list, not a number. G-HOLD-1..9 unchanged and still green.

New `§CPE_STATS_TAIL` log names the frame the Reveal round is entered, which boundary decided it, how many slots revolve, and `revolvedFrames/framesDone` at the end — 0 means the dead tail stayed dead.

eslint `no-undef`: 3 before, 3 after (pre-existing `VideoEncoder`/`VideoFrame`). `sw.js` CACHE_VERSION → **v1110** (v1109 was already taken by #1585 on main).

Spec: bim-compiler `prompts/CINEMA_PATH_EDITOR.md` §CPE_STATS_TAIL

🤖 Generated with [Claude Code](https://claude.com/claude-code)