### PR TITLE
fix(cpe): §CPE_CARD_FIT — stat-card text truncated once the pie took its column

### DIFF
--- a/viewer/cpe_resource_panel.js
+++ b/viewer/cpe_resource_panel.js
@@ -400,18 +400,73 @@ function setupCpeResourcePanel(A) {
     ctx.fillStyle = '#fff';
     var baseY = y + pad + big * 0.86;
     ctx.fillText(c.big, colX, baseY);
-    ctx.font = '600 ' + Math.round(bh * 0.105) + 'px ' + F;
+    // §CPE_CARD_FIT (2026-09-01, found in the user's OWN Hospital bake, not by reading): once
+    // §CPE_PIE_HOLD gave the pie its own permanent column, the card's text column narrowed from
+    // bw-2*pad (286 px at h=960) to availW (171 px) — and the labels started truncating:
+    // "labour cost ..." and "9 trades  ·  time-...". That is the SAME defect §CPE_HUD_ORDER already
+    // fixed once for the trade names, and the file's own ruling applies unchanged: a label a client
+    // cannot read is the same failure as a placeholder storey — the card is there but says nothing.
+    // SHRINK BEFORE ELLIPSIS. The number above already does exactly this; the label and sub simply
+    // never did, because at 286 px they never had to. Ellipsis stays as the last resort so a
+    // pathologically long sub still cannot overflow the panel.
     ctx.fillStyle = 'rgba(255,255,255,0.88)';
-    ctx.fillText(_fit(ctx, c.label, colW), colX, baseY + Math.round(bh * 0.17));
+    _fitText(ctx, c.label, colX, baseY + Math.round(bh * 0.17), colW,
+             Math.round(bh * 0.105), Math.round(bh * 0.072), '600', F);
     if (c.sub) {
-      ctx.font = '500 ' + Math.round(bh * 0.085) + 'px ' + F;
+      // The sub is a full sentence ("9 trades · time-phased, not a bill of quantities" = 48 chars).
+      // At 171 px even the floor size cannot fit it on one line, and the real bake cut it mid-word
+      // at "time-phased, n…". There IS vertical room — the dots sit at bh-pad*0.7 and the sub starts
+      // at 0.30*bh — so it wraps to a second line instead of losing the caveat it exists to carry.
       ctx.fillStyle = 'rgba(255,255,255,0.60)';
-      ctx.fillText(_fit(ctx, c.sub, colW), colX, baseY + Math.round(bh * 0.30));
+      _wrapText(ctx, c.sub, colX, baseY + Math.round(bh * 0.30), colW,
+                Math.round(bh * 0.085), Math.round(bh * 0.058), '500', F, 2);
     }
     _dots(ctx, colX, y + bh - pad * 0.7, bh, shown);
     ctx.restore();
     ctx.restore();
   };
