### PR TITLE
chore(lfs): untrack modeller/mesh.db — the last LFS file, dead weight since §GEO-SERVED

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,15 +1,35 @@
-modeller/*_geo.db filter=lfs diff=lfs merge=lfs -text
-modeller/mesh.db filter=lfs diff=lfs merge=lfs -text
+# ── NO GIT-LFS IN THIS REPO — TRACKING REMOVED 2026-09-01 ─────────────────────────────────────
+# `modeller/mesh.db` was the only LFS-tracked file left in HEAD, and it has had NO runtime consumer
+# since §GEO-SERVED (2026-07-30, str_walker_outliner.js:37-49). That fix already replaced the one
+# shared 120MB mesh.db with each resident's own small `<Name>_geo.db` fetched from OCI GEO_BASE,
+# precisely because "GitHub Pages does not resolve LFS — the live page was being handed a 134-byte
+# text pointer with HTTP 200, so the geometry index came back empty." Re-verified 2026-09-01:
+#   red1oon.github.io/bim-ootb/modeller/mesh.db  -> HTTP 200, 134 bytes (still the pointer)
+#   .../b/bim-ootb/o/modeller/mesh.db            -> HTTP 404 (never uploaded — nothing wants it)
+#   .../b/bim-ootb/o/modeller/Terminal_geo.db    -> HTTP 200, 52.5 MB (the real, live path)
+# So untracking it removes dead weight, not a working feature. The file stays on local disk for
+# `scripts/gen_buildings_manifest.js`, the only thing that still reads it.
+#
+# WHY IT MATTERS: measured 2026-09-01, this account holds ~9.3 GB of LFS objects against a 1 GB
+# free quota that is shared PER ACCOUNT with bim-compiler (8.53 GB there, 0.78 GB here).
+# See bim-compiler prompts/LFS_QUOTA_AUDIT.md for the full measurement and the reasoning.
+# ⚠ This does NOT reclaim the 0.78 GB — GitHub bills every object ever pushed and has no
+# self-serve purge (only delete-and-recreate the repo, or a Support ticket). It stops the growth:
+# a new mesh.db version would otherwise have added another 120 MB, permanently.
+#
+# DO NOT re-add any `filter=lfs` rule. Per CLAUDE.md's DB POLICY, extracted/derived mesh and geo
+# DBs are distributed as full binaries via object storage (deploy/OCI_UPLOAD.md §RULES) and DB
+# content changes ship as SQL patches plus a self-heal loader — never through git or LFS.
 
-# ── LFS EGRESS GUARD (2026-08-19) ──────────────────────────────────────────────────────────────
-# GitHub bills LFS BANDWIDTH when a source archive containing real LFS content is downloaded, and
-# this repo cuts a release DAILY (auto-publish-release.yml, cron 0 1 * * *) — every tag adds another
-# permanently-downloadable tar.gz/zip. Measured 2026-08-19: the v1.49.1 tarball streamed 48MB+ before
-# being aborted, i.e. it carries real blob content, not pointers.
-# `export-ignore` removes these from `git archive` output (GitHub's source tarball/zipball) WITHOUT
-# touching history, clones, checkouts, or the Modeller — modeller.html, str_walker_outliner.js and
-# buildings_manifest.json all still reference mesh.db and are unaffected by this.
-# NOTE: this is only half the fix. The other half is a WEB-UI-ONLY repo setting not exposed by the
-# REST API: Settings -> Archives -> uncheck "Include Git LFS objects in archives".
+# ── LFS EGRESS GUARD (2026-08-19) — kept, now belt-and-braces ─────────────────────────────────
+# Written when these paths WERE LFS-tracked: GitHub bills LFS bandwidth when a source archive
+# carrying real LFS content is downloaded, and this repo cuts a release DAILY
+# (auto-publish-release.yml, cron 0 1 * * *), each tag permanently downloadable.
+# VERIFIED WORKING 2026-09-01, without spending bandwidth to prove it — GitHub's v1.57.0 tarball is
+# 95,036,194 B and a local `git archive` of the same tag is 95,040,305 B with ZERO mesh.db/_geo.db
+# entries, i.e. the archive carries no LFS content. (That 95 MB is ordinary non-LFS binaries
+# committed directly to this repo — a separate, still-open concern.)
+# Kept after the LFS removal above so these paths can never leak into an archive if one is ever
+# re-committed as a regular blob.
 modeller/mesh.db export-ignore
 modeller/*_geo.db export-ignore

--- a/modeller/mesh.db
+++ b/modeller/mesh.db
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:1cb80e700512d8914f1b54500f0993f747227e804d4a9c1cce491f7cbf4e60dc
-size 120025088


### PR DESCRIPTION
## What

Untracks `modeller/mesh.db` (the repo's only remaining Git-LFS object) and removes both `filter=lfs` rules from `.gitattributes`. **The file is kept on local disk** (`git rm --cached`).

## Why it is safe — measured 2026-09-01, not assumed

| probe | result |
|---|---|
| `red1oon.github.io/bim-ootb/modeller/mesh.db` | HTTP 200, **134 bytes** — the LFS *pointer*, not the DB |
| `…/b/bim-ootb/o/modeller/mesh.db` | **HTTP 404** — never uploaded to OCI |
| `…/b/bim-ootb/o/modeller/Terminal_geo.db` | HTTP 200, **52.5 MB** — the real, live geometry path |

`str_walker_outliner.js:37-49` (**§GEO-SERVED, 2026-07-30**) already moved every resident off the one shared 120 MB `mesh.db` and onto its own small `<Name>_geo.db` from OCI `GEO_BASE`, for exactly this reason — quoting that comment: *"GitHub Pages does not resolve LFS — the live page was being handed a 134-byte text pointer with HTTP 200, so the geometry index came back empty."*

No runtime path has read `mesh.db` since. The only remaining reader is `scripts/gen_buildings_manifest.js`, which reads it from local disk — unaffected, the file stays there.

## Why it matters

The GitHub LFS quota is **per account**, shared with `bim-compiler`. Measured the same day: **8.53 GB** there + **0.78 GB** here = **~9.3 GB against a 1 GB free allowance**. `bim-compiler` was taken off LFS entirely earlier today (59 DBs untracked); this removes the last tracked object here, so neither repo can grow the total again.

Full measurement and method: `bim-compiler prompts/LFS_QUOTA_AUDIT.md`.

⚠ **This does not reclaim the 0.78 GB.** GitHub bills every object ever pushed and offers no self-serve purge — only delete-and-recreate the repo, or a Support ticket. This stops the *growth*: a future `mesh.db` version would otherwise have added another 120 MB, permanently.

## Verified before committing

- No workflow references `mesh.db` or `gen_buildings_manifest`, and no workflow sets `lfs:` on `actions/checkout` → **CI unaffected**.
- `.gitignore:1` `*.db` already covers the path → it cannot be re-added by accident.
- The 2026-08-19 `export-ignore` guard is **kept** as belt-and-braces, and re-verified working without spending bandwidth: GitHub's `v1.57.0` tarball is 95,036,194 B vs a local `git archive` of the same tag at 95,040,305 B, with **zero** `mesh.db`/`_geo.db` entries.
- `git lfs ls-files` on this branch: **0** (was 1).

🤖 Generated with [Claude Code](https://claude.com/claude-code)