### PR TITLE
fix(4d): §TM_REVEAL_TILED — the movie plays each element's own duration share of its bar, not a per-task affine

### DIFF
--- a/scripts/probe_tm_reveal_shipped.js
+++ b/scripts/probe_tm_reveal_shipped.js
@@ -1,0 +1,357 @@
+#!/usr/bin/env node
+// probe_tm_reveal_shipped.js — WHAT THE MOVIE ACTUALLY PLAYS, measured on the SHIPPED path.
+//
+// ⚠ DO NOT REMOVE — SCOPE (bim-compiler prompts/4D_GANTT_TM_REFACTOR.md §FUTURE item 2,
+// 2026-09-02 §TM_REVEAL_SHIPPED). User: "the sub structure and floor slabs are appearing all one
+// shot instead of nicer progressive animation." Read the log after every run.
+//
+// WHY A NEW PROBE. Every reveal-spread number this lane has (§TPL_REVEAL_SPREAD, cache_4d_run.js,
+// witness_day0_integrity.js) reads materializeZones' `displaySchedule` = remapSolveToTasks()
+// (schedule_author.js:965). That map has ZERO readers in time_machine.js — the kernel_ops
+// timestamps the Time Machine and the film play are written by injectGantt from
+//   _displayTimeline(_twItems)          (CpmSchedule.run, time_machine.js ~4838)
+//   -> _tmRescaleToTaskWindow(guid, s)  (per-task AFFINE onto the template window, ~4880)
+//   -> kernel_ops.timestamp / _end_ts   (~4900)
+// and the viewer reveals an element at op.start_ts <= cursor (time_machine.js:169-170, 2576).
+// So this probe mirrors THAT chain, slicing the live functions out of time_machine.js by brace
+// matching (same discipline as witness_tm_element_window_bind.js) — never re-typed.
+//
+// Per task it prints: the decile histogram of op.start inside the task's own window (the film's
+// reveal distribution), the CPM group's raw span vs its Tukey-fenced core span (how much of the
+// window the outlier-free mass is squashed into), and the outliers by name.
+//
+// Usage: node scripts/probe_tm_reveal_shipped.js [Building ...]   (default Duplex)
+'use strict';
+const fs = require('fs'), path = require('path'), vm = require('vm'), os = require('os');
+const HOME = os.homedir();
+const V = path.join(__dirname, '..', 'viewer');
+const BLD_DIR = process.env.BLD_DIR || path.join(HOME, 'bim-ootb', 'buildings');
+const DAY_MS = 86400000;
+const START = '2026-01-01';
+// Film arithmetic (§3 of the brief): the real Hospital bake was 2,027 frames (PR #1602 §CLI_BAKE);
+// FRAMES/FPS are only used to translate "elements per calendar day" into "elements per frame".
+const FRAMES = process.env.FRAMES ? Number(process.env.FRAMES) : 2027;
+const FPS = process.env.FPS ? Number(process.env.FPS) : 15;
+
+const SG = require(path.join(V, 'schedule_gate.js')); global.ScheduleGate = SG;
+const SA = require(path.join(V, 'schedule_author.js'));
+const SS = require(path.join(V, 'support_sweep.js')); global.SupportSweep = SS;
+const CP = require(path.join(V, 'cpm_schedule.js')); global.CpmSchedule = CP;
+const GM = require(path.join(V, 'gantt_model.js')); global.GanttModel = GM;
+// §S50: the CELL gate resolves these on globalThis exactly like a browser window would.
+globalThis.RoomWalker = require(path.join(V, 'lib', 'room_walker.js'));
+globalThis.LevelDeriver = require(path.join(V, 'lib', 'level_deriver.js'));
+globalThis.LocationAxis = require(path.join(V, 'location_axis.js'));
+const T = JSON.parse(fs.readFileSync(path.join(V, 'rates', '4D_template.json'), 'utf8'));
+const tmSrc = fs.readFileSync(path.join(V, 'time_machine.js'), 'utf8');
+
+function sliceFn(src, name) {
+  const idx = src.indexOf('function ' + name + '(');
+  if (idx < 0) throw new Error(name + ' not found in time_machine.js');
+  let d = 0, open = false;
+  for (let i = idx; i < src.length; i++) {
+    if (src[i] === '{') { d++; open = true; }
+    else if (src[i] === '}') { d--; if (open && d === 0) return src.slice(idx, i + 1); }
+  }
+  throw new Error('unbalanced braces for ' + name);
+}
+function executedRules() {
+  const sb = { console: { log() {}, warn() {}, error() {} } };
+  vm.createContext(sb);
+  vm.runInContext(fs.readFileSync(path.join(V, 'rates.js'), 'utf8'), sb);
+  return sb;
+}
+// §S39/§S37-A2 rule (witness_midair_zero.js): prefer <bld>_meta.db, fall back to _extracted.db.
+function resolveDbFile(bld) {
+  const meta = path.join(BLD_DIR, bld + '_meta.db');
+  const ext = path.join(BLD_DIR, bld + '_extracted.db');
+  if (process.env.DB_KIND === 'extracted' && fs.existsSync(ext)) return { path: ext, kind: 'extracted' };
+  if (fs.existsSync(meta)) return { path: meta, kind: 'meta' };
+  return { path: ext, kind: 'extracted' };
+}
+function deciles(vals) {
+  const h = new Array(10).fill(0);
+  vals.forEach(p => { let b = Math.floor(Math.max(0, Math.min(1, p)) * 10); if (b > 9) b = 9; h[b]++; });
+  return h.map(c => +(100 * c / Math.max(1, vals.length)).toFixed(1));
+}
+
+function buildSandbox(R) {
+  const sb = {
+    window: { LABOR_RATES: R.LABOR_RATES, GanttModel: GM, ScheduleAuthor: SA },
+    ScheduleGate: SG, CpmSchedule: CP, GanttModel: GM, ScheduleAuthor: SA,
+    _midairAudit: SS.midairAudit,
+    console: console,
+    // _tiledPlay stays null here so `_tmRescaleToTaskWindow` yields the PRE-FIX affine map (the
+    // "SHIPPED-affine" label below = what played before §TM_REVEAL_TILED); the CANDIDATE map is the
+    // shipped tiling function itself when the revision has it.
+    _cap: null, _winGroups: {}, _tiledPlay: null, _rawScheduleRemember: null,
+  };
+  vm.createContext(sb);
+  const code = [
+    'var _CPM_DISPLAY = true;',
+    sliceFn(tmSrc, '_tukeyBound'),
+    sliceFn(tmSrc, '_displayTimelineRemember'),
+    sliceFn(tmSrc, '_displayTimeline'),
+    sliceFn(tmSrc, '_tmDisplayRemap'),
+    sliceFn(tmSrc, '_tmRescaleToTaskWindow'),
+    // §TM_REVEAL_TILED — optional so the probe still runs against a pre-fix revision (then the
+    // CANDIDATE is computed by calling the verb directly, which is what the shipped function does).
+    (tmSrc.indexOf('function _tmTilePlayWithinTasks(') >= 0 ? sliceFn(tmSrc, '_tmTilePlayWithinTasks') : 'var _tmTilePlayWithinTasks = null;'),
+    'this._tmDisplayRemap = _tmDisplayRemap; this._displayTimeline = _displayTimeline;',
+    'this._tmRescaleToTaskWindow = _tmRescaleToTaskWindow; this._tmTilePlayWithinTasks = _tmTilePlayWithinTasks;',
+    'this.__getRaw = function () { return _rawScheduleRemember; };',
+  ].join('\n');
+  vm.runInContext(code, sb);
+  return sb;
+}
+
+async function runBuilding(bld, SQL, R) {
+  const dbf = resolveDbFile(bld);
+  if (!fs.existsSync(dbf.path)) { console.log('§TM_REVEAL_SHIPPED_SKIP ' + bld + ' — no db'); return null; }
+  const db = new SQL.Database(new Uint8Array(fs.readFileSync(dbf.path)));
+  const sb = buildSandbox(R);
+  const SHIFT = T.calendar.hours_per_shift;
+  const base = { start: START, laborRates: R.LABOR_RATES, rates: R.RATES,
+    nameOverrides: R.SEQUENCE_NAME_OVERRIDES, defaultRule: R.SEQUENCE_DEFAULT,
+    scheduleGate: SG, shiftHours: SHIFT, template: T, displayRemap: sb._tmDisplayRemap };
+  const t0 = Date.now();
+  const elements = SA._buildScheduleElements(db, R.SEQUENCE_RULES, base);
+  globalThis.APP = { db: db };
+  let res;
+  try { res = SA.materializeZones(db, R.SEQUENCE_RULES, base); }
+  finally { /* db stays open through the injectGantt mirror below */ }
+  if (!res || !res.ok || !res.tasks) { console.log('§TM_REVEAL_SHIPPED_FAIL ' + bld + ' materializeZones ' + JSON.stringify(res && res.reason)); db.close(); delete globalThis.APP; return null; }
+  console.log('§TM_REVEAL_SHIPPED_DB ' + bld + ' file=' + path.basename(dbf.path) + ' kind=' + dbf.kind +
+    ' elements=' + elements.length + ' tasks=' + res.tasks.length + ' totalDays=' + res.totalDays +
+    ' materializeMs=' + (Date.now() - t0));
+
+  // ── injectGantt mirror: _twItems -> _displayTimeline (REUSE branch replays the hook's CPM) ──
+  const raw = sb.__getRaw();
+  if (!raw || !raw.map) { console.log('§TM_REVEAL_SHIPPED_FAIL ' + bld + ' hook did not remember the raw schedule'); db.close(); delete globalThis.APP; return null; }
+  const baseMs = Date.parse(START);
+  const twItems = elements.map(el => {
+    const ts = raw.map[el.guid];
+    return { guid: el.guid, s: ts ? ts.start : baseMs, e: ts ? ts.end : baseMs + 60000,
+      bz: el.base_z, tz: el.top_z, x0: el.x0, x1: el.x1, y0: el.y0, y1: el.y1,
+      cls: el.cls, seq: el.seq, phase: el.phase, storey: el.storey, resource: el.resource };
+  });
+  const dt = sb._displayTimeline(twItems);
+  delete globalThis.APP;
+  console.log('§TM_REVEAL_SHIPPED_DISPLAY ' + bld + ' cpm=' + (dt && dt.cpm) + ' midair=' + (dt && dt.midair) +
+    ' (cpm=reuse means injectGantt replayed the hook\'s CPM timeline, exactly as the browser cold-open does)');
+  const disp = {};
+  twItems.forEach(it => { disp[it.guid] = { start: it.s, end: it.e }; });
+  let schedEnd = baseMs;
+  for (const g in disp) if (disp[g].end > schedEnd) schedEnd = disp[g].end;
+
+  // ── _cap mirror: template task windows (the persisted `tasks` rows), guid -> earliest task ──
+  const win = {}, guidTask = {};
+  res.tasks.forEach(t => {
+    win[t.id] = { s: baseMs + t.sDays * DAY_MS, e: baseMs + t.eDays * DAY_MS, name: t.id, sDays: t.sDays, eDays: t.eDays,
+      phase: t.phase, storey: t.storey };
+    t.guids.forEach(g => { if (!guidTask[g] || win[t.id].s < win[guidTask[g]].s) guidTask[g] = t.id; });
+  });
+  sb._cap = { win: win, guidTask: guidTask };
+  // _winGroups — verbatim shape of time_machine.js injectGantt (~4872-4880)
+  const winGroups = {};
+  elements.forEach(el => {
+    const s = disp[el.guid] || { start: schedEnd, end: schedEnd + 60000 };
+    const tid = guidTask[el.guid];
+    if (tid == null || !win[tid]) return;
+    const g = winGroups[tid] || (winGroups[tid] = { min: Infinity, max: -Infinity });
+    if (s.start < g.min) g.min = s.start;
+    if (s.end > g.max) g.max = s.end;
+  });
+  sb._winGroups = winGroups;
+  const op = {};
+  let clamped = 0, uncovered = 0;
+  elements.forEach(el => {
+    const s = disp[el.guid] || { start: schedEnd, end: schedEnd + 60000 };
+    const b = sb._tmRescaleToTaskWindow(el.guid, s);
+    if (b.clamped) clamped++; else if (guidTask[el.guid] == null) uncovered++;
+    op[el.guid] = { s: b.start, e: b.end };
+  });
+  console.log('§TM_REVEAL_SHIPPED_BIND ' + bld + ' total=' + elements.length + ' clamped=' + clamped + ' uncovered=' + uncovered +
+    ' (mirrors §TM_ELEMENT_WINDOW_BIND)');
+
+  // ── CANDIDATE (A/B): the tiling verb schedule_author already owns, applied in CPM order ──
+  // ScheduleAuthor.remapSolveToTasks(solve, tasks, startISO, layerOf=null): one band per task, members
+  // ordered by the solve's own start (here: the CPM display time the movie plays TODAY, so every
+  // ordering CPM established survives — monotone, ties on guid), each element's width = its own CPM
+  // duration, tiled edge-to-edge across the task's window. No number invented; no window moved.
+  const capTasks = res.tasks.map(t => ({ id: t.id, sDays: t.sDays, eDays: t.eDays, guids: t.guids.filter(g => guidTask[g] === t.id) }));
+  // Prefer the SHIPPED function (sliced out of time_machine.js) so the CANDIDATE column measures the
+  // code that ships, not a re-derivation; a pre-fix revision falls back to calling the verb directly.
+  const tiled = (typeof sb._tmTilePlayWithinTasks === 'function')
+    ? sb._tmTilePlayWithinTasks(disp, { base: baseMs, win: win, guidTask: guidTask }, true)
+    : SA.remapSolveToTasks(disp, capTasks, START, null).schedule;
+  console.log('§TM_REVEAL_SHIPPED_CANDIDATE ' + bld + ' source=' + (typeof sb._tmTilePlayWithinTasks === 'function' ? 'time_machine.js _tmTilePlayWithinTasks (shipped)' : 'ScheduleAuthor.remapSolveToTasks (direct call, pre-fix revision)'));
+  const opFix = {};
+  elements.forEach(el => { const t = tiled[el.guid]; opFix[el.guid] = t ? { s: t.start, e: t.end } : op[el.guid]; });
+  let pStart0 = Infinity, pEnd0 = -Infinity;
+  elements.forEach(e => { if (op[e.guid].s < pStart0) pStart0 = op[e.guid].s; if (op[e.guid].e > pEnd0) pEnd0 = op[e.guid].e; });
+
+  // ── judges on BOTH played maps (impact numbers, not opinions) ──
+  function judge(map, label) {
+    const m = {}; elements.forEach(e => { m[e.guid] = { start: map[e.guid].s, end: map[e.guid].e }; });
+    const q = console.log; console.log = () => {};
+    let fl, ma, cjp;
+    try {
+      fl = SG.auditFloating(elements, m, null, null, null);
+      const its = twItems.map(it => Object.assign({}, it, { s: map[it.guid].s, e: map[it.guid].e, task: guidTask[it.guid] }));
+      ma = SS.midairAudit(its);
+      cjp = SS.cjpJudgeParity(its.map(it => Object.assign({}, it)), win);
+    } finally { console.log = q; }
+    console.log('§TM_REVEAL_JUDGE ' + bld + ' map=' + label + ' auditFloating=' + fl + '/' + elements.length +
+      ' midair=' + ma.midair + ' orphans=' + ma.orphans + ' cjpFloating=' + cjp.floating + ' windowBlocked=' + cjp.windowBlocked +
+      ' cjpPushed=' + cjp.pushed + ' (same judges injectGantt runs: §SUPPORT_CHECK / §CPM_DISPLAY midair / §CROSSTASK_JUDGE_PARITY)');
+  }
+  // ── DAY-0 purity on the PLAYED layer (witness_day0_integrity C2 judges displaySchedule, not this) ──
+  function day0(map, label) {
+    let t0 = Infinity; elements.forEach(e => { if (map[e.guid].s < t0) t0 = map[e.guid].s; });
+    const hist = {}; let n = 0, impure = 0; const modelsSub = elements.some(e => e.seq === 1);
+    elements.forEach(e => { if (map[e.guid].s <= t0 + DAY_MS) { n++; hist[e.phase] = (hist[e.phase] || 0) + 1; if (modelsSub ? e.seq !== 1 : e.seq > 4) impure++; } });
+    console.log('§TM_REVEAL_DAY0 ' + bld + ' map=' + label + ' onScreenDay0=' + n + ' impure=' + impure + ' phases=' + JSON.stringify(hist));
+  }
+  // ── (task, class) concentration — the acceptance shape: "a whole floor slab should not appear all at once" ──
+  function groupConc(map, label) {
+    const groups = {};
+    elements.forEach(e => { const t = guidTask[e.guid]; if (!t) return; const k = t + '||' + e.cls; (groups[k] = groups[k] || []).push(e.guid); });
+    const rows = [];
+    for (const k in groups) {
+      const gs = groups[k]; if (gs.length < 5) continue;
+      const tid = k.split('||')[0], cls = k.split('||')[1]; const w = win[tid], span = w.e - w.s;
+      const pos = gs.map(g => (map[g].s - w.s) / span);
+      const dec = deciles(pos); const maxDec = Math.max.apply(null, dec);
+      const starts = gs.map(g => map[g].s).sort((a, b) => a - b);
+      const gSpanD = (starts[starts.length - 1] - starts[0]) / DAY_MS;
+      const distinct = new Set(starts).size;
+      // "one shot" = the densest 1% of the window (1.35 s of a 135 s film on Hospital's 318 d)
+      const bins = new Array(100).fill(0); pos.forEach(p => { bins[Math.floor(Math.max(0, Math.min(0.999, p)) * 100)]++; });
+      const max1 = Math.max.apply(null, bins);
+      rows.push({ task: tid, cls, n: gs.length, days: +(span / DAY_MS).toFixed(1), maxDecilePct: maxDec, max1pctBinPct: +(100 * max1 / gs.length).toFixed(1),
+        distinctStarts: distinct, groupSpanDays: +gSpanD.toFixed(2),
+        groupSpanFilmSec: +((gSpanD / ((pEnd0 - pStart0) / DAY_MS)) * (FRAMES / FPS)).toFixed(2), deciles: dec });
+    }
+    rows.sort((a, b) => b.maxDecilePct - a.maxDecilePct);
+    rows.filter(r => /IfcSlab|IfcFooting/.test(r.cls)).forEach(r => console.log('§TM_REVEAL_GROUP ' + bld + ' map=' + label + ' ' + r.task + ' ' + r.cls +
+      ' n=' + r.n + ' taskDays=' + r.days + ' maxDecile=' + r.maxDecilePct + '% max1pctBin=' + r.max1pctBinPct + '% distinctStarts=' + r.distinctStarts +
+      ' groupSpan=' + r.groupSpanDays + 'd=' + r.groupSpanFilmSec + 's-of-film deciles=[' + r.deciles.join(',') + ']'));
+    const worst = rows.slice(0, 6).map(r => r.task + '/' + r.cls + ' n=' + r.n + ' maxDecile=' + r.maxDecilePct + '% max1pct=' + r.max1pctBinPct + '%');
+    const over50 = rows.filter(r => r.maxDecilePct > 50).length;
+    console.log('§TM_REVEAL_GROUP_SUMMARY ' + bld + ' map=' + label + ' groups(n>=5)=' + rows.length + ' groupsWithOneDecileOver50pct=' + over50 +
+      ' worst=' + JSON.stringify(worst));
+  }
+  // dead air (no member in progress) + pile-up per task, both maps
+  function deadAir(map, label) {
+    let worst = { pct: -1 }, sumPct = 0, nT = 0, maxBin = { pct: -1 };
+    capTasks.forEach(t => { const w = win[t.id], span = w.e - w.s; const gs = t.guids; if (gs.length < 2) return;
+      const iv = gs.map(g => [map[g].s, map[g].e]).sort((a, b) => a[0] - b[0]);
+      let cov = 0, cur = w.s; iv.forEach(([s, e]) => { const a = Math.max(s, cur), b = Math.min(e, w.e); if (b > a) cov += b - a; if (e > cur) cur = e; });
+      const pct = 100 * (1 - cov / span); sumPct += pct; nT++; if (pct > worst.pct) worst = { pct, id: t.id, n: gs.length };
+      const bins = new Array(100).fill(0); gs.forEach(g => { bins[Math.floor(Math.max(0, Math.min(0.999, (map[g].s - w.s) / span)) * 100)]++; });
+      const m = Math.max.apply(null, bins) / gs.length * 100; if (gs.length >= 20 && m > maxBin.pct) maxBin = { pct: m, id: t.id, n: gs.length }; });
+    console.log('§TM_REVEAL_DEADAIR ' + bld + ' map=' + label + ' tasks=' + nT + ' meanDeadAirPct=' + (sumPct / Math.max(1, nT)).toFixed(1) +
+      ' worst=' + worst.pct.toFixed(1) + '%@' + worst.id + '(n=' + worst.n + ')' +
+      ' | pileup: max share of a task(n>=20) starting inside one 1%-of-window bin=' + maxBin.pct.toFixed(1) + '%@' + maxBin.id + '(n=' + maxBin.n + ')');
+  }
+  // ── REPORT-ONLY (axis B is out of this lane): §CPE_BUILDUP_ONSET_BLEND cursor over the played ops ──
+  function onset(map, label) {
+    const ends = elements.map(e => map[e.guid].e).sort((a, b) => a - b);
+    const ps = Math.min.apply(null, elements.map(e => map[e.guid].s)), pe = ends[ends.length - 1];
+    const totalSec = FRAMES / FPS, onsetU = Math.min(0.5, 10 / totalSec);
+    const subG = elements.filter(e => /Substructure/.test(guidTask[e.guid] || ''));
+    const subN = subG.length; if (!subN) return;
+    function placedAt(c) { let n = 0; subG.forEach(e => { if (map[e.guid].s <= c) n++; }); return n; }
+    function cursor(t, blend) { const cal = ps + t * (pe - ps); if (!blend || t >= onsetU) return cal;
+      const k = Math.max(1, Math.min(ends.length, Math.round(t * ends.length))); const el = ends[k - 1]; return el + (cal - el) * (t / onsetU); }
+    const out = {};
+    [false, true].forEach(bl => { const r = []; [0.5, 0.9, 1.0].forEach(m => { for (let f = 0; f < FRAMES; f++) { if (placedAt(cursor(f / FRAMES, bl)) >= m * subN) { r.push(m + '@f' + f + '=' + (f / FPS).toFixed(1) + 's'); break; } } }); out[bl ? 'onsetBlend' : 'calendarLinear'] = r.join(' '); });
+    let maxPerFrame = 0, prev = 0; for (let f = 1; f < 200; f++) { const c = placedAt(cursor(f / FRAMES, true)); if (c - prev > maxPerFrame) maxPerFrame = c - prev; prev = c; }
+    console.log('§TM_REVEAL_ONSET_REPORT ' + bld + ' map=' + label + ' substructure n=' + subN + ' film=' + totalSec.toFixed(1) + 's onsetU=' + onsetU.toFixed(4) +
+      ' calendarLinear{' + out.calendarLinear + '} onsetBlend{' + out.onsetBlend + '} maxSubstructurePlacedPerFrame(onsetBlend,first200f)=' + maxPerFrame +
+      ' — REPORT ONLY: the film cursor is out of this lane (coordinator scope correction 2026-09-02)');
+  }
+  judge(op, 'SHIPPED-affine'); judge(opFix, 'CANDIDATE-tiled');
+  day0(op, 'SHIPPED-affine'); day0(opFix, 'CANDIDATE-tiled');
+  groupConc(op, 'SHIPPED-affine'); groupConc(opFix, 'CANDIDATE-tiled');
+  deadAir(op, 'SHIPPED-affine'); deadAir(opFix, 'CANDIDATE-tiled');
+  { let viol = 0, pairs = 0;
+    capTasks.forEach(t => { const gs = t.guids.slice().sort((a, b) => disp[a].start - disp[b].start || (a < b ? -1 : 1));
+      for (let i = 1; i < gs.length; i++) { pairs++; if (opFix[gs[i]].s < opFix[gs[i - 1]].s) viol++; } });
+    console.log('§TM_REVEAL_ORDER ' + bld + ' candidate order-vs-CPM violations=' + viol + '/' + pairs + ' adjacent pairs (0 = every CPM ordering survives)'); }
+  onset(op, 'SHIPPED-affine'); onset(opFix, 'CANDIDATE-tiled');
+
+  // ── per-task reveal distribution of what PLAYS, vs what the cache measured (displaySchedule) ──
+  const elBy = {}; elements.forEach(e => { elBy[e.guid] = e; });
+  const rows = [];
+  const aggPlay = [], aggDisp = [];
+  res.tasks.forEach(t => {
+    const w = win[t.id], span = w.e - w.s;
+    const members = t.guids.filter(g => guidTask[g] === t.id && disp[g]);
+    if (!members.length) return;
+    const posPlay = members.map(g => (op[g].s - w.s) / span);
+    const posDisp = members.map(g => res.displaySchedule[g] ? (res.displaySchedule[g].start - w.s) / span : 0);
+    posPlay.forEach(p => aggPlay.push(p)); posDisp.forEach(p => aggDisp.push(p));
+    const g = winGroups[t.id];
+    const starts = members.map(g2 => disp[g2].start), ends = members.map(g2 => disp[g2].end);
+    const lo = GM.tukeyBound(starts, true), hi = GM.tukeyBound(ends, false);
+    const rawSpan = g.max - g.min, coreSpan = Math.max(0, hi - lo);
+    const outl = members.filter(g2 => disp[g2].start < lo || disp[g2].end > hi);
+    const first1 = posPlay.filter(p => p < 0.01).length, firstHour = members.filter(g2 => op[g2].s - w.s < 3600000).length;
+    // outliers by name — the elements whose CPM time stretches the group's raw span
+    const outlDesc = outl.slice().sort((a, b) => disp[b].end - disp[a].end).slice(0, 3).map(g2 => {
+      const e = elBy[g2];
+      return e.cls + '@' + (e.storey || '?') + ' cpm=[' + ((disp[g2].start - g.min) / DAY_MS).toFixed(1) + 'd,' + ((disp[g2].end - g.min) / DAY_MS).toFixed(1) + 'd]';
+    });
+    rows.push({ id: t.id, n: members.length, days: t.eDays - t.sDays,
+      playDeciles: deciles(posPlay), dispDeciles: deciles(posDisp),
+      first1pct: +(100 * first1 / members.length).toFixed(1), firstHourPct: +(100 * firstHour / members.length).toFixed(1),
+      rawSpanDays: +(rawSpan / DAY_MS).toFixed(2), coreSpanDays: +(coreSpan / DAY_MS).toFixed(2),
+      coreFracOfWindow: +(rawSpan > 0 ? coreSpan / rawSpan : 1).toFixed(4),
+      outliers: outl.length, outlierDesc: outlDesc });
+  });
+  rows.sort((a, b) => b.playDeciles[0] - a.playDeciles[0]);
+  rows.forEach(r => {
+    console.log('§TM_REVEAL_SHIPPED_TASK ' + bld + ' ' + r.id + ' n=' + r.n + ' days=' + r.days +
+      ' PLAY.deciles=[' + r.playDeciles.join(',') + '] first1pct=' + r.first1pct + '% firstHour=' + r.firstHourPct + '%' +
+      ' | cpmRawSpan=' + r.rawSpanDays + 'd coreSpan=' + r.coreSpanDays + 'd coreFracOfWindow=' + r.coreFracOfWindow +
+      ' outliers=' + r.outliers + (r.outlierDesc.length ? ' [' + r.outlierDesc.join(' | ') + ']' : '') +
+      ' | displaySchedule.deciles=[' + r.dispDeciles.join(',') + '] (the layer the cache measured — NOT played)');
+  });
+  const aggP = deciles(aggPlay), aggD = deciles(aggDisp);
+  console.log('§TM_REVEAL_SHIPPED_AGG ' + bld + ' n=' + aggPlay.length + ' PLAY.decilePct=[' + aggP.join(',') + ']' +
+    ' displaySchedule.decilePct=[' + aggD.join(',') + ']' +
+    ' — PLAY is what kernel_ops carries (the film + scrubber); displaySchedule is remapSolveToTasks, unread by time_machine.js');
+  const sub = rows.filter(r => /Substructure/.test(r.id));
+  const slabTasks = res.tasks.map(t => ({ id: t.id, slabs: t.guids.filter(g => elBy[g] && elBy[g].cls === 'IfcSlab' && guidTask[g] === t.id).length }))
+    .filter(x => x.slabs > 0).sort((a, b) => b.slabs - a.slabs).slice(0, 5);
+  console.log('§TM_REVEAL_SHIPPED_SLABS ' + bld + ' IfcSlab total=' + elements.filter(e => e.cls === 'IfcSlab').length +
+    ' topTasks=' + JSON.stringify(slabTasks));
+
+  // ── film arithmetic: elements placed per FRAME on a calendar-linear cursor (§CPE_BUILDUP_EVEN_TEMPO) ──
+  const starts = elements.map(e => op[e.guid].s).sort((a, b) => a - b);
+  const pStart = starts[0], pEnd = Math.max.apply(null, elements.map(e => op[e.guid].e));
+  const stepMs = (pEnd - pStart) / FRAMES;
+  const perFrame = new Array(FRAMES).fill(0);
+  starts.forEach(s => { let f = Math.floor((s - pStart) / stepMs); if (f >= FRAMES) f = FRAMES - 1; perFrame[f]++; });
+  const worst = perFrame.reduce((m, c, i) => c > m.c ? { c, i } : m, { c: -1, i: -1 });
+  const first30 = perFrame.slice(0, 30);
+  const subRow = sub[0];
+  const subFrames = subRow ? Math.round((subRow.days * DAY_MS) / stepMs) : 0;
+  console.log('§TM_REVEAL_SHIPPED_FILM ' + bld + ' frames=' + FRAMES + ' fps=' + FPS + ' projectDays=' + ((pEnd - pStart) / DAY_MS).toFixed(1) +
+    ' daysPerFrame=' + (stepMs / DAY_MS).toFixed(3) + ' meanPerFrame=' + (elements.length / FRAMES).toFixed(1) +
+    ' worstFrame=' + worst.c + '@f' + worst.i + ' first30frames=[' + first30.join(',') + ']' +
+    (subRow ? ' substructure: n=' + subRow.n + ' window=' + subRow.days + 'd=' + subFrames + ' frames (' + (subFrames / FPS).toFixed(1) + 's of film)' +
+      ' evenWouldBe=' + (subRow.n / Math.max(1, subFrames)).toFixed(1) + '/frame' : ''));
+  db.close();
+  return { bld, rows, aggP, aggD, perFrame };
+}
+
+(async () => {
+  const initSqlJs = require(path.join(HOME, 'bim-ootb', 'node_modules', 'sql.js'));
+  const SQL = await initSqlJs({ locateFile: f => path.join(HOME, 'bim-ootb', 'node_modules', 'sql.js', 'dist', f) });
+  const R = executedRules();
+  const list = process.argv.slice(2).filter(a => a[0] !== '-');
+  for (const b of (list.length ? list : ['Duplex'])) await runBuilding(b, SQL, R);
+})().catch(e => { console.error('§TM_REVEAL_SHIPPED_ERROR ' + (e && e.stack || e)); process.exit(2); });

