### PR TITLE
fix(landing): Clinic points at the single Clinic.db, no meta/geo split

### DIFF
--- a/index.html
+++ b/index.html
@@ -475,7 +475,7 @@ var BUILDINGS={
   'Ifc2x3_AC11Institute':{db:'AC11Institute_extracted.db'},'Duplex':{db:'Duplex_extracted.db'},
   'LTU_AHouse':{db:'LTU_AHouse_extracted.db'},'Hospital':{db:'Hospital_extracted.db'},
   'Hospital_3':{db:'Hospital_3_extracted.db'},'Terminal':{db:'Terminal_extracted.db'},
-  'Clinic':{db:'Clinic_extracted.db'},'Ifc4_Revit':{db:'Ifc4_Revit_extracted.db'},
+  'Clinic':{db:'Clinic.db'},'Ifc4_Revit':{db:'Ifc4_Revit_extracted.db'},
   'WBDG_Office':{db:'WBDG_Office_extracted.db'},'HHS_Office_Federated':{db:'HHS_Office_Federated_extracted.db',gh:'https://red1oon.github.io/bim-ootb/'},
   'HITOS':{db:'HITOS_extracted.db'},'Esplanades':{db:'Esplanades_extracted.db'},
   'HospitalGarage':{db:'HospitalGarage_extracted.db'},'HospitalGarage_2':{db:'HospitalGarage_2_extracted.db'},


### PR DESCRIPTION
Clinic is **16,071 elements** — below `split_db.sh`'s own documented `>20,000` threshold, so the meta/geo split buys nothing and the single file is the faster load.

- `buildings/Clinic.db` uploaded to OCI (user-supplied clean extraction), md5-verified against the source file.
- Landing entry: `'Clinic':{db:'Clinic_extracted.db'}` → `'Clinic':{db:'Clinic.db'}`.

Note for whoever touches this next: `streaming.js` derives `<name>_meta.db`/`<name>_geo.db` from the db URL and HEADs them — if both exist it uses the split pair regardless of what the landing points at. The stale `Clinic_meta.db`/`Clinic_geo.db` objects are being cleared so the single file is actually the one served.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012qqtWXK8Lp1DVTAMimwxdi