### PR TITLE
fix(security): harden before() in witness_room_graph_utility_penalty.js against shell injection

### DIFF
--- a/witness_room_graph_utility_penalty.js
+++ b/witness_room_graph_utility_penalty.js
@@ -39,9 +39,14 @@ const Database = require(path.join(process.env.HOME, 'bim-compiler', 'node_modul
 // "before" = origin/main @ #959 merge (post-PR-959, pre-this door-exemption change). Regenerated
 // next to the live siblings so requires resolve; gitignored, never committed. Pinning keeps it stable.
 const BEFORE_SHA = '6209f54';
+const BEFORE_PATHS = {
+  room_graph: path.join(__dirname, 'common', '_room_graph_before.js'),
+  room_habitability: path.join(__dirname, 'common', '_room_habitability_before.js')
+};
 function before(name) {
-  const p = path.join(__dirname, 'common', '_' + name + '_before.js');
-  if (!fs.existsSync(p)) fs.writeFileSync(p, cp.execSync('git show ' + BEFORE_SHA + ':common/' + name + '.js', { cwd: __dirname, maxBuffer: 1 << 24 }));
+  const p = BEFORE_PATHS[name];
+  if (!p) throw new Error('Unknown module: ' + name);
+  if (!fs.existsSync(p)) fs.writeFileSync(p, cp.execFileSync('git', ['show', BEFORE_SHA + ':common/' + name + '.js'], { cwd: __dirname, maxBuffer: 1 << 24 }));
   return require(p);
 }
 const RG = require('./common/room_graph.js');           // NEW (under test)


### PR DESCRIPTION
Re-submission of #990 (fork PR from anupamme/OrbisAI security bot) as a same-repo branch.

**Why re-submit instead of merging #990 directly:** this repo's `ci.yml` triggers on `push`
only (no `pull_request` trigger), so a fork-originated PR's commits never run CI in this repo
— `statusCheckRollup` stays empty forever. Branch protection requires `fast-checks` +
`e2e-tests` with `enforce_admins: true`, so #990 is permanently BLOCKED regardless of diff
quality. Diff verified correct and low-risk, so re-pushing it as a same-repo branch lets CI
actually run.

**The fix:** `witness_room_graph_utility_penalty.js`'s `before()` helper built a `git show`
invocation via `cp.execSync('git show ' + BEFORE_SHA + ':common/' + name + '.js', ...)` —
string-interpolated into a shell command. Semgrep correctly flagged the pattern. Replaced with
`cp.execFileSync('git', [...])` (no shell parsing) plus a `BEFORE_PATHS` whitelist restricting
`name` to the two literals the file actually passes (`'room_graph'`, `'room_habitability'`) —
verified both call sites are covered, so behavior is unchanged.

Diff is otherwise byte-identical to #990. Closing #990 with a pointer to this PR.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>