--- a/viewer/sw.js
+++ b/viewer/sw.js
@@ -21,8 +21,14 @@
 // now floored at its own members' crew-days (5 over-committed windows across 4 buildings -> 0/135).
 // schedule_author.js is in PRECACHE_ASSETS; v1088 shipped the STAGE 3 drawer change (#1528), so this
 // separate change needs its own bump (§CRISIS LESSON 4).
+// v1121 (2026-09-02) §TM_REVEAL_TILED (4D_GANTT_TM_REFACTOR.md §FUTURE item 2 / §TM_REVEAL_SHIPPED):
+// time_machine.js changed — kernel_ops timestamps are now tiled inside each task bar (CPM order,
+// own-duration width, no dead air) instead of the per-task affine that left 44-71% of every bar
+// empty and piled a floor's slabs into one instant. time_machine.js is in PRECACHE_ASSETS, so an
+// installed service worker keeps serving the affine without this bump (§CRISIS LESSON 4). Paired
+// with _GANTT_CACHE_VERSION 37→38 (the IDB kernel_ops self-heal) in the same commit.
 // DEPLOY: bump CACHE_VERSION on every OCI upload. Old caches are purged on activate.
-const CACHE_VERSION = 'v1120';   // bump on each deploy; per-change detail is the git commit message.
+const CACHE_VERSION = 'v1121';   // bump on each deploy; per-change detail is the git commit message.
 // MERGE NOTE (2026-09-01, third of the day, same standing rule: KEEP BOTH notes, take the HIGHER
 // version, each separate change gets its OWN bump):
 // v1119 (2026-09-01) §WALL_SIDE_AND_LIGHT_FLOOR: streaming.js class-keyed material.side (census-

