### PR TITLE
perf(still): §R11 §PHOTO_PREWARM — take the one-time work off the first Alt+S

### DIFF
--- a/viewer/effects.js
+++ b/viewer/effects.js
@@ -2209,6 +2209,56 @@ async function setupEffects(A, renderer, scene, camera) {
     if (window.requestIdleCallback) window.requestIdleCallback(run, { timeout: 6000 });
     else setTimeout(run, 4000);
   })();
+  // ══ §PHOTO_PREWARM (§R11, bim-compiler prompts/CPE_4D_PERF_MEM_STUDY.md) ══════════════════════
+  // User, 2026-09-01, on a real v1111 Hospital session: "it seems slow to come on first time."
+  //
+  // MEASURED from that session's own log — the FIRST Alt+S costs ~27 s and every one after it ~7 s:
+  //   §MEP_SMOOTH_NORMALS ms=8923.6   (once per session, 23,735,190 verts over 1,705 geoms)
+  //   §STILL_REFINE done elapsedMs=17933 first vs 6868 second
+  //   §PHOTO_AO done totalMs=576      (not worth touching — 2% of the press)
+  // The 20 s gap is ALL one-time work that happened to be sitting on the press. Two causes:
+  //   1. the smoothing pass itself, 8.9 s;
+  //   2. assets arriving DURING the fold — the run logged §STILL_REFINE_RESTART TWICE, with
+  //      §LAYER2_HDRI_READY and §GROUND_MAP key=earth landing in between, and every restart throws
+  //      away the samples accumulated so far.
+  //
+  // So this is a SCHEDULING change, not a behaviour change: the same work, done at idle once the
+  // model is fully streamed (streaming.js calls this from the point its own comment already calls
+  // "the model is fully streamed here"). The staging path KEEPS its own call as a fallback — if
+  // prewarm has not run yet, the first Alt+S still does the work itself. DEGRADE, DON'T DISABLE.
+  //
+  // Idle, not eager: requestIdleCallback with a timeout, the same idiom §PHOTO_STAFFAGE_PRELOAD
+  // above already uses, so a user who never presses Alt+S pays nothing on the interactive path.
+  A._photoPrewarm = function () {
+    if (A._photoPrewarmDone) return false;   // idempotent — streaming can flush more than once
+    A._photoPrewarmDone = true;
+    var run = function () {
+      var t0 = performance.now(), did = [], skipped = [];
+      try {
+        if (!A._mepSmoothDone && A.mepSmoothNormals) {
+          A.mepSmoothNormals(); A._mepSmoothDone = true; did.push('mepSmooth');
+        } else skipped.push('mepSmooth(already done)');
+      } catch (e) { skipped.push('mepSmooth:' + e.message); }
+      // Both of these are cached+idempotent, and both were landing mid-fold and restarting it.
+      try { _ensureHdriEnvMap(); did.push('hdri'); } catch (e) { skipped.push('hdri:' + e.message); }
+      try {
+        // The ground texture is loaded by tools.js on staging; warming the HTTP cache here is the
+        // whole cost of it and needs no handle into that module.
+        if (typeof fetch === 'function') {
+          fetch('textures/ground/earth_1k.jpg', { cache: 'force-cache' }).then(function (r) { return r && r.blob(); })
+            .catch(function () {});
+          did.push('groundTex');
+        }
+      } catch (e) { skipped.push('groundTex:' + e.message); }
+      console.log('§PHOTO_PREWARM ms=' + Math.round(performance.now() - t0) +
+        ' did=[' + did.join(',') + ']' + (skipped.length ? ' skipped=[' + skipped.join(',') + ']' : '') +
+        ' — this work is now OFF the first Alt+S press (measured 8,923.6 ms of it on Hospital)');
+    };
+    if (window.requestIdleCallback) window.requestIdleCallback(run, { timeout: 8000 });
+    else setTimeout(run, 2000);
+    return true;
+  };
+
   // ══ §BILLBOARD_ART (2026-07-28, user: "make it pick a png image i can place later in the same
   // DB folder. For now just 'RUANG IKLAN UNTUK DI SEWA'… if no image, it gives that notice.")
   //

--- a/viewer/streaming.js
+++ b/viewer/streaming.js
@@ -2122,6 +2122,12 @@ function setupStreaming(A) {
     // §BILLBOARD_ALWAYS: the model is fully streamed here, so any billboard element in the DB can
     // now be read and given its face. Idempotent and a no-op for buildings that have no billboard.
     if (A._billboardAutoBuild) A._billboardAutoBuild();
+    // §PHOTO_PREWARM (bim-compiler prompts/CPE_4D_PERF_MEM_STUDY.md §R11): the model is fully
+    // streamed here, which is the EARLIEST point the curve-smoothing pass can legally run — it
+    // walks streamed geometry. MEASURED on the user's own Hospital session: that pass costs
+    // 8,923.6 ms and it was being paid on the first Alt+S press, not here. Same idempotent,
+    // no-op-if-absent contract as the billboard build above.
+    if (A._photoPrewarm) A._photoPrewarm();
   };
 
   // §S261: Bbox-only BatchedMesh flush — ONE flush, all elements start as bbox cubes.