+
+  // §CPE_CARD_FIT — shrink to fit, then ellipsis only if still over. `floor` is the smallest size
+  // still worth printing; below that the text is decoration, so it gets the ellipsis instead.
+  function _fitText(ctx, text, x, y, maxW, size, floor, weight, F) {
+    var px = size;
+    while (px > floor) {
+      ctx.font = weight + ' ' + px + 'px ' + F;
+      if (ctx.measureText(text).width <= maxW) break;
+      px -= 1;
+    }
+    ctx.font = weight + ' ' + px + 'px ' + F;
+    ctx.fillText(_fit(ctx, text, maxW), x, y);
+    return px;
+  }
+
+  // §CPE_CARD_FIT — shrink, then wrap across at most `maxLines`, then ellipsis on the last line.
+  // Word-boundary wrap: a mid-word break reads as a rendering bug, which is the whole complaint.
+  function _wrapText(ctx, text, x, y, maxW, size, floor, weight, F, maxLines) {
+    var px = size;
+    // shrink first — one readable line beats two small ones
+    while (px > floor) {
+      ctx.font = weight + ' ' + px + 'px ' + F;
+      if (ctx.measureText(text).width <= maxW) break;
+      px -= 1;
+    }
+    ctx.font = weight + ' ' + px + 'px ' + F;
+    if (ctx.measureText(text).width <= maxW) { ctx.fillText(text, x, y); return px; }
+    var words = String(text).split(/\s+/), lines = [], cur = '';
+    for (var i = 0; i < words.length; i++) {
+      var next = cur ? cur + ' ' + words[i] : words[i];
+      if (ctx.measureText(next).width <= maxW || !cur) { cur = next; }
+      else { lines.push(cur); cur = words[i]; if (lines.length === maxLines) break; }
+    }
+    if (cur && lines.length < maxLines) lines.push(cur);
+    for (var j = 0; j < lines.length; j++) {
+      var last = (j === lines.length - 1);
+      var overflowed = last && (lines.length === maxLines) &&
+                       (words.join(' ').indexOf(lines[j]) + lines[j].length < words.join(' ').length);
+      ctx.fillText(overflowed ? _fit(ctx, lines[j] + ' …', maxW) : lines[j], x, y + j * Math.round(px * 1.25));
+    }
+    return px;
+  }
 
   // dots: which of the revolving slots this is, so a viewer knows more are coming
   function _dots(ctx, dx, dy, bh, shown) {

--- a/viewer/sw.js
+++ b/viewer/sw.js
@@ -22,7 +22,7 @@
 // schedule_author.js is in PRECACHE_ASSETS; v1088 shipped the STAGE 3 drawer change (#1528), so this
 // separate change needs its own bump (§CRISIS LESSON 4).
 // DEPLOY: bump CACHE_VERSION on every OCI upload. Old caches are purged on activate.
-const CACHE_VERSION = 'v1112';   // bump on each deploy; per-change detail is the git commit message.
+const CACHE_VERSION = 'v1113';   // bump on each deploy; per-change detail is the git commit message.
 // v1092 (2026-08-27) §R10 (bim-compiler prompts/CPE_4D_PERF_MEM_FINDINGS.md §7, extends R1's
 // §MAXQ_STAGE_KEEP contract): the MaxQ bake's per-frame §GLOW_LENS_QUAD rebuild (viewer/effects.js)
 // now skips the dispose+rebuild when the TM-visible fixture count is unchanged since the last

--- a/witness_cpe_resource_hold.js
+++ b/witness_cpe_resource_hold.js
@@ -109,6 +109,10 @@ for (let t = 0; t < (cards.length + 1) * 4.5; t += 0.25) {
   if (sh.roster) rosterSlots++; else cardSlots++;
   if (sh.opacity < 0.99) faded = true;
 }
+// §CPE_CARD_FIT — the exact card the user's bake truncated, drawn into the narrow column the held
+// pie leaves behind. The witness reads back what was actually PRINTED, not what was passed in.
+const longCard = { big: '1,771,249', label: 'labour cost committed',
+                   sub: '9 trades  ·  time-phased, not a bill of quantities', src: '§HR_COST' };
 const rotN = A.tailPanelAt(cards, 0, hLive);
 const noCards = A.tailPanelAt(null, 0, hLive);      // cards unbuildable -> roster still revolves
 
@@ -129,6 +133,9 @@ OFFSCREEN = []; const c4 = mkCtx(W, H);
 A.bigStatsCompositeOntoCanvas(c4, W, H, A.tailPanelAt(cards, 0, hLive), 1, 'tr', 60, hLive);
 const o4 = off();
 const rosterTexts = c4._rec.texts.concat(o4.texts);
+OFFSCREEN = []; const c5 = mkCtx(W, H);
+A.bigStatsCompositeOntoCanvas(c5, W, H, { card: longCard, idx: 3, n: 10, opacity: 1 }, 1, 'tr', 60, hLive);
+const cardTexts = c5._rec.texts.concat(off().texts);
 const capHeld = o1.texts.concat(o2.texts).concat(c1._rec.texts).concat(c2._rec.texts);
 
 console.log('='.repeat(84) + '\n§CPE_PIE_HOLD witness — synthetic programme, ' + DAYS +
@@ -155,6 +162,7 @@ console.log('  rotation: slots=' + (rotN && rotN.n) + ' (1 roster + ' + cards.le
   seenSlots.size + '  rosterHits=' + rosterSlots + ' cardHits=' + cardSlots + ' fades=' + faded +
   '  noCardsFallback=' + (noCards ? 'roster n=' + noCards.n : 'null'));
 console.log('  roster slot draws: ' + JSON.stringify(rosterTexts.filter(t => /on site|×/.test(t))));
+console.log('  long card prints:  ' + JSON.stringify(cardTexts));
 
 const G = [
   ['G-HOLD-1  a staffed day returns the LIVE composition (held=false), identical to resourcePanelAt',
@@ -188,7 +196,15 @@ const G = [
   ['G-TAIL-5  the roster slot draws the trade LIST (avatars + ×N), not a number',
     rosterTexts.some(t => /on site$/.test(t)) && rosterTexts.some(t => /^×\d+$/.test(t))],
   ['G-TAIL-6  no cards buildable -> the roster still revolves rather than the panel going blank',
-    !!noCards && noCards.n === 1 && !!noCards.roster]
+    !!noCards && noCards.n === 1 && !!noCards.roster],
+  // §CPE_CARD_FIT — the real Hospital bake showed "labour cost ..." and "9 trades  ·  time-..."
+  // truncating once the pie took its own column. Shrink-before-ellipsis must print the WHOLE label.
+  ['G-CARD-1  a long card label is printed IN FULL beside the pie, not ellipsised',
+    cardTexts.includes('labour cost committed')],
+  ['G-CARD-2  no card text on the panel ends in an ellipsis',
+    !cardTexts.some(function (t) { return /…$/.test(t); })],
+  ['G-CARD-3  the long sub WRAPS to a second line — the caveat survives, nothing is lost',
+    cardTexts.join(' ').indexOf('a bill of quantities') >= 0]
 ];
 let pass = 0;
 G.forEach(([n, v]) => { console.log('  ' + (v ? 'PASS' : 'FAIL') + '  ' + n); if (v) pass++; });


### PR DESCRIPTION
**Found in the user's own Hospital bake** (`BIM_MaxQ_Hospital_1788210263256.mp4`, 1,372 frames), not by reading: the Reveal-round cards render **"labour cost …"** and **"9 trades · time-…"** — cut mid-word.

**The cause is mine, from §CPE_PIE_HOLD.** Giving the pie a permanent column narrowed the card's text column from `bw - 2*pad` (286 px at h=960) to `availW` (171 px). The big number already auto-shrank to fit; the label and sub never did, because at 286 px they never had to.

This is the same defect §CPE_HUD_ORDER already fixed once for the trade names, and that ruling applies unchanged: *a label a client cannot read is the same failure as a placeholder storey — the card is there but says nothing.*

## Fix
- **label** — shrink before ellipsis (24 px, floor 17 px), the same treatment the number above it already had.
- **sub** — shrink, then **wrap at word boundaries** to a second line. 48 characters cannot fit 171 px at any readable size, and there is vertical room: the dots sit at `bh - pad*0.7` and the sub starts at `0.30*bh`. Mid-word breaks read as a rendering bug, which is the whole complaint.
- **ellipsis** survives as the last resort, so a pathological string still cannot overflow the panel.

## Witness — 18/18 PASS (was 15/15)
It reads back what was actually **printed**, not what was passed in:
```
["1,771,249","labour cost committed","9 trades · time-phased, not","a bill of quantities"]
```
- **G-CARD-1** a long label prints in full beside the pie
- **G-CARD-2** no card text on the panel ends in an ellipsis
- **G-CARD-3** the long sub wraps to a second line — the caveat survives

G-CARD-3 is the load-bearing one: G-CARD-2 alone would pass if the sub were silently **dropped** instead of wrapped.

## Also confirmed from that same mp4, by pixel measurement
- **§CPE_HUD_ORDER landed** — path box at y92–284 carries the yellow path + red head; the pie panel at y296–526 carries 2,783–3,544 trade-colour wedge px. Box above, pie below.
- **§CPE_STATS_TAIL is live** — 10 rotation slots, `20 levels` at u=0.75 and `1,771,249 labour cost` at u=0.90, with the pie holding its column in both.

eslint `no-undef`: 0 messages. `sw.js` CACHE_VERSION v1112 → **v1113**.

Spec: bim-compiler `prompts/CINEMA_PATH_EDITOR.md` §CPE_STATS_TAIL

🤖 Generated with [Claude Code](https://claude.com/claude-code)