### PR TITLE
feat(cinema): §CLI_SILENT_BAKE — dev-only CLI silent bake taking a stored path + §NIGHT_BAKE_POOL bake perf fix

### DIFF
--- a/cli_silent_bake.js
+++ b/cli_silent_bake.js
@@ -1,0 +1,263 @@
+#!/usr/bin/env node
+// ⚠ DO NOT REMOVE — §CLI_SILENT_BAKE runner (spec: bim-compiler prompts/CINEMA_PATH_EDITOR.md
+// §CLI_SILENT_BAKE, 2026-09-01). Scope: dev-only command-line silent bake of the SHIPPED MaxQ
+// pipeline, taking a STORED PATH as argument. Read the log after every run — exit code is not
+// evidence; the §-tagged lines in --log are the witness.
+//
+// Usage:
+//   node cli_silent_bake.js --db HospitalAjaibPath --out /tmp/hospital.mp4 \
+//     [--plan NAME | --override file.json]            path source (default: DB cinema_path table)
+//     [--buildup] [--label] [--reveal] [--day tr|tl|br|bl|off]   flags composed onto the path
+//     [--frames N | --seconds S] [--fps N]            length (default: the plan's own pacing)
+//     [--gpu sw|real|headful] [--chrome-args "..."]   GPU mode (stage-3 feasibility decides)
+//     [--width W --height H] [--port P] [--log FILE] [--profile DIR]
+//     [--stall-min N] [--max-frame-ms N]              health watchdog (abort early, not at the end)
+//     [--timeout-min N]                               hard wall-clock cap
+'use strict';
+const fs = require('fs'), path = require('path'), http = require('http');
+const { execFileSync } = require('child_process');
+const puppeteer = require('/home/red1/bim-compiler/node_modules/puppeteer');
+
+// ── args ─────────────────────────────────────────────────────────────────────
+const argv = process.argv.slice(2);
+function arg(name, dflt) { const i = argv.indexOf('--' + name); return i >= 0 ? argv[i + 1] : dflt; }
+function has(name) { return argv.indexOf('--' + name) >= 0; }
+const ROOT = path.resolve(arg('root', __dirname));
+const DB = arg('db', 'HospitalAjaibPath');                 // name (buildings/<name>.db) or path
+const OUT = path.resolve(arg('out', '/tmp/silent_bake.mp4'));
+const PORT = +arg('port', 8544);
+const GPU = arg('gpu', 'sw');                              // sw | real | headful
+const W = +arg('width', 1280), H = +arg('height', 720);
+const FPS = arg('fps', null) ? +arg('fps') : undefined;
+const FRAMES = arg('frames', null) ? +arg('frames')
+  : (arg('seconds', null) ? Math.round(+arg('seconds') * (FPS || 15)) : undefined);
+const LOG = path.resolve(arg('log', OUT.replace(/\.[a-z0-9]+$/i, '') + '.log'));
+const PROFILE = arg('profile', '/tmp/silent-bake-profile-' + PORT);
+const STALL_MIN = +arg('stall-min', 10);
+const MAX_FRAME_MS = +arg('max-frame-ms', 0);              // 0 = off (stage 3 measures, stage 5 guards)
+const TIMEOUT_MIN = +arg('timeout-min', 300);
+const PLAN_NAME = arg('plan', null);
+const OV_FILE = arg('override', null);
+const FLAGS = {};
+if (has('buildup')) FLAGS.buildup = true;
+if (has('label')) FLAGS.roomTitle = true;
+if (has('reveal')) FLAGS.reveal = true;
+if (arg('day', null)) FLAGS.dayCounter = arg('day');
+
+const logStream = fs.createWriteStream(LOG, { flags: 'w' });
+function log(line) { const s = new Date().toISOString().slice(11, 19) + ' ' + line; logStream.write(s + '\n'); console.log(s); }
+function logRaw(line) { logStream.write(line + '\n'); }   // full console firehose → file only
+
+// ── static server (serves the checkout; symlinked buildings/ resolve normally) ──
+const MIME = { '.html': 'text/html', '.js': 'text/javascript', '.mjs': 'text/javascript',
+  '.css': 'text/css', '.json': 'application/json', '.wasm': 'application/wasm',
+  '.db': 'application/octet-stream', '.png': 'image/png', '.jpg': 'image/jpeg',
+  '.svg': 'image/svg+xml', '.hdr': 'application/octet-stream', '.gz': 'application/gzip',
+  '.ico': 'image/x-icon', '.webp': 'image/webp', '.woff2': 'font/woff2' };
+const server = http.createServer((req, res) => {
+  try {
+    const u = decodeURIComponent(req.url.split('?')[0]);
+    let fp = path.join(ROOT, u.replace(/^\/+/, ''));
+    if (!fp.startsWith('/')) fp = '/' + fp;
+    if (fs.existsSync(fp) && fs.statSync(fp).isDirectory()) fp = path.join(fp, 'index.html');
+    if (!fs.existsSync(fp)) { res.writeHead(404); res.end('404'); return; }
+    res.writeHead(200, { 'Content-Type': MIME[path.extname(fp).toLowerCase()] || 'application/octet-stream',
+                         'Cache-Control': 'no-store' });
+    fs.createReadStream(fp).pipe(res);
+  } catch (e) { res.writeHead(500); res.end(String(e)); }
+});
+
+// ── main ─────────────────────────────────────────────────────────────────────
+(async () => {
+  await new Promise(r => server.listen(PORT, '127.0.0.1', r));
+  const commit = execFileSync('git', ['-C', ROOT, 'rev-parse', '--short', 'HEAD']).toString().trim();
+  const swv = (fs.readFileSync(path.join(ROOT, 'viewer/sw.js'), 'utf8').match(/CACHE_VERSION = '([^']+)'/) || [])[1];
+  log(`§CLI_BAKE_ENV root=${ROOT} commit=${commit} sw=${swv} db=${DB} gpu=${GPU} out=${OUT}`);
+
+  const gpuArgs = {
+    sw: ['--use-gl=angle', '--use-angle=swiftshader', '--enable-unsafe-swiftshader'],
+    real: ['--use-angle=vulkan', '--enable-features=Vulkan,VulkanFromANGLE,DefaultANGLEVulkan',
+           '--ignore-gpu-blocklist', '--enable-gpu-rasterization'],
+    headful: []
+  }[GPU] || [];
+  const extra = (arg('chrome-args', '') || '').split(/\s+/).filter(Boolean);
+  const browser = await puppeteer.launch({
+    headless: GPU === 'headful' ? false : true,
+    userDataDir: PROFILE,
+    protocolTimeout: 15 * 60 * 1000,
+    args: ['--no-sandbox', '--hide-crash-restore-bubble', `--window-size=${W + 20},${H + 120}`]
+      .concat(gpuArgs, extra)
+  });
+  const page = await browser.newPage();
+  await page.setViewport({ width: W, height: H });
+
+  // console firehose → log file; §-lines also drive the health watchdog + summary
+  const S = { frames: 0, lastProgress: Date.now(), perFrame: [], fatal: null, done: false,
+              claims: {}, heap: [] };
+  const CLAIM_RX = /§(PHOTO_PREWARM|CPE_STATS_TAIL|CPE_PIE_HOLD|MAXQ_FRAME_BUDGET|MAXQ_MP4_FALLBACK|MAXQ_DONE|MAXQ_QUALITY|MAXQ_DELIVERED|CLI_BAKE_RESOLVED|MAXQ_OVERRIDE_IN|MAXQ_START|MAXQ_START_REVISED|CPE_APPLIED|CINEMA_PATH_RESTORE|CPE_BUILDUP_TOPOUT|CPE_BUILDUP_SKIP|MAXQ_HDRI_RACE|MAXQ_STREAM_WAIT|CPE_REVEAL)\b/;
+  page.on('console', m => {
+    const t = m.text();
+    logRaw('[con] ' + t);
+    const mm = t.match(CLAIM_RX);
+    if (mm) { (S.claims[mm[1]] = S.claims[mm[1]] || []).push(t); }
+    if (/§MAXQ_FRAME i=|§CPE_BUILDUP frame=|§MAXQ_STREAM|warming up|§MAXQ_MP4 |§MAXQ_STITCH|§MAXQ_IDB_READY/.test(t)) S.lastProgress = Date.now();
+    const fm = t.match(/§MAXQ_FRAME i=(\d+)\/(\d+) elapsedMs=(\d+) perFrameMs=(\d+)/);
+    if (fm) { S.frames = +fm[1]; S.perFrame.push(+fm[4]);
+      if (MAX_FRAME_MS && +fm[4] > MAX_FRAME_MS) S.fatal = `perFrameMs ${fm[4]} > --max-frame-ms ${MAX_FRAME_MS}: ${t}`; }
+    if (/§MAXQ_FAIL|§MAXQ_GL_LOST|§MAXQ_IDB_LOST|§CPE_BUILDUP_SKIP/.test(t)) log('⚠ ' + t);
+    if (/§MAXQ_FAIL/.test(t)) S.fatal = t;
+  });
+  page.on('pageerror', e => { logRaw('[pageerror] ' + e.message); log('⚠ PAGEERROR ' + e.message.slice(0, 160)); });
+
+  // delivery sink: page → node file (chunked base64 through an exposed function)
+  let sink = null, sinkName = null, sinkBytes = 0;
+  await page.exposeFunction('__maxqSinkBegin', (name, type, total) => {
+    sinkName = name; sinkBytes = 0;
+    sink = fs.createWriteStream(OUT);
+    log(`§CLI_BAKE_SINK begin name=${name} type=${type} totalBytes=${total} → ${OUT}`);
+  });
+  await page.exposeFunction('__maxqSink', b64 => new Promise((res, rej) => {
+    const buf = Buffer.from(b64, 'base64'); sinkBytes += buf.length;
+    sink.write(buf, e => e ? rej(e) : res());
+  }));
+  await page.exposeFunction('__maxqSinkEnd', () => new Promise(res => {
+    sink.end(() => { log(`§CLI_BAKE_SINK end bytes=${sinkBytes}`); res(); });
+  }));
+
+  await page.evaluateOnNewDocument((flagsJson) => {
+    window.__MAXQ_SILENT = true;                       // gates window.__maxqBake (dev-only)
+    window.__maxqPoseLog = [];                          // §CLI_SILENT_BAKE item 4 — pose record
+    window.__maxqPoseTap = function(i, x, y, z, tx, ty, tz) {
+      window.__maxqPoseLog.push([i, x, y, z, tx, ty, tz, performance.now()]);
+    };
+    window.__maxqDeliverBlob = async function(blob, name, type) {
+      const buf = new Uint8Array(await blob.arrayBuffer());
+      await window.__maxqSinkBegin(name, type, buf.length);
+      const CH = 4 << 20;
+      for (let off = 0; off < buf.length; off += CH) {
+        const sub = buf.subarray(off, Math.min(off + CH, buf.length));
+        let s = '';
+        for (let i = 0; i < sub.length; i += 0x8000)
+          s += String.fromCharCode.apply(null, sub.subarray(i, i + 0x8000));
+        await window.__maxqSink(btoa(s));
+      }
+      await window.__maxqSinkEnd();
+    };
+  }, JSON.stringify(FLAGS));
+
+  const dbUrl = DB.includes('/') ? DB : `/buildings/${DB}.db`;
+  const url = `http://127.0.0.1:${PORT}/viewer/viewer.html?db=${dbUrl}`;
+  log(`§CLI_BAKE_NAV ${url}`);
+  await page.goto(url, { waitUntil: 'domcontentloaded', timeout: 120000 });
+  await page.waitForFunction(() => window.APP && window.APP.renderer && window.APP.camera &&
+    typeof window.APP.startMaxQualityOrbit === 'function' && typeof window.__maxqBake === 'function',
+    { timeout: 300000 });
+  // Authoritative load-complete signal: streaming.js's completion block adds the building to
+  // A.buildingsRendered THE SAME tick it sets A.streaming=false — `!APP.streaming` alone races
+  // the load (observed on the first smoke run: __maxqBake fired 7s after nav, before the DB).
+  await page.waitForFunction(() => window.APP.activeBuilding && window.APP.db &&
+    window.APP.buildingsRendered && window.APP.buildingsRendered.has(window.APP.activeBuilding) &&
+    !window.APP.streaming, { timeout: 900000, polling: 1000 });
+  log('§CLI_BAKE_LOADED building=' + await page.evaluate(() => window.APP.activeBuilding +
+    ' meshes=' + (window.APP.scene ? window.APP.scene.children.length : -1)));
+
+  // provable GPU identity (FUNDAMENTAL LAW: report the real context, not the flag we asked for)
+  const gl = await page.evaluate(() => {
+    const g = window.APP.renderer.getContext();
+    const d = g.getExtension('WEBGL_debug_renderer_info');
+    return { vendor: d ? g.getParameter(d.UNMASKED_VENDOR_WEBGL) : g.getParameter(g.VENDOR),
+             renderer: d ? g.getParameter(d.UNMASKED_RENDERER_WEBGL) : g.getParameter(g.RENDERER) };
+  });
+  log(`§CLI_BAKE_GL vendor="${gl.vendor}" renderer="${gl.renderer}"`);
+
+  // buildup needs an existing schedule; a fresh profile has no gantt cache — run the SHIPPED
+  // generation verb (same one a real Time Machine open runs) BEFORE the bake asks.
+  if (FLAGS.buildup) {
+    const tm = await page.evaluate(async () => {
+      if (typeof window.tmActivateForBake !== 'function') return 'no-hook';
+      const t0 = performance.now();
+      let ok = await window.tmActivateForBake();
+      if (!ok) ok = await window.tmActivateForBake();   // generation may outlive the first 30s poll
+      return (ok ? 'ok' : 'FAILED') + ' ms=' + Math.round(performance.now() - t0);
+    });
+    log(`§CLI_BAKE_TM_PRIME ${tm}`);
+    if (/FAILED|no-hook/.test(tm)) log('⚠ buildup will be skipped by the bake (no timeline)');
+  }
+
+  // heap sampling (Log Mandate: numbers, on an interval, into the log)
+  const heapIv = setInterval(async () => {
+    try { const m = await page.metrics(); S.heap.push(m.JSHeapUsedSize);
+      logRaw(`[heap] usedMB=${(m.JSHeapUsedSize / 1048576).toFixed(1)} totalMB=${(m.JSHeapTotalSize / 1048576).toFixed(1)}`);
+    } catch (e) {}
+  }, 20000);
+
+  // start the bake WITHOUT holding a CDP call open for hours: fire, then poll a page global.
+  const bakeOpts = { name: PLAN_NAME || undefined, flags: FLAGS, frames: FRAMES, fps: FPS };
+  if (OV_FILE) bakeOpts.override = JSON.parse(fs.readFileSync(OV_FILE, 'utf8'));
+  await page.evaluate(o => {
+    window.__bakeResult = null;
+    window.__maxqBake(o).then(r => { window.__bakeResult = { ok: true, r }; })
+      .catch(e => { window.__bakeResult = { ok: false, err: String(e && e.message || e) }; });
+  }, bakeOpts);
+  const t0 = Date.now();
+  let result = null, aborted = null;
+  while (!result) {
+    await new Promise(r => setTimeout(r, 5000));
+    result = await page.evaluate(() => window.__bakeResult).catch(() => null);
+    if (result) break;
+    const mins = (Date.now() - t0) / 60000;
+    if (S.fatal) { aborted = 'fatal: ' + S.fatal; break; }
+    if ((Date.now() - S.lastProgress) / 60000 > STALL_MIN) { aborted = `stall: no progress line for ${STALL_MIN} min (last frame=${S.frames})`; break; }
+    if (mins > TIMEOUT_MIN) { aborted = `timeout: ${TIMEOUT_MIN} min wall-clock cap`; break; }
+  }
+  clearInterval(heapIv);
+  if (aborted) {
+    log(`§CLI_BAKE_ABORT ${aborted}`);
+    try { await page.evaluate(() => window.APP.cancelMaxQualityOrbit()); await new Promise(r => setTimeout(r, 10000)); } catch (e) {}
+  } else {
+    log(`§CLI_BAKE_RESULT ${JSON.stringify(result)}`);
+  }
+
+  // pose record + independent plan check happen in the page, numbers only come back
+  const poseN = await page.evaluate(() => window.__maxqPoseLog.length);
+  if (poseN) {
+    const per = await page.evaluate(() => {
+      const L = window.__maxqPoseLog, d = [];
+      for (let i = 1; i < L.length; i++) d.push(L[i][7] - L[i - 1][7]);
+      d.sort((a, b) => a - b);
+      const mean = d.reduce((a, b) => a + b, 0) / (d.length || 1);
+      return { n: L.length, meanMs: +mean.toFixed(1), p50: +(d[d.length >> 1] || 0).toFixed(1),
+               worstMs: +(d[d.length - 1] || 0).toFixed(1) };
+    });
+    log(`§CLI_BAKE_FRAMES poses=${per.n} meanMs=${per.meanMs} p50Ms=${per.p50} worstMs=${per.worstMs}`);
+    fs.writeFileSync(OUT.replace(/\.[a-z0-9]+$/i, '') + '_poses.json',
+      JSON.stringify(await page.evaluate(() => window.__maxqPoseLog)));
+  }
+  const heapMB = S.heap.map(x => x / 1048576);
+  if (heapMB.length) log(`§CLI_BAKE_HEAP samples=${heapMB.length} minMB=${Math.min(...heapMB).toFixed(0)} maxMB=${Math.max(...heapMB).toFixed(0)} lastMB=${heapMB[heapMB.length - 1].toFixed(0)}`);
+
+  // the file, examined numerically — a zero-byte "success" is the guarded failure
+  let fileOk = false;
+  if (fs.existsSync(OUT) && fs.statSync(OUT).size > 0) {
+    fileOk = true;
+    log(`§CLI_BAKE_FILE path=${OUT} bytes=${fs.statSync(OUT).size}`);
+    try {
+      const probe = JSON.parse(execFileSync('ffprobe', ['-v', 'quiet', '-print_format', 'json',
+        '-show_format', '-show_streams', '-count_frames', OUT]).toString());
+      const v = probe.streams.find(s => s.codec_type === 'video') || {};
+      log(`§CLI_BAKE_FFPROBE codec=${v.codec_name} ${v.width}x${v.height} frames=${v.nb_read_frames} ` +
+          `fps=${v.r_frame_rate} durationSec=${(probe.format || {}).duration} bitrate=${(probe.format || {}).bit_rate}`);
+    } catch (e) { log('⚠ ffprobe failed: ' + e.message.slice(0, 200)); }
+  } else {
+    log(`§CLI_BAKE_FILE MISSING-OR-EMPTY path=${OUT} — the guarded failure mode`);
+  }
+
+  // shipped-claim summary (the big-prize § lines, verbatim)
+  for (const k of Object.keys(S.claims)) for (const line of S.claims[k]) log('§CLAIM ' + line.slice(0, 300));
+  log(`§CLI_BAKE_WALL totalSec=${((Date.now() - t0) / 1000).toFixed(0)} aborted=${aborted || 'no'} fileOk=${fileOk}`);
+
+  await browser.close();
+  server.close();
+  logStream.end();
+  process.exit(aborted || !fileOk ? 1 : 0);
+})().catch(e => { log('§CLI_BAKE_CRASH ' + (e && e.stack || e)); process.exit(2); });