--- a/viewer/sw.js
+++ b/viewer/sw.js
@@ -21,14 +21,17 @@
 // now floored at its own members' crew-days (5 over-committed windows across 4 buildings -> 0/135).
 // schedule_author.js is in PRECACHE_ASSETS; v1088 shipped the STAGE 3 drawer change (#1528), so this
 // separate change needs its own bump (§CRISIS LESSON 4).
-// v1121 (2026-09-02) §TM_REVEAL_TILED (4D_GANTT_TM_REFACTOR.md §FUTURE item 2 / §TM_REVEAL_SHIPPED):
+// MERGE NOTE (2026-09-02): this branch and origin/main both bumped to v1121 concurrently (§MEP_DISC_PALETTE
+// below took v1121 first). Same standing rule as every sw.js merge: KEEP BOTH notes, take the HIGHER
+// version, each separate change gets its OWN bump — so §TM_REVEAL_TILED is v1122.
+// v1122 (2026-09-02) §TM_REVEAL_TILED (4D_GANTT_TM_REFACTOR.md §FUTURE item 2 / §TM_REVEAL_SHIPPED):
 // time_machine.js changed — kernel_ops timestamps are now tiled inside each task bar (CPM order,
 // own-duration width, no dead air) instead of the per-task affine that left 44-71% of every bar
 // empty and piled a floor's slabs into one instant. time_machine.js is in PRECACHE_ASSETS, so an
 // installed service worker keeps serving the affine without this bump (§CRISIS LESSON 4). Paired
 // with _GANTT_CACHE_VERSION 37→38 (the IDB kernel_ops self-heal) in the same commit.
 // DEPLOY: bump CACHE_VERSION on every OCI upload. Old caches are purged on activate.