--- a/viewer/sw.js
+++ b/viewer/sw.js
@@ -22,7 +22,7 @@
 // schedule_author.js is in PRECACHE_ASSETS; v1088 shipped the STAGE 3 drawer change (#1528), so this
 // separate change needs its own bump (§CRISIS LESSON 4).
 // DEPLOY: bump CACHE_VERSION on every OCI upload. Old caches are purged on activate.
-const CACHE_VERSION = 'v1111';   // bump on each deploy; per-change detail is the git commit message.
+const CACHE_VERSION = 'v1112';   // bump on each deploy; per-change detail is the git commit message.
 // v1092 (2026-08-27) §R10 (bim-compiler prompts/CPE_4D_PERF_MEM_FINDINGS.md §7, extends R1's
 // §MAXQ_STAGE_KEEP contract): the MaxQ bake's per-frame §GLOW_LENS_QUAD rebuild (viewer/effects.js)
 // now skips the dispose+rebuild when the TM-visible fixture count is unchanged since the last

--- a/witness_photo_prewarm.js
+++ b/witness_photo_prewarm.js
@@ -1,0 +1,62 @@
+// WITNESS — §PHOTO_PREWARM (§R11, bim-compiler prompts/CPE_4D_PERF_MEM_STUDY.md).
+//
+// ISSUE IT PROVES/DISPROVES: the FIRST Alt+S cost the user ~27 s against ~7 s for every press
+// after it. MEASURED from their own v1111 Hospital log: §MEP_SMOOTH_NORMALS ms=8923.6 ran ON the
+// press, and §LAYER2_HDRI_READY / §GROUND_MAP arriving mid-fold restarted the accumulation twice
+// (§STILL_REFINE_RESTART). This moves that one-time work to idle-after-streaming. Does it (a) fire
+// at all, (b) actually do the smoothing THERE rather than on the press, (c) leave the press with
+// NO smoothing left to do, (d) still produce a finished still, and (e) stay idempotent?
+//
+// (b) and (c) are load-bearing together: (b) alone would pass if the pass simply ran twice, which
+// would be WORSE than the bug. Console ORDER is the evidence — §MEP_SMOOTH_NORMALS must appear
+// before §STILL_REFINE start, and must not appear again after it.
+const puppeteer = require('/home/red1/bim-compiler/node_modules/puppeteer');
+const PORT = process.env.PORT || 8521, BLD = process.env.BLD || 'HHS_Office_Federated';
+process.on('unhandledRejection', e => { console.error('UNHANDLED: ' + (e && e.stack || e)); process.exit(1); });
+(async () => {
+  const b = await puppeteer.launch({ headless: 'new',
+    args: ['--use-gl=angle', '--use-angle=swiftshader', '--no-sandbox', '--enable-unsafe-swiftshader'],
+    protocolTimeout: 1800000 });
+  const p = await b.newPage(); await p.setViewport({ width: 900, height: 500 });
+  const seq = [], errs = [];
+  p.on('pageerror', e => errs.push(e.message.slice(0, 160)));
+  p.on('console', m => { const t = m.text();
+    if (/§PHOTO_PREWARM|§MEP_SMOOTH_NORMALS|§STILL_REFINE start|§STILL_REFINE done|§PHOTO_STAGING on|§LAYER2_HDRI_READY/.test(t))
+      seq.push(t.slice(0, 160)); });
+  await p.goto(`http://localhost:${PORT}/viewer/viewer.html?db=/buildings/${BLD}_extracted.db`,
+    { waitUntil: 'domcontentloaded', timeout: 180000 });
+  await p.waitForFunction(() => window.APP && window.APP.camera && typeof window.APP.startStillRefine === 'function',
+    { timeout: 240000 });
+  await p.waitForFunction(() => window.APP.streaming === true || (window.APP.streamQueue || []).length > 0,
+    { timeout: 180000, polling: 250 }).catch(() => {});
+  await p.waitForFunction(() => !window.APP.streaming || (window.APP.streamIdx >= (window.APP.streamQueue || []).length),
+    { timeout: 900000, polling: 1000 }).catch(() => {});
+  // give the idle callback its window (timeout:8000 in the code)
+  await p.waitForFunction(() => window.APP._mepSmoothDone === true, { timeout: 120000, polling: 500 }).catch(() => {});
+  const prewarmFired = seq.some(l => l.startsWith('§PHOTO_PREWARM'));
+  const idxSmoothBefore = seq.findIndex(l => l.startsWith('§MEP_SMOOTH_NORMALS'));
+  const twice = await p.evaluate(() => window.APP._photoPrewarm());   // idempotency: must return false
+  const beforePress = seq.length;
+  await p.evaluate(() => window.APP.startStillRefine());
+  await p.waitForFunction(() => window.APP._stillRefineBusy === false, { timeout: 900000, polling: 200 }).catch(() => {});
+  const after = seq.slice(beforePress);
+  const idxStart = seq.findIndex(l => l.startsWith('§STILL_REFINE start'));
+  console.log('='.repeat(84) + `\n§PHOTO_PREWARM witness — ${BLD}\n` + '='.repeat(84));
+  seq.forEach((l, i) => console.log(`  ${String(i).padStart(2)} ${l}`));
+  const G = [
+    ['G-PW-1  §PHOTO_PREWARM fired after streaming', prewarmFired],
+    ['G-PW-2  the smoothing ran in the PREWARM, before any Alt+S press',
+      idxSmoothBefore >= 0 && (idxStart < 0 || idxSmoothBefore < idxStart)],
+    ['G-PW-3  the press did NOT redo the smoothing (guard held, not run twice)',
+      !after.some(l => l.startsWith('§MEP_SMOOTH_NORMALS'))],
+    ['G-PW-4  the still still completes after the change',
+      after.some(l => l.startsWith('§STILL_REFINE done'))],
+    ['G-PW-5  prewarm is idempotent — a second call is a no-op', twice === false],
+    ['G-PW-6  no page errors', errs.length === 0]
+  ];
+  let pass = 0; G.forEach(([n, v]) => { console.log('  ' + (v ? 'PASS' : 'FAIL') + '  ' + n); if (v) pass++; });
+  if (errs.length) console.log('  errors: ' + errs.slice(0, 3).join(' | '));
+  console.log(`\n  ${pass}/${G.length} — ${pass === G.length ? 'PASS' : 'FAIL'}`);
+  await b.close();
+  process.exit(pass === G.length ? 0 : 1);
+})();