--- a/cli_silent_bake.js
+++ b/cli_silent_bake.js
@@ -167,6 +167,12 @@ const server = http.createServer((req, res) => {
     !window.APP.streaming, { timeout: 900000, polling: 1000 });
   log('§CLI_BAKE_LOADED building=' + await page.evaluate(() => window.APP.activeBuilding +
     ' meshes=' + (window.APP.scene ? window.APP.scene.children.length : -1)));
+  // §R11: §PHOTO_PREWARM runs on requestIdleCallback (timeout 8s) after streaming completes.
+  // Give it its window BEFORE the bake so the claim is observable as shipped — the fallback path
+  // (first fold doing the work itself) would mask it. Proceed after 20s either way, with a note.
+  for (let w = 0; w < 20 && !S.claims.PHOTO_PREWARM; w++) await new Promise(r => setTimeout(r, 1000));
+  log(S.claims.PHOTO_PREWARM ? '§CLI_BAKE_PREWARM_SEEN ' + S.claims.PHOTO_PREWARM[0].slice(0, 200)
+      : '§CLI_BAKE_PREWARM_SEEN none after 20s — the bake fold will do the work itself (fallback path)');
 
   // provable GPU identity (FUNDAMENTAL LAW: report the real context, not the flag we asked for)
   const gl = await page.evaluate(() => {

--- a/cli_silent_bake.js
+++ b/cli_silent_bake.js
@@ -201,6 +201,14 @@ const server = http.createServer((req, res) => {
   // start the bake WITHOUT holding a CDP call open for hours: fire, then poll a page global.
   const bakeOpts = { name: PLAN_NAME || undefined, flags: FLAGS, frames: FRAMES, fps: FPS };
   if (OV_FILE) bakeOpts.override = JSON.parse(fs.readFileSync(OV_FILE, 'utf8'));
+  // The plan reads the live camera basis (§CPE_PREVIEW_DIVERGENCE) — save the pre-bake camera so
+  // the post-bake pose assertion can rebuild the SAME plan the bake built, not one based at the
+  // film's final pose (the loop leaves the camera at the last frame).
+  await page.evaluate(() => {
+    const A = window.APP;
+    window.__maxqCamSave = { px: A.camera.position.x, py: A.camera.position.y, pz: A.camera.position.z,
+                             tx: A.controls.target.x, ty: A.controls.target.y, tz: A.controls.target.z };
+  });
   await page.evaluate(o => {
     window.__bakeResult = null;
     window.__maxqBake(o).then(r => { window.__bakeResult = { ok: true, r }; })
@@ -239,6 +247,45 @@ const server = http.createServer((req, res) => {
     log(`§CLI_BAKE_FRAMES poses=${per.n} meanMs=${per.meanMs} p50Ms=${per.p50} worstMs=${per.worstMs}`);
     fs.writeFileSync(OUT.replace(/\.[a-z0-9]+$/i, '') + '_poses.json',
       JSON.stringify(await page.evaluate(() => window.__maxqPoseLog)));
+    // ── §CLI_SILENT_BAKE item 4, the numeric assertion — did the STORED path drive the camera? ──
+    // (a) rebuild the override plan at the pre-bake camera basis: flown poses must reproduce it
+    //     to ~0 (same code path — catches plumbing loss);
+    // (b) build the DERIVED plan (explicit null override): the flown track must DIFFER from it
+    //     (a bake that silently ignored the passed path would match derived and fail here);
+    // (c) the flown track must pass near every stored band anchor (ties to the DB rows themselves).
+    const chk = await page.evaluate((fpsUsed) => {
+      const A = window.APP, L = window.__maxqPoseLog, ov = window.__maxqResolvedOverride;
+      if (!L || L.length < 2 || !ov) return { skip: 'no poses or no resolved override' };
+      if (ov.clip) return { skip: 'clip window set — t-mapping not identity, check by hand' };
+      const cs = window.__maxqCamSave;
+      A.camera.position.set(cs.px, cs.py, cs.pz); A.controls.target.set(cs.tx, cs.ty, cs.tz);
+      A.camera.lookAt(cs.tx, cs.ty, cs.tz); A.camera.updateMatrixWorld(true); A.controls.update();
+      const n = L[L.length - 1][0] + 1;
+      const planOv = A.cinemaPathPlan(n / fpsUsed, ov);
+      const planDrv = A.cinemaPathPlan(n / fpsUsed, null);
+      let maxErr = 0, sumDrv = 0;
+      for (const r of L) {
+        const t = n > 1 ? r[0] / (n - 1) : 0;
+        const p = planOv.poseAt(t), d = planDrv.poseAt(t);
+        maxErr = Math.max(maxErr, Math.hypot(r[1] - p.x, r[2] - p.y, r[3] - p.z),
+                          Math.hypot(r[4] - p.tx, r[5] - p.ty, r[6] - p.tz));
+        sumDrv += Math.hypot(r[1] - d.x, r[2] - d.y, r[3] - d.z);
+      }
+      const bandDist = (ov.bands || []).map(b => {
+        let m = 1e9;
+        for (const r of L) m = Math.min(m, Math.hypot(r[1] - b.c.x, r[2] - b.c.y, r[3] - b.c.z));
+        return +m.toFixed(2);
+      });
+      return { n, maxErrM: +maxErr.toFixed(4), rmsVsDerivedM: +(sumDrv / L.length).toFixed(2), bandDist };
+    }, FPS || 15).catch(e => ({ skip: 'check threw: ' + e.message }));
+    if (chk.skip) log('§CLI_BAKE_POSECHECK INCONCLUSIVE ' + chk.skip);
+    else {
+      const pass = chk.maxErrM < 0.05;
+      const differs = chk.rmsVsDerivedM > 1.0;
+      log(`§CLI_BAKE_POSECHECK frames=${chk.n} maxErrVsOverridePlanM=${chk.maxErrM} (${pass ? 'MATCH' : '⚠ MISMATCH'})` +
+          ` meanDistVsDerivedPlanM=${chk.rmsVsDerivedM} (${differs ? 'differs — the stored path, not the derived one' : '⚠ INDISTINGUISHABLE from derived — inconclusive discriminator'})` +
+          ` bandAnchorMinDistM=[${chk.bandDist.join(',')}]`);
+    }
   }
   const heapMB = S.heap.map(x => x / 1048576);
   if (heapMB.length) log(`§CLI_BAKE_HEAP samples=${heapMB.length} minMB=${Math.min(...heapMB).toFixed(0)} maxMB=${Math.max(...heapMB).toFixed(0)} lastMB=${heapMB[heapMB.length - 1].toFixed(0)}`);

--- a/cli_silent_bake.js
+++ b/cli_silent_bake.js
@@ -74,17 +74,24 @@ const server = http.createServer((req, res) => {
   const swv = (fs.readFileSync(path.join(ROOT, 'viewer/sw.js'), 'utf8').match(/CACHE_VERSION = '([^']+)'/) || [])[1];
   log(`§CLI_BAKE_ENV root=${ROOT} commit=${commit} sw=${swv} db=${DB} gpu=${GPU} out=${OUT}`);
 
+  // MEASURED 2026-09-01 (gl_probe, this machine): headless '--use-angle=vulkan' = NO-CONTEXT;
+  // plain headless = SwiftShader; '--use-angle=gl-egl' = Intel UHD via Mesa; gl-egl PLUS
+  // __EGL_VENDOR_LIBRARY_FILENAMES=10_nvidia.json = the real RTX 4060 ("ANGLE (NVIDIA Corporation,
+  // NVIDIA GeForce RTX 4060 Laptop GPU/PCIe/SSE2, OpenGL ES 3.2)"), fully headless, no X needed.
   const gpuArgs = {
     sw: ['--use-gl=angle', '--use-angle=swiftshader', '--enable-unsafe-swiftshader'],
-    real: ['--use-angle=vulkan', '--enable-features=Vulkan,VulkanFromANGLE,DefaultANGLEVulkan',
-           '--ignore-gpu-blocklist', '--enable-gpu-rasterization'],
-    headful: []
+    real: ['--use-angle=gl-egl', '--ignore-gpu-blocklist'],
+    intel: ['--use-angle=gl-egl', '--ignore-gpu-blocklist'],
+    headful: ['--disable-backgrounding-occluded-windows']   // §MAXQ_HIDDEN_PAUSE parks hidden tabs
   }[GPU] || [];
+  const gpuEnv = GPU === 'real'
+    ? { __EGL_VENDOR_LIBRARY_FILENAMES: '/usr/share/glvnd/egl_vendor.d/10_nvidia.json' } : {};
   const extra = (arg('chrome-args', '') || '').split(/\s+/).filter(Boolean);
   const browser = await puppeteer.launch({
     headless: GPU === 'headful' ? false : true,
     userDataDir: PROFILE,
     protocolTimeout: 15 * 60 * 1000,
+    env: Object.assign({}, process.env, gpuEnv),
     args: ['--no-sandbox', '--hide-crash-restore-bubble', `--window-size=${W + 20},${H + 120}`]
       .concat(gpuArgs, extra)
   });

--- a/viewer/cinema_maxq.js
+++ b/viewer/cinema_maxq.js
@@ -911,11 +911,22 @@
 
       var mp4 = window.MP4Mux.mux({ width: ew, height: eh, fps: fps, avcC: avcC, samples: chunks });
       var blob = new Blob([mp4], { type: 'video/mp4' });
-      var a = document.createElement('a');
-      a.href = URL.createObjectURL(blob);
-      a.download = 'BIM_MaxQ_' + (A.activeBuilding || 'building') + '_' + Date.now() + '.mp4';
-      document.body.appendChild(a); a.click(); document.body.removeChild(a);
-      setTimeout(function() { URL.revokeObjectURL(a.href); }, 2000);
+      var _dlName = 'BIM_MaxQ_' + (A.activeBuilding || 'building') + '_' + Date.now() + '.mp4';
+      // §CLI_SILENT_BAKE item 3 — the a.click() below is INERT headless. When a scripted runner
+      // installed __maxqDeliverBlob, hand it the finished bytes so node writes + asserts the file.
+      if (typeof window.__maxqDeliverBlob === 'function') {
+        try {
+          await window.__maxqDeliverBlob(blob, _dlName, 'video/mp4');
+          window.__maxqDeliveredBytes = blob.size;
+          console.log('§MAXQ_DELIVERED bytes=' + blob.size + ' name=' + _dlName);
+        } catch (eDl) { console.warn('§MAXQ_DELIVER_FAIL ' + eDl.message); }
+      } else {
+        var a = document.createElement('a');
+        a.href = URL.createObjectURL(blob);
+        a.download = _dlName;
+        document.body.appendChild(a); a.click(); document.body.removeChild(a);
+        setTimeout(function() { URL.revokeObjectURL(a.href); }, 2000);
+      }
       console.log('§MAXQ_DONE frames=' + framesDone + ' bytes=' + blob.size + ' type=video/mp4 codec=' + chosen);
       _status('🎬 MaxQ mp4 saved (' + (blob.size / 1e6).toFixed(1) + ' MB) — plays on iPhone/WhatsApp');
       return true;
@@ -955,11 +966,22 @@
     rec.stop();
     await stopped;
     var blob = new Blob(chunks, { type: mime });
-    var a = document.createElement('a');
-    a.href = URL.createObjectURL(blob);
-    a.download = 'BIM_MaxQ_' + (A.activeBuilding || 'building') + '_' + Date.now() + '.webm';
-    document.body.appendChild(a); a.click(); document.body.removeChild(a);
-    setTimeout(function() { URL.revokeObjectURL(a.href); }, 2000);
+    var _dlName = 'BIM_MaxQ_' + (A.activeBuilding || 'building') + '_' + Date.now() + '.webm';
+    // §CLI_SILENT_BAKE item 3 — same delivery seam as _stitchMp4: the fallback container must be
+    // capturable headlessly too (§MAXQ_MP4_FALLBACK is expected there, not a blocker).
+    if (typeof window.__maxqDeliverBlob === 'function') {
+      try {
+        await window.__maxqDeliverBlob(blob, _dlName, mime);
+        window.__maxqDeliveredBytes = blob.size;
+        console.log('§MAXQ_DELIVERED bytes=' + blob.size + ' name=' + _dlName);
+      } catch (eDl2) { console.warn('§MAXQ_DELIVER_FAIL ' + eDl2.message); }
+    } else {
+      var a = document.createElement('a');
+      a.href = URL.createObjectURL(blob);
+      a.download = _dlName;
+      document.body.appendChild(a); a.click(); document.body.removeChild(a);
+      setTimeout(function() { URL.revokeObjectURL(a.href); }, 2000);
+    }
     console.log('§MAXQ_DONE frames=' + framesDone + ' bytes=' + blob.size + ' type=' + mime);
     _status('🎬 MaxQ movie saved (' + (blob.size / 1e6).toFixed(1) + ' MB)');
   }
@@ -1168,12 +1190,12 @@
     // user editing for five minutes would otherwise hold a screen wake lock and run Terminal/Hospital
     // at full detail with no LOD the entire time. So all three are released for the duration of the
     // editor and re-claimed on OK. Gated by G11 — proven released, not merely described as released.
-    if (A.cinemaPathEditor && plan && plan.waypoints && opts.editor !== false) {
+    var _cpeRes = null;
+    if (A.cinemaPathEditor && plan && plan.waypoints && opts.editor !== false && !opts.override) {
       A._maxqActive = false;
       _wakeRelease(); _dampRelease(); _bakeBudgetRelease();
       console.log('§CPE_LOCKS released for editing (maxqActive=false, wake+damping released)');
       _status('🎬 Edit the path, then OK to record');
-      var _cpeRes = null;
       try {
         _cpeRes = await A.cinemaPathEditor.open({ plan: plan, durationSec: nFrames / fps, fps: fps });
       } catch (eE) { console.warn('§CPE_FAIL ' + eE.message + ' — proceeding with the derived path'); }
@@ -1187,7 +1209,44 @@
         _wakeRelease(); _dampRelease(); _bakeBudgetRelease();
         return;
       }
-      if (_cpeRes && _cpeRes.override) {
+      if (!(_cpeRes && _cpeRes.override)) {
+        // Guardrail 2: OK with no edit re-uses the plan object computed before the editor opened —
+        // literally the same object, so the film is byte-identical to one recorded without the
+        // editor existing. The default cost of this feature is one click and nothing else.
+        console.log('§CPE_APPLIED none — derived plan unchanged (guardrail 2: OK is a no-op)');
+      }
+    } else if (opts.override) {
+      // ══ §CLI_SILENT_BAKE item 2 (spec: bim-compiler prompts/CINEMA_PATH_EDITOR.md) — a
+      // scripted bake hands the stored override straight in, and it becomes the SAME _cpeRes shape
+      // the editor returns, so the application block below runs unchanged for both sources: one
+      // code path, no second format, no drift. The editor path stays byte-identical (its gate
+      // above merely adds `&& !opts.override`).
+      var _ovIn = opts.override;
+      var _durIn;
+      if (opts.frames) {
+        // An explicit frame count wins outright — durationSec must reproduce it exactly, because
+        // the application block below re-derives nFrames from durationSec (round-trip identity).
+        _durIn = nFrames / fps;
+      } else {
+        _durIn = (typeof _ovIn._total === 'number' && isFinite(_ovIn._total) && _ovIn._total > 0)
+          ? _ovIn._total : nFrames / fps;
+        // §CPE_PACING, applied to the OVERRIDE plan: a stored _total that predates caller-added
+        // reveal/hose flags must still buy those beats real frames — the plan's own naturalTotal
+        // is the authority, same contract as the derived path above.
+        try {
+          var _pIn = A.cinemaPathPlan(_durIn, _ovIn);
+          if (_pIn && _pIn.naturalTotal && isFinite(_pIn.naturalTotal) && _pIn.naturalTotal > 0)
+            _durIn = _pIn.naturalTotal;
+        } catch (eOvP) { console.warn('§MAXQ_OVERRIDE_IN plan-probe failed: ' + eOvP.message); }
+      }
+      _cpeRes = { action: 'ok', override: _ovIn, durationSec: _durIn, saved: false };
+      console.log('§MAXQ_OVERRIDE_IN source=' + (opts.overrideSource || 'caller') +
+        ' bands=' + (_ovIn.bands ? _ovIn.bands.length : 0) +
+        ' hoseOps=' + (_ovIn.hose ? _ovIn.hose.length : 0) +
+        ' buildup=' + (_ovIn.buildup ? 1 : 0) + ' roomTitle=' + (_ovIn.roomTitle ? 1 : 0) +
+        ' reveal=' + (_ovIn.reveal ? 1 : 0) + ' durationSec=' + _durIn.toFixed(1));
+    }
+    if (_cpeRes && _cpeRes.override) {
         // Constant speed means an edited path generally changes the total, so the frame count is
         // re-derived from it (item 11 — this is the render cost the editor surfaced).
         var _framesWas = nFrames;
@@ -1256,12 +1315,6 @@
         // `_runPreview` STAYS — the `opts.editor === false` branch above (scripted/witness bakes: no
         // panel, therefore no Preview button) is the one caller that still needs a rehearsal, and
         // `opts.preview` keeps its meaning for it.
-      } else {
-        // Guardrail 2: OK with no edit re-uses the plan object computed before the editor opened —
-        // literally the same object, so the film is byte-identical to one recorded without the
-        // editor existing. The default cost of this feature is one click and nothing else.
-        console.log('§CPE_APPLIED none — derived plan unchanged (guardrail 2: OK is a no-op)');
-      }
     }
     var db = null;
     var framesDone = 0;
@@ -1461,6 +1514,11 @@
         A.camera.position.set(pose.x, pose.y, pose.z);
         A.controls.target.set(pose.tx, pose.ty, pose.tz);
         A.controls.update();
+        // §CLI_SILENT_BAKE item 4 — dev pose tap: undefined in every user session. A scripted
+        // runner records the REAL pose each frame and asserts it numerically against the stored
+        // path (a bake that runs but ignores the passed path is the silent failure this catches).
+        if (typeof window.__maxqPoseTap === 'function')
+          try { window.__maxqPoseTap(i, pose.x, pose.y, pose.z, pose.tx, pose.ty, pose.tz); } catch (ePT) {}
         if (A._updateCamLight) A._updateCamLight(pose.tx, pose.ty, pose.tz);
         // §CPE_BUILDUP: the SECOND per-frame state advance (§MAXQ_TIME's whole premise — mode A moves
         // only the camera, this adds construction state). _tFilm keeps the cursor on the film's own
@@ -1848,6 +1906,62 @@
       // §CPE_MAXQ_STATUS_DAY_LABEL — exposed for the witness (gates the pure formatter directly,
       // same precedent as the other pure functions on this line, instead of sitting through a bake).
       window.APP.maxqStatusDayRoomSegs = _maxqStatusDayRoomSegs;
+      // ══ §CLI_SILENT_BAKE item 1 (spec: bim-compiler prompts/CINEMA_PATH_EDITOR.md) — dev-only
+      // scripted entry, defined ONLY when the launcher pre-set __MAXQ_SILENT before any page
+      // script ran (puppeteer evaluateOnNewDocument), so no user session ever sees it. Resolves
+      // the stored path — object | named IndexedDB plan | the building DB's own cinema_path
+      // table — into the ONE _buildOverride() shape and hands it to start(). No second schema.
+      if (window.__MAXQ_SILENT) window.__maxqBake = async function(o) {
+        o = o || {};
+        var a = window.APP;
+        var ov = null, src = null;
+        if (o.override) { ov = o.override; src = 'caller-object'; }
+        else if (o.name) {
+          var bld = a.activeBuilding || a.buildingName || 'building';
+          var rec = await new Promise(function(res, rej) {
+            var rq = indexedDB.open('bim_ootb_cinema_paths', 1);
+            rq.onupgradeneeded = function() {
+              var d = rq.result;
+              if (!d.objectStoreNames.contains('paths')) d.createObjectStore('paths', { keyPath: 'key' });
+            };
+            rq.onsuccess = function() {
+              var db = rq.result;
+              try {
+                var g = db.transaction('paths', 'readonly').objectStore('paths').get(bld + '|' + o.name);
+                g.onsuccess = function() { db.close(); res(g.result || null); };
+                g.onerror = function() { db.close(); rej(g.error || new Error('idb-get-failed')); };
+              } catch (e) { db.close(); rej(e); }
+            };
+            rq.onerror = function() { rej(rq.error || new Error('idb-open-failed')); };
+          });
+          if (!rec || !rec.override) throw new Error('no stored plan "' + o.name + '" for building ' + bld);
+          ov = rec.override; src = 'idb:' + bld + '|' + o.name;
+        } else {
+          // The PORTABLE store: trigger effects.js's own lazy _cpeLoadFromDb via a throwaway
+          // plan, then read the staged result — the shipped loader, never a re-implementation.
+          // Guard FIRST: _cpeLoadFromDb latches _cpeLoaded=true on entry, so probing before the
+          // DB is open would permanently blind this session to the stored path (found live on the
+          // very first CLI smoke run, 2026-09-01 — the runner's readiness wait raced the load).
+          if (!a.db) throw new Error('building DB not open yet — wait for load before __maxqBake');
+          if (typeof a.cinemaPathPlan === 'function') try { a.cinemaPathPlan(60); } catch (ePl) {}
+          var staged = (a._getCinemaPathEdit && a._getCinemaPathEdit()) || null;
+          if (!staged) throw new Error('no stored path: cinema_path table absent/empty and no plan named');
+          ov = staged; src = 'db:cinema_path';
+        }
+        // Shallow copy before the flag-merge so a staged holder (A._cinemaPathEdit) is never
+        // mutated (§CPE_HOLDER_INTEGRITY, same reasoning as _buildOverride's deep copies).
+        var ov2 = {}; for (var k in ov) ov2[k] = ov[k]; ov = ov2;
+        if (o.flags) ['buildup', 'roomTitle', 'reveal', 'dayCounter'].forEach(function(fk) {
+          if (o.flags[fk] !== undefined) ov[fk] = o.flags[fk];
+        });
+        console.log('§CLI_BAKE_RESOLVED source=' + src + ' bands=' + (ov.bands ? ov.bands.length : 0) +
+          ' total=' + (ov._total != null ? (+ov._total).toFixed(1) : '?') + 's' +
+          ' buildup=' + (ov.buildup ? 1 : 0) + ' roomTitle=' + (ov.roomTitle ? 1 : 0) +
+          ' reveal=' + (ov.reveal ? 1 : 0) + ' dayCounter=' + (ov.dayCounter || 'tr'));
+        await start({ editor: false, preview: false, override: ov, overrideSource: src,
+                      frames: o.frames, fps: o.fps, forceWebm: o.forceWebm });
+        return { source: src, deliveredBytes: window.__maxqDeliveredBytes || 0 };
+      };
       clearInterval(_attach);
     }
   }, 500);

--- a/viewer/cinema_maxq.js
+++ b/viewer/cinema_maxq.js
@@ -1954,6 +1954,7 @@
         if (o.flags) ['buildup', 'roomTitle', 'reveal', 'dayCounter'].forEach(function(fk) {
           if (o.flags[fk] !== undefined) ov[fk] = o.flags[fk];
         });
+        window.__maxqResolvedOverride = ov;   // for the runner's post-bake pose assertion
         console.log('§CLI_BAKE_RESOLVED source=' + src + ' bands=' + (ov.bands ? ov.bands.length : 0) +
           ' total=' + (ov._total != null ? (+ov._total).toFixed(1) : '?') + 's' +
           ' buildup=' + (ov.buildup ? 1 : 0) + ' roomTitle=' + (ov.roomTitle ? 1 : 0) +

--- a/viewer/sw.js
+++ b/viewer/sw.js
@@ -22,15 +22,17 @@
 // schedule_author.js is in PRECACHE_ASSETS; v1088 shipped the STAGE 3 drawer change (#1528), so this
 // separate change needs its own bump (§CRISIS LESSON 4).
 // DEPLOY: bump CACHE_VERSION on every OCI upload. Old caches are purged on activate.
-const CACHE_VERSION = 'v1119';   // bump on each deploy; per-change detail is the git commit message.
-// MERGE NOTE (2026-09-01, second of the day): both this branch and origin/main (#1599
-// §CPE_PIE_FLYOUT_DROP) took v1118 concurrently — resolved by the standing sw.js rule again:
-// KEEP BOTH, take the HIGHER version, separate change gets its OWN bump -> this one is v1119.
+const CACHE_VERSION = 'v1120';   // bump on each deploy; per-change detail is the git commit message.
+// MERGE NOTE (2026-09-01, third of the day, same standing rule: KEEP BOTH notes, take the HIGHER
+// version, each separate change gets its OWN bump):
 // v1119 (2026-09-01) §WALL_SIDE_AND_LIGHT_FLOOR: streaming.js class-keyed material.side (census-
 // derived FRONT_SIDE_CLASSES, T1<=2% defect; §S260d "inconsistent normals" premise corrected —
 // measured false) + scene.js ambient/hemi lowered to the derived light floor so away-from-sun
 // faces darken. viewer.html streaming.js?v=65->66 + scene.js?v=57->58 bumped in the SAME commit.
 // Witness: witness_wall_side_light_floor.js (pick integrity + no-vanish + perf/mem gates).
+// v1120 (2026-09-01) §CLI_SILENT_BAKE (cinema_maxq.js?v=9 dev-only scripted bake entry) +
+// §NIGHT_BAKE_POOL (tools.js?v=44 — point-light COUNT frozen during a MaxQ bake; measured
+// 13-53 s/frame shader-recompile churn on the first headless Hospital bake, s4_300.log).
 // MERGE NOTE (2026-09-01): this branch and origin/main both bumped to a v1114/v1115 concurrently —
 // the conflict CLAUDE.md names sw.js as the magnet for. Resolved by its own rule: KEEP BOTH notes,
 // take the HIGHER version, and since §CPE_CORR_BRANCH is a SEPARATE change from §CPE_MATERIAL_KEY it

--- a/viewer/tools.js
+++ b/viewer/tools.js
@@ -1620,6 +1620,15 @@ function setupTools(A) {
   };
 
   A._nightUpdateLights = function() {
+    // §NIGHT_BAKE_POOL teardown — first update after a bake releases the frozen pool. Checked
+    // BEFORE the _nightMode gate so a night-off session still cleans up.
+    if (A._nightBakePool && !A._maxqActive) {
+      for (var _di = 0; _di < A._nightBakePool.length; _di++) {
+        A.scene.remove(A._nightBakePool[_di]); A._nightBakePool[_di].dispose();
+      }
+      console.log('§NIGHT_BAKE_POOL disposed n=' + A._nightBakePool.length + ' — bake over, nav path restored');
+      A._nightBakePool = null;
+    }
     if (!A._nightMode || !A._nightFixtures.length) return;
     var allPos = A._nightFixtureWorldPositions();
     var camPos = A.camera.position;
@@ -1686,6 +1695,49 @@ function setupTools(A) {
         }
       }
       needed = picked.map(function(p) { return { pos: p }; });
+    }
+    // ══ §NIGHT_BAKE_POOL (2026-09-01, found by the first headless CLI bake — bim-compiler
+    // prompts/CINEMA_PATH_EDITOR.md §CLI_SILENT_BAKE stage 4): during a MaxQ bake the in-frustum
+    // fixture census changes nearly every frame (the camera flies the path while the buildup keeps
+    // placing fixtures), and EVERY add/remove changes the scene's point-light COUNT — a shader
+    // DEFINE, so three.js recompiles every program in the scene. MEASURED (s4_300.log, Hospital
+    // 1854x963, RTX 4060 headless): count-stable frames fold in 0.8-1.3 s — even at the full 200
+    // lights — while every count-changed frame costs 13-53 s (21 §MAXQ_FRAME_TIMEOUTs, per-frame
+    // climbing to 26.4 s, a 9 h projection for a film whose budget is 2 h). §NIGHT_LIGHT_CHURN_FIX
+    // above already named this exact recompile cost but its delta reuse still lets the COUNT move.
+    // FIX, bake-only (gate A._maxqActive): the pool size is FROZEN at the still cap for the whole
+    // bake — created once, assigned per frame by slot (position/color/intensity are uniform
+    // updates, no recompile), unused slots dim to intensity 0 (contributes nothing — quality-
+    // identical). Interactive navigation and Alt+S keep the churn-fix path below, untouched.
+    if (A._maxqActive) {
+      if (!A._nightBakePool) {
+        var _poolN = Math.min(200, Math.max(1, allPos.length));
+        A._nightBakePool = [];
+        for (var _bi = 0; _bi < _poolN; _bi++) {
+          var _bl = new THREE.PointLight(0xffe4b5, 0, NIGHT_LIGHT_RANGE, NIGHT_LIGHT_DECAY);
+          A.scene.add(_bl);
+          A._nightBakePool.push(_bl);
+        }
+        console.log('§NIGHT_BAKE_POOL created n=' + _poolN +
+          ' — point-light COUNT frozen for the bake; unused slots ride at intensity 0');
+      }
+      var _pool = A._nightBakePool;
+      for (var _pi = 0; _pi < _pool.length; _pi++) {
+        var _f = needed[_pi];
+        if (_f) {
+          var _dist = camPos.distanceTo(_f.pos);
+          var _fade = Math.min(1.0, _dist / 15);
+          var _floor = A._nightNearFadeFloor;
+          _pool[_pi].position.copy(_f.pos);
+          _pool[_pi].color.set(_f.pos.__color || 0xffe4b5);
+          _pool[_pi].intensity = NIGHT_LIGHT_INTENSITY * (_floor + (1 - _floor) * _fade) * (A._nightPLScale || 1);   // §STAGED_PL_CUT
+        } else {
+          _pool[_pi].intensity = 0;
+        }
+      }
+      A._nightLights = _pool.slice();
+      if (A.markDirty) A.markDirty();
+      return;
     }
     // §NIGHT_LIGHT_CHURN_FIX (2026-08-08): this used to dispose EVERY light and rebuild the whole
     // set from scratch on every call — called on every 5m of camera travel while night mode is on,

--- a/viewer/viewer.html
+++ b/viewer/viewer.html
@@ -846,7 +846,7 @@ html.bim-embedded, html.bim-embedded body { background: #0b0b0b; }
 <script src="cinema_path_editor.js?v=15" onerror="console.warn('§LOAD_FAIL cinema_path_editor.js — Alt+C path editing disabled')"></script>
 <script src="cpe_walk.js?v=6" onerror="console.warn('§LOAD_FAIL cpe_walk.js — CPE walk-mode disabled')"></script>
 <script src="cpe_xr.js?v=1" onerror="console.warn('§LOAD_FAIL cpe_xr.js — VR entry disabled')"></script>
-<script src="cinema_maxq.js?v=8" onerror="console.warn('§LOAD_FAIL cinema_maxq.js — Alt+M MaxQ export disabled')"></script>
+<script src="cinema_maxq.js?v=9" onerror="console.warn('§LOAD_FAIL cinema_maxq.js — Alt+M MaxQ export disabled')"></script>
 <script src="input_registry.js?v=1" onerror="console.warn('§LOAD_FAIL input_registry.js')"></script>
 <script src="../common/pill_builder.js?v=1" onerror="console.warn('§LOAD_FAIL pill_builder.js')"></script>
 <script src="list_builder.js?v=1" onerror="console.warn('§LOAD_FAIL list_builder.js')"></script>
@@ -858,7 +858,7 @@ html.bim-embedded, html.bim-embedded body { background: #0b0b0b; }
 <script src="streaming.js?v=66" onerror="console.warn('§LOAD_FAIL streaming.js')"></script>
 <script src="dlod.js?v=8" onerror="console.warn('§LOAD_FAIL dlod.js')"></script>
 <script src="panels.js?v=44" onerror="console.warn('§LOAD_FAIL panels.js')"></script>
-<script src="tools.js?v=43" onerror="console.warn('§LOAD_FAIL tools.js')"></script>
+<script src="tools.js?v=44" onerror="console.warn('§LOAD_FAIL tools.js')"></script>
 <script src="picking.js?v=30" onerror="console.warn('§LOAD_FAIL picking.js')"></script>
 <script src="hover_name.js?v=1" onerror="console.warn('§LOAD_FAIL hover_name.js — hover-name disabled')"></script>
 <script src="cpe_room_title.js?v=1" onerror="console.warn('§LOAD_FAIL cpe_room_title.js — room titles disabled')"></script>


### PR DESCRIPTION
Spec + full measured record: bim-compiler `prompts/CINEMA_PATH_EDITOR.md §CLI_SILENT_BAKE` (2026-09-01).

**Dev-only CLI silent bake** (`window.__maxqBake`, gated on launcher-set `__MAXQ_SILENT` — no user session sees it; `cli_silent_bake.js` runner): takes a STORED PATH as argument (override object | named IndexedDB plan | the building DB's own `cinema_path` table via the shipped lazy loader). `start()` grows ONE branch — the override becomes the same `_cpeRes` the editor returns; application block unchanged, editor path byte-identical. Delivery seam (`__maxqDeliverBlob`) + guarded pose tap for numeric assertions.

**§NIGHT_BAKE_POOL** (own commit, own witness — a PRODUCT fix the first headless bake found): during a bake the in-frustum fixture census changes nearly every frame; every add/remove changes the point-light COUNT = a shader define → full-scene recompile. MEASURED (s4_300.log): count-stable frames fold 0.8-1.3 s even at 200 lights; count-changed frames 13-53 s (21 timeouts, 9 h projection). Fix: frozen fixed-size pool during `A._maxqActive`, unused slots intensity 0, disposed on first nav update after. A/B short film: 26.4 s/frame climbing + 21 timeouts → **1.36 s/frame, 0 timeouts**.

**Real Hospital bake on this branch (e1369b7a, sw v1120, RTX 4060 headless):** 2,027 frames @15 fps from the stored path (81.9 s authored + reveal = 135.1 s film), wall **44 m 40 s**, mean **1,264 ms/frame**, unconverged=0, heap flat 229-477 MB; mp4 h264 1854x962, 90.2 MB, ffprobe-verified 2,027 decoded frames / 135.133 s. `§CLI_BAKE_POSECHECK maxErr=0` vs the stored-path plan, 80 m mean divergence from the derived plan, band anchors [0, 0.02, 0.03] m. First real-bake confirmations: §PHOTO_PREWARM (R11), 20-render budget (R10, −44 %/frame vs the 2.26 s reference), `§CPE_STATS_TAIL … pie=dropped (§CPE_PIE_FLYOUT_DROP)` at u=0.428.

sw v1120 + `cinema_maxq.js?v=9` + `tools.js?v=44`; sw.js conflict resolved KEEP-BOTH/higher.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AAMJ1oyEfFXQq7fX19Z1eV