-const CACHE_VERSION = 'v1121';   // bump on each deploy; per-change detail is the git commit message.
+const CACHE_VERSION = 'v1122';   // bump on each deploy; per-change detail is the git commit message.
 // MERGE NOTE (2026-09-01, third of the day, same standing rule: KEEP BOTH notes, take the HIGHER
 // version, each separate change gets its OWN bump):
 // v1119 (2026-09-01) §WALL_SIDE_AND_LIGHT_FLOOR: streaming.js class-keyed material.side (census-

--- a/viewer/tests/witness_tm_element_window_bind.js
+++ b/viewer/tests/witness_tm_element_window_bind.js
@@ -92,7 +92,11 @@ function hardClamp(win, s) {
   // first pass over ALL elements before the write loop). Reproduced here exactly: same two-pass
   // shape, driven by the same real _cap, so the extracted function runs unmodified.
   function buildRescaler(_winGroups) {
-    const ctx = vm.createContext({ _cap, _winGroups, Math, console, isFinite });
+    // §TM_REVEAL_TILED (2026-09-02): the shipped function now consults `_tiledPlay` (the tiled
+    // within-bar layout) before its affine fallback. This witness proves the AFFINE FALLBACK, so the
+    // map is null here — exactly the state of an imported/captured/baselined schedule live
+    // (display_authored=0). The tiled path has its own witness: witness_tm_reveal_within_bar.js.
+    const ctx = vm.createContext({ _cap, _winGroups, _tiledPlay: null, Math, console, isFinite });
     return vm.runInContext('(' + rescaleSlice + ')', ctx);
   }
 

--- a/viewer/tests/witness_tm_reveal_within_bar.js
+++ b/viewer/tests/witness_tm_reveal_within_bar.js
@@ -1,0 +1,278 @@
+#!/usr/bin/env node
+// WITNESS — W-RWB — §TM_REVEAL_TILED: WHERE inside its bar each element PLAYS (the kernel_ops layer).
+// Spec: bim-compiler prompts/4D_GANTT_TM_REFACTOR.md §FUTURE item 2, "2026-09-02 — §TM_REVEAL_SHIPPED"
+// §D (the fix) and §E (these claims, written before the code).
+//
+// ISSUE THIS PROVES OR DISPROVES (user, 2026-09-02: "the sub structure and floor slabs are appearing
+// all one shot instead of nicer progressive animation"): the timestamps the Time Machine scrubber and
+// the film play were written by injectGantt's per-task AFFINE (_tmRescaleToTaskWindow), which
+// preserves the CPM group's absolute spacing — and CPM's global crew pools give a task's members a raw
+// span of up to 434 d for a 35-day bar, so the group's core mass landed in a sliver of the bar and the
+// rest was dead air (measured mean 44-71% of every bar, 4 buildings; Hospital footings on 200 distinct
+// instants in the first half of an 11-day bar). Every earlier reveal-spread number in this lane
+// (§TPL_REVEAL_SPREAD, the cache, witness_day0_integrity) judged `displaySchedule` — a map
+// time_machine.js never reads.
+//
+// WHICH LAYER THIS PROVES: the PLAYED layer — the interval _tmRescaleToTaskWindow hands the kernel_ops
+// INSERT — produced by the SHIPPED functions sliced out of time_machine.js by brace matching (the
+// witness_tm_element_window_bind.js discipline) and driven by REAL buildings through the real chain
+// (_buildScheduleElements → computeSchedule → _tmDisplayRemap/_displayTimeline (CpmSchedule, CELL
+// gate live) → template tasks → _tmTilePlayWithinTasks → _tmRescaleToTaskWindow). No browser, no
+// bake. It says nothing about pixels or the film cursor (out of this lane).
+//
+// Every claim reports the population it judged; a claim over an empty population prints INCONCLUSIVE,
+// never PASS (PRIMAL LAW clause 4). Read the log after every run.
+//
+//   W-RWB-R  redControl: with the tiling DISABLED (the pre-fix affine), this input shows the defect —
+//            mean dead air > 0 and at least one (task,class) group with >50% of its members in one
+//            decile of its bar. Proves W-RWB-1/5 are not vacuous.
+//   W-RWB-1  no dead air: with the shipped tiling, every task (n>=2) has a dead-air share of 0 (tolerance
+//            1 ms of rounding per element).
+//   W-RWB-2  inside window: every tiled element satisfies wS <= start < end <= wE.
+//   W-RWB-3  order preserved: within each task, starts are non-decreasing in CPM-start order (ties on
+//            guid) — the monotone property the affine was chosen for survives.
+//   W-RWB-4  contiguous tiles: first start == wS, last end == wE, each start == the previous end (±1 ms).
+//   W-RWB-5  the acceptance shape ("a whole floor slab should not appear all at once"): every
+//            (task,class) group (n>=5) has distinctStarts == n, and the number of groups with one decile
+//            holding >50% of the group is <= the affine's count (both reported).
+//   W-RWB-6  fallback: an unmapped guid gets the affine result unchanged; displayAuthored=false returns
+//            null and logs the §TM_REVEAL_TILED skip.
+//   W-RWB-7  wiring (source text): injectGantt calls _tmTilePlayWithinTasks before the write loop;
+//            _tmRescaleToTaskWindow consults _tiledPlay before the affine; _GANTT_CACHE_VERSION >= 38;
+//            §TM_ELEMENT_WINDOW_BIND reports tiled=.
+//   Reported, not gated (no threshold exists that is not invented): the three judges injectGantt runs
+//   (auditFloating / midair / cjpJudgeParity) on the affine map and on the tiled map, per building.
+//
+// Command: node viewer/tests/witness_tm_reveal_within_bar.js [Building ...]
+//          (default Duplex HHS_Office_Federated Hospital; env DB_KIND=extracted to force *_extracted.db)
+'use strict';
+const fs = require('fs'), path = require('path'), vm = require('vm'), os = require('os');
+const HOME = os.homedir();
+const V = path.join(__dirname, '..');
+const BLD_DIR = process.env.BLD_DIR || path.join(HOME, 'bim-ootb', 'buildings');
+const DAY_MS = 86400000, START = '2026-01-01';
+
+const SG = require(path.join(V, 'schedule_gate.js')); global.ScheduleGate = SG;
+const SA = require(path.join(V, 'schedule_author.js'));
+const SS = require(path.join(V, 'support_sweep.js')); global.SupportSweep = SS;
+const CP = require(path.join(V, 'cpm_schedule.js')); global.CpmSchedule = CP;
+const GM = require(path.join(V, 'gantt_model.js')); global.GanttModel = GM;
+globalThis.RoomWalker = require(path.join(V, 'lib', 'room_walker.js'));
+globalThis.LevelDeriver = require(path.join(V, 'lib', 'level_deriver.js'));
+globalThis.LocationAxis = require(path.join(V, 'location_axis.js'));
+const T = JSON.parse(fs.readFileSync(path.join(V, 'rates', '4D_template.json'), 'utf8'));
+const tmSrc = fs.readFileSync(path.join(V, 'time_machine.js'), 'utf8');
+
+let pass = 0, fail = 0, inconclusive = 0;
+function claim(id, pop, bad, detail) {
+  const v = pop === 0 ? 'INCONCLUSIVE' : (bad === 0 ? 'PASS' : 'FAIL');
+  if (v === 'PASS') pass++; else if (v === 'FAIL') fail++; else inconclusive++;
+  console.log('§W_RWB ' + id.padEnd(9) + v.padEnd(13) + 'judged=' + String(pop).padEnd(7) + 'bad=' + String(bad).padEnd(6) + (detail || ''));
+  return v;
+}
+function sliceFn(src, name) {
+  const idx = src.indexOf('function ' + name + '(');
+  if (idx < 0) throw new Error(name + ' not found in time_machine.js');
+  let d = 0, open = false;
+  for (let i = idx; i < src.length; i++) {
+    if (src[i] === '{') { d++; open = true; }
+    else if (src[i] === '}') { d--; if (open && d === 0) return src.slice(idx, i + 1); }
+  }
+  throw new Error('unbalanced braces for ' + name);
+}
+function executedRules() {
+  const sb = { console: { log() {}, warn() {}, error() {} } };
+  vm.createContext(sb); vm.runInContext(fs.readFileSync(path.join(V, 'rates.js'), 'utf8'), sb);
+  return sb;
+}
+function resolveDbFile(bld) {
+  const meta = path.join(BLD_DIR, bld + '_meta.db'), ext = path.join(BLD_DIR, bld + '_extracted.db');
+  if (process.env.DB_KIND === 'extracted' && fs.existsSync(ext)) return ext;
+  // *_meta.db is the viewer's file where it exists, but a split without elements_meta (Duplex) is not usable here
+  if (fs.existsSync(meta)) { try { const b = fs.readFileSync(meta); if (b.length > 100 && b.indexOf('elements_meta') > 0) return meta; } catch (e) {} }
+  return ext;
+}
+function buildSandbox(R, logSink) {
+  const sb = {
+    window: { LABOR_RATES: R.LABOR_RATES, GanttModel: GM, ScheduleAuthor: SA },
+    ScheduleGate: SG, CpmSchedule: CP, GanttModel: GM, ScheduleAuthor: SA,
+    _midairAudit: SS.midairAudit,
+    console: { log: (...a) => logSink.push(a.join(' ')), warn: (...a) => logSink.push(a.join(' ')), error: (...a) => logSink.push(a.join(' ')) },
+    _cap: null, _winGroups: {}, _tiledPlay: null, _rawScheduleRemember: null, isFinite, Math, Date, Infinity,
+  };
+  vm.createContext(sb);
+  vm.runInContext(['var _CPM_DISPLAY = true;', sliceFn(tmSrc, '_tukeyBound'), sliceFn(tmSrc, '_displayTimelineRemember'),
+    sliceFn(tmSrc, '_displayTimeline'), sliceFn(tmSrc, '_tmDisplayRemap'), sliceFn(tmSrc, '_tmTilePlayWithinTasks'),
+    sliceFn(tmSrc, '_tmRescaleToTaskWindow'),
+    'this._tmDisplayRemap = _tmDisplayRemap; this._displayTimeline = _displayTimeline;',
+    'this._tmTilePlayWithinTasks = _tmTilePlayWithinTasks; this._tmRescaleToTaskWindow = _tmRescaleToTaskWindow;',
+    'this.__getRaw = function () { return _rawScheduleRemember; };'].join('\n'), sb);
+  return sb;
+}
+function deciles(pos) { const h = new Array(10).fill(0); pos.forEach(p => { let b = Math.floor(Math.max(0, Math.min(1, p)) * 10); if (b > 9) b = 9; h[b]++; }); return h; }
+
+// ── W-RWB-7 wiring, source text (no DB needed) ────────────────────────────────────────────────
+{
+  const ig = tmSrc.indexOf('async function injectGantt(') >= 0 ? tmSrc.slice(tmSrc.indexOf('async function injectGantt(')) : tmSrc.slice(tmSrc.indexOf('function injectGantt('));
+  const iCall = ig.indexOf('var _tiledPlay = _tmTilePlayWithinTasks(_disp, _cap, _playDisplayAuthored);');
+  const iBound = ig.indexOf('var bound = _tmRescaleToTaskWindow(el.guid, s);');
+  const rs = sliceFn(tmSrc, '_tmRescaleToTaskWindow');
+  const iConsult = rs.indexOf('if (_tiledPlay && _tiledPlay[guid])'), iAffine = rs.indexOf('if (!_cap) return s;');
+  const ver = (tmSrc.match(/var _GANTT_CACHE_VERSION = (\d+);/) || [])[1];
+  const bindLine = /'§TM_ELEMENT_WINDOW_BIND total=' \+ elements\.length \+ ' clamped=' \+ _windowClamped \+\s*' tiled=' \+ _windowTiled/.test(tmSrc);
+  let bad = 0;
+  if (!(iCall > 0 && iBound > iCall)) bad++;
+  if (!(iConsult >= 0 && iAffine > iConsult)) bad++;
+  if (!(Number(ver) >= 38)) bad++;
+  if (!bindLine) bad++;
+  claim('W-RWB-7', 4, bad, 'call-before-write=' + (iCall > 0 && iBound > iCall) + ' consult-before-affine=' + (iConsult >= 0 && iAffine > iConsult) +
+    ' _GANTT_CACHE_VERSION=' + ver + ' bindLogsTiled=' + bindLine);
+}
+
+async function runBuilding(bld, SQL, R) {
+  const dbf = resolveDbFile(bld);
+  if (!fs.existsSync(dbf)) { console.log('§W_RWB SKIP ' + bld + ' — no db'); return; }
+  const db = new SQL.Database(new Uint8Array(fs.readFileSync(dbf)));
+  const sbLog = [];
+  const sb = buildSandbox(R, sbLog);
+  const base = { start: START, laborRates: R.LABOR_RATES, rates: R.RATES, nameOverrides: R.SEQUENCE_NAME_OVERRIDES,
+    defaultRule: R.SEQUENCE_DEFAULT, scheduleGate: SG, shiftHours: T.calendar.hours_per_shift, template: T, displayRemap: sb._tmDisplayRemap };
+  const quiet = console.log; const saLog = []; console.log = (...a) => saLog.push(a.join(' '));
+  let elements, res, raw, twItems, dt;
+  try {
+    elements = SA._buildScheduleElements(db, R.SEQUENCE_RULES, base);
+    globalThis.APP = { db };
+    res = SA.materializeZones(db, R.SEQUENCE_RULES, base);
+    raw = sb.__getRaw();
+    const baseMs = Date.parse(START);
+    twItems = elements.map(el => { const ts = raw && raw.map[el.guid];
+      return { guid: el.guid, s: ts ? ts.start : baseMs, e: ts ? ts.end : baseMs + 60000, bz: el.base_z, tz: el.top_z,
+        x0: el.x0, x1: el.x1, y0: el.y0, y1: el.y1, cls: el.cls, seq: el.seq, phase: el.phase, storey: el.storey, resource: el.resource }; });
+    dt = sb._displayTimeline(twItems);
+  } finally { console.log = quiet; delete globalThis.APP; }
+  const cellLine = sbLog.find(l => l.indexOf('§CELL_GATE') === 0) || '';
+  console.log('§W_RWB_BUILDING ' + bld + ' db=' + path.basename(dbf) + ' elements=' + elements.length + ' tasks=' + (res && res.tasks ? res.tasks.length : 0) +
+    ' cpm=' + (dt && dt.cpm) + ' ' + (cellLine.match(/repr=[\d.]+% mark=\d+% promoted=\d+ path=\w+/) || [''])[0]);
+  if (!res || !res.ok || !res.tasks || !(dt && (dt.cpm === 'reuse' || dt.cpm === true))) {
+    claim('W-RWB-0', 0, 0, bld + ' chain did not produce a played timeline (materializeZones ok=' + (res && res.ok) + ', cpm=' + (dt && dt.cpm) + ')');
+    db.close(); return;
+  }
+  const disp = {}; twItems.forEach(it => { disp[it.guid] = { start: it.s, end: it.e }; });
+  let schedEnd = -Infinity; for (const g in disp) if (disp[g].end > schedEnd) schedEnd = disp[g].end;
+  const baseMs = Date.parse(START), win = {}, guidTask = {};
+  res.tasks.forEach(t => { win[t.id] = { s: baseMs + t.sDays * DAY_MS, e: baseMs + t.eDays * DAY_MS, name: t.id };
+    t.guids.forEach(g => { if (!guidTask[g] || win[t.id].s < win[guidTask[g]].s) guidTask[g] = t.id; }); });
+  const cap = { base: baseMs, win, guidTask, taskCount: res.tasks.length };
+  const winGroups = {};
+  elements.forEach(el => { const s = disp[el.guid] || { start: schedEnd, end: schedEnd + 60000 }; const tid = guidTask[el.guid];
+    if (tid == null || !win[tid]) return; const g = winGroups[tid] || (winGroups[tid] = { min: Infinity, max: -Infinity });
+    if (s.start < g.min) g.min = s.start; if (s.end > g.max) g.max = s.end; });
+  sb._cap = cap; sb._winGroups = winGroups;
+  const tasks = res.tasks.map(t => ({ id: t.id, guids: t.guids.filter(g => guidTask[g] === t.id && disp[g]) })).filter(t => t.guids.length);
+
+  function playMap(tiled) {
+    sb._tiledPlay = tiled;
+    const m = {};
+    elements.forEach(el => { const s = disp[el.guid] || { start: schedEnd, end: schedEnd + 60000 }; const b = sb._tmRescaleToTaskWindow(el.guid, s); m[el.guid] = { s: b.start, e: b.end, tiled: !!b.tiled }; });
+    return m;
+  }
+  function deadAir(map) {
+    let sum = 0, n = 0, badTasks = 0, worst = { pct: -1 };
+    tasks.forEach(t => { if (t.guids.length < 2) return; const w = win[t.id], span = w.e - w.s;
+      const iv = t.guids.map(g => [map[g].s, map[g].e]).sort((a, b) => a[0] - b[0]);
+      let cov = 0, cur = w.s; iv.forEach(([s, e]) => { const a = Math.max(s, cur), b = Math.min(e, w.e); if (b > a) cov += b - a; if (e > cur) cur = e; });
+      const deadMs = span - cov, pct = 100 * deadMs / span; sum += pct; n++;
+      if (deadMs > t.guids.length) badTasks++;           // 1 ms of rounding per element is the only tolerance
+      if (pct > worst.pct) worst = { pct, id: t.id, n: t.guids.length }; });
+    return { mean: n ? sum / n : 0, n, badTasks, worst };
+  }
+  function groups(map) {
+    const gr = {}; elements.forEach(e => { const t = guidTask[e.guid]; if (!t || !disp[e.guid]) return; (gr[t + '||' + e.cls] = gr[t + '||' + e.cls] || []).push(e.guid); });
+    const rows = [];
+    for (const k in gr) { const gs = gr[k]; if (gs.length < 5) continue; const tid = k.split('||')[0], w = win[tid], span = w.e - w.s;
+      const dec = deciles(gs.map(g => (map[g].s - w.s) / span)); const maxDec = Math.max.apply(null, dec) / gs.length * 100;
+      rows.push({ k, n: gs.length, maxDec, distinct: new Set(gs.map(g => map[g].s)).size }); }
+    return rows;
+  }
+  function judges(map, label) {
+    const m = {}; elements.forEach(e => { m[e.guid] = { start: map[e.guid].s, end: map[e.guid].e }; });
+    const q = console.log; console.log = () => {};
+    let fl, ma, cjp;
+    try { fl = SG.auditFloating(elements, m, null, null, null);
+      const its = twItems.map(it => Object.assign({}, it, { s: map[it.guid].s, e: map[it.guid].e, task: guidTask[it.guid] }));
+      ma = SS.midairAudit(its); cjp = SS.cjpJudgeParity(its.map(it => Object.assign({}, it)), win);
+    } finally { console.log = q; }
+    console.log('§W_RWB_JUDGE ' + bld + ' map=' + label + ' auditFloating=' + fl + '/' + elements.length + ' midair=' + ma.midair +
+      ' cjpFloating=' + cjp.floating + ' windowBlocked=' + cjp.windowBlocked + ' (reported, not gated)');
+  }
+
+  // ── W-RWB-R redControl: the affine alone (tiling disabled) ────────────────────────────────
+  const affine = playMap(null);
+  const daA = deadAir(affine), grA = groups(affine), over50A = grA.filter(r => r.maxDec > 50).length;
+  claim('W-RWB-R', daA.n + grA.length, (daA.mean > 0 && over50A >= 1) ? 0 : 1, bld + ' affine-only: meanDeadAir=' + daA.mean.toFixed(1) +
+    '% worst=' + daA.worst.pct.toFixed(1) + '%@' + daA.worst.id + ' groups>50%InOneDecile=' + over50A + '/' + grA.length + ' — the defect is present on this input');
+
+  // ── the shipped tiling ────────────────────────────────────────────────────────────────────
+  const before = sbLog.length;
+  const tiled = sb._tmTilePlayWithinTasks(disp, cap, true);
+  const tiledLine = sbLog.slice(before).find(l => l.indexOf('§TM_REVEAL_TILED') === 0) || '';
+  console.log(tiledLine + '  [' + bld + ']');
+  const map = playMap(tiled);
+  const nTiled = elements.filter(e => map[e.guid].tiled).length;
+
+  // W-RWB-1 no dead air
+  const daT = deadAir(map);
+  claim('W-RWB-1', daT.n, daT.badTasks, bld + ' tiled: meanDeadAir=' + daT.mean.toFixed(3) + '% tasksWithDeadAir>1ms/el=' + daT.badTasks + ' (was ' + daA.mean.toFixed(1) + '%) tiledElements=' + nTiled + '/' + elements.length);
+
+  // W-RWB-2 inside window
+  { let bad = 0, pop = 0; elements.forEach(e => { const t = guidTask[e.guid]; if (!t || !map[e.guid].tiled) return; pop++; const w = win[t], m = map[e.guid];
+      if (!(w.s <= m.s && m.s < m.e && m.e <= w.e)) bad++; });
+    claim('W-RWB-2', pop, bad, bld + ' every tiled element inside its own bar (wS <= start < end <= wE)'); }
+
+  // W-RWB-3 order preserved (CPM start, ties on guid)
+  { let bad = 0, pop = 0; tasks.forEach(t => { const gs = t.guids.slice().sort((a, b) => disp[a].start - disp[b].start || (a < b ? -1 : 1));
+      for (let i = 1; i < gs.length; i++) { pop++; if (map[gs[i]].s < map[gs[i - 1]].s) bad++; } });
+    claim('W-RWB-3', pop, bad, bld + ' adjacent CPM-ordered pairs whose played starts are non-decreasing'); }
+
+  // W-RWB-4 contiguous tiles
+  { let bad = 0, pop = 0; tasks.forEach(t => { const w = win[t.id]; const iv = t.guids.map(g => map[g]).sort((a, b) => a.s - b.s);
+      pop += iv.length + 1;
+      if (Math.abs(iv[0].s - w.s) > 1) bad++; if (Math.abs(iv[iv.length - 1].e - w.e) > 1) bad++;
+      for (let i = 1; i < iv.length; i++) if (Math.abs(iv[i].s - iv[i - 1].e) > 1) bad++; });
+    claim('W-RWB-4', pop, bad, bld + ' tile boundaries: first==wS, last==wE, each start==previous end (±1 ms)'); }
+
+  // W-RWB-5 acceptance shape
+  { const grT = groups(map); const over50T = grT.filter(r => r.maxDec > 50).length;
+    let bad = 0; const offenders = []; grT.forEach(r => { if (r.distinct !== r.n) { bad++; offenders.push(r.k + ' n=' + r.n + ' distinct=' + r.distinct); } });
+    if (over50T > over50A) bad++;
+    const slabs = grT.filter(r => /IfcSlab|IfcFooting/.test(r.k)).map(r => r.k.replace('TASK_', '') + ' n=' + r.n + ' maxDecile=' + r.maxDec.toFixed(0) + '% distinct=' + r.distinct);
+    claim('W-RWB-5', grT.length, bad, bld + ' (task,class) groups n>=5: distinctStarts==n for all (offenders=' + (offenders.length ? offenders.slice(0, 3).join('; ') : 'none') +
+      ') groups>50%InOneDecile ' + over50A + ' -> ' + over50T + ' | slabs/footings: ' + slabs.join(' | ')); }
+
+  // W-RWB-6 fallback
+  { let bad = 0;
+    const ghost = 'NOT_A_REAL_GUID_' + Date.now(); const sIn = { start: 12345, end: 23456 };
+    const out = sb._tmRescaleToTaskWindow(ghost, sIn);
+    if (!(out.start === sIn.start && out.end === sIn.end)) bad++;
+    const g0 = elements.find(e => map[e.guid].tiled).guid; const t0 = tiled[g0]; delete tiled[g0];
+    const fb = sb._tmRescaleToTaskWindow(g0, disp[g0]); tiled[g0] = t0;
+    if (!(fb.start === affine[g0].s && fb.end === affine[g0].e && !fb.tiled)) bad++;
+    const b2 = sbLog.length; const nul = sb._tmTilePlayWithinTasks(disp, cap, false);
+    const skip = sbLog.slice(b2).find(l => l.indexOf('§TM_REVEAL_TILED skip reason=schedule not display-authored') === 0);
+    if (!(nul === null && skip)) bad++;
+    claim('W-RWB-6', 3, bad, bld + ' unmapped guid passes through; an element dropped from the map gets the affine result; displayAuthored=false -> null + skip log'); }
+
+  judges(affine, 'affine'); judges(map, 'tiled');
+  db.close();
+}
+
+(async () => {
+  const initSqlJs = require(path.join(HOME, 'bim-ootb', 'node_modules', 'sql.js'));
+  const SQL = await initSqlJs({ locateFile: f => path.join(HOME, 'bim-ootb', 'node_modules', 'sql.js', 'dist', f) });
+  const R = executedRules();
+  const list = process.argv.slice(2).filter(a => a[0] !== '-');
+  for (const b of (list.length ? list : ['Duplex', 'HHS_Office_Federated', 'Hospital'])) await runBuilding(b, SQL, R);
+  console.log('§W_RWB_SUMMARY pass=' + pass + ' fail=' + fail + ' inconclusive=' + inconclusive);
+  if (fail) { console.error('FAIL — ' + fail + ' claim(s) failed'); process.exit(1); }
+  console.log(pass ? 'PASS — every element plays its own CPM-duration share of its bar, in CPM order, with no dead air' : 'INCONCLUSIVE — nothing judged');
+})().catch(e => { console.error('§W_RWB_ERROR ' + (e && e.stack || e)); process.exit(2); });

--- a/viewer/time_machine.js
+++ b/viewer/time_machine.js
@@ -4260,8 +4260,9 @@
       console.log('§TM_REVEAL_TILED skip reason=schedule not display-authored (imported/captured/baselined windows) — affine rescale kept');
       return null;
     }