### PR DESCRIPTION
**User, on a real v1111 Hospital session:** *"it seems slow to come on first time."*

## Measured, from that session's own log
The **first** Alt+S costs ~27 s; every press after it ~7 s.

| | 1st Alt+S | 2nd Alt+S |
|---|---|---|
| `§MEP_SMOOTH_NORMALS` | **8,923.6 ms** | — (once per session) |
| `§STILL_REFINE done elapsedMs` | **17,933** | **6,868** |
| `§PHOTO_AO done totalMs` | 576 | 625 |

The 20-second gap is **all one-time work that happened to sit on the press**:
1. the smoothing pass itself — 8.9 s (23,735,190 verts over 1,705 geoms);
2. assets arriving **during** the fold — that run logged `§STILL_REFINE_RESTART` **twice**, with `§LAYER2_HDRI_READY` and `§GROUND_MAP key=earth` landing between them, and every restart discards the samples accumulated so far.

## The change is scheduling, not behaviour
`streaming.js` already had a point its own comment calls *"the model is fully streamed here"* — the earliest moment the smoothing may legally run, since it walks streamed geometry. `A._photoPrewarm()` hooks in there beside the billboard build, with the same idempotent, no-op-if-absent contract, and runs at **idle** (`requestIdleCallback`, timeout 8000 — the idiom `§PHOTO_STAFFAGE_PRELOAD` already uses), so a user who never presses Alt+S pays nothing on the interactive path.

**The staging path keeps its own call as a fallback.** If prewarm hasn't run yet, the first Alt+S still does the work itself — degrade, don't disable.

`§PHOTO_AO` is deliberately untouched: 576 ms of a 27-second press.

## Witness — `witness_photo_prewarm.js`, 6/6 PASS
```
 0 §MEP_SMOOTH_NORMALS geoms=149 ranges=1615 vertsSmoothed=1965493 ... ms=1339.4
 1 §PHOTO_PREWARM ms=1342 did=[mepSmooth,hdri,groundTex]
 2 §PHOTO_STAGING on nightWasOn=false
 3 §STILL_REFINE start samples=16 triplanarMaterials=17
 5 §STILL_REFINE done accumulateIndex=16
```
- **G-PW-1** prewarm fired after streaming
- **G-PW-2** the smoothing ran in the prewarm, before any press — by console **order**
- **G-PW-3** the press did **not** redo it; the guard held
- **G-PW-4** the still still completes
- **G-PW-5** idempotent — a second `_photoPrewarm()` returns false
- **G-PW-6** no page errors

G-PW-2 and G-PW-3 are load-bearing **together**: "prewarm fired" alone would also pass if the pass simply ran twice, which is worse than the original bug.

## Honest limit
The HDRI is **started** earlier, not guaranteed **finished**. The witness presses Alt+S immediately, and `§LAYER2_HDRI_READY` still lands after `§STILL_REFINE start` there. A real user takes seconds, so it should resolve first — but the guarantee is "started sooner", not "done".

eslint `no-undef`: 0 messages on both touched files. `sw.js` CACHE_VERSION v1111 → **v1112**.

Spec: bim-compiler `prompts/CPE_4D_PERF_MEM_STUDY.md` §R11

🤖 Generated with [Claude Code](https://claude.com/claude-code)