-    var SA = (typeof window !== 'undefined' && window.ScheduleAuthor) ||
-             (typeof ScheduleAuthor !== 'undefined' ? ScheduleAuthor : null);
+    // Resolved through `window` only — the same seam every real UI call site in this file uses for
+    // ScheduleAuthor (buildTaskIndex, generateGanttSchedule); a witness sandbox supplies window.ScheduleAuthor.
+    var SA = (typeof window !== 'undefined' && window.ScheduleAuthor) || null;
     if (!SA || typeof SA.remapSolveToTasks !== 'function') {
       console.log('§TM_REVEAL_TILED skip reason=ScheduleAuthor.remapSolveToTasks unavailable — affine rescale kept');
       return null;

--- a/viewer/time_machine.js
+++ b/viewer/time_machine.js
@@ -4217,6 +4217,76 @@
     return out;
   }
 
+  // ══ §TM_REVEAL_TILED (2026-09-02, bim-compiler prompts/4D_GANTT_TM_REFACTOR.md §FUTURE item 2,
+  // §TM_REVEAL_SHIPPED) — WHERE inside its bar each element PLAYS. ════════════════════════════
+  // Witness: viewer/tests/witness_tm_reveal_within_bar.js (W-RWB). Probe: scripts/probe_tm_reveal_shipped.js.
+  //
+  // THE FINDING. materializeZones returns `displaySchedule` (= ScheduleAuthor.remapSolveToTasks:
+  // support-layer bands, duration-weighted tiling — §TPL_MOVIE_BINDS_BARS "every element now plays
+  // inside the bar that claims it") and this file never read it. The kernel_ops timestamps the
+  // scrubber and the film actually play were written by injectGantt's _tmRescaleToTaskWindow: a
+  // per-task AFFINE of the CPM group's raw [min,max] onto the template window. CpmSchedule's GLOBAL
+  // per-resource crew pools give a task's members a raw span of up to 434 d for a 35-day bar
+  // (Hospital TASK_MEP_Rough_in_Level_1), so the affine squashed the group's core into a sliver and
+  // left the rest of the bar empty. Measured on the shipped chain (sliced live functions, no
+  // browser): dead air (bar lit, NOTHING in progress) mean 44/63/63/71% of every bar on Duplex/HHS/
+  // Hospital/Terminal, worst 99.9%; Hospital TASK_MEP_Final_Level_5 n=564 days=3 reveal deciles
+  // [3.5,0,0,0,0,0,0,0,0,96.5]; 553 Hospital footings on 200 distinct instants inside the first
+  // half of an 11-day bar, days 6-11 empty. User, 2026-09-02: "the sub structure and floor slabs
+  // are appearing all one shot instead of nicer progressive animation."
+  //
+  // THE FIX. Call the verb the codebase already owns for this question (4D_MODEL_INTEGRITY.md §I
+  // "where inside its task?") instead of re-deriving a layout here: remapSolveToTasks with the CPM
+  // display times as the solve and NO layer map — one band per task, members in CPM start order
+  // (ties on guid), each element's width its own CPM-duration share, tiled edge-to-edge across the
+  // task's real window. Monotone, so every ordering CPM established survives — the exact property
+  // the affine was chosen for (measured: 0 order violations over 119k adjacent pairs, 4 buildings);
+  // no dead air by construction (measured 0.0% on all four); no number invented (widths are the
+  // durations the solve computed, windows are the template's). §S50's cell order stays the live
+  // precedence carrier — this changes SPACING, never order. Gated on schedules.display_authored=1
+  // (our own authored windows — the same flag §CAP_RESCALE_SKIP/§OG_SWEEP_SKIP key on); imported/
+  // captured/baselined schedules keep the affine byte-identically, as does any element this map
+  // misses. Task windows, dates, crews, cost and the film cursor are untouched.
+  //
+  // WHAT IT DOES NOT DO, ON PURPOSE: a superstructure level's slab SET stays compact — _installSecs
+  // prices every IfcSlab at a flat 823 s (0.8% of Hospital L3's labour) and the cell order lays a
+  // level out trade-by-trade — both rulings, neither this function's to change (spec §D).
+  function _tmTilePlayWithinTasks(disp, cap, displayAuthored) {
+    if (!cap || !cap.win || !cap.guidTask) {
+      console.log('§TM_REVEAL_TILED skip reason=no dated task windows (_cap null) — affine rescale kept');
+      return null;
+    }
+    if (!displayAuthored) {
+      console.log('§TM_REVEAL_TILED skip reason=schedule not display-authored (imported/captured/baselined windows) — affine rescale kept');
+      return null;
+    }
+    var SA = (typeof window !== 'undefined' && window.ScheduleAuthor) ||
+             (typeof ScheduleAuthor !== 'undefined' ? ScheduleAuthor : null);
+    if (!SA || typeof SA.remapSolveToTasks !== 'function') {
+      console.log('§TM_REVEAL_TILED skip reason=ScheduleAuthor.remapSolveToTasks unavailable — affine rescale kept');
+      return null;
+    }
+    var base = cap.base;
+    if (!isFinite(base)) { base = Infinity; for (var k0 in cap.win) if (cap.win[k0].s < base) base = cap.win[k0].s; }
+    var tasks = [], byTid = {}, skipped = 0;
+    for (var g in cap.guidTask) {
+      var tid = cap.guidTask[g], w = cap.win[tid];
+      if (!w || !disp[g]) { skipped++; continue; }
+      var t = byTid[tid];
+      if (!t) { t = byTid[tid] = { id: tid, sDays: (w.s - base) / 86400000, eDays: (w.e - base) / 86400000, guids: [] }; tasks.push(t); }
+      t.guids.push(g);
+    }
+    if (!tasks.length) {
+      console.log('§TM_REVEAL_TILED skip reason=no element resolves to a dated task — affine rescale kept');
+      return null;
+    }
+    var r = SA.remapSolveToTasks(disp, tasks, new Date(base).toISOString(), null);
+    console.log('§TM_REVEAL_TILED tasks=' + tasks.length + ' mapped=' + r.mapped + ' skipped=' + skipped +
+      ' degenerate=' + r.degenerateTasks +
+      ' — each element plays its own CPM-duration share of its bar, CPM order kept, no dead air (was: per-task affine, §TM_ELEMENT_WINDOW_RESCALE)');
+    return r.schedule;
+  }
+
   // _twoTierRemap (retired §S20 Part B, 2026-08-17, 4D_GANTT_TM_REFACTOR.md) — the legacy
   // two-tier (Substructure/Superstructure/Architecture-serial, then audit-physics-regate) display
   // orchestrator. Reachable ONLY via _displayTimeline's now-deleted fallback branch — confirmed
@@ -4888,7 +4958,23 @@
         if (s.end > g.max) g.max = s.end;
       });
     }
+    // §TM_REVEAL_TILED — same DB flag §CAP_RESCALE_SKIP / §OG_SWEEP_SKIP key on (display_authored=1:
+    // the windows are our own authored ones), read HERE because the tiling decides WHERE inside its
+    // bar each element is written, i.e. before the write loop, not in the overlay pass after it.
+    var _playDisplayAuthored = false;
+    try {
+      var _pdaR = db.exec('SELECT 1 FROM schedules WHERE display_authored=1 LIMIT 1');
+      _playDisplayAuthored = !!(_pdaR.length && _pdaR[0].values.length);
+    } catch (ePda) { /* legacy DB without the column — affine rescale stays */ }
+    var _tiledPlay = _tmTilePlayWithinTasks(_disp, _cap, _playDisplayAuthored);
     function _tmRescaleToTaskWindow(guid, s) {
+      // §TM_REVEAL_TILED — the tiled interval wins when one exists (see _tmTilePlayWithinTasks).
+      // Everything below is the affine fallback, byte-identical for every element and every
+      // schedule the tiling does not cover (imported/captured/baselined windows, unmapped guids).
+      if (_tiledPlay && _tiledPlay[guid]) {
+        var _tp = _tiledPlay[guid];
+        return { start: _tp.start, end: _tp.end, clamped: true, tiled: true };
+      }
       if (!_cap) return s;
       var taskId = _cap.guidTask[guid];
       var win = (taskId != null) ? _cap.win[taskId] : null;
@@ -4912,11 +4998,12 @@
     db.run('BEGIN');
     var _gStmt = db.prepare('INSERT INTO kernel_ops (timestamp,op_type,parameters,input_guids,output_guid,undone) VALUES(?,?,?,?,?,0)');
     var _projEnd = baseMs;
-    var _windowClamped = 0, _windowUncovered = 0;
+    var _windowClamped = 0, _windowUncovered = 0, _windowTiled = 0;   // §TM_REVEAL_TILED: tiled ⊂ clamped
     elements.forEach(function(el) {
       var s = _disp[el.guid] || { start: _schedEnd, end: _schedEnd + 60000 };   // §4D_NOGEO park at the DISPLAY end (§TIER_SERIAL), was baseMs (day 0)
       var bound = _tmRescaleToTaskWindow(el.guid, s);
       if (bound.clamped) _windowClamped++; else if (!_cap || _cap.guidTask[el.guid] == null) _windowUncovered++;
+      if (bound.tiled) _windowTiled++;   // §TM_REVEAL_TILED
       s = bound;
       _gStmt.run([s.start, 'ELEMENT_PLACE',
          JSON.stringify({phase:el.phase, cls:el.cls, name:el.name, storey:el.storey,
@@ -4928,7 +5015,8 @@
     });
     _gStmt.free();
     console.log('§TM_ELEMENT_WINDOW_BIND total=' + elements.length + ' clamped=' + _windowClamped +
-      ' uncovered=' + _windowUncovered + ' (uncovered = no resolvable real task window, prior behavior kept)');
+      ' tiled=' + _windowTiled + ' uncovered=' + _windowUncovered +
+      ' (tiled = §TM_REVEAL_TILED laid it out inside its bar; clamped-not-tiled = affine fallback; uncovered = no resolvable real task window, prior behavior kept)');
     _s4Mark('insertLoop');
     db.run('COMMIT');
     resourceCursor['_end'] = _projEnd;   // feed the endDate computation below (Math.max over values)
@@ -8262,7 +8350,8 @@
   // huts going first before the walls" AFTER a hard reset, because §GANTT_CACHE_HIT served a
   // gantt:v4 entry generated under the old ordering. A hard reset cannot clear it — the entry is in
   // IndexedDB, not the HTTP cache. This bump is that fix's second half.
-  var _GANTT_CACHE_VERSION = 37;   // §S51 item d — ops now carry the cell stamp (_cell) so the Gantt groups by the schedule's own cells; pre-§S51 kernel_ops lack it, regenerate
+  var _GANTT_CACHE_VERSION = 38;   // §TM_REVEAL_TILED (2026-09-02) — kernel_ops timestamps are now tiled inside each bar (CPM order, own-duration width) instead of the per-task affine; a v37 IDB entry still carries the affine layout (dead air 44-71% of every bar), regenerate
+  // was 37:   // §S51 item d — ops now carry the cell stamp (_cell) so the Gantt groups by the schedule's own cells; pre-§S51 kernel_ops lack it, regenerate
   // was 28:   // §CPM_DISPLAY (2026-08-16): display timeline authored by the one-DAG CPM pass
   // was 27:   // §ZONE_DISPLAY_AUTHORING (2026-08-16): task windows authored from
                                    // the DISPLAY timeline + strict-bar sweep skipped on that path —


### PR DESCRIPTION
## Root cause — measured on the SHIPPED chain, 4 buildings, no browser, no bake

User (2026-09-02): *"the sub structure and floor slabs are appearing all one shot instead of nicer progressive animation."*

`materializeZones` returns `displaySchedule` (= `remapSolveToTasks`, the map every prior reveal-spread number in this lane judged — `§TPL_REVEAL_SPREAD`, `cache_4d_run.js`, `witness_day0_integrity`) and **`time_machine.js` never reads it**. The kernel_ops timestamps the Time Machine scrubber and the film play were written by `injectGantt`'s `_tmRescaleToTaskWindow`: a per-task **affine** of the CPM group's raw `[min,max]` onto the template window. CpmSchedule's global crew pools give a task's members a raw span of up to **434 d for a 35-day bar**, so the affine squashed each group's core into a sliver and left the rest of the bar empty:

| `§TM_REVEAL_DEADAIR` (share of a bar with nothing in progress) | Duplex | HHS | Hospital | Terminal |
|---|---|---|---|---|
| affine (before) mean / worst | 44.1% / 98.2% | 63.2% / 99.7% | 63.3% / 99.5% | 70.7% / 99.9% |
| tiled (after) | **0.0%** | **0.0%** | **0.0%** | **0.0%** |
| pile-up: max share of a task starting inside ONE 1%-of-bar bin, before → after | 13.8 → 9.9% | 48.0 → 4.0% | **77.0 → 5.6%** | 62.5 → 8.3% |
| (task,class) groups with >50% in one decile, before → after | 9 → 5 /23 | 19 → 7 /42 | **99 → 34 /126** | 86 → 21 /128 |

- Hospital `TASK_MEP_Final_Level_5 n=564 days=3` reveal deciles `[3.5,0,0,0,0,0,0,0,0,96.5]`; `TASK_MEP_Rough_in_Level_2 n=5286 days=34 [0.4,4.2,94.2,0.9,…]`.
- Hospital substructure: 553 footings on **200 distinct instants** inside the first half of an 11-day bar, days 6-11 empty → after: **553 distinct starts, deciles `[10.1,9.9,10.1,9.9,9.9,10.1,9.9,10.1,9.9,9.8]`**.
- HHS `TASK_Superstructure_Level_1 IfcSlab n=27`: 100% in one decile, 66.7% in a single 1% bin → 27 distinct instants.

## The fix (axis A — WHERE inside its bar each element plays)

`injectGantt` now **calls the verb the codebase already owns** for "where inside its task" (`4D_MODEL_INTEGRITY.md` §I) — `ScheduleAuthor.remapSolveToTasks` — with the CPM display times as the solve and no layer map (new `_tmTilePlayWithinTasks`): one band per task, members in CPM start order, each element's width its own CPM-duration share, tiled edge-to-edge. `_tmRescaleToTaskWindow` returns the tiled interval when one exists; the affine stays as the **byte-identical fallback** for imported/captured/baselined schedules (`display_authored=0`) and any unmapped element.

**Impact statement** (the user asked for this explicitly):
- Changes: WHEN each element appears inside its already-correct bar, on generated schedules, every building (Hospital: 63,182 elements move within their bars). `_GANTT_CACHE_VERSION` 37→38 regenerates IDB-cached ops; `sw.js` v1122.
- Keeps, by construction and measured: every task window, date, crew, cost; the film cursor (`cinema_maxq.js` untouched); **CPM order inside every bar** — monotone map, `§TM_REVEAL_ORDER violations=0/1099, 0/6819, 0/63140, 0/48351`; §S50's cell order stays the live precedence carrier.
- Judges (same three `injectGantt` runs), reported not gated: Hospital auditFloating 424→416, midair 482→498, cjpFloating 70→70; HHS 315→304 / 183→218 / 53→49; Terminal 367→365 / 1611→1400 / 175→181; Duplex 20→17 / 25→27 / 2→2.
- Not done, on purpose (rulings, named in the spec §D): a superstructure level's slab SET stays compact — `_installSecs` prices every IfcSlab at a flat **823 s** (0.8% of Hospital L3's labour) and the cell order lays a level out trade-by-trade. Hospital Levels 2-6 are **single-element** floor plates (7.6-9.2k m²) — sub-element reveal would be invention.

## Witness — red → green, through the SHIPPED slice
`viewer/tests/witness_tm_reveal_within_bar.js` — **`§W_RWB_SUMMARY pass=22 fail=0 inconclusive=0`** (Duplex, HHS, Hospital). W-RWB-R red control proves the defect on the affine (44.1/63.2/63.3% dead air); W-RWB-1 no dead air; -2 inside window (63,182 judged); -3 order preserved (63,140 pairs); -4 contiguous tiles; -5 distinctStarts==n for every (task,class) group + non-regression of the >50%-in-one-decile count; -6 fallbacks; -7 wiring by source text.

Tripwires (this worktree): `witness_tm_element_window_bind` 7/7 (sandbox gains `_tiledPlay=null` — it proves the affine fallback), `witness_crosstask_judge_parity` 20/20, `witness_4d_movie_binds_bars` 7/7, `witness_bake_plays_schedule` 16/16, `witness_tm_refold` 7/7, `witness_gantt_lock_integrity` 20/20, `witness_kernel_ops_sched_version` 19/19. Pre-existing and identical on unmodified `main` (verified): `witness_gantt_props_epoch` W-PE-5/6/7 (date formatting, 17/21), `witness_midair_zero` W-MZ Duplex meta-db + W-MZ-8 HHS baseline (12/14), `witness_day0_integrity` (judges the cache's `displaySchedule`, not the played layer).

Probe: `scripts/probe_tm_reveal_shipped.js [Building…]` (~10 s Hospital) — A/B of affine vs the shipped tiling with judges, day-0, (task,class) concentration, dead air, and a report-only film-cursor arithmetic.

Spec: bim-compiler `prompts/4D_GANTT_TM_REFACTOR.md` §FUTURE item 2 "2026-09-02 — §TM_REVEAL_SHIPPED" (§A-§F), `4D_MODEL_INTEGRITY.md` §I new row, `GANTT_ACCURACY.md` §BUILDUP_DAY_BATCH_FEASIBILITY correction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RTX9gUq3tQoytC1vthLmcq
