### PR TITLE
fix(witness): §VAC — the nine per-frame tags of §R13.9 can now report their own failure

### DIFF
--- a/tests/fixtures/vac_tag_series_s5_hospital.json
+++ b/tests/fixtures/vac_tag_series_s5_hospital.json
@@ -1,0 +1,4317 @@
+{
+ "_source": "s5_hospital.log — Hospital HospitalAjaibPath MaxQ bake, commit e1369b7a sw=v1120 gpu=real(ANGLE RTX 4060 Laptop), 2027 frames, wall 2680s, aborted=no fileOk=true, 2026-09-01. 41,705 lines. Run-length encoded per tag, ORDER PRESERVED; expand to reconstruct the exact original series.",
+ "series": {
+  "GROUP_SPARK_TICK": {
+   "total": 2027,
+   "runs": 404,
+   "rle": [
+    [
+     "§GROUP_SPARK_TICK playing=false cand=0 (frontier=0 recent=0) roll=0 decay=1.00",
+     4
+    ],
+    [
+     "§GROUP_SPARK_TICK playing=false cand=0 (frontier=1 recent=13) roll=0 decay=1.00",
+     1
+    ],
+    [
+     "§GROUP_SPARK_TICK playing=false cand=0 (frontier=10 recent=8) roll=0 decay=1.00",
+     1
+    ],
+    [
+     "§GROUP_SPARK_TICK playing=false cand=0 (frontier=2 recent=11) roll=0 decay=1.00",
+     1
+    ],
+    [
+     "§GROUP_SPARK_TICK playing=false cand=0 (frontier=30 recent=14) roll=0 decay=1.00",
+     1
+    ],
+    [
+     "§GROUP_SPARK_TICK playing=false cand=0 (frontier=30 recent=22) roll=0 decay=1.00",
+     1
+    ],
+    [
+     "§GROUP_SPARK_TICK playing=false cand=0 (frontier=30 recent=12) roll=0 decay=1.00",
+     1
+    ],
+    [
+     "§GROUP_SPARK_TICK playing=false cand=0 (frontier=21 recent=13) roll=0 decay=1.00",
+     1
+    ],
+    [
+     "§GROUP_SPARK_TICK playing=false cand=0 (frontier=0 recent=0) roll=0 decay=1.00",
+     8
+    ],
+    [
+     "§GROUP_SPARK_TICK playing=false cand=0 (frontier=2 recent=0) roll=0 decay=1.00",
+     1
+    ],
+    [
+     "§GROUP_SPARK_TICK playing=false cand=0 (frontier=0 recent=1) roll=0 decay=1.00",
+     1
+    ],
+    [
+     "§GROUP_SPARK_TICK playing=false cand=0 (frontier=0 recent=0) roll=0 decay=1.00",
+     6
+    ],
+    [
+     "§GROUP_SPARK_TICK playing=false cand=0 (frontier=0 recent=3) roll=0 decay=1.00",
+     1
+    ],
+    [
+     "§GROUP_SPARK_TICK playing=false cand=0 (frontier=0 recent=0) roll=0 decay=1.00",
+     6
+    ],
+    [
+     "§GROUP_SPARK_TICK playing=false cand=0 (frontier=1 recent=0) roll=0 decay=1.00",
+     1
+    ],
+    [
+     "§GROUP_SPARK_TICK playing=false cand=0 (frontier=5 recent=22) roll=0 decay=1.00",
+     1
+    ],
+    [
+     "§GROUP_SPARK_TICK playing=false cand=0 (frontier=4 recent=14) roll=0 decay=1.00",
+     1
+    ],
+    [
+     "§GROUP_SPARK_TICK playing=false cand=0 (frontier=5 recent=19) roll=0 decay=1.00",
+     1
+    ],
+    [
+     "§GROUP_SPARK_TICK playing=false cand=0 (frontier=5 recent=25) roll=0 decay=1.00",
+     1
+    ],
+    [
+     "§GROUP_SPARK_TICK playing=false cand=0 (frontier=5 recent=26) roll=0 decay=1.00",
+     1
+    ],
+    [
+     "§GROUP_SPARK_TICK playing=false cand=0 (frontier=5 recent=36) roll=0 decay=1.00",
+     1
+    ],
+    [
+     "§GROUP_SPARK_TICK playing=false cand=0 (frontier=5 recent=35) roll=0 decay=1.00",
+     1
+    ],
+    [
+     "§GROUP_SPARK_TICK playing=false cand=0 (frontier=5 recent=26) roll=0 decay=1.00",
+     1
+    ],
+    [
+     "§GROUP_SPARK_TICK playing=false cand=0 (frontier=5 recent=16) roll=0 decay=1.00",
+     1
+    ],
+    [
+     "§GROUP_SPARK_TICK playing=false cand=0 (frontier=7 recent=26) roll=0 decay=1.00",
+     1
+    ],
+    [
+     "§GROUP_SPARK_TICK playing=false cand=0 (frontier=7 recent=45) roll=0 decay=1.00",
+     1
+    ],
+    [
+     "§GROUP_SPARK_TICK playing=false cand=0 (frontier=7 recent=26) roll=0 decay=1.00",
+     1
+    ],
+    [
+     "§GROUP_SPARK_TICK playing=false cand=0 (frontier=7 recent=6) roll=0 decay=1.00",
+     1
+    ],
+    [
+     "§GROUP_SPARK_TICK playing=false cand=0 (frontier=5 recent=14) roll=0 decay=1.00",
+     1
+    ],
+    [
+     "§GROUP_SPARK_TICK playing=false cand=0 (frontier=0 recent=0) roll=0 decay=1.00",
+     4
+    ],
+    [
+     "§GROUP_SPARK_TICK playing=false cand=0 (frontier=2 recent=3) roll=0 decay=1.00",
+     1
+    ],
+    [
+     "§GROUP_SPARK_TICK playing=false cand=0 (frontier=0 recent=2) roll=0 decay=1.00",
+     1
+    ],
+    [
+     "§GROUP_SPARK_TICK playing=false cand=0 (frontier=0 recent=0) roll=0 decay=1.00",
+     3
+    ],
+    [
+     "§GROUP_SPARK_TICK playing=false cand=0 (frontier=2 recent=2) roll=0 decay=1.00",
+     1
+    ],
+    [
+     "§GROUP_SPARK_TICK playing=false cand=0 (frontier=2 recent=18) roll=0 decay=1.00",
+     1
+    ],
+    [
+     "§GROUP_SPARK_TICK playing=false cand=0 (frontier=2 recent=5) roll=0 decay=1.00",
+     1
+    ],
+    [
+     "§GROUP_SPARK_TICK playing=false cand=0 (frontier=2 recent=15) roll=0 decay=1.00",
+     1
+    ],
+    [
+     "§GROUP_SPARK_TICK playing=false cand=0 (frontier=1 recent=0) roll=0 decay=1.00",
+     1
+    ],
+    [
+     "§GROUP_SPARK_TICK playing=false cand=0 (frontier=0 recent=7) roll=0 decay=1.00",
+     1
+    ],
+    [
+     "§GROUP_SPARK_TICK playing=false cand=0 (frontier=0 recent=0) roll=0 decay=1.00",
+     3
+    ],
+    [
+     "§GROUP_SPARK_TICK playing=false cand=0 (frontier=5 recent=4) roll=0 decay=1.00",
+     1
+    ],
+    [
+     "§GROUP_SPARK_TICK playing=false cand=0 (frontier=3 recent=3) roll=0 decay=1.00",
+     1
+    ],
+    [
+     "§GROUP_SPARK_TICK playing=false cand=0 (frontier=3 recent=1) roll=0 decay=1.00",
+     1
+    ],
+    [
+     "§GROUP_SPARK_TICK playing=false cand=0 (frontier=3 recent=0) roll=0 decay=1.00",
+     1
+    ],
+    [
+     "§GROUP_SPARK_TICK playing=false cand=0 (frontier=3 recent=3) roll=0 decay=1.00",
+     2
+    ],
+    [
+     "§GROUP_SPARK_TICK playing=false cand=0 (frontier=3 recent=4) roll=0 decay=1.00",
+     3
+    ],
+    [
+     "§GROUP_SPARK_TICK playing=false cand=0 (frontier=3 recent=1) roll=0 decay=1.00",
+     1
+    ],
+    [
+     "§GROUP_SPARK_TICK playing=false cand=0 (frontier=3 recent=3) roll=0 decay=1.00",
+     2
+    ],
+    [
+     "§GROUP_SPARK_TICK playing=false cand=0 (frontier=3 recent=4) roll=0 decay=1.00",
+     2
+    ],
+    [
+     "§GROUP_SPARK_TICK playing=false cand=0 (frontier=3 recent=0) roll=0 decay=1.00",
+     1
+    ],
+    [
+     "§GROUP_SPARK_TICK playing=false cand=0 (frontier=11 recent=110) roll=0 decay=1.00",
+     1
+    ],
+    [
+     "§GROUP_SPARK_TICK playing=false cand=0 (frontier=7 recent=106) roll=0 decay=1.00",
+     1
+    ],
+    [
+     "§GROUP_SPARK_TICK playing=false cand=0 (frontier=5 recent=33) roll=0 decay=1.00",
+     1
+    ],
+    [
+     "§GROUP_SPARK_TICK playing=false cand=0 (frontier=5 recent=41) roll=0 decay=1.00",
+     1
+    ],
+    [
+     "§GROUP_SPARK_TICK playing=false cand=0 (frontier=5 recent=10) roll=0 decay=1.00",
+     1
+    ],
+    [
+     "§GROUP_SPARK_TICK playing=false cand=0 (frontier=7 recent=106) roll=0 decay=1.00",
+     1
+    ],
+    [
+     "§GROUP_SPARK_TICK playing=false cand=0 (frontier=7 recent=156) roll=0 decay=1.00",
+     1
+    ],
+    [
+     "§GROUP_SPARK_TICK playing=false cand=0 (frontier=7 recent=116) roll=0 decay=1.00",
+     1
+    ],
+    [
+     "§GROUP_SPARK_TICK playing=false cand=0 (frontier=7 recent=252) roll=0 decay=1.00",
+     1
+    ],
+    [
+     "§GROUP_SPARK_TICK playing=false cand=0 (frontier=5 recent=138) roll=0 decay=1.00",
+     1
+    ],
+    [
+     "§GROUP_SPARK_TICK playing=false cand=0 (frontier=5 recent=78) roll=0 decay=1.00",
+     1
+    ],
+    [
+     "§GROUP_SPARK_TICK playing=false cand=0 (frontier=4 recent=55) roll=0 decay=1.00",
+     1
+    ],
+    [
+     "§GROUP_SPARK_TICK playing=false cand=0 (frontier=5 recent=7) roll=0 decay=1.00",
+     1
+    ],
+    [
+     "§GROUP_SPARK_TICK playing=false cand=0 (frontier=3 recent=5) roll=0 decay=1.00",
+     1
+    ],
+    [
+     "§GROUP_SPARK_TICK playing=false cand=0 (frontier=3 recent=20) roll=0 decay=1.00",
+     1
+    ],
+    [
+     "§GROUP_SPARK_TICK playing=false cand=0 (frontier=3 recent=0) roll=0 decay=1.00",
+     1
+    ],
+    [
+     "§GROUP_SPARK_TICK playing=false cand=0 (frontier=5 recent=14) roll=0 decay=1.00",
+     1
+    ],
+    [
+     "§GROUP_SPARK_TICK playing=false cand=0 (frontier=3 recent=0) roll=0 decay=1.00",
+     1
+    ],
+    [
+     "§GROUP_SPARK_TICK playing=false cand=0 (frontier=5 recent=23) roll=0 decay=1.00",
+     1
+    ],
+    [
+     "§GROUP_SPARK_TICK playing=false cand=0 (frontier=3 recent=4) roll=0 decay=1.00",
+     2
+    ],
+    [
+     "§GROUP_SPARK_TICK playing=false cand=0 (frontier=3 recent=3) roll=0 decay=1.00",
+     1
+    ],
+    [
+     "§GROUP_SPARK_TICK playing=false cand=0 (frontier=5 recent=4) roll=0 decay=1.00",
+     1
+    ],
+    [
+     "§GROUP_SPARK_TICK playing=false cand=0 (frontier=3 recent=2) roll=0 decay=1.00",
+     1
+    ],
+    [
+     "§GROUP_SPARK_TICK playing=false cand=0 (frontier=3 recent=0) roll=0 decay=1.00",
+     1
+    ],
+    [
+     "§GROUP_SPARK_TICK playing=false cand=0 (frontier=3 recent=5) roll=0 decay=1.00",
+     1
+    ],
+    [
+     "§GROUP_SPARK_TICK playing=false cand=0 (frontier=2 recent=5) roll=0 decay=1.00",
+     1
+    ],
+    [
+     "§GROUP_SPARK_TICK playing=false cand=0 (frontier=3 recent=19) roll=0 decay=1.00",
+     1
+    ],
+    [
+     "§GROUP_SPARK_TICK playing=false cand=0 (frontier=0 recent=11) roll=0 decay=1.00",
+     1
+    ],
+    [
+     "§GROUP_SPARK_TICK playing=false cand=0 (frontier=4 recent=4) roll=0 decay=1.00",
+     1
+    ],
+    [
+     "§GROUP_SPARK_TICK playing=false cand=0 (frontier=3 recent=6) roll=0 decay=1.00",
+     1
+    ],
+    [
+     "§GROUP_SPARK_TICK playing=false cand=0 (frontier=3 recent=0) roll=0 decay=1.00",
+     1
+    ],
+    [
+     "§GROUP_SPARK_TICK playing=false cand=0 (frontier=3 recent=3) roll=0 decay=1.00",
+     1
+    ],
+    [
+     "§GROUP_SPARK_TICK playing=false cand=0 (frontier=5 recent=57) roll=0 decay=1.00",
+     1
+    ],
+    [
+     "§GROUP_SPARK_TICK playing=false cand=0 (frontier=7 recent=86) roll=0 decay=1.00",
+     1
+    ],
+    [
+     "§GROUP_SPARK_TICK playing=false cand=0 (frontier=5 recent=93) roll=0 decay=1.00",
+     1
+    ],
+    [
+     "§GROUP_SPARK_TICK playing=false cand=0 (frontier=5 recent=43) roll=0 decay=1.00",
+     1
+    ],
+    [
+     "§GROUP_SPARK_TICK playing=false cand=0 (frontier=7 recent=94) roll=0 decay=1.00",
+     1
+    ],
+    [
+     "§GROUP_SPARK_TICK playing=false cand=0 (frontier=3 recent=39) roll=0 decay=1.00",
+     1
+    ],
+    [
+     "§GROUP_SPARK_TICK playing=false cand=0 (frontier=3 recent=1) roll=0 decay=1.00",
+     1
+    ],
+    [
+     "§GROUP_SPARK_TICK playing=false cand=0 (frontier=3 recent=23) roll=0 decay=1.00",
+     1
+    ],
+    [
+     "§GROUP_SPARK_TICK playing=false cand=0 (frontier=3 recent=1) roll=0 decay=1.00",
+     1
+    ],
+    [
+     "§GROUP_SPARK_TICK playing=false cand=0 (frontier=3 recent=13) roll=0 decay=1.00",
+     1
+    ],
+    [
+     "§GROUP_SPARK_TICK playing=false cand=0 (frontier=3 recent=6) roll=0 decay=1.00",
+     1
+    ],
+    [
+     "§GROUP_SPARK_TICK playing=false cand=0 (frontier=3 recent=4) roll=0 decay=1.00",
+     1
+    ],
+    [
+     "§GROUP_SPARK_TICK playing=false cand=0 (frontier=2 recent=1) roll=0 decay=1.00",
+     1
+    ],
+    [
+     "§GROUP_SPARK_TICK playing=false cand=0 (frontier=4 recent=8) roll=0 decay=1.00",
+     1
+    ],
+    [
+     "§GROUP_SPARK_TICK playing=false cand=0 (frontier=6 recent=22) roll=0 decay=1.00",
+     1
+    ],
+    [
+     "§GROUP_SPARK_TICK playing=false cand=0 (frontier=5 recent=21) roll=0 decay=1.00",
+     1
+    ],
+    [
+     "§GROUP_SPARK_TICK playing=false cand=0 (frontier=3 recent=17) roll=0 decay=1.00",
+     1
+    ],
+    [
+     "§GROUP_SPARK_TICK playing=false cand=0 (frontier=5 recent=8) roll=0 decay=1.00",
+     1
+    ],
+    [
+     "§GROUP_SPARK_TICK playing=false cand=0 (frontier=3 recent=14) roll=0 decay=1.00",
+     1
+    ],
+    [
+     "§GROUP_SPARK_TICK playing=false cand=0 (frontier=2 recent=5) roll=0 decay=1.00",
+     1
+    ],
+    [
+     "§GROUP_SPARK_TICK playing=false cand=0 (frontier=3 recent=3) roll=0 decay=1.00",
+     3
+    ],
+    [
+     "§GROUP_SPARK_TICK playing=false cand=0 (frontier=3 recent=4) roll=0 decay=1.00",
+     1
+    ],
+    [
+     "§GROUP_SPARK_TICK playing=false cand=0 (frontier=3 recent=3) roll=0 decay=1.00",
+     1
+    ],
+    [
+     "§GROUP_SPARK_TICK playing=false cand=0 (frontier=3 recent=1) roll=0 decay=1.00",
+     1
+    ],
+    [
+     "§GROUP_SPARK_TICK playing=false cand=0 (frontier=1 recent=4) roll=0 decay=1.00",
+     1
+    ],
+    [
+     "§GROUP_SPARK_TICK playing=false cand=0 (frontier=3 recent=18) roll=0 decay=1.00",
+     1
+    ],
+    [
+     "§GROUP_SPARK_TICK playing=false cand=0 (frontier=0 recent=12) roll=0 decay=1.00",
+     1
+    ],
+    [
+     "§GROUP_SPARK_TICK playing=false cand=0 (frontier=0 recent=0) roll=0 decay=1.00",
+     1
+    ],
+    [
+     "§GROUP_SPARK_TICK playing=false cand=0 (frontier=6 recent=0) roll=0 decay=1.00",
+     1
+    ],
+    [
+     "§GROUP_SPARK_TICK playing=false cand=0 (frontier=5 recent=7) roll=0 decay=1.00",
+     1
+    ],
+    [
+     "§GROUP_SPARK_TICK playing=false cand=0 (frontier=5 recent=23) roll=0 decay=1.00",
+     1
+    ],
+    [
+     "§GROUP_SPARK_TICK playing=false cand=0 (frontier=5 recent=10) roll=0 decay=1.00",
+     1
+    ],
+    [
+     "§GROUP_SPARK_TICK playing=false cand=0 (frontier=5 recent=20) roll=0 decay=1.00",
+     1
+    ],
+    [
+     "§GROUP_SPARK_TICK playing=false cand=0 (frontier=5 recent=66) roll=0 decay=1.00",
+     1
+    ],
+    [
+     "§GROUP_SPARK_TICK playing=false cand=0 (frontier=5 recent=13) roll=0 decay=1.00",
+     1
+    ],
+    [
+     "§GROUP_SPARK_TICK playing=false cand=0 (frontier=1 recent=25) roll=0 decay=1.00",
+     1
+    ],
+    [
+     "§GROUP_SPARK_TICK playing=false cand=0 (frontier=0 recent=2) roll=0 decay=1.00",
+     1
+    ],
+    [
+     "§GROUP_SPARK_TICK playing=false cand=0 (frontier=0 recent=0) roll=0 decay=1.00",
+     15
+    ],
+    [
+     "§GROUP_SPARK_TICK playing=false cand=0 (frontier=0 recent=1) roll=0 decay=1.00",
+     1
+    ],
+    [
+     "§GROUP_SPARK_TICK playing=false cand=0 (frontier=0 recent=0) roll=0 decay=1.00",
+     4
+    ],
+    [
+     "§GROUP_SPARK_TICK playing=false cand=0 (frontier=0 recent=1) roll=0 decay=1.00",
+     1
+    ],
+    [
+     "§GROUP_SPARK_TICK playing=false cand=0 (frontier=0 recent=0) roll=0 decay=1.00",
+     1
+    ],
+    [
+     "§GROUP_SPARK_TICK playing=false cand=0 (frontier=0 recent=1) roll=0 decay=1.00",
+     1
+    ],
+    [
+     "§GROUP_SPARK_TICK playing=false cand=0 (frontier=0 recent=0) roll=0 decay=1.00",
+     2
+    ],
+    [
+     "§GROUP_SPARK_TICK playing=false cand=0 (frontier=2 recent=13) roll=0 decay=1.00",
+     1
+    ],
+    [
+     "§GROUP_SPARK_TICK playing=false cand=0 (frontier=0 recent=0) roll=0 decay=1.00",
+     5
+    ],
+    [
+     "§GROUP_SPARK_TICK playing=false cand=0 (frontier=0 recent=3) roll=0 decay=1.00",
+     1
+    ],
+    [
+     "§GROUP_SPARK_TICK playing=false cand=0 (frontier=0 recent=0) roll=0 decay=1.00",
+     1
+    ],
+    [
+     "§GROUP_SPARK_TICK playing=false cand=0 (frontier=0 recent=2) roll=0 decay=1.00",
+     1
+    ],
+    [
+     "§GROUP_SPARK_TICK playing=false cand=0 (frontier=0 recent=3) roll=0 decay=1.00",
+     1
+    ],
+    [
+     "§GROUP_SPARK_TICK playing=false cand=0 (frontier=0 recent=0) roll=0 decay=1.00",
+     1
+    ],
+    [
+     "§GROUP_SPARK_TICK playing=false cand=0 (frontier=0 recent=1) roll=0 decay=1.00",
+     1
+    ],
+    [
+     "§GROUP_SPARK_TICK playing=false cand=0 (frontier=2 recent=3) roll=0 decay=1.00",
+     1
+    ],
+    [
+     "§GROUP_SPARK_TICK playing=false cand=0 (frontier=0 recent=0) roll=0 decay=1.00",
+     3
+    ],
+    [
+     "§GROUP_SPARK_TICK playing=false cand=0 (frontier=4 recent=179) roll=0 decay=1.00",
+     1
+    ],
+    [
+     "§GROUP_SPARK_TICK playing=false cand=0 (frontier=4 recent=108) roll=0 decay=1.00",
+     1
+    ],
+    [
+     "§GROUP_SPARK_TICK playing=false cand=0 (frontier=4 recent=149) roll=0 decay=1.00",
+     1
+    ],
+    [
+     "§GROUP_SPARK_TICK playing=false cand=0 (frontier=4 recent=124) roll=0 decay=1.00",
+     1
+    ],
+    [
+     "§GROUP_SPARK_TICK playing=false cand=0 (frontier=2 recent=108) roll=0 decay=1.00",
+     1
+    ],
+    [
+     "§GROUP_SPARK_TICK playing=false cand=0 (frontier=2 recent=54) roll=0 decay=1.00",
+     1
+    ],
+    [
+     "§GROUP_SPARK_TICK playing=false cand=0 (frontier=0 recent=44) roll=0 decay=1.00",
+     1
+    ],
+    [
+     "§GROUP_SPARK_TICK playing=false cand=0 (frontier=2 recent=63) roll=0 decay=1.00",
+     1
+    ],
+    [
+     "§GROUP_SPARK_TICK playing=false cand=0 (frontier=0 recent=0) roll=0 decay=1.00",
+     1
+    ],
+    [
+     "§GROUP_SPARK_TICK playing=false cand=0 (frontier=1 recent=49) roll=0 decay=1.00",
+     1
+    ],
+    [
+     "§GROUP_SPARK_TICK playing=false cand=0 (frontier=0 recent=0) roll=0 decay=1.00",
+     8
+    ],
+    [
+     "§GROUP_SPARK_TICK playing=false cand=0 (frontier=2 recent=48) roll=0 decay=1.00",
+     1
+    ],
+    [
+     "§GROUP_SPARK_TICK playing=false cand=0 (frontier=0 recent=0) roll=0 decay=1.00",
+     9
+    ],
+    [
+     "§GROUP_SPARK_TICK playing=false cand=0 (frontier=2 recent=60) roll=0 decay=1.00",
+     1
+    ],
+    [
+     "§GROUP_SPARK_TICK playing=false cand=0 (frontier=2 recent=24) roll=0 decay=1.00",
+     1
+    ],
+    [
+     "§GROUP_SPARK_TICK playing=false cand=0 (frontier=2 recent=74) roll=0 decay=1.00",
+     1
+    ],
+    [
+     "§GROUP_SPARK_TICK playing=false cand=0 (frontier=2 recent=78) roll=0 decay=1.00",
+     1
+    ],
+    [
+     "§GROUP_SPARK_TICK playing=false cand=0 (frontier=0 recent=0) roll=0 decay=1.00",
+     1
+    ],
+    [
+     "§GROUP_SPARK_TICK playing=false cand=0 (frontier=2 recent=17) roll=0 decay=1.00",
+     1
+    ],
+    [
+     "§GROUP_SPARK_TICK playing=false cand=0 (frontier=0 recent=11) roll=0 decay=1.00",
+     1
+    ],
+    [
+     "§GROUP_SPARK_TICK playing=false cand=0 (frontier=0 recent=0) roll=0 decay=1.00",
+     2
+    ],
+    [
+     "§GROUP_SPARK_TICK playing=false cand=0 (frontier=0 recent=1) roll=0 decay=1.00",
+     1
+    ],
+    [
+     "§GROUP_SPARK_TICK playing=false cand=0 (frontier=0 recent=0) roll=0 decay=1.00",
+     19
+    ],
+    [
+     "§GROUP_SPARK_TICK playing=false cand=0 (frontier=0 recent=9) roll=0 decay=1.00",
+     1
+    ],
+    [
+     "§GROUP_SPARK_TICK playing=false cand=0 (frontier=2 recent=8) roll=0 decay=1.00",
+     1
+    ],
+    [
+     "§GROUP_SPARK_TICK playing=false cand=0 (frontier=2 recent=3) roll=0 decay=1.00",
+     1
+    ],
+    [
+     "§GROUP_SPARK_TICK playing=false cand=0 (frontier=2 recent=0) roll=0 decay=1.00",
+     1
+    ],
+    [
+     "§GROUP_SPARK_TICK playing=false cand=0 (frontier=0 recent=7) roll=0 decay=1.00",
+     1
+    ],
+    [
+     "§GROUP_SPARK_TICK playing=false cand=0 (frontier=0 recent=0) roll=0 decay=1.00",
+     6
+    ],
+    [
+     "§GROUP_SPARK_TICK playing=false cand=0 (frontier=0 recent=5) roll=0 decay=1.00",
+     1
+    ],
+    [
+     "§GROUP_SPARK_TICK playing=false cand=0 (frontier=0 recent=0) roll=0 decay=1.00",
+     14
+    ],
+    [
+     "§GROUP_SPARK_TICK playing=false cand=0 (frontier=2 recent=8) roll=0 decay=1.00",
+     1
+    ],
+    [
+     "§GROUP_SPARK_TICK playing=false cand=0 (frontier=2 recent=28) roll=0 decay=1.00",
+     1
+    ],
+    [
+     "§GROUP_SPARK_TICK playing=false cand=0 (frontier=2 recent=33) roll=0 decay=1.00",
+     1
+    ],
+    [
+     "§GROUP_SPARK_TICK playing=false cand=0 (frontier=2 recent=11) roll=0 decay=1.00",
+     1
+    ],
+    [
+     "§GROUP_SPARK_TICK playing=false cand=0 (frontier=2 recent=24) roll=0 decay=1.00",
+     1
+    ],
+    [
+     "§GROUP_SPARK_TICK playing=false cand=0 (frontier=2 recent=17) roll=0 decay=1.00",
+     1
+    ],
+    [
+     "§GROUP_SPARK_TICK playing=false cand=0 (frontier=2 recent=16) roll=0 decay=1.00",
+     1
+    ],
+    [
+     "§GROUP_SPARK_TICK playing=false cand=0 (frontier=0 recent=0) roll=0 decay=1.00",
+     1
+    ],
+    [
+     "§GROUP_SPARK_TICK playing=false cand=0 (frontier=0 recent=1) roll=0 decay=1.00",
+     1
+    ],
+    [
+     "§GROUP_SPARK_TICK playing=false cand=0 (frontier=0 recent=0) roll=0 decay=1.00",
+     6
+    ],
+    [
+     "§GROUP_SPARK_TICK playing=false cand=0 (frontier=0 recent=1) roll=0 decay=1.00",
+     1
+    ],
+    [
+     "§GROUP_SPARK_TICK playing=false cand=0 (frontier=0 recent=0) roll=0 decay=1.00",
+     3
+    ],
+    [
+     "§GROUP_SPARK_TICK playing=false cand=0 (frontier=2 recent=64) roll=0 decay=1.00",
+     1
+    ],
+    [
+     "§GROUP_SPARK_TICK playing=false cand=0 (frontier=0 recent=4) roll=0 decay=1.00",
+     1
+    ],
+    [
+     "§GROUP_SPARK_TICK playing=false cand=0 (frontier=0 recent=0) roll=0 decay=1.00",
+     1
+    ],
+    [
+     "§GROUP_SPARK_TICK playing=false cand=0 (frontier=2 recent=27) roll=0 decay=1.00",
+     1
+    ],
+    [
+     "§GROUP_SPARK_TICK playing=false cand=0 (frontier=2 recent=68) roll=0 decay=1.00",
+     1
+    ],
+    [
+     "§GROUP_SPARK_TICK playing=false cand=0 (frontier=2 recent=31) roll=0 decay=1.00",
+     1
+    ],
+    [
+     "§GROUP_SPARK_TICK playing=false cand=0 (frontier=2 recent=3) roll=0 decay=1.00",
+     1
+    ],
+    [
+     "§GROUP_SPARK_TICK playing=false cand=0 (frontier=0 recent=8) roll=0 decay=1.00",
+     1
+    ],
+    [
+     "§GROUP_SPARK_TICK playing=false cand=0 (frontier=0 recent=4) roll=0 decay=1.00",
+     1
+    ],
+    [
+     "§GROUP_SPARK_TICK playing=false cand=0 (frontier=0 recent=0) roll=0 decay=1.00",
+     3
+    ],
+    [
+     "§GROUP_SPARK_TICK playing=false cand=0 (frontier=0 recent=8) roll=0 decay=1.00",
+     1
+    ],
+    [
+     "§GROUP_SPARK_TICK playing=false cand=0 (frontier=0 recent=0) roll=0 decay=1.00",
+     17
+    ],
+    [
+     "§GROUP_SPARK_TICK playing=false cand=0 (frontier=4 recent=71) roll=0 decay=1.00",
+     1
+    ],
+    [
+     "§GROUP_SPARK_TICK playing=false cand=0 (frontier=4 recent=123) roll=0 decay=1.00",
+     1
+    ],
+    [
+     "§GROUP_SPARK_TICK playing=false cand=0 (frontier=4 recent=121) roll=0 decay=1.00",
+     1
+    ],
+    [
+     "§GROUP_SPARK_TICK playing=false cand=0 (frontier=4 recent=35) roll=0 decay=1.00",
+     1
+    ],
+    [
+     "§GROUP_SPARK_TICK playing=false cand=0 (frontier=4 recent=65) roll=0 decay=1.00",
+     1
+    ],
+    [
+     "§GROUP_SPARK_TICK playing=false cand=0 (frontier=5 recent=52) roll=0 decay=1.00",
+     1
+    ],
+    [
+     "§GROUP_SPARK_TICK playing=false cand=0 (frontier=6 recent=46) roll=0 decay=1.00",
+     1
+    ],
+    [
+     "§GROUP_SPARK_TICK playing=false cand=0 (frontier=6 recent=77) roll=0 decay=1.00",
+     1
+    ],
+    [
+     "§GROUP_SPARK_TICK playing=false cand=0 (frontier=6 recent=57) roll=0 decay=1.00",
+     1
+    ],
+    [
+     "§GROUP_SPARK_TICK playing=false cand=0 (frontier=6 recent=52) roll=0 decay=1.00",
+     1
+    ],
+    [
+     "§GROUP_SPARK_TICK playing=false cand=0 (frontier=6 recent=153) roll=0 decay=1.00",
+     1
+    ],
+    [
+     "§GROUP_SPARK_TICK playing=false cand=0 (frontier=0 recent=103) roll=0 decay=1.00",
+     1
+    ],
+    [
+     "§GROUP_SPARK_TICK playing=false cand=0 (frontier=6 recent=95) roll=0 decay=1.00",
+     1
+    ],
+    [
+     "§GROUP_SPARK_TICK playing=false cand=0 (frontier=6 recent=140) roll=0 decay=1.00",
+     1
+    ],
+    [
+     "§GROUP_SPARK_TICK playing=false cand=0 (frontier=4 recent=82) roll=0 decay=1.00",
+     1
+    ],
+    [
+     "§GROUP_SPARK_TICK playing=false cand=0 (frontier=2 recent=3) roll=0 decay=1.00",
+     1
+    ],
+    [
+     "§GROUP_SPARK_TICK playing=false cand=0 (frontier=2 recent=32) roll=0 decay=1.00",
+     1
+    ],
+    [
+     "§GROUP_SPARK_TICK playing=false cand=0 (frontier=2 recent=12) roll=0 decay=1.00",
+     1
+    ],
+    [
+     "§GROUP_SPARK_TICK playing=false cand=0 (frontier=2 recent=26) roll=0 decay=1.00",
+     1
+    ],
+    [
+     "§GROUP_SPARK_TICK playing=false cand=0 (frontier=2 recent=17) roll=0 decay=1.00",
+     1
+    ],
+    [
+     "§GROUP_SPARK_TICK playing=false cand=0 (frontier=2 recent=15) roll=0 decay=1.00",
+     1
+    ],
+    [
+     "§GROUP_SPARK_TICK playing=false cand=0 (frontier=2 recent=23) roll=0 decay=1.00",
+     1
+    ],
+    [
+     "§GROUP_SPARK_TICK playing=false cand=0 (frontier=2 recent=25) roll=0 decay=1.00",
+     1
+    ],
+    [
+     "§GROUP_SPARK_TICK playing=false cand=0 (frontier=2 recent=35) roll=0 decay=1.00",
+     1
+    ],
+    [
+     "§GROUP_SPARK_TICK playing=false cand=0 (frontier=2 recent=25) roll=0 decay=1.00",
+     1
+    ],
+    [
+     "§GROUP_SPARK_TICK playing=false cand=0 (frontier=2 recent=35) roll=0 decay=1.00",
+     1
+    ],
+    [
+     "§GROUP_SPARK_TICK playing=false cand=0 (frontier=2 recent=51) roll=0 decay=1.00",
+     1
+    ],
+    [
+     "§GROUP_SPARK_TICK playing=false cand=0 (frontier=2 recent=43) roll=0 decay=1.00",
+     1
+    ],
+    [
+     "§GROUP_SPARK_TICK playing=false cand=0 (frontier=2 recent=0) roll=0 decay=1.00",
+     1
+    ],
+    [
+     "§GROUP_SPARK_TICK playing=false cand=0 (frontier=0 recent=0) roll=0 decay=1.00",
+     1
+    ],
+    [
+     "§GROUP_SPARK_TICK playing=false cand=0 (frontier=0 recent=65) roll=0 decay=1.00",
+     1
+    ],
+    [
+     "§GROUP_SPARK_TICK playing=false cand=0 (frontier=0 recent=1) roll=0 decay=1.00",
+     1
+    ],
+    [
+     "§GROUP_SPARK_TICK playing=false cand=0 (frontier=0 recent=0) roll=0 decay=1.00",
+     2
+    ],
+    [
+     "§GROUP_SPARK_TICK playing=false cand=0 (frontier=2 recent=21) roll=0 decay=1.00",
+     1
+    ],
+    [
+     "§GROUP_SPARK_TICK playing=false cand=0 (frontier=2 recent=29) roll=0 decay=1.00",
+     1
+    ],
+    [
+     "§GROUP_SPARK_TICK playing=false cand=0 (frontier=2 recent=32) roll=0 decay=1.00",
+     1
+    ],
+    [
+     "§GROUP_SPARK_TICK playing=false cand=0 (frontier=2 recent=21) roll=0 decay=1.00",
+     1
+    ],
+    [
+     "§GROUP_SPARK_TICK playing=false cand=0 (frontier=0 recent=0) roll=0 decay=1.00",
+     23
+    ],
+    [
+     "§GROUP_SPARK_TICK playing=false cand=0 (frontier=0 recent=26) roll=0 decay=1.00",
+     1
+    ],
+    [
+     "§GROUP_SPARK_TICK playing=false cand=0 (frontier=2 recent=21) roll=0 decay=1.00",
+     1
+    ],
+    [
+     "§GROUP_SPARK_TICK playing=false cand=0 (frontier=2 recent=0) roll=0 decay=1.00",
+     1
+    ],
+    [
+     "§GROUP_SPARK_TICK playing=false cand=0 (frontier=0 recent=13) roll=0 decay=1.00",
+     1
+    ],
+    [
+     "§GROUP_SPARK_TICK playing=false cand=0 (frontier=0 recent=0) roll=0 decay=1.00",
+     2
+    ],
+    [
+     "§GROUP_SPARK_TICK playing=false cand=0 (frontier=2 recent=12) roll=0 decay=1.00",
+     1
+    ],
+    [
+     "§GROUP_SPARK_TICK playing=false cand=0 (frontier=0 recent=0) roll=0 decay=1.00",
+     8
+    ],
+    [
+     "§GROUP_SPARK_TICK playing=false cand=0 (frontier=0 recent=5) roll=0 decay=1.00",
+     1
+    ],
+    [
+     "§GROUP_SPARK_TICK playing=false cand=0 (frontier=0 recent=0) roll=0 decay=1.00",
+     6
+    ],
+    [
+     "§GROUP_SPARK_TICK playing=false cand=0 (frontier=2 recent=27) roll=0 decay=1.00",
+     1
+    ],
+    [
+     "§GROUP_SPARK_TICK playing=false cand=0 (frontier=2 recent=41) roll=0 decay=1.00",
+     1
+    ],
+    [
+     "§GROUP_SPARK_TICK playing=false cand=0 (frontier=2 recent=47) roll=0 decay=1.00",
+     1
+    ],
+    [
+     "§GROUP_SPARK_TICK playing=false cand=0 (frontier=2 recent=33) roll=0 decay=1.00",
+     1
+    ],
+    [
+     "§GROUP_SPARK_TICK playing=false cand=0 (frontier=2 recent=68) roll=0 decay=1.00",
+     1
+    ],
+    [
+     "§GROUP_SPARK_TICK playing=false cand=0 (frontier=2 recent=21) roll=0 decay=1.00",
+     1
+    ],
+    [
+     "§GROUP_SPARK_TICK playing=false cand=0 (frontier=2 recent=7) roll=0 decay=1.00",
+     1
+    ],
+    [
+     "§GROUP_SPARK_TICK playing=false cand=0 (frontier=0 recent=0) roll=0 decay=1.00",
+     29
+    ],
+    [
+     "§GROUP_SPARK_TICK playing=false cand=0 (frontier=2 recent=11) roll=0 decay=1.00",
+     1
+    ],
+    [
+     "§GROUP_SPARK_TICK playing=false cand=0 (frontier=0 recent=0) roll=0 decay=1.00",
+     2
+    ],
+    [
+     "§GROUP_SPARK_TICK playing=false cand=0 (frontier=0 recent=13) roll=0 decay=1.00",
+     1
+    ],
+    [
+     "§GROUP_SPARK_TICK playing=false cand=0 (frontier=0 recent=0) roll=0 decay=1.00",
+     2
+    ],
+    [
+     "§GROUP_SPARK_TICK playing=false cand=0 (frontier=0 recent=2) roll=0 decay=1.00",
+     1
+    ],
+    [
+     "§GROUP_SPARK_TICK playing=false cand=0 (frontier=0 recent=0) roll=0 decay=1.00",
+     1
+    ],
+    [
+     "§GROUP_SPARK_TICK playing=false cand=0 (frontier=0 recent=6) roll=0 decay=1.00",
+     1
+    ],
+    [
+     "§GROUP_SPARK_TICK playing=false cand=0 (frontier=2 recent=2) roll=0 decay=1.00",
+     1
+    ],
+    [
+     "§GROUP_SPARK_TICK playing=false cand=0 (frontier=0 recent=2) roll=0 decay=1.00",
+     1
+    ],
+    [
+     "§GROUP_SPARK_TICK playing=false cand=0 (frontier=0 recent=0) roll=0 decay=1.00",
+     16
+    ],
+    [
+     "§GROUP_SPARK_TICK playing=false cand=0 (frontier=2 recent=4) roll=0 decay=1.00",
+     2
+    ],
+    [
+     "§GROUP_SPARK_TICK playing=false cand=0 (frontier=3 recent=110) roll=0 decay=1.00",
+     1
+    ],
+    [
+     "§GROUP_SPARK_TICK playing=false cand=0 (frontier=2 recent=4) roll=0 decay=1.00",
+     1
+    ],
+    [
+     "§GROUP_SPARK_TICK playing=false cand=0 (frontier=2 recent=5) roll=0 decay=1.00",
+     1
+    ],
+    [
+     "§GROUP_SPARK_TICK playing=false cand=0 (frontier=2 recent=2) roll=0 decay=1.00",
+     1
+    ],
+    [
+     "§GROUP_SPARK_TICK playing=false cand=0 (frontier=2 recent=4) roll=0 decay=1.00",
+     1
+    ],
+    [
+     "§GROUP_SPARK_TICK playing=false cand=0 (frontier=0 recent=1) roll=0 decay=1.00",
+     1
+    ],
+    [
+     "§GROUP_SPARK_TICK playing=false cand=0 (frontier=0 recent=0) roll=0 decay=1.00",
+     4
+    ],
+    [
+     "§GROUP_SPARK_TICK playing=false cand=0 (frontier=0 recent=3) roll=0 decay=1.00",
+     1
+    ],
+    [
+     "§GROUP_SPARK_TICK playing=false cand=0 (frontier=0 recent=0) roll=0 decay=1.00",
+     3
+    ],
+    [
+     "§GROUP_SPARK_TICK playing=false cand=0 (frontier=2 recent=10) roll=0 decay=1.00",
+     1
+    ],
+    [
+     "§GROUP_SPARK_TICK playing=false cand=0 (frontier=0 recent=0) roll=0 decay=1.00",
+     9
+    ],
+    [
+     "§GROUP_SPARK_TICK playing=false cand=0 (frontier=2 recent=3) roll=0 decay=1.00",
+     1
+    ],
+    [
+     "§GROUP_SPARK_TICK playing=false cand=0 (frontier=0 recent=2) roll=0 decay=1.00",
+     1
+    ],
+    [
+     "§GROUP_SPARK_TICK playing=false cand=0 (frontier=0 recent=0) roll=0 decay=1.00",
+     1
+    ],
+    [
+     "§GROUP_SPARK_TICK playing=false cand=0 (frontier=0 recent=2) roll=0 decay=1.00",
+     1
+    ],
+    [
+     "§GROUP_SPARK_TICK playing=false cand=0 (frontier=2 recent=0) roll=0 decay=1.00",
+     1
+    ],
+    [
+     "§GROUP_SPARK_TICK playing=false cand=0 (frontier=0 recent=0) roll=0 decay=1.00",
+     19
+    ],
+    [
+     "§GROUP_SPARK_TICK playing=false cand=0 (frontier=2 recent=2) roll=0 decay=1.00",
+     1
+    ],
+    [
+     "§GROUP_SPARK_TICK playing=false cand=0 (frontier=2 recent=4) roll=0 decay=1.00",
+     1
+    ],
+    [
+     "§GROUP_SPARK_TICK playing=false cand=0 (frontier=2 recent=26) roll=0 decay=1.00",
+     1
+    ],
+    [
+     "§GROUP_SPARK_TICK playing=false cand=0 (frontier=0 recent=0) roll=0 decay=1.00",
+     1
+    ],
+    [
+     "§GROUP_SPARK_TICK playing=false cand=0 (frontier=2 recent=8) roll=0 decay=1.00",
+     1
+    ],
+    [
+     "§GROUP_SPARK_TICK playing=false cand=0 (frontier=2 recent=51) roll=0 decay=1.00",
+     1
+    ],
+    [
+     "§GROUP_SPARK_TICK playing=false cand=0 (frontier=2 recent=96) roll=0 decay=1.00",
+     1
+    ],
+    [
+     "§GROUP_SPARK_TICK playing=false cand=0 (frontier=2 recent=12) roll=0 decay=1.00",
+     1
+    ],
+    [
+     "§GROUP_SPARK_TICK playing=false cand=0 (frontier=2 recent=4) roll=0 decay=1.00",
+     1
+    ],
+    [
+     "§GROUP_SPARK_TICK playing=false cand=0 (frontier=0 recent=0) roll=0 decay=1.00",
+     1
+    ],
+    [
+     "§GROUP_SPARK_TICK playing=false cand=0 (frontier=0 recent=4) roll=0 decay=1.00",
+     1
+    ],
+    [
+     "§GROUP_SPARK_TICK playing=false cand=0 (frontier=0 recent=5) roll=0 decay=1.00",
+     1
+    ],
+    [
+     "§GROUP_SPARK_TICK playing=false cand=0 (frontier=0 recent=0) roll=0 decay=1.00",
+     35
+    ],
+    [
+     "§GROUP_SPARK_TICK playing=false cand=0 (frontier=2 recent=14) roll=0 decay=1.00",
+     1
+    ],
+    [
+     "§GROUP_SPARK_TICK playing=false cand=0 (frontier=4 recent=41) roll=0 decay=1.00",
+     1
+    ],
+    [
+     "§GROUP_SPARK_TICK playing=false cand=0 (frontier=4 recent=110) roll=0 decay=1.00",
+     1
+    ],
+    [
+     "§GROUP_SPARK_TICK playing=false cand=0 (frontier=4 recent=40) roll=0 decay=1.00",
+     1
+    ],
+    [
+     "§GROUP_SPARK_TICK playing=false cand=0 (frontier=4 recent=29) roll=0 decay=1.00",
+     1
+    ],
+    [
+     "§GROUP_SPARK_TICK playing=false cand=0 (frontier=2 recent=22) roll=0 decay=1.00",
+     1
+    ],
+    [
+     "§GROUP_SPARK_TICK playing=false cand=0 (frontier=4 recent=24) roll=0 decay=1.00",
+     1
+    ],
+    [
+     "§GROUP_SPARK_TICK playing=false cand=0 (frontier=4 recent=53) roll=0 decay=1.00",
+     1
+    ],
+    [
+     "§GROUP_SPARK_TICK playing=false cand=0 (frontier=4 recent=46) roll=0 decay=1.00",
+     1
+    ],
+    [
+     "§GROUP_SPARK_TICK playing=false cand=0 (frontier=3 recent=22) roll=0 decay=1.00",
+     1
+    ],
+    [
+     "§GROUP_SPARK_TICK playing=false cand=0 (frontier=4 recent=17) roll=0 decay=1.00",
+     1
+    ],
+    [
+     "§GROUP_SPARK_TICK playing=false cand=0 (frontier=4 recent=42) roll=0 decay=1.00",
+     1
+    ],
+    [
+     "§GROUP_SPARK_TICK playing=false cand=0 (frontier=4 recent=50) roll=0 decay=1.00",
+     1
+    ],
+    [
+     "§GROUP_SPARK_TICK playing=false cand=0 (frontier=4 recent=36) roll=0 decay=1.00",
+     1
+    ],
+    [
+     "§GROUP_SPARK_TICK playing=false cand=0 (frontier=4 recent=34) roll=0 decay=1.00",
+     1
+    ],
+    [
+     "§GROUP_SPARK_TICK playing=false cand=0 (frontier=4 recent=81) roll=0 decay=1.00",
+     1
+    ],
+    [
+     "§GROUP_SPARK_TICK playing=false cand=0 (frontier=4 recent=13) roll=0 decay=1.00",
+     1
+    ],
+    [
+     "§GROUP_SPARK_TICK playing=false cand=0 (frontier=2 recent=22) roll=0 decay=1.00",
+     1
+    ],
+    [
+     "§GROUP_SPARK_TICK playing=false cand=0 (frontier=4 recent=10) roll=0 decay=1.00",
+     1
+    ],
+    [
+     "§GROUP_SPARK_TICK playing=false cand=0 (frontier=4 recent=16) roll=0 decay=1.00",
+     1
+    ],
+    [
+     "§GROUP_SPARK_TICK playing=false cand=0 (frontier=4 recent=50) roll=0 decay=1.00",
+     1
+    ],
+    [
+     "§GROUP_SPARK_TICK playing=false cand=0 (frontier=4 recent=28) roll=0 decay=1.00",
+     1
+    ],
+    [
+     "§GROUP_SPARK_TICK playing=false cand=0 (frontier=2 recent=1) roll=0 decay=1.00",
+     1
+    ],
+    [
+     "§GROUP_SPARK_TICK playing=false cand=0 (frontier=2 recent=26) roll=0 decay=1.00",
+     1
+    ],
+    [
+     "§GROUP_SPARK_TICK playing=false cand=0 (frontier=2 recent=7) roll=0 decay=1.00",
+     1
+    ],
+    [
+     "§GROUP_SPARK_TICK playing=false cand=0 (frontier=2 recent=14) roll=0 decay=1.00",
+     1
+    ],
+    [
+     "§GROUP_SPARK_TICK playing=false cand=0 (frontier=2 recent=42) roll=0 decay=1.00",
+     1
+    ],
+    [
+     "§GROUP_SPARK_TICK playing=false cand=0 (frontier=2 recent=26) roll=0 decay=1.00",
+     1
+    ],
+    [
+     "§GROUP_SPARK_TICK playing=false cand=0 (frontier=2 recent=3) roll=0 decay=1.00",
+     1
+    ],
+    [
+     "§GROUP_SPARK_TICK playing=false cand=0 (frontier=2 recent=8) roll=0 decay=1.00",
+     1
+    ],
+    [
+     "§GROUP_SPARK_TICK playing=false cand=0 (frontier=2 recent=67) roll=0 decay=1.00",
+     1
+    ],
+    [
+     "§GROUP_SPARK_TICK playing=false cand=0 (frontier=2 recent=40) roll=0 decay=1.00",
+     1
+    ],
+    [
+     "§GROUP_SPARK_TICK playing=false cand=0 (frontier=2 recent=11) roll=0 decay=1.00",
+     1
+    ],
+    [
+     "§GROUP_SPARK_TICK playing=false cand=0 (frontier=2 recent=32) roll=0 decay=1.00",
+     1
+    ],
+    [
+     "§GROUP_SPARK_TICK playing=false cand=0 (frontier=2 recent=18) roll=0 decay=1.00",
+     1
+    ],
+    [
+     "§GROUP_SPARK_TICK playing=false cand=0 (frontier=2 recent=22) roll=0 decay=1.00",
+     1
+    ],
+    [
+     "§GROUP_SPARK_TICK playing=false cand=0 (frontier=2 recent=18) roll=0 decay=1.00",
+     1
+    ],
+    [
+     "§GROUP_SPARK_TICK playing=false cand=0 (frontier=2 recent=23) roll=0 decay=1.00",
+     1
+    ],
+    [
+     "§GROUP_SPARK_TICK playing=false cand=0 (frontier=2 recent=97) roll=0 decay=1.00",
+     1
+    ],
+    [
+     "§GROUP_SPARK_TICK playing=false cand=0 (frontier=0 recent=1) roll=0 decay=1.00",
+     1
+    ],
+    [
+     "§GROUP_SPARK_TICK playing=false cand=0 (frontier=0 recent=84) roll=0 decay=1.00",
+     1
+    ],
+    [
+     "§GROUP_SPARK_TICK playing=false cand=0 (frontier=2 recent=105) roll=0 decay=1.00",
+     1
+    ],
+    [
+     "§GROUP_SPARK_TICK playing=false cand=0 (frontier=0 recent=7) roll=0 decay=1.00",
+     1
+    ],
+    [
+     "§GROUP_SPARK_TICK playing=false cand=0 (frontier=0 recent=0) roll=0 decay=1.00",
+     7
+    ],
+    [
+     "§GROUP_SPARK_TICK playing=false cand=0 (frontier=1 recent=24) roll=0 decay=1.00",
+     1
+    ],
+    [
+     "§GROUP_SPARK_TICK playing=false cand=0 (frontier=2 recent=25) roll=0 decay=1.00",
+     1
+    ],
+    [
+     "§GROUP_SPARK_TICK playing=false cand=0 (frontier=2 recent=29) roll=0 decay=1.00",
+     1
+    ],
+    [
+     "§GROUP_SPARK_TICK playing=false cand=0 (frontier=2 recent=13) roll=0 decay=1.00",
+     1
+    ],
+    [
+     "§GROUP_SPARK_TICK playing=false cand=0 (frontier=2 recent=27) roll=0 decay=1.00",
+     1
+    ],
+    [
+     "§GROUP_SPARK_TICK playing=false cand=0 (frontier=0 recent=0) roll=0 decay=1.00",
+     29
+    ],
+    [
+     "§GROUP_SPARK_TICK playing=false cand=0 (frontier=2 recent=12) roll=0 decay=1.00",
+     1
+    ],
+    [
+     "§GROUP_SPARK_TICK playing=false cand=0 (frontier=0 recent=29) roll=0 decay=1.00",
+     1
+    ],
+    [
+     "§GROUP_SPARK_TICK playing=false cand=0 (frontier=0 recent=0) roll=0 decay=1.00",
+     6
+    ],
+    [
+     "§GROUP_SPARK_TICK playing=false cand=0 (frontier=2 recent=86) roll=0 decay=1.00",
+     1
+    ],
+    [
+     "§GROUP_SPARK_TICK playing=false cand=0 (frontier=0 recent=0) roll=0 decay=1.00",
+     23
+    ],
+    [
+     "§GROUP_SPARK_TICK playing=false cand=0 (frontier=0 recent=2) roll=0 decay=1.00",
+     1
+    ],
+    [
+     "§GROUP_SPARK_TICK playing=false cand=0 (frontier=0 recent=0) roll=0 decay=1.00",
+     6
+    ],
+    [
+     "§GROUP_SPARK_TICK playing=false cand=0 (frontier=0 recent=1) roll=0 decay=1.00",
+     1
+    ],
+    [
+     "§GROUP_SPARK_TICK playing=false cand=0 (frontier=0 recent=0) roll=0 decay=1.00",
+     35
+    ],
+    [
+     "§GROUP_SPARK_TICK playing=false cand=0 (frontier=0 recent=2) roll=0 decay=1.00",
+     1
+    ],
+    [
+     "§GROUP_SPARK_TICK playing=false cand=0 (frontier=0 recent=0) roll=0 decay=1.00",
+     6
+    ],
+    [
+     "§GROUP_SPARK_TICK playing=false cand=0 (frontier=0 recent=1) roll=0 decay=1.00",
+     1
+    ],
+    [
+     "§GROUP_SPARK_TICK playing=false cand=0 (frontier=0 recent=0) roll=0 decay=1.00",
+     31
+    ],
+    [
+     "§GROUP_SPARK_TICK playing=false cand=0 (frontier=0 recent=1) roll=0 decay=1.00",
+     1
+    ],
+    [
+     "§GROUP_SPARK_TICK playing=false cand=0 (frontier=0 recent=0) roll=0 decay=1.00",
+     3
+    ],
+    [
+     "§GROUP_SPARK_TICK playing=false cand=0 (frontier=0 recent=23) roll=0 decay=1.00",
+     1
+    ],
+    [
+     "§GROUP_SPARK_TICK playing=false cand=0 (frontier=0 recent=11) roll=0 decay=1.00",
+     1
+    ],
+    [
+     "§GROUP_SPARK_TICK playing=false cand=0 (frontier=0 recent=0) roll=0 decay=1.00",
+     5
+    ],
+    [
+     "§GROUP_SPARK_TICK playing=false cand=0 (frontier=0 recent=3) roll=0 decay=1.00",
+     1
+    ],
+    [
+     "§GROUP_SPARK_TICK playing=false cand=0 (frontier=0 recent=0) roll=0 decay=1.00",
+     2
+    ],
+    [
+     "§GROUP_SPARK_TICK playing=false cand=0 (frontier=1 recent=49) roll=0 decay=1.00",
+     1
+    ],
+    [
+     "§GROUP_SPARK_TICK playing=false cand=0 (frontier=2 recent=28) roll=0 decay=1.00",
+     1
+    ],
+    [
+     "§GROUP_SPARK_TICK playing=false cand=0 (frontier=2 recent=37) roll=0 decay=1.00",
+     1
+    ],
+    [
+     "§GROUP_SPARK_TICK playing=false cand=0 (frontier=2 recent=44) roll=0 decay=1.00",
+     1
+    ],
+    [
+     "§GROUP_SPARK_TICK playing=false cand=0 (frontier=2 recent=38) roll=0 decay=1.00",
+     1
+    ],
+    [
+     "§GROUP_SPARK_TICK playing=false cand=0 (frontier=0 recent=19) roll=0 decay=1.00",
+     1
+    ],
+    [
+     "§GROUP_SPARK_TICK playing=false cand=0 (frontier=0 recent=14) roll=0 decay=1.00",
+     1
+    ],
+    [
+     "§GROUP_SPARK_TICK playing=false cand=0 (frontier=0 recent=0) roll=0 decay=1.00",
+     13
+    ],
+    [
+     "§GROUP_SPARK_TICK playing=false cand=0 (frontier=4 recent=131) roll=0 decay=1.00",
+     1
+    ],
+    [
+     "§GROUP_SPARK_TICK playing=false cand=0 (frontier=4 recent=71) roll=0 decay=1.00",
+     1
+    ],
+    [
+     "§GROUP_SPARK_TICK playing=false cand=0 (frontier=4 recent=117) roll=0 decay=1.00",
+     1
+    ],
+    [
+     "§GROUP_SPARK_TICK playing=false cand=0 (frontier=4 recent=88) roll=0 decay=1.00",
+     1
+    ],
+    [
+     "§GROUP_SPARK_TICK playing=false cand=0 (frontier=4 recent=92) roll=0 decay=1.00",
+     1
+    ],
+    [
+     "§GROUP_SPARK_TICK playing=false cand=0 (frontier=4 recent=123) roll=0 decay=1.00",
+     1
+    ],
+    [
+     "§GROUP_SPARK_TICK playing=false cand=0 (frontier=2 recent=69) roll=0 decay=1.00",
+     1
+    ],
+    [
+     "§GROUP_SPARK_TICK playing=false cand=0 (frontier=2 recent=15) roll=0 decay=1.00",
+     1
+    ],
+    [
+     "§GROUP_SPARK_TICK playing=false cand=0 (frontier=2 recent=51) roll=0 decay=1.00",
+     1
+    ],
+    [
+     "§GROUP_SPARK_TICK playing=false cand=0 (frontier=2 recent=8) roll=0 decay=1.00",
+     1
+    ],
+    [
+     "§GROUP_SPARK_TICK playing=false cand=0 (frontier=2 recent=25) roll=0 decay=1.00",
+     1
+    ],
+    [
+     "§GROUP_SPARK_TICK playing=false cand=0 (frontier=2 recent=36) roll=0 decay=1.00",
+     1
+    ],
+    [
+     "§GROUP_SPARK_TICK playing=false cand=0 (frontier=2 recent=62) roll=0 decay=1.00",
+     1
+    ],
+    [
+     "§GROUP_SPARK_TICK playing=false cand=0 (frontier=2 recent=115) roll=0 decay=1.00",
+     1
+    ],
+    [
+     "§GROUP_SPARK_TICK playing=false cand=0 (frontier=0 recent=4) roll=0 decay=1.00",
+     1
+    ],
+    [
+     "§GROUP_SPARK_TICK playing=false cand=0 (frontier=0 recent=0) roll=0 decay=1.00",
+     1
+    ],
+    [
+     "§GROUP_SPARK_TICK playing=false cand=0 (frontier=1 recent=16) roll=0 decay=1.00",
+     1
+    ],
+    [
+     "§GROUP_SPARK_TICK playing=false cand=0 (frontier=2 recent=4) roll=0 decay=1.00",
+     1
+    ],
+    [
+     "§GROUP_SPARK_TICK playing=false cand=0 (frontier=2 recent=2) roll=0 decay=1.00",
+     1
+    ],
+    [
+     "§GROUP_SPARK_TICK playing=false cand=0 (frontier=2 recent=4) roll=0 decay=1.00",
+     1
+    ],
+    [
+     "§GROUP_SPARK_TICK playing=false cand=0 (frontier=2 recent=2) roll=0 decay=1.00",
+     2
+    ],
+    [
+     "§GROUP_SPARK_TICK playing=false cand=0 (frontier=2 recent=4) roll=0 decay=1.00",
+     1
+    ],
+    [
+     "§GROUP_SPARK_TICK playing=false cand=0 (frontier=2 recent=2) roll=0 decay=1.00",
+     1
+    ],
+    [
+     "§GROUP_SPARK_TICK playing=false cand=0 (frontier=0 recent=0) roll=0 decay=1.00",
+     4
+    ],
+    [
+     "§GROUP_SPARK_TICK playing=false cand=0 (frontier=0 recent=67) roll=0 decay=1.00",
+     1
+    ],
+    [
+     "§GROUP_SPARK_TICK playing=false cand=0 (frontier=0 recent=0) roll=0 decay=1.00",
+     21
+    ],
+    [
+     "§GROUP_SPARK_TICK playing=false cand=0 (frontier=0 recent=2) roll=0 decay=1.00",
+     1
+    ],
+    [
+     "§GROUP_SPARK_TICK playing=false cand=0 (frontier=2 recent=3) roll=0 decay=1.00",
+     1
+    ],
+    [
+     "§GROUP_SPARK_TICK playing=false cand=0 (frontier=0 recent=0) roll=0 decay=1.00",
+     1
+    ],
+    [
+     "§GROUP_SPARK_TICK playing=false cand=0 (frontier=2 recent=268) roll=0 decay=1.00",
+     1
+    ],
+    [
+     "§GROUP_SPARK_TICK playing=false cand=0 (frontier=2 recent=3) roll=0 decay=1.00",
+     1
+    ],
+    [
+     "§GROUP_SPARK_TICK playing=false cand=0 (frontier=2 recent=0) roll=0 decay=1.00",
+     1
+    ],
+    [
+     "§GROUP_SPARK_TICK playing=false cand=0 (frontier=0 recent=1) roll=0 decay=1.00",
+     1
+    ],
+    [
+     "§GROUP_SPARK_TICK playing=false cand=0 (frontier=0 recent=0) roll=0 decay=1.00",
+     6
+    ],
+    [
+     "§GROUP_SPARK_TICK playing=false cand=0 (frontier=1 recent=57) roll=0 decay=1.00",
+     1
+    ],
+    [
+     "§GROUP_SPARK_TICK playing=false cand=0 (frontier=0 recent=0) roll=0 decay=1.00",
+     1
+    ],
+    [
+     "§GROUP_SPARK_TICK playing=false cand=0 (frontier=1 recent=0) roll=0 decay=1.00",
+     1
+    ],
+    [
+     "§GROUP_SPARK_TICK playing=false cand=0 (frontier=0 recent=1) roll=0 decay=1.00",
+     1
+    ],
+    [
+     "§GROUP_SPARK_TICK playing=false cand=0 (frontier=0 recent=0) roll=0 decay=1.00",
+     1158
+    ]
+   ]
+  },
+  "GROUND_WETNESS_OVERRIDE": {
+   "total": 2028,
+   "runs": 1,
+   "rle": [
+    [
+     "§GROUND_WETNESS_OVERRIDE value=0.5 userSet=false",
+     2028
+    ]
+   ]
+  },
+  "NIGHT_STILL_LIGHTS": {
+   "total": 2026,
+   "runs": 1,
+   "rle": [
+    [
+     "§NIGHT_STILL_LIGHTS raised to 200 lights, near-fade floor 1 (was 0.3), plScale 0.5 (§STAGED_PL_CUT) for the still",
+     2026
+    ]
+   ]
+  },
+  "PHOTO_GLOW_SPRITE_staged": {
+   "total": 1751,
+   "runs": 11,
+   "rle": [
+    [
+     "§PHOTO_GLOW_SPRITE staged 57/1273 sprites (0 luminaires gain 3, 57 exit signs gain 0.9 x0.4 size — §GLOW_EXIT_SOFT, below the bloom threshold on purpose), 1 draw call, 0 scene materials touched (size 1.1m, eye-offset 0.3m, bloom threshold 1.2, strength 0.45)",
+     1
+    ],
+    [
+     "§PHOTO_GLOW_SPRITE staged 9/1273 sprites (0 luminaires gain 3, 9 exit signs gain 0.9 x0.4 size — §GLOW_EXIT_SOFT, below the bloom threshold on purpose), 1 draw call, 0 scene materials touched (size 1.1m, eye-offset 0.3m, bloom threshold 1.2, strength 0.45)",
+     198
+    ],
+    [
+     "§PHOTO_GLOW_SPRITE staged 19/1273 sprites (0 luminaires gain 3, 19 exit signs gain 0.9 x0.4 size — §GLOW_EXIT_SOFT, below the bloom threshold on purpose), 1 draw call, 0 scene materials touched (size 1.1m, eye-offset 0.3m, bloom threshold 1.2, strength 0.45)",
+     5
+    ],
+    [
+     "§PHOTO_GLOW_SPRITE staged 21/1273 sprites (0 luminaires gain 3, 21 exit signs gain 0.9 x0.4 size — §GLOW_EXIT_SOFT, below the bloom threshold on purpose), 1 draw call, 0 scene materials touched (size 1.1m, eye-offset 0.3m, bloom threshold 1.2, strength 0.45)",
+     5
+    ],
+    [
+     "§PHOTO_GLOW_SPRITE staged 24/1273 sprites (0 luminaires gain 3, 24 exit signs gain 0.9 x0.4 size — §GLOW_EXIT_SOFT, below the bloom threshold on purpose), 1 draw call, 0 scene materials touched (size 1.1m, eye-offset 0.3m, bloom threshold 1.2, strength 0.45)",
+     4
+    ],
+    [
+     "§PHOTO_GLOW_SPRITE staged 26/1273 sprites (0 luminaires gain 3, 26 exit signs gain 0.9 x0.4 size — §GLOW_EXIT_SOFT, below the bloom threshold on purpose), 1 draw call, 0 scene materials touched (size 1.1m, eye-offset 0.3m, bloom threshold 1.2, strength 0.45)",
+     173
+    ],
+    [
+     "§PHOTO_GLOW_SPRITE staged 35/1273 sprites (0 luminaires gain 3, 35 exit signs gain 0.9 x0.4 size — §GLOW_EXIT_SOFT, below the bloom threshold on purpose), 1 draw call, 0 scene materials touched (size 1.1m, eye-offset 0.3m, bloom threshold 1.2, strength 0.45)",
+     1
+    ],
+    [
+     "§PHOTO_GLOW_SPRITE staged 36/1273 sprites (0 luminaires gain 3, 36 exit signs gain 0.9 x0.4 size — §GLOW_EXIT_SOFT, below the bloom threshold on purpose), 1 draw call, 0 scene materials touched (size 1.1m, eye-offset 0.3m, bloom threshold 1.2, strength 0.45)",
+     7
+    ],
+    [
+     "§PHOTO_GLOW_SPRITE staged 46/1273 sprites (0 luminaires gain 3, 46 exit signs gain 0.9 x0.4 size — §GLOW_EXIT_SOFT, below the bloom threshold on purpose), 1 draw call, 0 scene materials touched (size 1.1m, eye-offset 0.3m, bloom threshold 1.2, strength 0.45)",
+     6
+    ],
+    [
+     "§PHOTO_GLOW_SPRITE staged 55/1273 sprites (0 luminaires gain 3, 55 exit signs gain 0.9 x0.4 size — §GLOW_EXIT_SOFT, below the bloom threshold on purpose), 1 draw call, 0 scene materials touched (size 1.1m, eye-offset 0.3m, bloom threshold 1.2, strength 0.45)",
+     187
+    ],
+    [
+     "§PHOTO_GLOW_SPRITE staged 57/1273 sprites (0 luminaires gain 3, 57 exit signs gain 0.9 x0.4 size — §GLOW_EXIT_SOFT, below the bloom threshold on purpose), 1 draw call, 0 scene materials touched (size 1.1m, eye-offset 0.3m, bloom threshold 1.2, strength 0.45)",
+     1164
+    ]
+   ]
+  },
+  "PHOTO_GLOW_SPRITE_removed": {
+   "total": 1751,
+   "runs": 11,
+   "rle": [
+    [
+     "§PHOTO_GLOW_SPRITE removed 57 sprites",
+     1
+    ],
+    [
+     "§PHOTO_GLOW_SPRITE removed 9 sprites",
+     198
+    ],
+    [
+     "§PHOTO_GLOW_SPRITE removed 19 sprites",
+     5
+    ],
+    [
+     "§PHOTO_GLOW_SPRITE removed 21 sprites",
+     5
+    ],
+    [
+     "§PHOTO_GLOW_SPRITE removed 24 sprites",
+     4
+    ],
+    [
+     "§PHOTO_GLOW_SPRITE removed 26 sprites",
+     173
+    ],
+    [
+     "§PHOTO_GLOW_SPRITE removed 35 sprites",
+     1
+    ],
+    [
+     "§PHOTO_GLOW_SPRITE removed 36 sprites",
+     7
+    ],
+    [
+     "§PHOTO_GLOW_SPRITE removed 46 sprites",
+     6
+    ],
+    [
+     "§PHOTO_GLOW_SPRITE removed 55 sprites",
+     187
+    ],
+    [
+     "§PHOTO_GLOW_SPRITE removed 57 sprites",
+     1164
+    ]
+   ]
+  },
+  "GLOW_LENS_QUAD_skip": {
+   "total": 1740,
+   "runs": 13,
+   "rle": [
+    [
+     "§GLOW_LENS_QUAD skip (count unchanged 8)",
+     3
+    ],
+    [
+     "§GLOW_LENS_QUAD skip (count unchanged 303)",
+     195
+    ],
+    [
+     "§GLOW_LENS_QUAD skip (count unchanged 307)",
+     1
+    ],
+    [
+     "§GLOW_LENS_QUAD skip (count unchanged 635)",
+     4
+    ],
+    [
+     "§GLOW_LENS_QUAD skip (count unchanged 637)",
+     4
+    ],
+    [
+     "§GLOW_LENS_QUAD skip (count unchanged 640)",
+     3
+    ],
+    [
+     "§GLOW_LENS_QUAD skip (count unchanged 642)",
+     172
+    ],
+    [
+     "§GLOW_LENS_QUAD skip (count unchanged 825)",
+     7
+    ],
+    [
+     "§GLOW_LENS_QUAD skip (count unchanged 835)",
+     5
+    ],
+    [
+     "§GLOW_LENS_QUAD skip (count unchanged 844)",
+     146
+    ],
+    [
+     "§GLOW_LENS_QUAD skip (count unchanged 1024)",
+     32
+    ],
+    [
+     "§GLOW_LENS_QUAD skip (count unchanged 1037)",
+     6
+    ],
+    [
+     "§GLOW_LENS_QUAD skip (count unchanged 1273)",
+     1162
+    ]
+   ]
+  },
+  "ENVMAP_STOMP_GUARD": {
+   "total": 906,
+   "runs": 1,
+   "rle": [
+    [
+     "§ENVMAP_STOMP_GUARD skipped procedural regen — HDRI active",
+     906
+    ]
+   ]
+  },
+  "IDLE_GATE": {
+   "total": 330,
+   "runs": 330,
+   "rle": [
+    [
+     "§IDLE_GATE park — rAF chain stopped (self-parking, 0 frames) cycles=1",
+     1
+    ],
+    [
+     "§IDLE_GATE wake cycles=1",
+     1
+    ],
+    [
+     "§IDLE_GATE park — rAF chain stopped (self-parking, 0 frames) cycles=2",
+     1
+    ],
+    [
+     "§IDLE_GATE wake cycles=2",
+     1
+    ],
+    [
+     "§IDLE_GATE park — rAF chain stopped (self-parking, 0 frames) cycles=3",
+     1
+    ],
+    [
+     "§IDLE_GATE wake cycles=3",
+     1
+    ],
+    [
+     "§IDLE_GATE park — rAF chain stopped (self-parking, 0 frames) cycles=25 (throttled: every 25th)",
+     1
+    ],
+    [
+     "§IDLE_GATE wake cycles=25",
+     1
+    ],
+    [
+     "§IDLE_GATE park — rAF chain stopped (self-parking, 0 frames) cycles=50 (throttled: every 25th)",
+     1
+    ],
+    [
+     "§IDLE_GATE wake cycles=50",
+     1
+    ],
+    [
+     "§IDLE_GATE park — rAF chain stopped (self-parking, 0 frames) cycles=75 (throttled: every 25th)",
+     1
+    ],
+    [
+     "§IDLE_GATE wake cycles=75",
+     1
+    ],
+    [
+     "§IDLE_GATE park — rAF chain stopped (self-parking, 0 frames) cycles=100 (throttled: every 25th)",
+     1
+    ],
+    [
+     "§IDLE_GATE wake cycles=100",
+     1
+    ],
+    [
+     "§IDLE_GATE park — rAF chain stopped (self-parking, 0 frames) cycles=125 (throttled: every 25th)",
+     1
+    ],
+    [
+     "§IDLE_GATE wake cycles=125",
+     1
+    ],
+    [
+     "§IDLE_GATE park — rAF chain stopped (self-parking, 0 frames) cycles=150 (throttled: every 25th)",
+     1
+    ],
+    [
+     "§IDLE_GATE wake cycles=150",
+     1
+    ],
+    [
+     "§IDLE_GATE park — rAF chain stopped (self-parking, 0 frames) cycles=175 (throttled: every 25th)",
+     1
+    ],
+    [
+     "§IDLE_GATE wake cycles=175",
+     1
+    ],
+    [
+     "§IDLE_GATE park — rAF chain stopped (self-parking, 0 frames) cycles=200 (throttled: every 25th)",
+     1
+    ],
+    [
+     "§IDLE_GATE wake cycles=200",
+     1
+    ],
+    [
+     "§IDLE_GATE park — rAF chain stopped (self-parking, 0 frames) cycles=225 (throttled: every 25th)",
+     1
+    ],
+    [
+     "§IDLE_GATE wake cycles=225",
+     1
+    ],
+    [
+     "§IDLE_GATE park — rAF chain stopped (self-parking, 0 frames) cycles=250 (throttled: every 25th)",
+     1
+    ],
+    [
+     "§IDLE_GATE wake cycles=250",
+     1
+    ],
+    [
+     "§IDLE_GATE park — rAF chain stopped (self-parking, 0 frames) cycles=275 (throttled: every 25th)",
+     1
+    ],
+    [
+     "§IDLE_GATE wake cycles=275",
+     1
+    ],
+    [
+     "§IDLE_GATE park — rAF chain stopped (self-parking, 0 frames) cycles=300 (throttled: every 25th)",
+     1
+    ],
+    [
+     "§IDLE_GATE wake cycles=300",
+     1
+    ],
+    [
+     "§IDLE_GATE park — rAF chain stopped (self-parking, 0 frames) cycles=325 (throttled: every 25th)",
+     1
+    ],
+    [
+     "§IDLE_GATE wake cycles=325",
+     1
+    ],
+    [
+     "§IDLE_GATE park — rAF chain stopped (self-parking, 0 frames) cycles=350 (throttled: every 25th)",
+     1
+    ],
+    [
+     "§IDLE_GATE wake cycles=350",
+     1
+    ],
+    [
+     "§IDLE_GATE park — rAF chain stopped (self-parking, 0 frames) cycles=375 (throttled: every 25th)",
+     1
+    ],
+    [
+     "§IDLE_GATE wake cycles=375",
+     1
+    ],
+    [
+     "§IDLE_GATE park — rAF chain stopped (self-parking, 0 frames) cycles=400 (throttled: every 25th)",
+     1
+    ],
+    [
+     "§IDLE_GATE wake cycles=400",
+     1
+    ],
+    [
+     "§IDLE_GATE park — rAF chain stopped (self-parking, 0 frames) cycles=425 (throttled: every 25th)",
+     1
+    ],
+    [
+     "§IDLE_GATE wake cycles=425",
+     1
+    ],
+    [
+     "§IDLE_GATE park — rAF chain stopped (self-parking, 0 frames) cycles=450 (throttled: every 25th)",
+     1
+    ],
+    [
+     "§IDLE_GATE wake cycles=450",
+     1
+    ],
+    [
+     "§IDLE_GATE park — rAF chain stopped (self-parking, 0 frames) cycles=475 (throttled: every 25th)",
+     1
+    ],
+    [
+     "§IDLE_GATE wake cycles=475",
+     1
+    ],
+    [
+     "§IDLE_GATE park — rAF chain stopped (self-parking, 0 frames) cycles=500 (throttled: every 25th)",
+     1
+    ],
+    [
+     "§IDLE_GATE wake cycles=500",
+     1
+    ],
+    [
+     "§IDLE_GATE park — rAF chain stopped (self-parking, 0 frames) cycles=525 (throttled: every 25th)",
+     1
+    ],
+    [
+     "§IDLE_GATE wake cycles=525",
+     1
+    ],
+    [
+     "§IDLE_GATE park — rAF chain stopped (self-parking, 0 frames) cycles=550 (throttled: every 25th)",
+     1
+    ],
+    [
+     "§IDLE_GATE wake cycles=550",
+     1
+    ],
+    [
+     "§IDLE_GATE park — rAF chain stopped (self-parking, 0 frames) cycles=575 (throttled: every 25th)",
+     1
+    ],
+    [
+     "§IDLE_GATE wake cycles=575",
+     1
+    ],
+    [
+     "§IDLE_GATE park — rAF chain stopped (self-parking, 0 frames) cycles=600 (throttled: every 25th)",
+     1
+    ],
+    [
+     "§IDLE_GATE wake cycles=600",
+     1
+    ],
+    [
+     "§IDLE_GATE park — rAF chain stopped (self-parking, 0 frames) cycles=625 (throttled: every 25th)",
+     1
+    ],
+    [
+     "§IDLE_GATE wake cycles=625",
+     1
+    ],
+    [
+     "§IDLE_GATE park — rAF chain stopped (self-parking, 0 frames) cycles=650 (throttled: every 25th)",
+     1
+    ],
+    [
+     "§IDLE_GATE wake cycles=650",
+     1
+    ],
+    [
+     "§IDLE_GATE park — rAF chain stopped (self-parking, 0 frames) cycles=675 (throttled: every 25th)",
+     1
+    ],
+    [
+     "§IDLE_GATE wake cycles=675",
+     1
+    ],
+    [
+     "§IDLE_GATE park — rAF chain stopped (self-parking, 0 frames) cycles=700 (throttled: every 25th)",
+     1
+    ],
+    [
+     "§IDLE_GATE wake cycles=700",
+     1
+    ],
+    [
+     "§IDLE_GATE park — rAF chain stopped (self-parking, 0 frames) cycles=725 (throttled: every 25th)",
+     1
+    ],
+    [
+     "§IDLE_GATE wake cycles=725",
+     1
+    ],
+    [
+     "§IDLE_GATE park — rAF chain stopped (self-parking, 0 frames) cycles=750 (throttled: every 25th)",
+     1
+    ],
+    [
+     "§IDLE_GATE wake cycles=750",
+     1
+    ],
+    [
+     "§IDLE_GATE park — rAF chain stopped (self-parking, 0 frames) cycles=775 (throttled: every 25th)",
+     1
+    ],
+    [
+     "§IDLE_GATE wake cycles=775",
+     1
+    ],
+    [
+     "§IDLE_GATE park — rAF chain stopped (self-parking, 0 frames) cycles=800 (throttled: every 25th)",
+     1
+    ],
+    [
+     "§IDLE_GATE wake cycles=800",
+     1
+    ],
+    [
+     "§IDLE_GATE park — rAF chain stopped (self-parking, 0 frames) cycles=825 (throttled: every 25th)",
+     1
+    ],
+    [
+     "§IDLE_GATE wake cycles=825",
+     1
+    ],
+    [
+     "§IDLE_GATE park — rAF chain stopped (self-parking, 0 frames) cycles=850 (throttled: every 25th)",
+     1
+    ],
+    [
+     "§IDLE_GATE wake cycles=850",
+     1
+    ],
+    [
+     "§IDLE_GATE park — rAF chain stopped (self-parking, 0 frames) cycles=875 (throttled: every 25th)",
+     1
+    ],
+    [
+     "§IDLE_GATE wake cycles=875",
+     1
+    ],
+    [
+     "§IDLE_GATE park — rAF chain stopped (self-parking, 0 frames) cycles=900 (throttled: every 25th)",
+     1
+    ],
+    [
+     "§IDLE_GATE wake cycles=900",
+     1
+    ],
+    [
+     "§IDLE_GATE park — rAF chain stopped (self-parking, 0 frames) cycles=925 (throttled: every 25th)",
+     1
+    ],
+    [
+     "§IDLE_GATE wake cycles=925",
+     1
+    ],
+    [
+     "§IDLE_GATE park — rAF chain stopped (self-parking, 0 frames) cycles=950 (throttled: every 25th)",
+     1
+    ],
+    [
+     "§IDLE_GATE wake cycles=950",
+     1
+    ],
+    [
+     "§IDLE_GATE park — rAF chain stopped (self-parking, 0 frames) cycles=975 (throttled: every 25th)",
+     1
+    ],
+    [
+     "§IDLE_GATE wake cycles=975",
+     1
+    ],
+    [
+     "§IDLE_GATE park — rAF chain stopped (self-parking, 0 frames) cycles=1000 (throttled: every 25th)",
+     1
+    ],
+    [
+     "§IDLE_GATE wake cycles=1000",
+     1
+    ],
+    [
+     "§IDLE_GATE park — rAF chain stopped (self-parking, 0 frames) cycles=1025 (throttled: every 25th)",
+     1
+    ],
+    [
+     "§IDLE_GATE wake cycles=1025",
+     1
+    ],
+    [
+     "§IDLE_GATE park — rAF chain stopped (self-parking, 0 frames) cycles=1050 (throttled: every 25th)",
+     1
+    ],
+    [
+     "§IDLE_GATE wake cycles=1050",
+     1
+    ],
+    [
+     "§IDLE_GATE park — rAF chain stopped (self-parking, 0 frames) cycles=1075 (throttled: every 25th)",
+     1
+    ],
+    [
+     "§IDLE_GATE wake cycles=1075",
+     1
+    ],
+    [
+     "§IDLE_GATE park — rAF chain stopped (self-parking, 0 frames) cycles=1100 (throttled: every 25th)",
+     1
+    ],
+    [
+     "§IDLE_GATE wake cycles=1100",
+     1
+    ],
+    [
+     "§IDLE_GATE park — rAF chain stopped (self-parking, 0 frames) cycles=1125 (throttled: every 25th)",
+     1
+    ],
+    [
+     "§IDLE_GATE wake cycles=1125",
+     1
+    ],
+    [
+     "§IDLE_GATE park — rAF chain stopped (self-parking, 0 frames) cycles=1150 (throttled: every 25th)",
+     1
+    ],
+    [
+     "§IDLE_GATE wake cycles=1150",
+     1
+    ],
+    [
+     "§IDLE_GATE park — rAF chain stopped (self-parking, 0 frames) cycles=1175 (throttled: every 25th)",
+     1
+    ],
+    [
+     "§IDLE_GATE wake cycles=1175",
+     1
+    ],
+    [
+     "§IDLE_GATE park — rAF chain stopped (self-parking, 0 frames) cycles=1200 (throttled: every 25th)",
+     1
+    ],
+    [
+     "§IDLE_GATE wake cycles=1200",
+     1
+    ],
+    [
+     "§IDLE_GATE park — rAF chain stopped (self-parking, 0 frames) cycles=1225 (throttled: every 25th)",
+     1
+    ],
+    [
+     "§IDLE_GATE wake cycles=1225",
+     1
+    ],
+    [
+     "§IDLE_GATE park — rAF chain stopped (self-parking, 0 frames) cycles=1250 (throttled: every 25th)",
+     1
+    ],
+    [
+     "§IDLE_GATE wake cycles=1250",
+     1
+    ],
+    [
+     "§IDLE_GATE park — rAF chain stopped (self-parking, 0 frames) cycles=1275 (throttled: every 25th)",
+     1
+    ],
+    [
+     "§IDLE_GATE wake cycles=1275",
+     1
+    ],
+    [
+     "§IDLE_GATE park — rAF chain stopped (self-parking, 0 frames) cycles=1300 (throttled: every 25th)",
+     1
+    ],
+    [
+     "§IDLE_GATE wake cycles=1300",
+     1
+    ],
+    [
+     "§IDLE_GATE park — rAF chain stopped (self-parking, 0 frames) cycles=1325 (throttled: every 25th)",
+     1
+    ],
+    [
+     "§IDLE_GATE wake cycles=1325",
+     1
+    ],
+    [
+     "§IDLE_GATE park — rAF chain stopped (self-parking, 0 frames) cycles=1350 (throttled: every 25th)",
+     1
+    ],
+    [
+     "§IDLE_GATE wake cycles=1350",
+     1
+    ],
+    [
+     "§IDLE_GATE park — rAF chain stopped (self-parking, 0 frames) cycles=1375 (throttled: every 25th)",
+     1
+    ],
+    [
+     "§IDLE_GATE wake cycles=1375",
+     1
+    ],
+    [
+     "§IDLE_GATE park — rAF chain stopped (self-parking, 0 frames) cycles=1400 (throttled: every 25th)",
+     1
+    ],
+    [
+     "§IDLE_GATE wake cycles=1400",
+     1
+    ],
+    [
+     "§IDLE_GATE park — rAF chain stopped (self-parking, 0 frames) cycles=1425 (throttled: every 25th)",
+     1
+    ],
+    [
+     "§IDLE_GATE wake cycles=1425",
+     1
+    ],
+    [
+     "§IDLE_GATE park — rAF chain stopped (self-parking, 0 frames) cycles=1450 (throttled: every 25th)",
+     1
+    ],
+    [
+     "§IDLE_GATE wake cycles=1450",
+     1
+    ],
+    [
+     "§IDLE_GATE park — rAF chain stopped (self-parking, 0 frames) cycles=1475 (throttled: every 25th)",
+     1
+    ],
+    [
+     "§IDLE_GATE wake cycles=1475",
+     1
+    ],
+    [
+     "§IDLE_GATE park — rAF chain stopped (self-parking, 0 frames) cycles=1500 (throttled: every 25th)",
+     1
+    ],
+    [
+     "§IDLE_GATE wake cycles=1500",
+     1
+    ],
+    [
+     "§IDLE_GATE park — rAF chain stopped (self-parking, 0 frames) cycles=1525 (throttled: every 25th)",
+     1
+    ],
+    [
+     "§IDLE_GATE wake cycles=1525",
+     1
+    ],
+    [
+     "§IDLE_GATE park — rAF chain stopped (self-parking, 0 frames) cycles=1550 (throttled: every 25th)",
+     1
+    ],
+    [
+     "§IDLE_GATE wake cycles=1550",
+     1
+    ],
+    [
+     "§IDLE_GATE park — rAF chain stopped (self-parking, 0 frames) cycles=1575 (throttled: every 25th)",
+     1
+    ],
+    [
+     "§IDLE_GATE wake cycles=1575",
+     1
+    ],
+    [
+     "§IDLE_GATE park — rAF chain stopped (self-parking, 0 frames) cycles=1600 (throttled: every 25th)",
+     1
+    ],
+    [
+     "§IDLE_GATE wake cycles=1600",
+     1
+    ],
+    [
+     "§IDLE_GATE park — rAF chain stopped (self-parking, 0 frames) cycles=1625 (throttled: every 25th)",
+     1
+    ],
+    [
+     "§IDLE_GATE wake cycles=1625",
+     1
+    ],
+    [
+     "§IDLE_GATE park — rAF chain stopped (self-parking, 0 frames) cycles=1650 (throttled: every 25th)",
+     1
+    ],
+    [
+     "§IDLE_GATE wake cycles=1650",
+     1
+    ],
+    [
+     "§IDLE_GATE park — rAF chain stopped (self-parking, 0 frames) cycles=1675 (throttled: every 25th)",
+     1
+    ],
+    [
+     "§IDLE_GATE wake cycles=1675",
+     1
+    ],
+    [
+     "§IDLE_GATE park — rAF chain stopped (self-parking, 0 frames) cycles=1700 (throttled: every 25th)",
+     1
+    ],
+    [
+     "§IDLE_GATE wake cycles=1700",
+     1
+    ],
+    [
+     "§IDLE_GATE park — rAF chain stopped (self-parking, 0 frames) cycles=1725 (throttled: every 25th)",
+     1
+    ],
+    [
+     "§IDLE_GATE wake cycles=1725",
+     1
+    ],
+    [
+     "§IDLE_GATE park — rAF chain stopped (self-parking, 0 frames) cycles=1750 (throttled: every 25th)",
+     1
+    ],
+    [
+     "§IDLE_GATE wake cycles=1750",
+     1
+    ],
+    [
+     "§IDLE_GATE park — rAF chain stopped (self-parking, 0 frames) cycles=1775 (throttled: every 25th)",
+     1
+    ],
+    [
+     "§IDLE_GATE wake cycles=1775",
+     1
+    ],
+    [
+     "§IDLE_GATE park — rAF chain stopped (self-parking, 0 frames) cycles=1800 (throttled: every 25th)",
+     1
+    ],
+    [
+     "§IDLE_GATE wake cycles=1800",
+     1
+    ],
+    [
+     "§IDLE_GATE park — rAF chain stopped (self-parking, 0 frames) cycles=1825 (throttled: every 25th)",
+     1
+    ],
+    [
+     "§IDLE_GATE wake cycles=1825",
+     1
+    ],
+    [
+     "§IDLE_GATE park — rAF chain stopped (self-parking, 0 frames) cycles=1850 (throttled: every 25th)",
+     1
+    ],
+    [
+     "§IDLE_GATE wake cycles=1850",
+     1
+    ],
+    [
+     "§IDLE_GATE park — rAF chain stopped (self-parking, 0 frames) cycles=1875 (throttled: every 25th)",
+     1
+    ],
+    [
+     "§IDLE_GATE wake cycles=1875",
+     1
+    ],
+    [
+     "§IDLE_GATE park — rAF chain stopped (self-parking, 0 frames) cycles=1900 (throttled: every 25th)",
+     1
+    ],
+    [
+     "§IDLE_GATE wake cycles=1900",
+     1
+    ],
+    [
+     "§IDLE_GATE park — rAF chain stopped (self-parking, 0 frames) cycles=1925 (throttled: every 25th)",
+     1
+    ],
+    [
+     "§IDLE_GATE wake cycles=1925",
+     1
+    ],
+    [
+     "§IDLE_GATE park — rAF chain stopped (self-parking, 0 frames) cycles=1950 (throttled: every 25th)",
+     1
+    ],
+    [
+     "§IDLE_GATE wake cycles=1950",
+     1
+    ],
+    [
+     "§IDLE_GATE park — rAF chain stopped (self-parking, 0 frames) cycles=1975 (throttled: every 25th)",
+     1
+    ],
+    [
+     "§IDLE_GATE wake cycles=1975",
+     1
+    ],
+    [
+     "§IDLE_GATE park — rAF chain stopped (self-parking, 0 frames) cycles=2000 (throttled: every 25th)",
+     1
+    ],
+    [
+     "§IDLE_GATE wake cycles=2000",
+     1
+    ],
+    [
+     "§IDLE_GATE park — rAF chain stopped (self-parking, 0 frames) cycles=2025 (throttled: every 25th)",
+     1
+    ],
+    [
+     "§IDLE_GATE wake cycles=2025",
+     1
+    ],
+    [
+     "§IDLE_GATE park — rAF chain stopped (self-parking, 0 frames) cycles=2050 (throttled: every 25th)",
+     1
+    ],
+    [
+     "§IDLE_GATE wake cycles=2050",
+     1
+    ],
+    [
+     "§IDLE_GATE park — rAF chain stopped (self-parking, 0 frames) cycles=2075 (throttled: every 25th)",
+     1
+    ],
+    [
+     "§IDLE_GATE wake cycles=2075",
+     1
+    ],
+    [
+     "§IDLE_GATE park — rAF chain stopped (self-parking, 0 frames) cycles=2100 (throttled: every 25th)",
+     1
+    ],
+    [
+     "§IDLE_GATE wake cycles=2100",
+     1
+    ],
+    [
+     "§IDLE_GATE park — rAF chain stopped (self-parking, 0 frames) cycles=2125 (throttled: every 25th)",
+     1
+    ],
+    [
+     "§IDLE_GATE wake cycles=2125",
+     1
+    ],
+    [
+     "§IDLE_GATE park — rAF chain stopped (self-parking, 0 frames) cycles=2150 (throttled: every 25th)",
+     1
+    ],
+    [
+     "§IDLE_GATE wake cycles=2150",
+     1
+    ],
+    [
+     "§IDLE_GATE park — rAF chain stopped (self-parking, 0 frames) cycles=2175 (throttled: every 25th)",
+     1
+    ],
+    [
+     "§IDLE_GATE wake cycles=2175",
+     1
+    ],
+    [
+     "§IDLE_GATE park — rAF chain stopped (self-parking, 0 frames) cycles=2200 (throttled: every 25th)",
+     1
+    ],
+    [
+     "§IDLE_GATE wake cycles=2200",
+     1
+    ],
+    [
+     "§IDLE_GATE park — rAF chain stopped (self-parking, 0 frames) cycles=2225 (throttled: every 25th)",
+     1
+    ],
+    [
+     "§IDLE_GATE wake cycles=2225",
+     1
+    ],
+    [
+     "§IDLE_GATE park — rAF chain stopped (self-parking, 0 frames) cycles=2250 (throttled: every 25th)",
+     1
+    ],
+    [
+     "§IDLE_GATE wake cycles=2250",
+     1
+    ],
+    [
+     "§IDLE_GATE park — rAF chain stopped (self-parking, 0 frames) cycles=2275 (throttled: every 25th)",
+     1
+    ],
+    [
+     "§IDLE_GATE wake cycles=2275",
+     1
+    ],
+    [
+     "§IDLE_GATE park — rAF chain stopped (self-parking, 0 frames) cycles=2300 (throttled: every 25th)",
+     1
+    ],
+    [
+     "§IDLE_GATE wake cycles=2300",
+     1
+    ],
+    [
+     "§IDLE_GATE park — rAF chain stopped (self-parking, 0 frames) cycles=2325 (throttled: every 25th)",
+     1
+    ],
+    [
+     "§IDLE_GATE wake cycles=2325",
+     1
+    ],
+    [
+     "§IDLE_GATE park — rAF chain stopped (self-parking, 0 frames) cycles=2350 (throttled: every 25th)",
+     1
+    ],
+    [
+     "§IDLE_GATE wake cycles=2350",
+     1
+    ],
+    [
+     "§IDLE_GATE park — rAF chain stopped (self-parking, 0 frames) cycles=2375 (throttled: every 25th)",
+     1
+    ],
+    [
+     "§IDLE_GATE wake cycles=2375",
+     1
+    ],
+    [
+     "§IDLE_GATE park — rAF chain stopped (self-parking, 0 frames) cycles=2400 (throttled: every 25th)",
+     1
+    ],
+    [
+     "§IDLE_GATE wake cycles=2400",
+     1
+    ],
+    [
+     "§IDLE_GATE park — rAF chain stopped (self-parking, 0 frames) cycles=2425 (throttled: every 25th)",
+     1
+    ],
+    [
+     "§IDLE_GATE wake cycles=2425",
+     1
+    ],
+    [
+     "§IDLE_GATE park — rAF chain stopped (self-parking, 0 frames) cycles=2450 (throttled: every 25th)",
+     1
+    ],
+    [
+     "§IDLE_GATE wake cycles=2450",
+     1
+    ],
+    [
+     "§IDLE_GATE park — rAF chain stopped (self-parking, 0 frames) cycles=2475 (throttled: every 25th)",
+     1
+    ],
+    [
+     "§IDLE_GATE wake cycles=2475",
+     1
+    ],
+    [
+     "§IDLE_GATE park — rAF chain stopped (self-parking, 0 frames) cycles=2500 (throttled: every 25th)",
+     1
+    ],
+    [
+     "§IDLE_GATE wake cycles=2500",
+     1
+    ],
+    [
+     "§IDLE_GATE park — rAF chain stopped (self-parking, 0 frames) cycles=2525 (throttled: every 25th)",
+     1
+    ],
+    [
+     "§IDLE_GATE wake cycles=2525",
+     1
+    ],
+    [
+     "§IDLE_GATE park — rAF chain stopped (self-parking, 0 frames) cycles=2550 (throttled: every 25th)",
+     1
+    ],
+    [
+     "§IDLE_GATE wake cycles=2550",
+     1
+    ],
+    [
+     "§IDLE_GATE park — rAF chain stopped (self-parking, 0 frames) cycles=2575 (throttled: every 25th)",
+     1
+    ],
+    [
+     "§IDLE_GATE wake cycles=2575",
+     1
+    ],
+    [
+     "§IDLE_GATE park — rAF chain stopped (self-parking, 0 frames) cycles=2600 (throttled: every 25th)",
+     1
+    ],
+    [
+     "§IDLE_GATE wake cycles=2600",
+     1
+    ],
+    [
+     "§IDLE_GATE park — rAF chain stopped (self-parking, 0 frames) cycles=2625 (throttled: every 25th)",
+     1
+    ],
+    [
+     "§IDLE_GATE wake cycles=2625",
+     1
+    ],
+    [
+     "§IDLE_GATE park — rAF chain stopped (self-parking, 0 frames) cycles=2650 (throttled: every 25th)",
+     1
+    ],
+    [
+     "§IDLE_GATE wake cycles=2650",
+     1
+    ],
+    [
+     "§IDLE_GATE park — rAF chain stopped (self-parking, 0 frames) cycles=2675 (throttled: every 25th)",
+     1
+    ],
+    [
+     "§IDLE_GATE wake cycles=2675",
+     1
+    ],
+    [
+     "§IDLE_GATE park — rAF chain stopped (self-parking, 0 frames) cycles=2700 (throttled: every 25th)",
+     1
+    ],
+    [
+     "§IDLE_GATE wake cycles=2700",
+     1
+    ],
+    [
+     "§IDLE_GATE park — rAF chain stopped (self-parking, 0 frames) cycles=2725 (throttled: every 25th)",
+     1
+    ],
+    [
+     "§IDLE_GATE wake cycles=2725",
+     1
+    ],
+    [
+     "§IDLE_GATE park — rAF chain stopped (self-parking, 0 frames) cycles=2750 (throttled: every 25th)",
+     1
+    ],
+    [
+     "§IDLE_GATE wake cycles=2750",
+     1
+    ],
+    [
+     "§IDLE_GATE park — rAF chain stopped (self-parking, 0 frames) cycles=2775 (throttled: every 25th)",
+     1
+    ],
+    [
+     "§IDLE_GATE wake cycles=2775",
+     1
+    ],
+    [
+     "§IDLE_GATE park — rAF chain stopped (self-parking, 0 frames) cycles=2800 (throttled: every 25th)",
+     1
+    ],
+    [
+     "§IDLE_GATE wake cycles=2800",
+     1
+    ],
+    [
+     "§IDLE_GATE park — rAF chain stopped (self-parking, 0 frames) cycles=2825 (throttled: every 25th)",
+     1
+    ],
+    [
+     "§IDLE_GATE wake cycles=2825",
+     1
+    ],
+    [
+     "§IDLE_GATE park — rAF chain stopped (self-parking, 0 frames) cycles=2850 (throttled: every 25th)",
+     1
+    ],
+    [
+     "§IDLE_GATE wake cycles=2850",
+     1
+    ],
+    [
+     "§IDLE_GATE park — rAF chain stopped (self-parking, 0 frames) cycles=2875 (throttled: every 25th)",
+     1
+    ],
+    [
+     "§IDLE_GATE wake cycles=2875",
+     1
+    ],
+    [
+     "§IDLE_GATE park — rAF chain stopped (self-parking, 0 frames) cycles=2900 (throttled: every 25th)",
+     1
+    ],
+    [
+     "§IDLE_GATE wake cycles=2900",
+     1
+    ],
+    [
+     "§IDLE_GATE park — rAF chain stopped (self-parking, 0 frames) cycles=2925 (throttled: every 25th)",
+     1
+    ],
+    [
+     "§IDLE_GATE wake cycles=2925",
+     1
+    ],
+    [
+     "§IDLE_GATE park — rAF chain stopped (self-parking, 0 frames) cycles=2950 (throttled: every 25th)",
+     1
+    ],
+    [
+     "§IDLE_GATE wake cycles=2950",
+     1
+    ],
+    [
+     "§IDLE_GATE park — rAF chain stopped (self-parking, 0 frames) cycles=2975 (throttled: every 25th)",
+     1
+    ],
+    [
+     "§IDLE_GATE wake cycles=2975",
+     1
+    ],
+    [
+     "§IDLE_GATE park — rAF chain stopped (self-parking, 0 frames) cycles=3000 (throttled: every 25th)",
+     1
+    ],
+    [
+     "§IDLE_GATE wake cycles=3000",
+     1
+    ],
+    [
+     "§IDLE_GATE park — rAF chain stopped (self-parking, 0 frames) cycles=3025 (throttled: every 25th)",
+     1
+    ],
+    [
+     "§IDLE_GATE wake cycles=3025",
+     1
+    ],
+    [
+     "§IDLE_GATE park — rAF chain stopped (self-parking, 0 frames) cycles=3050 (throttled: every 25th)",
+     1
+    ],
+    [
+     "§IDLE_GATE wake cycles=3050",
+     1
+    ],
+    [
+     "§IDLE_GATE park — rAF chain stopped (self-parking, 0 frames) cycles=3075 (throttled: every 25th)",
+     1
+    ],
+    [
+     "§IDLE_GATE wake cycles=3075",
+     1
+    ],
+    [
+     "§IDLE_GATE park — rAF chain stopped (self-parking, 0 frames) cycles=3100 (throttled: every 25th)",
+     1
+    ],
+    [
+     "§IDLE_GATE wake cycles=3100",
+     1
+    ],
+    [
+     "§IDLE_GATE park — rAF chain stopped (self-parking, 0 frames) cycles=3125 (throttled: every 25th)",
+     1
+    ],
+    [
+     "§IDLE_GATE wake cycles=3125",
+     1
+    ],
+    [
+     "§IDLE_GATE park — rAF chain stopped (self-parking, 0 frames) cycles=3150 (throttled: every 25th)",
+     1
+    ],
+    [
+     "§IDLE_GATE wake cycles=3150",
+     1
+    ],
+    [
+     "§IDLE_GATE park — rAF chain stopped (self-parking, 0 frames) cycles=3175 (throttled: every 25th)",
+     1
+    ],
+    [
+     "§IDLE_GATE wake cycles=3175",
+     1
+    ],
+    [
+     "§IDLE_GATE park — rAF chain stopped (self-parking, 0 frames) cycles=3200 (throttled: every 25th)",
+     1
+    ],
+    [
+     "§IDLE_GATE wake cycles=3200",
+     1
+    ],
+    [
+     "§IDLE_GATE park — rAF chain stopped (self-parking, 0 frames) cycles=3225 (throttled: every 25th)",
+     1
+    ],
+    [
+     "§IDLE_GATE wake cycles=3225",
+     1
+    ],
+    [
+     "§IDLE_GATE park — rAF chain stopped (self-parking, 0 frames) cycles=3250 (throttled: every 25th)",
+     1
+    ],
+    [
+     "§IDLE_GATE wake cycles=3250",
+     1
+    ],
+    [
+     "§IDLE_GATE park — rAF chain stopped (self-parking, 0 frames) cycles=3275 (throttled: every 25th)",
+     1
+    ],
+    [
+     "§IDLE_GATE wake cycles=3275",
+     1
+    ],
+    [
+     "§IDLE_GATE park — rAF chain stopped (self-parking, 0 frames) cycles=3300 (throttled: every 25th)",
+     1
+    ],
+    [
+     "§IDLE_GATE wake cycles=3300",
+     1
+    ],
+    [
+     "§IDLE_GATE park — rAF chain stopped (self-parking, 0 frames) cycles=3325 (throttled: every 25th)",
+     1
+    ],
+    [
+     "§IDLE_GATE wake cycles=3325",
+     1
+    ],
+    [
+     "§IDLE_GATE park — rAF chain stopped (self-parking, 0 frames) cycles=3350 (throttled: every 25th)",
+     1
+    ],
+    [
+     "§IDLE_GATE wake cycles=3350",
+     1
+    ],
+    [
+     "§IDLE_GATE park — rAF chain stopped (self-parking, 0 frames) cycles=3375 (throttled: every 25th)",
+     1
+    ],
+    [
+     "§IDLE_GATE wake cycles=3375",
+     1
+    ],
+    [
+     "§IDLE_GATE park — rAF chain stopped (self-parking, 0 frames) cycles=3400 (throttled: every 25th)",
+     1
+    ],
+    [
+     "§IDLE_GATE wake cycles=3400",
+     1
+    ],
+    [
+     "§IDLE_GATE park — rAF chain stopped (self-parking, 0 frames) cycles=3425 (throttled: every 25th)",
+     1
+    ],
+    [
+     "§IDLE_GATE wake cycles=3425",
+     1
+    ],
+    [
+     "§IDLE_GATE park — rAF chain stopped (self-parking, 0 frames) cycles=3450 (throttled: every 25th)",
+     1
+    ],
+    [
+     "§IDLE_GATE wake cycles=3450",
+     1
+    ],
+    [
+     "§IDLE_GATE park — rAF chain stopped (self-parking, 0 frames) cycles=3475 (throttled: every 25th)",
+     1
+    ],
+    [
+     "§IDLE_GATE wake cycles=3475",
+     1
+    ],
+    [
+     "§IDLE_GATE park — rAF chain stopped (self-parking, 0 frames) cycles=3500 (throttled: every 25th)",
+     1
+    ],
+    [
+     "§IDLE_GATE wake cycles=3500",
+     1
+    ],
+    [
+     "§IDLE_GATE park — rAF chain stopped (self-parking, 0 frames) cycles=3525 (throttled: every 25th)",
+     1
+    ],
+    [
+     "§IDLE_GATE wake cycles=3525",
+     1
+    ],
+    [
+     "§IDLE_GATE park — rAF chain stopped (self-parking, 0 frames) cycles=3550 (throttled: every 25th)",
+     1
+    ],
+    [
+     "§IDLE_GATE wake cycles=3550",
+     1
+    ],
+    [
+     "§IDLE_GATE park — rAF chain stopped (self-parking, 0 frames) cycles=3575 (throttled: every 25th)",
+     1
+    ],
+    [
+     "§IDLE_GATE wake cycles=3575",
+     1
+    ],
+    [
+     "§IDLE_GATE park — rAF chain stopped (self-parking, 0 frames) cycles=3600 (throttled: every 25th)",
+     1
+    ],
+    [
+     "§IDLE_GATE wake cycles=3600",
+     1
+    ],
+    [
+     "§IDLE_GATE park — rAF chain stopped (self-parking, 0 frames) cycles=3625 (throttled: every 25th)",
+     1
+    ],
+    [
+     "§IDLE_GATE wake cycles=3625",
+     1
+    ],
+    [
+     "§IDLE_GATE park — rAF chain stopped (self-parking, 0 frames) cycles=3650 (throttled: every 25th)",
+     1
+    ],
+    [
+     "§IDLE_GATE wake cycles=3650",
+     1
+    ],
+    [
+     "§IDLE_GATE park — rAF chain stopped (self-parking, 0 frames) cycles=3675 (throttled: every 25th)",
+     1
+    ],
+    [
+     "§IDLE_GATE wake cycles=3675",
+     1
+    ],
+    [
+     "§IDLE_GATE park — rAF chain stopped (self-parking, 0 frames) cycles=3700 (throttled: every 25th)",
+     1
+    ],
+    [
+     "§IDLE_GATE wake cycles=3700",
+     1
+    ],
+    [
+     "§IDLE_GATE park — rAF chain stopped (self-parking, 0 frames) cycles=3725 (throttled: every 25th)",
+     1
+    ],
+    [
+     "§IDLE_GATE wake cycles=3725",
+     1
+    ],
+    [
+     "§IDLE_GATE park — rAF chain stopped (self-parking, 0 frames) cycles=3750 (throttled: every 25th)",
+     1
+    ],
+    [
+     "§IDLE_GATE wake cycles=3750",
+     1
+    ],
+    [
+     "§IDLE_GATE park — rAF chain stopped (self-parking, 0 frames) cycles=3775 (throttled: every 25th)",
+     1
+    ],
+    [
+     "§IDLE_GATE wake cycles=3775",
+     1
+    ],
+    [
+     "§IDLE_GATE park — rAF chain stopped (self-parking, 0 frames) cycles=3800 (throttled: every 25th)",
+     1
+    ],
+    [
+     "§IDLE_GATE wake cycles=3800",
+     1
+    ],
+    [
+     "§IDLE_GATE park — rAF chain stopped (self-parking, 0 frames) cycles=3825 (throttled: every 25th)",
+     1
+    ],
+    [
+     "§IDLE_GATE wake cycles=3825",
+     1
+    ],
+    [
+     "§IDLE_GATE park — rAF chain stopped (self-parking, 0 frames) cycles=3850 (throttled: every 25th)",
+     1
+    ],
+    [
+     "§IDLE_GATE wake cycles=3850",
+     1
+    ],
+    [
+     "§IDLE_GATE park — rAF chain stopped (self-parking, 0 frames) cycles=3875 (throttled: every 25th)",
+     1
+    ],
+    [
+     "§IDLE_GATE wake cycles=3875",
+     1
+    ],
+    [
+     "§IDLE_GATE park — rAF chain stopped (self-parking, 0 frames) cycles=3900 (throttled: every 25th)",
+     1
+    ],
+    [
+     "§IDLE_GATE wake cycles=3900",
+     1
+    ],
+    [
+     "§IDLE_GATE park — rAF chain stopped (self-parking, 0 frames) cycles=3925 (throttled: every 25th)",
+     1
+    ],
+    [
+     "§IDLE_GATE wake cycles=3925",
+     1
+    ],
+    [
+     "§IDLE_GATE park — rAF chain stopped (self-parking, 0 frames) cycles=3950 (throttled: every 25th)",
+     1
+    ],
+    [
+     "§IDLE_GATE wake cycles=3950",
+     1
+    ],
+    [
+     "§IDLE_GATE park — rAF chain stopped (self-parking, 0 frames) cycles=3975 (throttled: every 25th)",
+     1
+    ],
+    [
+     "§IDLE_GATE wake cycles=3975",
+     1
+    ],
+    [
+     "§IDLE_GATE park — rAF chain stopped (self-parking, 0 frames) cycles=4000 (throttled: every 25th)",
+     1
+    ],
+    [
+     "§IDLE_GATE wake cycles=4000",
+     1
+    ],
+    [
+     "§IDLE_GATE park — rAF chain stopped (self-parking, 0 frames) cycles=4025 (throttled: every 25th)",
+     1
+    ],
+    [
+     "§IDLE_GATE wake cycles=4025",
+     1
+    ],
+    [
+     "§IDLE_GATE park — rAF chain stopped (self-parking, 0 frames) cycles=4050 (throttled: every 25th)",
+     1
+    ],
+    [
+     "§IDLE_GATE wake cycles=4050",
+     1
+    ]
+   ]
+  },
+  "SHADOW_FRONTIER": {
+   "total": 33,
+   "runs": 1,
+   "rle": [
+    [
+     "§SHADOW_FRONTIER casters=0 receivers=0",
+     33
+    ]
+   ]
+  },
+  "SHADOW_FRONTIER_AT_CAPTURE": {
+   "total": 286,
+   "runs": 286,
+   "rle": [
+    [
+     "§SHADOW_FRONTIER_AT_CAPTURE frame=4 frontierGuids=1 singleMesh_matched=0 castShadowTrue=0 castShadowFalse=0 batchObjsContainingFrontier=1 batchCastShadowTrue=1 batchCastShadowFalse=0",
+     1
+    ],
+    [
+     "§SHADOW_FRONTIER_AT_CAPTURE frame=5 frontierGuids=10 singleMesh_matched=0 castShadowTrue=0 castShadowFalse=0 batchObjsContainingFrontier=4 batchCastShadowTrue=4 batchCastShadowFalse=0",
+     1
+    ],
+    [
+     "§SHADOW_FRONTIER_AT_CAPTURE frame=6 frontierGuids=2 singleMesh_matched=0 castShadowTrue=0 castShadowFalse=0 batchObjsContainingFrontier=1 batchCastShadowTrue=1 batchCastShadowFalse=0",
+     1
+    ],
+    [
+     "§SHADOW_FRONTIER_AT_CAPTURE frame=7 frontierGuids=30 singleMesh_matched=0 castShadowTrue=0 castShadowFalse=0 batchObjsContainingFrontier=7 batchCastShadowTrue=7 batchCastShadowFalse=0",
+     1
+    ],
+    [
+     "§SHADOW_FRONTIER_AT_CAPTURE frame=8 frontierGuids=30 singleMesh_matched=0 castShadowTrue=0 castShadowFalse=0 batchObjsContainingFrontier=5 batchCastShadowTrue=5 batchCastShadowFalse=0",
+     1
+    ],
+    [
+     "§SHADOW_FRONTIER_AT_CAPTURE frame=9 frontierGuids=30 singleMesh_matched=0 castShadowTrue=0 castShadowFalse=0 batchObjsContainingFrontier=7 batchCastShadowTrue=7 batchCastShadowFalse=0",
+     1
+    ],
+    [
+     "§SHADOW_FRONTIER_AT_CAPTURE frame=10 frontierGuids=21 singleMesh_matched=0 castShadowTrue=0 castShadowFalse=0 batchObjsContainingFrontier=5 batchCastShadowTrue=5 batchCastShadowFalse=0",
+     1
+    ],
+    [
+     "§SHADOW_FRONTIER_AT_CAPTURE frame=19 frontierGuids=2 singleMesh_matched=0 castShadowTrue=0 castShadowFalse=0 batchObjsContainingFrontier=2 batchCastShadowTrue=2 batchCastShadowFalse=0",
+     1
+    ],
+    [
+     "§SHADOW_FRONTIER_AT_CAPTURE frame=34 frontierGuids=1 singleMesh_matched=0 castShadowTrue=0 castShadowFalse=0 batchObjsContainingFrontier=1 batchCastShadowTrue=1 batchCastShadowFalse=0",
+     1
+    ],
+    [
+     "§SHADOW_FRONTIER_AT_CAPTURE frame=35 frontierGuids=5 singleMesh_matched=0 castShadowTrue=0 castShadowFalse=0 batchObjsContainingFrontier=4 batchCastShadowTrue=4 batchCastShadowFalse=0",
+     1
+    ],
+    [
+     "§SHADOW_FRONTIER_AT_CAPTURE frame=36 frontierGuids=4 singleMesh_matched=0 castShadowTrue=0 castShadowFalse=0 batchObjsContainingFrontier=3 batchCastShadowTrue=3 batchCastShadowFalse=0",
+     1
+    ],
+    [
+     "§SHADOW_FRONTIER_AT_CAPTURE frame=37 frontierGuids=5 singleMesh_matched=0 castShadowTrue=0 castShadowFalse=0 batchObjsContainingFrontier=4 batchCastShadowTrue=4 batchCastShadowFalse=0",
+     1
+    ],
+    [
+     "§SHADOW_FRONTIER_AT_CAPTURE frame=38 frontierGuids=5 singleMesh_matched=0 castShadowTrue=0 castShadowFalse=0 batchObjsContainingFrontier=5 batchCastShadowTrue=5 batchCastShadowFalse=0",
+     1
+    ],
+    [
+     "§SHADOW_FRONTIER_AT_CAPTURE frame=39 frontierGuids=5 singleMesh_matched=0 castShadowTrue=0 castShadowFalse=0 batchObjsContainingFrontier=4 batchCastShadowTrue=4 batchCastShadowFalse=0",
+     1
+    ],
+    [
+     "§SHADOW_FRONTIER_AT_CAPTURE frame=40 frontierGuids=5 singleMesh_matched=0 castShadowTrue=0 castShadowFalse=0 batchObjsContainingFrontier=4 batchCastShadowTrue=4 batchCastShadowFalse=0",
+     1
+    ],
+    [
+     "§SHADOW_FRONTIER_AT_CAPTURE frame=41 frontierGuids=5 singleMesh_matched=0 castShadowTrue=0 castShadowFalse=0 batchObjsContainingFrontier=4 batchCastShadowTrue=4 batchCastShadowFalse=0",
+     1
+    ],
+    [
+     "§SHADOW_FRONTIER_AT_CAPTURE frame=42 frontierGuids=5 singleMesh_matched=0 castShadowTrue=0 castShadowFalse=0 batchObjsContainingFrontier=5 batchCastShadowTrue=5 batchCastShadowFalse=0",
+     1
+    ],
+    [
+     "§SHADOW_FRONTIER_AT_CAPTURE frame=43 frontierGuids=5 singleMesh_matched=0 castShadowTrue=0 castShadowFalse=0 batchObjsContainingFrontier=4 batchCastShadowTrue=4 batchCastShadowFalse=0",
+     1
+    ],
+    [
+     "§SHADOW_FRONTIER_AT_CAPTURE frame=44 frontierGuids=7 singleMesh_matched=0 castShadowTrue=0 castShadowFalse=0 batchObjsContainingFrontier=5 batchCastShadowTrue=5 batchCastShadowFalse=0",
+     1
+    ],
+    [
+     "§SHADOW_FRONTIER_AT_CAPTURE frame=45 frontierGuids=7 singleMesh_matched=0 castShadowTrue=0 castShadowFalse=0 batchObjsContainingFrontier=5 batchCastShadowTrue=5 batchCastShadowFalse=0",
+     1
+    ],
+    [
+     "§SHADOW_FRONTIER_AT_CAPTURE frame=46 frontierGuids=7 singleMesh_matched=0 castShadowTrue=0 castShadowFalse=0 batchObjsContainingFrontier=6 batchCastShadowTrue=6 batchCastShadowFalse=0",
+     1
+    ],
+    [
+     "§SHADOW_FRONTIER_AT_CAPTURE frame=47 frontierGuids=7 singleMesh_matched=0 castShadowTrue=0 castShadowFalse=0 batchObjsContainingFrontier=5 batchCastShadowTrue=5 batchCastShadowFalse=0",
+     1
+    ],
+    [
+     "§SHADOW_FRONTIER_AT_CAPTURE frame=48 frontierGuids=5 singleMesh_matched=0 castShadowTrue=0 castShadowFalse=0 batchObjsContainingFrontier=5 batchCastShadowTrue=5 batchCastShadowFalse=0",
+     1
+    ],
+    [
+     "§SHADOW_FRONTIER_AT_CAPTURE frame=53 frontierGuids=2 singleMesh_matched=0 castShadowTrue=0 castShadowFalse=0 batchObjsContainingFrontier=2 batchCastShadowTrue=2 batchCastShadowFalse=0",
+     1
+    ],
+    [
+     "§SHADOW_FRONTIER_AT_CAPTURE frame=58 frontierGuids=2 singleMesh_matched=0 castShadowTrue=0 castShadowFalse=0 batchObjsContainingFrontier=2 batchCastShadowTrue=2 batchCastShadowFalse=0",
+     1
+    ],
+    [
+     "§SHADOW_FRONTIER_AT_CAPTURE frame=59 frontierGuids=2 singleMesh_matched=0 castShadowTrue=0 castShadowFalse=0 batchObjsContainingFrontier=1 batchCastShadowTrue=1 batchCastShadowFalse=0",
+     1
+    ],
+    [
+     "§SHADOW_FRONTIER_AT_CAPTURE frame=60 frontierGuids=2 singleMesh_matched=0 castShadowTrue=0 castShadowFalse=0 batchObjsContainingFrontier=1 batchCastShadowTrue=1 batchCastShadowFalse=0",
+     1
+    ],
+    [
+     "§SHADOW_FRONTIER_AT_CAPTURE frame=61 frontierGuids=2 singleMesh_matched=0 castShadowTrue=0 castShadowFalse=0 batchObjsContainingFrontier=2 batchCastShadowTrue=2 batchCastShadowFalse=0",
+     1
+    ],
+    [
+     "§SHADOW_FRONTIER_AT_CAPTURE frame=62 frontierGuids=1 singleMesh_matched=0 castShadowTrue=0 castShadowFalse=0 batchObjsContainingFrontier=1 batchCastShadowTrue=1 batchCastShadowFalse=0",
+     1
+    ],
+    [
+     "§SHADOW_FRONTIER_AT_CAPTURE frame=67 frontierGuids=5 singleMesh_matched=0 castShadowTrue=0 castShadowFalse=0 batchObjsContainingFrontier=4 batchCastShadowTrue=4 batchCastShadowFalse=0",
+     1
+    ],
+    [
+     "§SHADOW_FRONTIER_AT_CAPTURE frame=68 frontierGuids=3 singleMesh_matched=0 castShadowTrue=0 castShadowFalse=0 batchObjsContainingFrontier=3 batchCastShadowTrue=3 batchCastShadowFalse=0",
+     1
+    ],
+    [
+     "§SHADOW_FRONTIER_AT_CAPTURE frame=69 frontierGuids=3 singleMesh_matched=0 castShadowTrue=0 castShadowFalse=0 batchObjsContainingFrontier=3 batchCastShadowTrue=3 batchCastShadowFalse=0",
+     1
+    ],
+    [
+     "§SHADOW_FRONTIER_AT_CAPTURE frame=70 frontierGuids=3 singleMesh_matched=0 castShadowTrue=0 castShadowFalse=0 batchObjsContainingFrontier=3 batchCastShadowTrue=3 batchCastShadowFalse=0",
+     1
+    ],
+    [
+     "§SHADOW_FRONTIER_AT_CAPTURE frame=71 frontierGuids=3 singleMesh_matched=0 castShadowTrue=0 castShadowFalse=0 batchObjsContainingFrontier=3 batchCastShadowTrue=3 batchCastShadowFalse=0",
+     1
+    ],
+    [
+     "§SHADOW_FRONTIER_AT_CAPTURE frame=72 frontierGuids=3 singleMesh_matched=0 castShadowTrue=0 castShadowFalse=0 batchObjsContainingFrontier=2 batchCastShadowTrue=2 batchCastShadowFalse=0",
+     1
+    ],
+    [
+     "§SHADOW_FRONTIER_AT_CAPTURE frame=73 frontierGuids=3 singleMesh_matched=0 castShadowTrue=0 castShadowFalse=0 batchObjsContainingFrontier=3 batchCastShadowTrue=3 batchCastShadowFalse=0",
+     1
+    ],
+    [
+     "§SHADOW_FRONTIER_AT_CAPTURE frame=74 frontierGuids=3 singleMesh_matched=0 castShadowTrue=0 castShadowFalse=0 batchObjsContainingFrontier=2 batchCastShadowTrue=2 batchCastShadowFalse=0",
+     1
+    ],
+    [
+     "§SHADOW_FRONTIER_AT_CAPTURE frame=75 frontierGuids=3 singleMesh_matched=0 castShadowTrue=0 castShadowFalse=0 batchObjsContainingFrontier=2 batchCastShadowTrue=2 batchCastShadowFalse=0",
+     1
+    ],
+    [
+     "§SHADOW_FRONTIER_AT_CAPTURE frame=76 frontierGuids=3 singleMesh_matched=0 castShadowTrue=0 castShadowFalse=0 batchObjsContainingFrontier=3 batchCastShadowTrue=3 batchCastShadowFalse=0",
+     1
+    ],
+    [
+     "§SHADOW_FRONTIER_AT_CAPTURE frame=77 frontierGuids=3 singleMesh_matched=0 castShadowTrue=0 castShadowFalse=0 batchObjsContainingFrontier=2 batchCastShadowTrue=2 batchCastShadowFalse=0",
+     1
+    ],
+    [
+     "§SHADOW_FRONTIER_AT_CAPTURE frame=78 frontierGuids=3 singleMesh_matched=0 castShadowTrue=0 castShadowFalse=0 batchObjsContainingFrontier=2 batchCastShadowTrue=2 batchCastShadowFalse=0",
+     1
+    ],
+    [
+     "§SHADOW_FRONTIER_AT_CAPTURE frame=79 frontierGuids=3 singleMesh_matched=0 castShadowTrue=0 castShadowFalse=0 batchObjsContainingFrontier=3 batchCastShadowTrue=3 batchCastShadowFalse=0",
+     1
+    ],
+    [
+     "§SHADOW_FRONTIER_AT_CAPTURE frame=80 frontierGuids=3 singleMesh_matched=0 castShadowTrue=0 castShadowFalse=0 batchObjsContainingFrontier=3 batchCastShadowTrue=3 batchCastShadowFalse=0",
+     1
+    ],
+    [
+     "§SHADOW_FRONTIER_AT_CAPTURE frame=81 frontierGuids=3 singleMesh_matched=0 castShadowTrue=0 castShadowFalse=0 batchObjsContainingFrontier=2 batchCastShadowTrue=2 batchCastShadowFalse=0",
+     1
+    ],
+    [
+     "§SHADOW_FRONTIER_AT_CAPTURE frame=82 frontierGuids=11 singleMesh_matched=0 castShadowTrue=0 castShadowFalse=0 batchObjsContainingFrontier=9 batchCastShadowTrue=9 batchCastShadowFalse=0",
+     1
+    ],
+    [
+     "§SHADOW_FRONTIER_AT_CAPTURE frame=83 frontierGuids=7 singleMesh_matched=0 castShadowTrue=0 castShadowFalse=0 batchObjsContainingFrontier=6 batchCastShadowTrue=6 batchCastShadowFalse=0",
+     1
+    ],
+    [
+     "§SHADOW_FRONTIER_AT_CAPTURE frame=84 frontierGuids=5 singleMesh_matched=0 castShadowTrue=0 castShadowFalse=0 batchObjsContainingFrontier=4 batchCastShadowTrue=4 batchCastShadowFalse=0",
+     1
+    ],
+    [
+     "§SHADOW_FRONTIER_AT_CAPTURE frame=85 frontierGuids=5 singleMesh_matched=0 castShadowTrue=0 castShadowFalse=0 batchObjsContainingFrontier=5 batchCastShadowTrue=5 batchCastShadowFalse=0",
+     1
+    ],
+    [
+     "§SHADOW_FRONTIER_AT_CAPTURE frame=86 frontierGuids=5 singleMesh_matched=0 castShadowTrue=0 castShadowFalse=0 batchObjsContainingFrontier=4 batchCastShadowTrue=4 batchCastShadowFalse=0",
+     1
+    ],
+    [
+     "§SHADOW_FRONTIER_AT_CAPTURE frame=87 frontierGuids=7 singleMesh_matched=0 castShadowTrue=0 castShadowFalse=0 batchObjsContainingFrontier=4 batchCastShadowTrue=4 batchCastShadowFalse=0",
+     1
+    ],
+    [
+     "§SHADOW_FRONTIER_AT_CAPTURE frame=88 frontierGuids=7 singleMesh_matched=0 castShadowTrue=0 castShadowFalse=0 batchObjsContainingFrontier=5 batchCastShadowTrue=5 batchCastShadowFalse=0",
+     1
+    ],
+    [
+     "§SHADOW_FRONTIER_AT_CAPTURE frame=89 frontierGuids=7 singleMesh_matched=0 castShadowTrue=0 castShadowFalse=0 batchObjsContainingFrontier=7 batchCastShadowTrue=7 batchCastShadowFalse=0",
+     1
+    ],
+    [
+     "§SHADOW_FRONTIER_AT_CAPTURE frame=90 frontierGuids=7 singleMesh_matched=0 castShadowTrue=0 castShadowFalse=0 batchObjsContainingFrontier=5 batchCastShadowTrue=5 batchCastShadowFalse=0",
+     1
+    ],
+    [
+     "§SHADOW_FRONTIER_AT_CAPTURE frame=91 frontierGuids=5 singleMesh_matched=0 castShadowTrue=0 castShadowFalse=0 batchObjsContainingFrontier=3 batchCastShadowTrue=3 batchCastShadowFalse=0",
+     1
+    ],
+    [
+     "§SHADOW_FRONTIER_AT_CAPTURE frame=92 frontierGuids=5 singleMesh_matched=0 castShadowTrue=0 castShadowFalse=0 batchObjsContainingFrontier=4 batchCastShadowTrue=4 batchCastShadowFalse=0",
+     1
+    ],
+    [
+     "§SHADOW_FRONTIER_AT_CAPTURE frame=93 frontierGuids=4 singleMesh_matched=0 castShadowTrue=0 castShadowFalse=0 batchObjsContainingFrontier=4 batchCastShadowTrue=4 batchCastShadowFalse=0",
+     1
+    ],
+    [
+     "§SHADOW_FRONTIER_AT_CAPTURE frame=94 frontierGuids=5 singleMesh_matched=0 castShadowTrue=0 castShadowFalse=0 batchObjsContainingFrontier=3 batchCastShadowTrue=3 batchCastShadowFalse=0",
+     1
+    ],
+    [
+     "§SHADOW_FRONTIER_AT_CAPTURE frame=95 frontierGuids=3 singleMesh_matched=0 castShadowTrue=0 castShadowFalse=0 batchObjsContainingFrontier=3 batchCastShadowTrue=3 batchCastShadowFalse=0",
+     1
+    ],
+    [
+     "§SHADOW_FRONTIER_AT_CAPTURE frame=96 frontierGuids=3 singleMesh_matched=0 castShadowTrue=0 castShadowFalse=0 batchObjsContainingFrontier=2 batchCastShadowTrue=2 batchCastShadowFalse=0",
+     1
+    ],
+    [
+     "§SHADOW_FRONTIER_AT_CAPTURE frame=97 frontierGuids=3 singleMesh_matched=0 castShadowTrue=0 castShadowFalse=0 batchObjsContainingFrontier=3 batchCastShadowTrue=3 batchCastShadowFalse=0",
+     1
+    ],
+    [
+     "§SHADOW_FRONTIER_AT_CAPTURE frame=98 frontierGuids=5 singleMesh_matched=0 castShadowTrue=0 castShadowFalse=0 batchObjsContainingFrontier=4 batchCastShadowTrue=4 batchCastShadowFalse=0",
+     1
+    ],
+    [
+     "§SHADOW_FRONTIER_AT_CAPTURE frame=99 frontierGuids=3 singleMesh_matched=0 castShadowTrue=0 castShadowFalse=0 batchObjsContainingFrontier=3 batchCastShadowTrue=3 batchCastShadowFalse=0",
+     1
+    ],
+    [
+     "§SHADOW_FRONTIER_AT_CAPTURE frame=100 frontierGuids=5 singleMesh_matched=0 castShadowTrue=0 castShadowFalse=0 batchObjsContainingFrontier=3 batchCastShadowTrue=3 batchCastShadowFalse=0",
+     1
+    ],
+    [
+     "§SHADOW_FRONTIER_AT_CAPTURE frame=101 frontierGuids=3 singleMesh_matched=0 castShadowTrue=0 castShadowFalse=0 batchObjsContainingFrontier=3 batchCastShadowTrue=3 batchCastShadowFalse=0",
+     1
+    ],
+    [
+     "§SHADOW_FRONTIER_AT_CAPTURE frame=102 frontierGuids=3 singleMesh_matched=0 castShadowTrue=0 castShadowFalse=0 batchObjsContainingFrontier=3 batchCastShadowTrue=3 batchCastShadowFalse=0",
+     1
+    ],
+    [
+     "§SHADOW_FRONTIER_AT_CAPTURE frame=103 frontierGuids=3 singleMesh_matched=0 castShadowTrue=0 castShadowFalse=0 batchObjsContainingFrontier=3 batchCastShadowTrue=3 batchCastShadowFalse=0",
+     1
+    ],
+    [
+     "§SHADOW_FRONTIER_AT_CAPTURE frame=104 frontierGuids=5 singleMesh_matched=0 castShadowTrue=0 castShadowFalse=0 batchObjsContainingFrontier=5 batchCastShadowTrue=5 batchCastShadowFalse=0",
+     1
+    ],
+    [
+     "§SHADOW_FRONTIER_AT_CAPTURE frame=105 frontierGuids=3 singleMesh_matched=0 castShadowTrue=0 castShadowFalse=0 batchObjsContainingFrontier=3 batchCastShadowTrue=3 batchCastShadowFalse=0",
+     1
+    ],
+    [
+     "§SHADOW_FRONTIER_AT_CAPTURE frame=106 frontierGuids=3 singleMesh_matched=0 castShadowTrue=0 castShadowFalse=0 batchObjsContainingFrontier=3 batchCastShadowTrue=3 batchCastShadowFalse=0",
+     1
+    ],
+    [
+     "§SHADOW_FRONTIER_AT_CAPTURE frame=107 frontierGuids=3 singleMesh_matched=0 castShadowTrue=0 castShadowFalse=0 batchObjsContainingFrontier=3 batchCastShadowTrue=3 batchCastShadowFalse=0",
+     1
+    ],
+    [
+     "§SHADOW_FRONTIER_AT_CAPTURE frame=108 frontierGuids=2 singleMesh_matched=0 castShadowTrue=0 castShadowFalse=0 batchObjsContainingFrontier=2 batchCastShadowTrue=2 batchCastShadowFalse=0",
+     1
+    ],
+    [
+     "§SHADOW_FRONTIER_AT_CAPTURE frame=109 frontierGuids=3 singleMesh_matched=0 castShadowTrue=0 castShadowFalse=0 batchObjsContainingFrontier=2 batchCastShadowTrue=2 batchCastShadowFalse=0",
+     1
+    ],
+    [
+     "§SHADOW_FRONTIER_AT_CAPTURE frame=111 frontierGuids=4 singleMesh_matched=0 castShadowTrue=0 castShadowFalse=0 batchObjsContainingFrontier=3 batchCastShadowTrue=3 batchCastShadowFalse=0",
+     1
+    ],
+    [
+     "§SHADOW_FRONTIER_AT_CAPTURE frame=112 frontierGuids=3 singleMesh_matched=0 castShadowTrue=0 castShadowFalse=0 batchObjsContainingFrontier=3 batchCastShadowTrue=3 batchCastShadowFalse=0",
+     1
+    ],
+    [
+     "§SHADOW_FRONTIER_AT_CAPTURE frame=113 frontierGuids=3 singleMesh_matched=0 castShadowTrue=0 castShadowFalse=0 batchObjsContainingFrontier=2 batchCastShadowTrue=2 batchCastShadowFalse=0",
+     1
+    ],
+    [
+     "§SHADOW_FRONTIER_AT_CAPTURE frame=114 frontierGuids=3 singleMesh_matched=0 castShadowTrue=0 castShadowFalse=0 batchObjsContainingFrontier=3 batchCastShadowTrue=3 batchCastShadowFalse=0",
+     1
+    ],
+    [
+     "§SHADOW_FRONTIER_AT_CAPTURE frame=115 frontierGuids=5 singleMesh_matched=0 castShadowTrue=0 castShadowFalse=0 batchObjsContainingFrontier=4 batchCastShadowTrue=4 batchCastShadowFalse=0",
+     1
+    ],
+    [
+     "§SHADOW_FRONTIER_AT_CAPTURE frame=116 frontierGuids=7 singleMesh_matched=0 castShadowTrue=0 castShadowFalse=0 batchObjsContainingFrontier=6 batchCastShadowTrue=6 batchCastShadowFalse=0",
+     1
+    ],
+    [
+     "§SHADOW_FRONTIER_AT_CAPTURE frame=117 frontierGuids=5 singleMesh_matched=0 castShadowTrue=0 castShadowFalse=0 batchObjsContainingFrontier=5 batchCastShadowTrue=5 batchCastShadowFalse=0",
+     1
+    ],
+    [
+     "§SHADOW_FRONTIER_AT_CAPTURE frame=118 frontierGuids=5 singleMesh_matched=0 castShadowTrue=0 castShadowFalse=0 batchObjsContainingFrontier=4 batchCastShadowTrue=4 batchCastShadowFalse=0",
+     1
+    ],
+    [
+     "§SHADOW_FRONTIER_AT_CAPTURE frame=119 frontierGuids=7 singleMesh_matched=0 castShadowTrue=0 castShadowFalse=0 batchObjsContainingFrontier=7 batchCastShadowTrue=7 batchCastShadowFalse=0",
+     1
+    ],
+    [
+     "§SHADOW_FRONTIER_AT_CAPTURE frame=120 frontierGuids=3 singleMesh_matched=0 castShadowTrue=0 castShadowFalse=0 batchObjsContainingFrontier=3 batchCastShadowTrue=3 batchCastShadowFalse=0",
+     1
+    ],
+    [
+     "§SHADOW_FRONTIER_AT_CAPTURE frame=121 frontierGuids=3 singleMesh_matched=0 castShadowTrue=0 castShadowFalse=0 batchObjsContainingFrontier=3 batchCastShadowTrue=3 batchCastShadowFalse=0",
+     1
+    ],
+    [
+     "§SHADOW_FRONTIER_AT_CAPTURE frame=122 frontierGuids=3 singleMesh_matched=0 castShadowTrue=0 castShadowFalse=0 batchObjsContainingFrontier=3 batchCastShadowTrue=3 batchCastShadowFalse=0",
+     1
+    ],
+    [
+     "§SHADOW_FRONTIER_AT_CAPTURE frame=123 frontierGuids=3 singleMesh_matched=0 castShadowTrue=0 castShadowFalse=0 batchObjsContainingFrontier=1 batchCastShadowTrue=1 batchCastShadowFalse=0",
+     1
+    ],
+    [
+     "§SHADOW_FRONTIER_AT_CAPTURE frame=124 frontierGuids=3 singleMesh_matched=0 castShadowTrue=0 castShadowFalse=0 batchObjsContainingFrontier=2 batchCastShadowTrue=2 batchCastShadowFalse=0",
+     1
+    ],
+    [
+     "§SHADOW_FRONTIER_AT_CAPTURE frame=125 frontierGuids=3 singleMesh_matched=0 castShadowTrue=0 castShadowFalse=0 batchObjsContainingFrontier=3 batchCastShadowTrue=3 batchCastShadowFalse=0",
+     1
+    ],
+    [
+     "§SHADOW_FRONTIER_AT_CAPTURE frame=126 frontierGuids=3 singleMesh_matched=0 castShadowTrue=0 castShadowFalse=0 batchObjsContainingFrontier=3 batchCastShadowTrue=3 batchCastShadowFalse=0",
+     1
+    ],
+    [
+     "§SHADOW_FRONTIER_AT_CAPTURE frame=127 frontierGuids=2 singleMesh_matched=0 castShadowTrue=0 castShadowFalse=0 batchObjsContainingFrontier=2 batchCastShadowTrue=2 batchCastShadowFalse=0",
+     1
+    ],
+    [
+     "§SHADOW_FRONTIER_AT_CAPTURE frame=128 frontierGuids=4 singleMesh_matched=0 castShadowTrue=0 castShadowFalse=0 batchObjsContainingFrontier=2 batchCastShadowTrue=2 batchCastShadowFalse=0",
+     1
+    ],
+    [
+     "§SHADOW_FRONTIER_AT_CAPTURE frame=129 frontierGuids=6 singleMesh_matched=0 castShadowTrue=0 castShadowFalse=0 batchObjsContainingFrontier=3 batchCastShadowTrue=3 batchCastShadowFalse=0",
+     1
+    ],
+    [
+     "§SHADOW_FRONTIER_AT_CAPTURE frame=130 frontierGuids=5 singleMesh_matched=0 castShadowTrue=0 castShadowFalse=0 batchObjsContainingFrontier=5 batchCastShadowTrue=5 batchCastShadowFalse=0",
+     1
+    ],
+    [
+     "§SHADOW_FRONTIER_AT_CAPTURE frame=131 frontierGuids=3 singleMesh_matched=0 castShadowTrue=0 castShadowFalse=0 batchObjsContainingFrontier=3 batchCastShadowTrue=3 batchCastShadowFalse=0",
+     1
+    ],
+    [
+     "§SHADOW_FRONTIER_AT_CAPTURE frame=132 frontierGuids=5 singleMesh_matched=0 castShadowTrue=0 castShadowFalse=0 batchObjsContainingFrontier=3 batchCastShadowTrue=3 batchCastShadowFalse=0",
+     1
+    ],
+    [
+     "§SHADOW_FRONTIER_AT_CAPTURE frame=133 frontierGuids=3 singleMesh_matched=0 castShadowTrue=0 castShadowFalse=0 batchObjsContainingFrontier=3 batchCastShadowTrue=3 batchCastShadowFalse=0",
+     1
+    ],
+    [
+     "§SHADOW_FRONTIER_AT_CAPTURE frame=134 frontierGuids=2 singleMesh_matched=0 castShadowTrue=0 castShadowFalse=0 batchObjsContainingFrontier=2 batchCastShadowTrue=2 batchCastShadowFalse=0",
+     1
+    ],
+    [
+     "§SHADOW_FRONTIER_AT_CAPTURE frame=135 frontierGuids=3 singleMesh_matched=0 castShadowTrue=0 castShadowFalse=0 batchObjsContainingFrontier=3 batchCastShadowTrue=3 batchCastShadowFalse=0",
+     1
+    ],
+    [
+     "§SHADOW_FRONTIER_AT_CAPTURE frame=136 frontierGuids=3 singleMesh_matched=0 castShadowTrue=0 castShadowFalse=0 batchObjsContainingFrontier=3 batchCastShadowTrue=3 batchCastShadowFalse=0",
+     1
+    ],
+    [
+     "§SHADOW_FRONTIER_AT_CAPTURE frame=137 frontierGuids=3 singleMesh_matched=0 castShadowTrue=0 castShadowFalse=0 batchObjsContainingFrontier=1 batchCastShadowTrue=1 batchCastShadowFalse=0",
+     1
+    ],
+    [
+     "§SHADOW_FRONTIER_AT_CAPTURE frame=138 frontierGuids=3 singleMesh_matched=0 castShadowTrue=0 castShadowFalse=0 batchObjsContainingFrontier=2 batchCastShadowTrue=2 batchCastShadowFalse=0",
+     1
+    ],
+    [
+     "§SHADOW_FRONTIER_AT_CAPTURE frame=139 frontierGuids=3 singleMesh_matched=0 castShadowTrue=0 castShadowFalse=0 batchObjsContainingFrontier=2 batchCastShadowTrue=2 batchCastShadowFalse=0",
+     1
+    ],
+    [
+     "§SHADOW_FRONTIER_AT_CAPTURE frame=140 frontierGuids=3 singleMesh_matched=0 castShadowTrue=0 castShadowFalse=0 batchObjsContainingFrontier=3 batchCastShadowTrue=3 batchCastShadowFalse=0",
+     1
+    ],
+    [
+     "§SHADOW_FRONTIER_AT_CAPTURE frame=141 frontierGuids=1 singleMesh_matched=0 castShadowTrue=0 castShadowFalse=0 batchObjsContainingFrontier=1 batchCastShadowTrue=1 batchCastShadowFalse=0",
+     1
+    ],
+    [
+     "§SHADOW_FRONTIER_AT_CAPTURE frame=142 frontierGuids=3 singleMesh_matched=0 castShadowTrue=0 castShadowFalse=0 batchObjsContainingFrontier=2 batchCastShadowTrue=2 batchCastShadowFalse=0",
+     1
+    ],
+    [
+     "§SHADOW_FRONTIER_AT_CAPTURE frame=145 frontierGuids=6 singleMesh_matched=0 castShadowTrue=0 castShadowFalse=0 batchObjsContainingFrontier=5 batchCastShadowTrue=5 batchCastShadowFalse=0",
+     1
+    ],
+    [
+     "§SHADOW_FRONTIER_AT_CAPTURE frame=146 frontierGuids=5 singleMesh_matched=0 castShadowTrue=0 castShadowFalse=0 batchObjsContainingFrontier=4 batchCastShadowTrue=4 batchCastShadowFalse=0",
+     1
+    ],
+    [
+     "§SHADOW_FRONTIER_AT_CAPTURE frame=147 frontierGuids=5 singleMesh_matched=0 castShadowTrue=0 castShadowFalse=0 batchObjsContainingFrontier=2 batchCastShadowTrue=2 batchCastShadowFalse=0",
+     1
+    ],
+    [
+     "§SHADOW_FRONTIER_AT_CAPTURE frame=148 frontierGuids=5 singleMesh_matched=0 castShadowTrue=0 castShadowFalse=0 batchObjsContainingFrontier=3 batchCastShadowTrue=3 batchCastShadowFalse=0",
+     1
+    ],
+    [
+     "§SHADOW_FRONTIER_AT_CAPTURE frame=149 frontierGuids=5 singleMesh_matched=0 castShadowTrue=0 castShadowFalse=0 batchObjsContainingFrontier=5 batchCastShadowTrue=5 batchCastShadowFalse=0",
+     1
+    ],
+    [
+     "§SHADOW_FRONTIER_AT_CAPTURE frame=150 frontierGuids=5 singleMesh_matched=0 castShadowTrue=0 castShadowFalse=0 batchObjsContainingFrontier=3 batchCastShadowTrue=3 batchCastShadowFalse=0",
+     1
+    ],
+    [
+     "§SHADOW_FRONTIER_AT_CAPTURE frame=151 frontierGuids=5 singleMesh_matched=0 castShadowTrue=0 castShadowFalse=0 batchObjsContainingFrontier=4 batchCastShadowTrue=4 batchCastShadowFalse=0",
+     1
+    ],
+    [
+     "§SHADOW_FRONTIER_AT_CAPTURE frame=152 frontierGuids=1 singleMesh_matched=0 castShadowTrue=0 castShadowFalse=0 batchObjsContainingFrontier=1 batchCastShadowTrue=1 batchCastShadowFalse=0",
+     1
+    ],
+    [
+     "§SHADOW_FRONTIER_AT_CAPTURE frame=179 frontierGuids=2 singleMesh_matched=0 castShadowTrue=0 castShadowFalse=0 batchObjsContainingFrontier=2 batchCastShadowTrue=2 batchCastShadowFalse=0",
+     1
+    ],
+    [
+     "§SHADOW_FRONTIER_AT_CAPTURE frame=191 frontierGuids=2 singleMesh_matched=0 castShadowTrue=0 castShadowFalse=0 batchObjsContainingFrontier=1 batchCastShadowTrue=1 batchCastShadowFalse=0",
+     1
+    ],
+    [
+     "§SHADOW_FRONTIER_AT_CAPTURE frame=195 frontierGuids=4 singleMesh_matched=0 castShadowTrue=0 castShadowFalse=0 batchObjsContainingFrontier=3 batchCastShadowTrue=3 batchCastShadowFalse=0",
+     1
+    ],
+    [
+     "§SHADOW_FRONTIER_AT_CAPTURE frame=196 frontierGuids=4 singleMesh_matched=0 castShadowTrue=0 castShadowFalse=0 batchObjsContainingFrontier=4 batchCastShadowTrue=4 batchCastShadowFalse=0",
+     1
+    ],
+    [
+     "§SHADOW_FRONTIER_AT_CAPTURE frame=197 frontierGuids=4 singleMesh_matched=0 castShadowTrue=0 castShadowFalse=0 batchObjsContainingFrontier=3 batchCastShadowTrue=3 batchCastShadowFalse=0",
+     1
+    ],
+    [
+     "§SHADOW_FRONTIER_AT_CAPTURE frame=198 frontierGuids=4 singleMesh_matched=0 castShadowTrue=0 castShadowFalse=0 batchObjsContainingFrontier=4 batchCastShadowTrue=4 batchCastShadowFalse=0",
+     1
+    ],
+    [
+     "§SHADOW_FRONTIER_AT_CAPTURE frame=199 frontierGuids=2 singleMesh_matched=0 castShadowTrue=0 castShadowFalse=0 batchObjsContainingFrontier=2 batchCastShadowTrue=2 batchCastShadowFalse=0",
+     1
+    ],
+    [
+     "§SHADOW_FRONTIER_AT_CAPTURE frame=200 frontierGuids=2 singleMesh_matched=0 castShadowTrue=0 castShadowFalse=0 batchObjsContainingFrontier=2 batchCastShadowTrue=2 batchCastShadowFalse=0",
+     1
+    ],
+    [
+     "§SHADOW_FRONTIER_AT_CAPTURE frame=202 frontierGuids=2 singleMesh_matched=0 castShadowTrue=0 castShadowFalse=0 batchObjsContainingFrontier=1 batchCastShadowTrue=1 batchCastShadowFalse=0",
+     1
+    ],
+    [
+     "§SHADOW_FRONTIER_AT_CAPTURE frame=204 frontierGuids=1 singleMesh_matched=0 castShadowTrue=0 castShadowFalse=0 batchObjsContainingFrontier=1 batchCastShadowTrue=1 batchCastShadowFalse=0",
+     1
+    ],
+    [
+     "§SHADOW_FRONTIER_AT_CAPTURE frame=213 frontierGuids=2 singleMesh_matched=0 castShadowTrue=0 castShadowFalse=0 batchObjsContainingFrontier=1 batchCastShadowTrue=1 batchCastShadowFalse=0",
+     1
+    ],
+    [
+     "§SHADOW_FRONTIER_AT_CAPTURE frame=223 frontierGuids=2 singleMesh_matched=0 castShadowTrue=0 castShadowFalse=0 batchObjsContainingFrontier=1 batchCastShadowTrue=1 batchCastShadowFalse=0",
+     1
+    ],
+    [
+     "§SHADOW_FRONTIER_AT_CAPTURE frame=224 frontierGuids=2 singleMesh_matched=0 castShadowTrue=0 castShadowFalse=0 batchObjsContainingFrontier=2 batchCastShadowTrue=2 batchCastShadowFalse=0",
+     1
+    ],
+    [
+     "§SHADOW_FRONTIER_AT_CAPTURE frame=225 frontierGuids=2 singleMesh_matched=0 castShadowTrue=0 castShadowFalse=0 batchObjsContainingFrontier=1 batchCastShadowTrue=1 batchCastShadowFalse=0",
+     1
+    ],
+    [
+     "§SHADOW_FRONTIER_AT_CAPTURE frame=226 frontierGuids=2 singleMesh_matched=0 castShadowTrue=0 castShadowFalse=0 batchObjsContainingFrontier=1 batchCastShadowTrue=1 batchCastShadowFalse=0",
+     1
+    ],
+    [
+     "§SHADOW_FRONTIER_AT_CAPTURE frame=228 frontierGuids=2 singleMesh_matched=0 castShadowTrue=0 castShadowFalse=0 batchObjsContainingFrontier=2 batchCastShadowTrue=2 batchCastShadowFalse=0",
+     1
+    ],
+    [
+     "§SHADOW_FRONTIER_AT_CAPTURE frame=253 frontierGuids=2 singleMesh_matched=0 castShadowTrue=0 castShadowFalse=0 batchObjsContainingFrontier=2 batchCastShadowTrue=2 batchCastShadowFalse=0",
+     1
+    ],
+    [
+     "§SHADOW_FRONTIER_AT_CAPTURE frame=254 frontierGuids=2 singleMesh_matched=0 castShadowTrue=0 castShadowFalse=0 batchObjsContainingFrontier=1 batchCastShadowTrue=1 batchCastShadowFalse=0",
+     1
+    ],
+    [
+     "§SHADOW_FRONTIER_AT_CAPTURE frame=255 frontierGuids=2 singleMesh_matched=0 castShadowTrue=0 castShadowFalse=0 batchObjsContainingFrontier=2 batchCastShadowTrue=2 batchCastShadowFalse=0",
+     1
+    ],
+    [
+     "§SHADOW_FRONTIER_AT_CAPTURE frame=278 frontierGuids=2 singleMesh_matched=0 castShadowTrue=0 castShadowFalse=0 batchObjsContainingFrontier=2 batchCastShadowTrue=2 batchCastShadowFalse=0",
+     1
+    ],
+    [
+     "§SHADOW_FRONTIER_AT_CAPTURE frame=279 frontierGuids=2 singleMesh_matched=0 castShadowTrue=0 castShadowFalse=0 batchObjsContainingFrontier=1 batchCastShadowTrue=1 batchCastShadowFalse=0",
+     1
+    ],
+    [
+     "§SHADOW_FRONTIER_AT_CAPTURE frame=280 frontierGuids=2 singleMesh_matched=0 castShadowTrue=0 castShadowFalse=0 batchObjsContainingFrontier=1 batchCastShadowTrue=1 batchCastShadowFalse=0",
+     1
+    ],
+    [
+     "§SHADOW_FRONTIER_AT_CAPTURE frame=281 frontierGuids=2 singleMesh_matched=0 castShadowTrue=0 castShadowFalse=0 batchObjsContainingFrontier=2 batchCastShadowTrue=2 batchCastShadowFalse=0",
+     1
+    ],
+    [
+     "§SHADOW_FRONTIER_AT_CAPTURE frame=282 frontierGuids=2 singleMesh_matched=0 castShadowTrue=0 castShadowFalse=0 batchObjsContainingFrontier=2 batchCastShadowTrue=2 batchCastShadowFalse=0",
+     1
+    ],
+    [
+     "§SHADOW_FRONTIER_AT_CAPTURE frame=283 frontierGuids=2 singleMesh_matched=0 castShadowTrue=0 castShadowFalse=0 batchObjsContainingFrontier=1 batchCastShadowTrue=1 batchCastShadowFalse=0",
+     1
+    ],
+    [
+     "§SHADOW_FRONTIER_AT_CAPTURE frame=284 frontierGuids=2 singleMesh_matched=0 castShadowTrue=0 castShadowFalse=0 batchObjsContainingFrontier=1 batchCastShadowTrue=1 batchCastShadowFalse=0",
+     1
+    ],
+    [
+     "§SHADOW_FRONTIER_AT_CAPTURE frame=297 frontierGuids=2 singleMesh_matched=0 castShadowTrue=0 castShadowFalse=0 batchObjsContainingFrontier=2 batchCastShadowTrue=2 batchCastShadowFalse=0",
+     1
+    ],
+    [
+     "§SHADOW_FRONTIER_AT_CAPTURE frame=300 frontierGuids=2 singleMesh_matched=0 castShadowTrue=0 castShadowFalse=0 batchObjsContainingFrontier=1 batchCastShadowTrue=1 batchCastShadowFalse=0",
+     1
+    ],
+    [
+     "§SHADOW_FRONTIER_AT_CAPTURE frame=301 frontierGuids=2 singleMesh_matched=0 castShadowTrue=0 castShadowFalse=0 batchObjsContainingFrontier=1 batchCastShadowTrue=1 batchCastShadowFalse=0",
+     1
+    ],
+    [
+     "§SHADOW_FRONTIER_AT_CAPTURE frame=302 frontierGuids=2 singleMesh_matched=0 castShadowTrue=0 castShadowFalse=0 batchObjsContainingFrontier=2 batchCastShadowTrue=2 batchCastShadowFalse=0",
+     1
+    ],
+    [
+     "§SHADOW_FRONTIER_AT_CAPTURE frame=303 frontierGuids=2 singleMesh_matched=0 castShadowTrue=0 castShadowFalse=0 batchObjsContainingFrontier=2 batchCastShadowTrue=2 batchCastShadowFalse=0",
+     1
+    ],
+    [
+     "§SHADOW_FRONTIER_AT_CAPTURE frame=327 frontierGuids=4 singleMesh_matched=0 castShadowTrue=0 castShadowFalse=0 batchObjsContainingFrontier=2 batchCastShadowTrue=2 batchCastShadowFalse=0",
+     1
+    ],
+    [
+     "§SHADOW_FRONTIER_AT_CAPTURE frame=328 frontierGuids=4 singleMesh_matched=0 castShadowTrue=0 castShadowFalse=0 batchObjsContainingFrontier=4 batchCastShadowTrue=4 batchCastShadowFalse=0",
+     1
+    ],
+    [
+     "§SHADOW_FRONTIER_AT_CAPTURE frame=329 frontierGuids=4 singleMesh_matched=0 castShadowTrue=0 castShadowFalse=0 batchObjsContainingFrontier=4 batchCastShadowTrue=4 batchCastShadowFalse=0",
+     1
+    ],
+    [
+     "§SHADOW_FRONTIER_AT_CAPTURE frame=330 frontierGuids=4 singleMesh_matched=0 castShadowTrue=0 castShadowFalse=0 batchObjsContainingFrontier=3 batchCastShadowTrue=3 batchCastShadowFalse=0",
+     1
+    ],
+    [
+     "§SHADOW_FRONTIER_AT_CAPTURE frame=331 frontierGuids=4 singleMesh_matched=0 castShadowTrue=0 castShadowFalse=0 batchObjsContainingFrontier=3 batchCastShadowTrue=3 batchCastShadowFalse=0",
+     1
+    ],
+    [
+     "§SHADOW_FRONTIER_AT_CAPTURE frame=332 frontierGuids=5 singleMesh_matched=0 castShadowTrue=0 castShadowFalse=0 batchObjsContainingFrontier=5 batchCastShadowTrue=5 batchCastShadowFalse=0",
+     1
+    ],
+    [
+     "§SHADOW_FRONTIER_AT_CAPTURE frame=333 frontierGuids=6 singleMesh_matched=0 castShadowTrue=0 castShadowFalse=0 batchObjsContainingFrontier=4 batchCastShadowTrue=4 batchCastShadowFalse=0",
+     1
+    ],
+    [
+     "§SHADOW_FRONTIER_AT_CAPTURE frame=334 frontierGuids=6 singleMesh_matched=0 castShadowTrue=0 castShadowFalse=0 batchObjsContainingFrontier=4 batchCastShadowTrue=4 batchCastShadowFalse=0",
+     1
+    ],
+    [
+     "§SHADOW_FRONTIER_AT_CAPTURE frame=335 frontierGuids=6 singleMesh_matched=0 castShadowTrue=0 castShadowFalse=0 batchObjsContainingFrontier=6 batchCastShadowTrue=6 batchCastShadowFalse=0",
+     1
+    ],
+    [
+     "§SHADOW_FRONTIER_AT_CAPTURE frame=336 frontierGuids=6 singleMesh_matched=0 castShadowTrue=0 castShadowFalse=0 batchObjsContainingFrontier=4 batchCastShadowTrue=4 batchCastShadowFalse=0",
+     1
+    ],
+    [
+     "§SHADOW_FRONTIER_AT_CAPTURE frame=337 frontierGuids=6 singleMesh_matched=0 castShadowTrue=0 castShadowFalse=0 batchObjsContainingFrontier=4 batchCastShadowTrue=4 batchCastShadowFalse=0",
+     1
+    ],
+    [
+     "§SHADOW_FRONTIER_AT_CAPTURE frame=339 frontierGuids=6 singleMesh_matched=0 castShadowTrue=0 castShadowFalse=0 batchObjsContainingFrontier=4 batchCastShadowTrue=4 batchCastShadowFalse=0",
+     1
+    ],
+    [
+     "§SHADOW_FRONTIER_AT_CAPTURE frame=340 frontierGuids=6 singleMesh_matched=0 castShadowTrue=0 castShadowFalse=0 batchObjsContainingFrontier=4 batchCastShadowTrue=4 batchCastShadowFalse=0",
+     1
+    ],
+    [
+     "§SHADOW_FRONTIER_AT_CAPTURE frame=341 frontierGuids=4 singleMesh_matched=0 castShadowTrue=0 castShadowFalse=0 batchObjsContainingFrontier=3 batchCastShadowTrue=3 batchCastShadowFalse=0",
+     1
+    ],
+    [
+     "§SHADOW_FRONTIER_AT_CAPTURE frame=342 frontierGuids=2 singleMesh_matched=0 castShadowTrue=0 castShadowFalse=0 batchObjsContainingFrontier=2 batchCastShadowTrue=2 batchCastShadowFalse=0",
+     1
+    ],
+    [
+     "§SHADOW_FRONTIER_AT_CAPTURE frame=343 frontierGuids=2 singleMesh_matched=0 castShadowTrue=0 castShadowFalse=0 batchObjsContainingFrontier=1 batchCastShadowTrue=1 batchCastShadowFalse=0",
+     1
+    ],
+    [
+     "§SHADOW_FRONTIER_AT_CAPTURE frame=344 frontierGuids=2 singleMesh_matched=0 castShadowTrue=0 castShadowFalse=0 batchObjsContainingFrontier=2 batchCastShadowTrue=2 batchCastShadowFalse=0",
+     1
+    ],
+    [
+     "§SHADOW_FRONTIER_AT_CAPTURE frame=345 frontierGuids=2 singleMesh_matched=0 castShadowTrue=0 castShadowFalse=0 batchObjsContainingFrontier=1 batchCastShadowTrue=1 batchCastShadowFalse=0",
+     1
+    ],
+    [
+     "§SHADOW_FRONTIER_AT_CAPTURE frame=346 frontierGuids=2 singleMesh_matched=0 castShadowTrue=0 castShadowFalse=0 batchObjsContainingFrontier=2 batchCastShadowTrue=2 batchCastShadowFalse=0",
+     1
+    ],
+    [
+     "§SHADOW_FRONTIER_AT_CAPTURE frame=347 frontierGuids=2 singleMesh_matched=0 castShadowTrue=0 castShadowFalse=0 batchObjsContainingFrontier=2 batchCastShadowTrue=2 batchCastShadowFalse=0",
+     1
+    ],
+    [
+     "§SHADOW_FRONTIER_AT_CAPTURE frame=348 frontierGuids=2 singleMesh_matched=0 castShadowTrue=0 castShadowFalse=0 batchObjsContainingFrontier=2 batchCastShadowTrue=2 batchCastShadowFalse=0",
+     1
+    ],
+    [
+     "§SHADOW_FRONTIER_AT_CAPTURE frame=349 frontierGuids=2 singleMesh_matched=0 castShadowTrue=0 castShadowFalse=0 batchObjsContainingFrontier=1 batchCastShadowTrue=1 batchCastShadowFalse=0",
+     1
+    ],
+    [
+     "§SHADOW_FRONTIER_AT_CAPTURE frame=350 frontierGuids=2 singleMesh_matched=0 castShadowTrue=0 castShadowFalse=0 batchObjsContainingFrontier=1 batchCastShadowTrue=1 batchCastShadowFalse=0",
+     1
+    ],
+    [
+     "§SHADOW_FRONTIER_AT_CAPTURE frame=351 frontierGuids=2 singleMesh_matched=0 castShadowTrue=0 castShadowFalse=0 batchObjsContainingFrontier=2 batchCastShadowTrue=2 batchCastShadowFalse=0",
+     1
+    ],
+    [
+     "§SHADOW_FRONTIER_AT_CAPTURE frame=352 frontierGuids=2 singleMesh_matched=0 castShadowTrue=0 castShadowFalse=0 batchObjsContainingFrontier=2 batchCastShadowTrue=2 batchCastShadowFalse=0",
+     1
+    ],
+    [
+     "§SHADOW_FRONTIER_AT_CAPTURE frame=353 frontierGuids=2 singleMesh_matched=0 castShadowTrue=0 castShadowFalse=0 batchObjsContainingFrontier=2 batchCastShadowTrue=2 batchCastShadowFalse=0",
+     1
+    ],
+    [
+     "§SHADOW_FRONTIER_AT_CAPTURE frame=354 frontierGuids=2 singleMesh_matched=0 castShadowTrue=0 castShadowFalse=0 batchObjsContainingFrontier=2 batchCastShadowTrue=2 batchCastShadowFalse=0",
+     1
+    ],
+    [
+     "§SHADOW_FRONTIER_AT_CAPTURE frame=355 frontierGuids=2 singleMesh_matched=0 castShadowTrue=0 castShadowFalse=0 batchObjsContainingFrontier=2 batchCastShadowTrue=2 batchCastShadowFalse=0",
+     1
+    ],
+    [
+     "§SHADOW_FRONTIER_AT_CAPTURE frame=361 frontierGuids=2 singleMesh_matched=0 castShadowTrue=0 castShadowFalse=0 batchObjsContainingFrontier=2 batchCastShadowTrue=2 batchCastShadowFalse=0",
+     1
+    ],
+    [
+     "§SHADOW_FRONTIER_AT_CAPTURE frame=362 frontierGuids=2 singleMesh_matched=0 castShadowTrue=0 castShadowFalse=0 batchObjsContainingFrontier=2 batchCastShadowTrue=2 batchCastShadowFalse=0",
+     1
+    ],
+    [
+     "§SHADOW_FRONTIER_AT_CAPTURE frame=363 frontierGuids=2 singleMesh_matched=0 castShadowTrue=0 castShadowFalse=0 batchObjsContainingFrontier=1 batchCastShadowTrue=1 batchCastShadowFalse=0",
+     1
+    ],
+    [
+     "§SHADOW_FRONTIER_AT_CAPTURE frame=364 frontierGuids=2 singleMesh_matched=0 castShadowTrue=0 castShadowFalse=0 batchObjsContainingFrontier=1 batchCastShadowTrue=1 batchCastShadowFalse=0",
+     1
+    ],
+    [
+     "§SHADOW_FRONTIER_AT_CAPTURE frame=389 frontierGuids=2 singleMesh_matched=0 castShadowTrue=0 castShadowFalse=0 batchObjsContainingFrontier=1 batchCastShadowTrue=1 batchCastShadowFalse=0",
+     1
+    ],
+    [
+     "§SHADOW_FRONTIER_AT_CAPTURE frame=390 frontierGuids=2 singleMesh_matched=0 castShadowTrue=0 castShadowFalse=0 batchObjsContainingFrontier=2 batchCastShadowTrue=2 batchCastShadowFalse=0",
+     1
+    ],
+    [
+     "§SHADOW_FRONTIER_AT_CAPTURE frame=394 frontierGuids=2 singleMesh_matched=0 castShadowTrue=0 castShadowFalse=0 batchObjsContainingFrontier=2 batchCastShadowTrue=2 batchCastShadowFalse=0",
+     1
+    ],
+    [
+     "§SHADOW_FRONTIER_AT_CAPTURE frame=410 frontierGuids=2 singleMesh_matched=0 castShadowTrue=0 castShadowFalse=0 batchObjsContainingFrontier=1 batchCastShadowTrue=1 batchCastShadowFalse=0",
+     1
+    ],
+    [
+     "§SHADOW_FRONTIER_AT_CAPTURE frame=411 frontierGuids=2 singleMesh_matched=0 castShadowTrue=0 castShadowFalse=0 batchObjsContainingFrontier=2 batchCastShadowTrue=2 batchCastShadowFalse=0",
+     1
+    ],
+    [
+     "§SHADOW_FRONTIER_AT_CAPTURE frame=412 frontierGuids=2 singleMesh_matched=0 castShadowTrue=0 castShadowFalse=0 batchObjsContainingFrontier=2 batchCastShadowTrue=2 batchCastShadowFalse=0",
+     1
+    ],
+    [
+     "§SHADOW_FRONTIER_AT_CAPTURE frame=413 frontierGuids=2 singleMesh_matched=0 castShadowTrue=0 castShadowFalse=0 batchObjsContainingFrontier=1 batchCastShadowTrue=1 batchCastShadowFalse=0",
+     1
+    ],
+    [
+     "§SHADOW_FRONTIER_AT_CAPTURE frame=414 frontierGuids=2 singleMesh_matched=0 castShadowTrue=0 castShadowFalse=0 batchObjsContainingFrontier=1 batchCastShadowTrue=1 batchCastShadowFalse=0",
+     1
+    ],
+    [
+     "§SHADOW_FRONTIER_AT_CAPTURE frame=415 frontierGuids=2 singleMesh_matched=0 castShadowTrue=0 castShadowFalse=0 batchObjsContainingFrontier=1 batchCastShadowTrue=1 batchCastShadowFalse=0",
+     1
+    ],
+    [
+     "§SHADOW_FRONTIER_AT_CAPTURE frame=416 frontierGuids=2 singleMesh_matched=0 castShadowTrue=0 castShadowFalse=0 batchObjsContainingFrontier=1 batchCastShadowTrue=1 batchCastShadowFalse=0",
+     1
+    ],
+    [
+     "§SHADOW_FRONTIER_AT_CAPTURE frame=446 frontierGuids=2 singleMesh_matched=0 castShadowTrue=0 castShadowFalse=0 batchObjsContainingFrontier=2 batchCastShadowTrue=2 batchCastShadowFalse=0",
+     1
+    ],
+    [
+     "§SHADOW_FRONTIER_AT_CAPTURE frame=455 frontierGuids=2 singleMesh_matched=0 castShadowTrue=0 castShadowFalse=0 batchObjsContainingFrontier=1 batchCastShadowTrue=1 batchCastShadowFalse=0",
+     1
+    ],
+    [
+     "§SHADOW_FRONTIER_AT_CAPTURE frame=473 frontierGuids=2 singleMesh_matched=0 castShadowTrue=0 castShadowFalse=0 batchObjsContainingFrontier=2 batchCastShadowTrue=2 batchCastShadowFalse=0",
+     1
+    ],
+    [
+     "§SHADOW_FRONTIER_AT_CAPTURE frame=474 frontierGuids=2 singleMesh_matched=0 castShadowTrue=0 castShadowFalse=0 batchObjsContainingFrontier=1 batchCastShadowTrue=1 batchCastShadowFalse=0",
+     1
+    ],
+    [
+     "§SHADOW_FRONTIER_AT_CAPTURE frame=475 frontierGuids=3 singleMesh_matched=0 castShadowTrue=0 castShadowFalse=0 batchObjsContainingFrontier=3 batchCastShadowTrue=3 batchCastShadowFalse=0",
+     1
+    ],
+    [
+     "§SHADOW_FRONTIER_AT_CAPTURE frame=476 frontierGuids=3 singleMesh_matched=0 castShadowTrue=0 castShadowFalse=0 batchObjsContainingFrontier=3 batchCastShadowTrue=3 batchCastShadowFalse=0",
+     1
+    ],
+    [
+     "§SHADOW_FRONTIER_AT_CAPTURE frame=477 frontierGuids=2 singleMesh_matched=0 castShadowTrue=0 castShadowFalse=0 batchObjsContainingFrontier=2 batchCastShadowTrue=2 batchCastShadowFalse=0",
+     1
+    ],
+    [
+     "§SHADOW_FRONTIER_AT_CAPTURE frame=478 frontierGuids=2 singleMesh_matched=0 castShadowTrue=0 castShadowFalse=0 batchObjsContainingFrontier=1 batchCastShadowTrue=1 batchCastShadowFalse=0",
+     1
+    ],
+    [
+     "§SHADOW_FRONTIER_AT_CAPTURE frame=479 frontierGuids=2 singleMesh_matched=0 castShadowTrue=0 castShadowFalse=0 batchObjsContainingFrontier=2 batchCastShadowTrue=2 batchCastShadowFalse=0",
+     1
+    ],
+    [
+     "§SHADOW_FRONTIER_AT_CAPTURE frame=489 frontierGuids=2 singleMesh_matched=0 castShadowTrue=0 castShadowFalse=0 batchObjsContainingFrontier=1 batchCastShadowTrue=1 batchCastShadowFalse=0",
+     1
+    ],
+    [
+     "§SHADOW_FRONTIER_AT_CAPTURE frame=499 frontierGuids=2 singleMesh_matched=0 castShadowTrue=0 castShadowFalse=0 batchObjsContainingFrontier=2 batchCastShadowTrue=2 batchCastShadowFalse=0",
+     1
+    ],
+    [
+     "§SHADOW_FRONTIER_AT_CAPTURE frame=503 frontierGuids=2 singleMesh_matched=0 castShadowTrue=0 castShadowFalse=0 batchObjsContainingFrontier=2 batchCastShadowTrue=2 batchCastShadowFalse=0",
+     1
+    ],
+    [
+     "§SHADOW_FRONTIER_AT_CAPTURE frame=523 frontierGuids=2 singleMesh_matched=0 castShadowTrue=0 castShadowFalse=0 batchObjsContainingFrontier=2 batchCastShadowTrue=2 batchCastShadowFalse=0",
+     1
+    ],
+    [
+     "§SHADOW_FRONTIER_AT_CAPTURE frame=524 frontierGuids=2 singleMesh_matched=0 castShadowTrue=0 castShadowFalse=0 batchObjsContainingFrontier=2 batchCastShadowTrue=2 batchCastShadowFalse=0",
+     1
+    ],
+    [
+     "§SHADOW_FRONTIER_AT_CAPTURE frame=525 frontierGuids=2 singleMesh_matched=0 castShadowTrue=0 castShadowFalse=0 batchObjsContainingFrontier=1 batchCastShadowTrue=1 batchCastShadowFalse=0",
+     1
+    ],
+    [
+     "§SHADOW_FRONTIER_AT_CAPTURE frame=527 frontierGuids=2 singleMesh_matched=0 castShadowTrue=0 castShadowFalse=0 batchObjsContainingFrontier=1 batchCastShadowTrue=1 batchCastShadowFalse=0",
+     1
+    ],
+    [
+     "§SHADOW_FRONTIER_AT_CAPTURE frame=528 frontierGuids=2 singleMesh_matched=0 castShadowTrue=0 castShadowFalse=0 batchObjsContainingFrontier=2 batchCastShadowTrue=2 batchCastShadowFalse=0",
+     1
+    ],
+    [
+     "§SHADOW_FRONTIER_AT_CAPTURE frame=529 frontierGuids=2 singleMesh_matched=0 castShadowTrue=0 castShadowFalse=0 batchObjsContainingFrontier=2 batchCastShadowTrue=2 batchCastShadowFalse=0",
+     1
+    ],
+    [
+     "§SHADOW_FRONTIER_AT_CAPTURE frame=530 frontierGuids=2 singleMesh_matched=0 castShadowTrue=0 castShadowFalse=0 batchObjsContainingFrontier=2 batchCastShadowTrue=2 batchCastShadowFalse=0",
+     1
+    ],
+    [
+     "§SHADOW_FRONTIER_AT_CAPTURE frame=531 frontierGuids=2 singleMesh_matched=0 castShadowTrue=0 castShadowFalse=0 batchObjsContainingFrontier=2 batchCastShadowTrue=2 batchCastShadowFalse=0",
+     1
+    ],
+    [
+     "§SHADOW_FRONTIER_AT_CAPTURE frame=570 frontierGuids=2 singleMesh_matched=0 castShadowTrue=0 castShadowFalse=0 batchObjsContainingFrontier=1 batchCastShadowTrue=1 batchCastShadowFalse=0",
+     1
+    ],
+    [
+     "§SHADOW_FRONTIER_AT_CAPTURE frame=571 frontierGuids=4 singleMesh_matched=0 castShadowTrue=0 castShadowFalse=0 batchObjsContainingFrontier=3 batchCastShadowTrue=3 batchCastShadowFalse=0",
+     1
+    ],
+    [
+     "§SHADOW_FRONTIER_AT_CAPTURE frame=572 frontierGuids=4 singleMesh_matched=0 castShadowTrue=0 castShadowFalse=0 batchObjsContainingFrontier=3 batchCastShadowTrue=3 batchCastShadowFalse=0",
+     1
+    ],
+    [
+     "§SHADOW_FRONTIER_AT_CAPTURE frame=573 frontierGuids=4 singleMesh_matched=0 castShadowTrue=0 castShadowFalse=0 batchObjsContainingFrontier=2 batchCastShadowTrue=2 batchCastShadowFalse=0",
+     1
+    ],
+    [
+     "§SHADOW_FRONTIER_AT_CAPTURE frame=574 frontierGuids=4 singleMesh_matched=0 castShadowTrue=0 castShadowFalse=0 batchObjsContainingFrontier=4 batchCastShadowTrue=4 batchCastShadowFalse=0",
+     1
+    ],
+    [
+     "§SHADOW_FRONTIER_AT_CAPTURE frame=575 frontierGuids=2 singleMesh_matched=0 castShadowTrue=0 castShadowFalse=0 batchObjsContainingFrontier=2 batchCastShadowTrue=2 batchCastShadowFalse=0",
+     1
+    ],
+    [
+     "§SHADOW_FRONTIER_AT_CAPTURE frame=576 frontierGuids=4 singleMesh_matched=0 castShadowTrue=0 castShadowFalse=0 batchObjsContainingFrontier=3 batchCastShadowTrue=3 batchCastShadowFalse=0",
+     1
+    ],
+    [
+     "§SHADOW_FRONTIER_AT_CAPTURE frame=577 frontierGuids=4 singleMesh_matched=0 castShadowTrue=0 castShadowFalse=0 batchObjsContainingFrontier=4 batchCastShadowTrue=4 batchCastShadowFalse=0",
+     1
+    ],
+    [
+     "§SHADOW_FRONTIER_AT_CAPTURE frame=578 frontierGuids=4 singleMesh_matched=0 castShadowTrue=0 castShadowFalse=0 batchObjsContainingFrontier=2 batchCastShadowTrue=2 batchCastShadowFalse=0",
+     1
+    ],
+    [
+     "§SHADOW_FRONTIER_AT_CAPTURE frame=579 frontierGuids=3 singleMesh_matched=0 castShadowTrue=0 castShadowFalse=0 batchObjsContainingFrontier=2 batchCastShadowTrue=2 batchCastShadowFalse=0",
+     1
+    ],
+    [
+     "§SHADOW_FRONTIER_AT_CAPTURE frame=580 frontierGuids=4 singleMesh_matched=0 castShadowTrue=0 castShadowFalse=0 batchObjsContainingFrontier=4 batchCastShadowTrue=4 batchCastShadowFalse=0",
+     1
+    ],
+    [
+     "§SHADOW_FRONTIER_AT_CAPTURE frame=581 frontierGuids=4 singleMesh_matched=0 castShadowTrue=0 castShadowFalse=0 batchObjsContainingFrontier=4 batchCastShadowTrue=4 batchCastShadowFalse=0",
+     1
+    ],
+    [
+     "§SHADOW_FRONTIER_AT_CAPTURE frame=582 frontierGuids=4 singleMesh_matched=0 castShadowTrue=0 castShadowFalse=0 batchObjsContainingFrontier=3 batchCastShadowTrue=3 batchCastShadowFalse=0",
+     1
+    ],
+    [
+     "§SHADOW_FRONTIER_AT_CAPTURE frame=583 frontierGuids=4 singleMesh_matched=0 castShadowTrue=0 castShadowFalse=0 batchObjsContainingFrontier=3 batchCastShadowTrue=3 batchCastShadowFalse=0",
+     1
+    ],
+    [
+     "§SHADOW_FRONTIER_AT_CAPTURE frame=584 frontierGuids=4 singleMesh_matched=0 castShadowTrue=0 castShadowFalse=0 batchObjsContainingFrontier=3 batchCastShadowTrue=3 batchCastShadowFalse=0",
+     1
+    ],
+    [
+     "§SHADOW_FRONTIER_AT_CAPTURE frame=585 frontierGuids=4 singleMesh_matched=0 castShadowTrue=0 castShadowFalse=0 batchObjsContainingFrontier=4 batchCastShadowTrue=4 batchCastShadowFalse=0",
+     1
+    ],
+    [
+     "§SHADOW_FRONTIER_AT_CAPTURE frame=586 frontierGuids=4 singleMesh_matched=0 castShadowTrue=0 castShadowFalse=0 batchObjsContainingFrontier=3 batchCastShadowTrue=3 batchCastShadowFalse=0",
+     1
+    ],
+    [
+     "§SHADOW_FRONTIER_AT_CAPTURE frame=587 frontierGuids=2 singleMesh_matched=0 castShadowTrue=0 castShadowFalse=0 batchObjsContainingFrontier=2 batchCastShadowTrue=2 batchCastShadowFalse=0",
+     1
+    ],
+    [
+     "§SHADOW_FRONTIER_AT_CAPTURE frame=588 frontierGuids=4 singleMesh_matched=0 castShadowTrue=0 castShadowFalse=0 batchObjsContainingFrontier=4 batchCastShadowTrue=4 batchCastShadowFalse=0",
+     1
+    ],
+    [
+     "§SHADOW_FRONTIER_AT_CAPTURE frame=589 frontierGuids=4 singleMesh_matched=0 castShadowTrue=0 castShadowFalse=0 batchObjsContainingFrontier=3 batchCastShadowTrue=3 batchCastShadowFalse=0",
+     1
+    ],
+    [
+     "§SHADOW_FRONTIER_AT_CAPTURE frame=590 frontierGuids=4 singleMesh_matched=0 castShadowTrue=0 castShadowFalse=0 batchObjsContainingFrontier=3 batchCastShadowTrue=3 batchCastShadowFalse=0",
+     1
+    ],
+    [
+     "§SHADOW_FRONTIER_AT_CAPTURE frame=591 frontierGuids=4 singleMesh_matched=0 castShadowTrue=0 castShadowFalse=0 batchObjsContainingFrontier=3 batchCastShadowTrue=3 batchCastShadowFalse=0",
+     1
+    ],
+    [
+     "§SHADOW_FRONTIER_AT_CAPTURE frame=592 frontierGuids=2 singleMesh_matched=0 castShadowTrue=0 castShadowFalse=0 batchObjsContainingFrontier=1 batchCastShadowTrue=1 batchCastShadowFalse=0",
+     1
+    ],
+    [
+     "§SHADOW_FRONTIER_AT_CAPTURE frame=593 frontierGuids=2 singleMesh_matched=0 castShadowTrue=0 castShadowFalse=0 batchObjsContainingFrontier=2 batchCastShadowTrue=2 batchCastShadowFalse=0",
+     1
+    ],
+    [
+     "§SHADOW_FRONTIER_AT_CAPTURE frame=594 frontierGuids=2 singleMesh_matched=0 castShadowTrue=0 castShadowFalse=0 batchObjsContainingFrontier=1 batchCastShadowTrue=1 batchCastShadowFalse=0",
+     1
+    ],
+    [
+     "§SHADOW_FRONTIER_AT_CAPTURE frame=595 frontierGuids=2 singleMesh_matched=0 castShadowTrue=0 castShadowFalse=0 batchObjsContainingFrontier=2 batchCastShadowTrue=2 batchCastShadowFalse=0",
+     1
+    ],
+    [
+     "§SHADOW_FRONTIER_AT_CAPTURE frame=596 frontierGuids=2 singleMesh_matched=0 castShadowTrue=0 castShadowFalse=0 batchObjsContainingFrontier=1 batchCastShadowTrue=1 batchCastShadowFalse=0",
+     1
+    ],
+    [
+     "§SHADOW_FRONTIER_AT_CAPTURE frame=597 frontierGuids=2 singleMesh_matched=0 castShadowTrue=0 castShadowFalse=0 batchObjsContainingFrontier=2 batchCastShadowTrue=2 batchCastShadowFalse=0",
+     1
+    ],
+    [
+     "§SHADOW_FRONTIER_AT_CAPTURE frame=598 frontierGuids=2 singleMesh_matched=0 castShadowTrue=0 castShadowFalse=0 batchObjsContainingFrontier=2 batchCastShadowTrue=2 batchCastShadowFalse=0",
+     1
+    ],
+    [
+     "§SHADOW_FRONTIER_AT_CAPTURE frame=599 frontierGuids=2 singleMesh_matched=0 castShadowTrue=0 castShadowFalse=0 batchObjsContainingFrontier=1 batchCastShadowTrue=1 batchCastShadowFalse=0",
+     1
+    ],
+    [
+     "§SHADOW_FRONTIER_AT_CAPTURE frame=600 frontierGuids=2 singleMesh_matched=0 castShadowTrue=0 castShadowFalse=0 batchObjsContainingFrontier=1 batchCastShadowTrue=1 batchCastShadowFalse=0",
+     1
+    ],
+    [
+     "§SHADOW_FRONTIER_AT_CAPTURE frame=601 frontierGuids=2 singleMesh_matched=0 castShadowTrue=0 castShadowFalse=0 batchObjsContainingFrontier=1 batchCastShadowTrue=1 batchCastShadowFalse=0",
+     1
+    ],
+    [
+     "§SHADOW_FRONTIER_AT_CAPTURE frame=602 frontierGuids=2 singleMesh_matched=0 castShadowTrue=0 castShadowFalse=0 batchObjsContainingFrontier=2 batchCastShadowTrue=2 batchCastShadowFalse=0",
+     1
+    ],
+    [
+     "§SHADOW_FRONTIER_AT_CAPTURE frame=603 frontierGuids=2 singleMesh_matched=0 castShadowTrue=0 castShadowFalse=0 batchObjsContainingFrontier=2 batchCastShadowTrue=2 batchCastShadowFalse=0",
+     1
+    ],
+    [
+     "§SHADOW_FRONTIER_AT_CAPTURE frame=604 frontierGuids=2 singleMesh_matched=0 castShadowTrue=0 castShadowFalse=0 batchObjsContainingFrontier=2 batchCastShadowTrue=2 batchCastShadowFalse=0",
+     1
+    ],
+    [
+     "§SHADOW_FRONTIER_AT_CAPTURE frame=605 frontierGuids=2 singleMesh_matched=0 castShadowTrue=0 castShadowFalse=0 batchObjsContainingFrontier=2 batchCastShadowTrue=2 batchCastShadowFalse=0",
+     1
+    ],
+    [
+     "§SHADOW_FRONTIER_AT_CAPTURE frame=606 frontierGuids=2 singleMesh_matched=0 castShadowTrue=0 castShadowFalse=0 batchObjsContainingFrontier=1 batchCastShadowTrue=1 batchCastShadowFalse=0",
+     1
+    ],
+    [
+     "§SHADOW_FRONTIER_AT_CAPTURE frame=607 frontierGuids=2 singleMesh_matched=0 castShadowTrue=0 castShadowFalse=0 batchObjsContainingFrontier=1 batchCastShadowTrue=1 batchCastShadowFalse=0",
+     1
+    ],
+    [
+     "§SHADOW_FRONTIER_AT_CAPTURE frame=608 frontierGuids=2 singleMesh_matched=0 castShadowTrue=0 castShadowFalse=0 batchObjsContainingFrontier=2 batchCastShadowTrue=2 batchCastShadowFalse=0",
+     1
+    ],
+    [
+     "§SHADOW_FRONTIER_AT_CAPTURE frame=611 frontierGuids=2 singleMesh_matched=0 castShadowTrue=0 castShadowFalse=0 batchObjsContainingFrontier=2 batchCastShadowTrue=2 batchCastShadowFalse=0",
+     1
+    ],
+    [
+     "§SHADOW_FRONTIER_AT_CAPTURE frame=620 frontierGuids=1 singleMesh_matched=0 castShadowTrue=0 castShadowFalse=0 batchObjsContainingFrontier=1 batchCastShadowTrue=1 batchCastShadowFalse=0",
+     1
+    ],
+    [
+     "§SHADOW_FRONTIER_AT_CAPTURE frame=621 frontierGuids=2 singleMesh_matched=0 castShadowTrue=0 castShadowFalse=0 batchObjsContainingFrontier=1 batchCastShadowTrue=1 batchCastShadowFalse=0",
+     1
+    ],
+    [
+     "§SHADOW_FRONTIER_AT_CAPTURE frame=622 frontierGuids=2 singleMesh_matched=0 castShadowTrue=0 castShadowFalse=0 batchObjsContainingFrontier=2 batchCastShadowTrue=2 batchCastShadowFalse=0",
+     1
+    ],
+    [
+     "§SHADOW_FRONTIER_AT_CAPTURE frame=623 frontierGuids=2 singleMesh_matched=0 castShadowTrue=0 castShadowFalse=0 batchObjsContainingFrontier=1 batchCastShadowTrue=1 batchCastShadowFalse=0",
+     1
+    ],
+    [
+     "§SHADOW_FRONTIER_AT_CAPTURE frame=624 frontierGuids=2 singleMesh_matched=0 castShadowTrue=0 castShadowFalse=0 batchObjsContainingFrontier=1 batchCastShadowTrue=1 batchCastShadowFalse=0",
+     1
+    ],
+    [
+     "§SHADOW_FRONTIER_AT_CAPTURE frame=654 frontierGuids=2 singleMesh_matched=0 castShadowTrue=0 castShadowFalse=0 batchObjsContainingFrontier=2 batchCastShadowTrue=2 batchCastShadowFalse=0",
+     1
+    ],
+    [
+     "§SHADOW_FRONTIER_AT_CAPTURE frame=662 frontierGuids=2 singleMesh_matched=0 castShadowTrue=0 castShadowFalse=0 batchObjsContainingFrontier=2 batchCastShadowTrue=2 batchCastShadowFalse=0",
+     1
+    ],
+    [
+     "§SHADOW_FRONTIER_AT_CAPTURE frame=782 frontierGuids=1 singleMesh_matched=0 castShadowTrue=0 castShadowFalse=0 batchObjsContainingFrontier=1 batchCastShadowTrue=1 batchCastShadowFalse=0",
+     1
+    ],
+    [
+     "§SHADOW_FRONTIER_AT_CAPTURE frame=783 frontierGuids=2 singleMesh_matched=0 castShadowTrue=0 castShadowFalse=0 batchObjsContainingFrontier=1 batchCastShadowTrue=1 batchCastShadowFalse=0",
+     1
+    ],
+    [
+     "§SHADOW_FRONTIER_AT_CAPTURE frame=784 frontierGuids=2 singleMesh_matched=0 castShadowTrue=0 castShadowFalse=0 batchObjsContainingFrontier=1 batchCastShadowTrue=1 batchCastShadowFalse=0",
+     1
+    ],
+    [
+     "§SHADOW_FRONTIER_AT_CAPTURE frame=785 frontierGuids=2 singleMesh_matched=0 castShadowTrue=0 castShadowFalse=0 batchObjsContainingFrontier=1 batchCastShadowTrue=1 batchCastShadowFalse=0",
+     1
+    ],
+    [
+     "§SHADOW_FRONTIER_AT_CAPTURE frame=786 frontierGuids=2 singleMesh_matched=0 castShadowTrue=0 castShadowFalse=0 batchObjsContainingFrontier=1 batchCastShadowTrue=1 batchCastShadowFalse=0",
+     1
+    ],
+    [
+     "§SHADOW_FRONTIER_AT_CAPTURE frame=802 frontierGuids=4 singleMesh_matched=0 castShadowTrue=0 castShadowFalse=0 batchObjsContainingFrontier=4 batchCastShadowTrue=4 batchCastShadowFalse=0",
+     1
+    ],
+    [
+     "§SHADOW_FRONTIER_AT_CAPTURE frame=803 frontierGuids=4 singleMesh_matched=0 castShadowTrue=0 castShadowFalse=0 batchObjsContainingFrontier=4 batchCastShadowTrue=4 batchCastShadowFalse=0",
+     1
+    ],
+    [
+     "§SHADOW_FRONTIER_AT_CAPTURE frame=804 frontierGuids=4 singleMesh_matched=0 castShadowTrue=0 castShadowFalse=0 batchObjsContainingFrontier=3 batchCastShadowTrue=3 batchCastShadowFalse=0",
+     1
+    ],
+    [
+     "§SHADOW_FRONTIER_AT_CAPTURE frame=805 frontierGuids=4 singleMesh_matched=0 castShadowTrue=0 castShadowFalse=0 batchObjsContainingFrontier=3 batchCastShadowTrue=3 batchCastShadowFalse=0",
+     1
+    ],
+    [
+     "§SHADOW_FRONTIER_AT_CAPTURE frame=806 frontierGuids=4 singleMesh_matched=0 castShadowTrue=0 castShadowFalse=0 batchObjsContainingFrontier=4 batchCastShadowTrue=4 batchCastShadowFalse=0",
+     1
+    ],
+    [
+     "§SHADOW_FRONTIER_AT_CAPTURE frame=807 frontierGuids=4 singleMesh_matched=0 castShadowTrue=0 castShadowFalse=0 batchObjsContainingFrontier=3 batchCastShadowTrue=3 batchCastShadowFalse=0",
+     1
+    ],
+    [
+     "§SHADOW_FRONTIER_AT_CAPTURE frame=808 frontierGuids=2 singleMesh_matched=0 castShadowTrue=0 castShadowFalse=0 batchObjsContainingFrontier=2 batchCastShadowTrue=2 batchCastShadowFalse=0",
+     1
+    ],
+    [
+     "§SHADOW_FRONTIER_AT_CAPTURE frame=809 frontierGuids=2 singleMesh_matched=0 castShadowTrue=0 castShadowFalse=0 batchObjsContainingFrontier=1 batchCastShadowTrue=1 batchCastShadowFalse=0",
+     1
+    ],
+    [
+     "§SHADOW_FRONTIER_AT_CAPTURE frame=810 frontierGuids=2 singleMesh_matched=0 castShadowTrue=0 castShadowFalse=0 batchObjsContainingFrontier=2 batchCastShadowTrue=2 batchCastShadowFalse=0",
+     1
+    ],
+    [
+     "§SHADOW_FRONTIER_AT_CAPTURE frame=811 frontierGuids=2 singleMesh_matched=0 castShadowTrue=0 castShadowFalse=0 batchObjsContainingFrontier=1 batchCastShadowTrue=1 batchCastShadowFalse=0",
+     1
+    ],
+    [
+     "§SHADOW_FRONTIER_AT_CAPTURE frame=812 frontierGuids=2 singleMesh_matched=0 castShadowTrue=0 castShadowFalse=0 batchObjsContainingFrontier=1 batchCastShadowTrue=1 batchCastShadowFalse=0",
+     1
+    ],
+    [
+     "§SHADOW_FRONTIER_AT_CAPTURE frame=813 frontierGuids=2 singleMesh_matched=0 castShadowTrue=0 castShadowFalse=0 batchObjsContainingFrontier=2 batchCastShadowTrue=2 batchCastShadowFalse=0",
+     1
+    ],
+    [
+     "§SHADOW_FRONTIER_AT_CAPTURE frame=814 frontierGuids=2 singleMesh_matched=0 castShadowTrue=0 castShadowFalse=0 batchObjsContainingFrontier=2 batchCastShadowTrue=2 batchCastShadowFalse=0",
+     1
+    ],
+    [
+     "§SHADOW_FRONTIER_AT_CAPTURE frame=815 frontierGuids=2 singleMesh_matched=0 castShadowTrue=0 castShadowFalse=0 batchObjsContainingFrontier=2 batchCastShadowTrue=2 batchCastShadowFalse=0",
+     1
+    ],
+    [
+     "§SHADOW_FRONTIER_AT_CAPTURE frame=818 frontierGuids=1 singleMesh_matched=0 castShadowTrue=0 castShadowFalse=0 batchObjsContainingFrontier=1 batchCastShadowTrue=1 batchCastShadowFalse=0",
+     1
+    ],
+    [
+     "§SHADOW_FRONTIER_AT_CAPTURE frame=819 frontierGuids=2 singleMesh_matched=0 castShadowTrue=0 castShadowFalse=0 batchObjsContainingFrontier=2 batchCastShadowTrue=2 batchCastShadowFalse=0",
+     1
+    ],
+    [
+     "§SHADOW_FRONTIER_AT_CAPTURE frame=820 frontierGuids=2 singleMesh_matched=0 castShadowTrue=0 castShadowFalse=0 batchObjsContainingFrontier=2 batchCastShadowTrue=2 batchCastShadowFalse=0",
+     1
+    ],
+    [
+     "§SHADOW_FRONTIER_AT_CAPTURE frame=821 frontierGuids=2 singleMesh_matched=0 castShadowTrue=0 castShadowFalse=0 batchObjsContainingFrontier=1 batchCastShadowTrue=1 batchCastShadowFalse=0",
+     1
+    ],
+    [
+     "§SHADOW_FRONTIER_AT_CAPTURE frame=822 frontierGuids=2 singleMesh_matched=0 castShadowTrue=0 castShadowFalse=0 batchObjsContainingFrontier=1 batchCastShadowTrue=1 batchCastShadowFalse=0",
+     1
+    ],
+    [
+     "§SHADOW_FRONTIER_AT_CAPTURE frame=823 frontierGuids=2 singleMesh_matched=0 castShadowTrue=0 castShadowFalse=0 batchObjsContainingFrontier=1 batchCastShadowTrue=1 batchCastShadowFalse=0",
+     1
+    ],
+    [
+     "§SHADOW_FRONTIER_AT_CAPTURE frame=824 frontierGuids=2 singleMesh_matched=0 castShadowTrue=0 castShadowFalse=0 batchObjsContainingFrontier=2 batchCastShadowTrue=2 batchCastShadowFalse=0",
+     1
+    ],
+    [
+     "§SHADOW_FRONTIER_AT_CAPTURE frame=825 frontierGuids=2 singleMesh_matched=0 castShadowTrue=0 castShadowFalse=0 batchObjsContainingFrontier=2 batchCastShadowTrue=2 batchCastShadowFalse=0",
+     1
+    ],
+    [
+     "§SHADOW_FRONTIER_AT_CAPTURE frame=853 frontierGuids=2 singleMesh_matched=0 castShadowTrue=0 castShadowFalse=0 batchObjsContainingFrontier=2 batchCastShadowTrue=2 batchCastShadowFalse=0",
+     1
+    ],
+    [
+     "§SHADOW_FRONTIER_AT_CAPTURE frame=855 frontierGuids=2 singleMesh_matched=0 castShadowTrue=0 castShadowFalse=0 batchObjsContainingFrontier=2 batchCastShadowTrue=2 batchCastShadowFalse=0",
+     1
+    ],
+    [
+     "§SHADOW_FRONTIER_AT_CAPTURE frame=856 frontierGuids=2 singleMesh_matched=0 castShadowTrue=0 castShadowFalse=0 batchObjsContainingFrontier=2 batchCastShadowTrue=2 batchCastShadowFalse=0",
+     1
+    ],
+    [
+     "§SHADOW_FRONTIER_AT_CAPTURE frame=857 frontierGuids=2 singleMesh_matched=0 castShadowTrue=0 castShadowFalse=0 batchObjsContainingFrontier=2 batchCastShadowTrue=2 batchCastShadowFalse=0",
+     1
+    ],
+    [
+     "§SHADOW_FRONTIER_AT_CAPTURE frame=865 frontierGuids=1 singleMesh_matched=0 castShadowTrue=0 castShadowFalse=0 batchObjsContainingFrontier=1 batchCastShadowTrue=1 batchCastShadowFalse=0",
+     1
+    ],
+    [
+     "§SHADOW_FRONTIER_AT_CAPTURE frame=866 frontierGuids=1 singleMesh_matched=0 castShadowTrue=0 castShadowFalse=0 batchObjsContainingFrontier=1 batchCastShadowTrue=1 batchCastShadowFalse=0",
+     1
+    ],
+    [
+     "§SHADOW_FRONTIER_AT_CAPTURE frame=867 frontierGuids=1 singleMesh_matched=0 castShadowTrue=0 castShadowFalse=0 batchObjsContainingFrontier=1 batchCastShadowTrue=1 batchCastShadowFalse=0",
+     1
+    ]
+   ]
+  }
+ },
+ "facts": {
+  "shadow_frontier_idx_line": "§SHADOW_FRONTIER_IDX built gen=2814 meshGuids=0 groupGuids=63182 ms=8.6",
+  "shadow_frontier_idx_meshGuids": 0,
+  "shadow_frontier_idx_groupGuids": 63182,
+  "shadow_frontier_idx_firings": 1,
+  "batched_fail_count": 0,
+  "renderer_caps_line": "§RENDERER_CAPS multi_draw=on (fast batched path) gpu=ANGLE (NVIDIA Corporation, NVIDIA GeForce RTX 4060 Laptop GPU/PCIe/SSE2, OpenGL ES 3.2)",
+  "at_capture_firings": 286,
+  "at_capture_singleMesh_matched_zero": 286,
+  "at_capture_batchObjs_nonzero": 286,
+  "tm_shadow_inherit_line": "§TM_SHADOW_INHERIT shadowOn=false groundVisible=false",
+  "perf_traverse_firings": 2027,
+  "group_spark_roll_zero": 2027,
+  "idle_gate_max_cycles": 4050,
+  "frames": 35
+ }
+}

--- a/viewer/cinema_maxq.js
+++ b/viewer/cinema_maxq.js
@@ -1620,15 +1620,38 @@
               ' groupGuids=' + _fcIdx.group.size + ' ms=' + (performance.now() - _fcT0).toFixed(1));
           }
           var _fSeenGroups = new Set();
+          // §VAC / §R14.1 (CPE_4D_PERF_MEM_STUDY.md): _fUnmatched counts the third outcome this
+          // forEach always had and never reported — a frontier guid present in NEITHER index.
+          // Without it, "frontierGuids=10 batchObjsContainingFrontier=4" cannot distinguish six
+          // guids DEDUPED into already-seen batch objects from six guids the indexes never had
+          // (the streamed set is 63,182 guids; TM places 63,417 — a 235-guid gap that nothing on
+          // disk can currently attribute). This is a counter on an existing else-branch, not a
+          // new measurement.
+          var _fUnmatched = 0;
           _fGuids.forEach(function(g) {
             var _ml = _fcIdx.mesh.get(g);
             if (_ml) { for (var _mi = 0; _mi < _ml.length; _mi++) { _fMatched++; if (_ml[_mi].castShadow) _fTrue++; else _fFalse++; } return; }
             var _go = _fcIdx.group.get(g);
-            if (_go && !_fSeenGroups.has(_go)) { _fSeenGroups.add(_go); _fBatchObjs++; if (_go.castShadow) _fBatchTrue++; else _fBatchFalse++; }
+            if (_go) { if (!_fSeenGroups.has(_go)) { _fSeenGroups.add(_go); _fBatchObjs++; if (_go.castShadow) _fBatchTrue++; else _fBatchFalse++; } return; }
+            _fUnmatched++;
           });
+          // §VAC V1 — the singleMesh_* triplet is VACUOUS whenever the single-mesh index is empty,
+          // and on a device that took the fast batched path it always is. MEASURED, s5_hospital.log
+          // (2,027 frames): §SHADOW_FRONTIER_IDX meshGuids=0 groupGuids=63182, §BATCHED_FAIL count 0,
+          // §RENDERER_CAPS multi_draw=on — so all three streaming.js fallbacks that give a lone
+          // THREE.Mesh a userData.guid (BatchedMesh ctor throw / BatchedMesh unavailable / oversized
+          // spill) were never taken. The matcher is NOT broken: it is a Map.get against a Map of
+          // size 0. Printing three bare zeros made 286 firings look like a judged result; they were
+          // never a result. The batch half of the line IS judging (batchObjsContainingFrontier was
+          // non-zero on every one of those 286 firings) and is printed unchanged.
+          var _fSingle = (_fcIdx.mesh.size === 0)
+            ? 'singleMesh=VACUOUS (no individually-meshed elements in this scene — §SHADOW_FRONTIER_IDX meshGuids=0; all geometry is batched/instanced)'
+            : 'singleMesh_matched=' + _fMatched + ' castShadowTrue=' + _fTrue + ' castShadowFalse=' + _fFalse;
           console.log('§SHADOW_FRONTIER_AT_CAPTURE frame=' + i + ' frontierGuids=' + _fGuids.size +
-            ' singleMesh_matched=' + _fMatched + ' castShadowTrue=' + _fTrue + ' castShadowFalse=' + _fFalse +
-            ' batchObjsContainingFrontier=' + _fBatchObjs + ' batchCastShadowTrue=' + _fBatchTrue + ' batchCastShadowFalse=' + _fBatchFalse);
+            ' ' + _fSingle +
+            ' batchObjsContainingFrontier=' + _fBatchObjs + ' batchCastShadowTrue=' + _fBatchTrue + ' batchCastShadowFalse=' + _fBatchFalse +
+            ' unmatched=' + _fUnmatched +
+            ((_fcIdx.mesh.size === 0 && _fBatchObjs === 0) ? ' VERDICT=INCONCLUSIVE (nothing judged this frame)' : ''));
         }
         _restoreRandom();
         // A timeout can now only mean a genuinely slow frame, since hidden time no longer counts

--- a/viewer/effects.js
+++ b/viewer/effects.js
@@ -3178,12 +3178,28 @@ async function setupEffects(A, renderer, scene, camera) {
   var GROUND_WETNESS_STAGE_DEFAULT = 0.5;
   var _groundWetnessUserSet = false;
   A._groundWetnessOverride = 0;
+  // §VAC V2 / §R14.1 (bim-compiler prompts/CPE_4D_PERF_MEM_STUDY.md): this setter logged
+  // unconditionally, including when it re-set the value it already held. Alt+S staging is torn
+  // down and rebuilt on EVERY bake frame, so MEASURED on s5_hospital.log it emitted 2,028
+  // firings of ONE distinct line — `value=0.5 userSet=false` — a state-change log reporting no
+  // state change. Routed through the shared _vacLog below so it gets the SAME run-length reporting
+  // (and the same bounded heartbeat) as the other repeated per-frame tags: a run of 2,028 identical
+  // NO-OP re-sets that never ends must still say how long it is, or the compression has dropped
+  // the signal instead of compressing it.
+  // Declared here, next to its only user, rather than beside the other §VAC state further down:
+  // `var` hoists but its ASSIGNMENT does not, so keeping it above the setter removes any
+  // ordering hazard if this setter is ever called earlier than it is today (it runs from
+  // _applyPhotoStaging, i.e. at Alt+S, long after setupEffects returns). `_vacLog` itself is a
+  // hoisted function declaration in this same scope, so it is callable from here regardless.
+  var _vacGroundWetness = { last: null, n: 0 };
   A._setGroundWetness = function(v, _isUserAction) {
     _wireGroundPuddleShader();  // safe no-op if already wired (Alt+S may have wired it first)
     A._groundWetnessOverride = Math.max(0, Math.min(1, v));
     if (_isUserAction !== false) _groundWetnessUserSet = true;  // default true — only the internal
     // staging auto-default call below passes false, so it never overrides a user's own choice
-    console.log('§GROUND_WETNESS_OVERRIDE value=' + A._groundWetnessOverride + ' userSet=' + _groundWetnessUserSet);
+    _vacLog(_vacGroundWetness,
+      '§GROUND_WETNESS_OVERRIDE value=' + A._groundWetnessOverride + ' userSet=' + _groundWetnessUserSet,
+      'NO-OP re-sets of the value already held — Alt+S staging rebuilds every frame');
     if (A.markDirty) A.markDirty();
   };
   function _wireGroundPuddleShader() {
@@ -4153,9 +4169,41 @@ async function setupEffects(A, renderer, scene, camera) {
       })();
     });
   }
+  // §VAC V2 / §R14.1 — run-length state for the per-frame still-fold tags. A MaxQ bake tears the
+  // staging down and rebuilds it on every frame, so each of these lines fired 1,700-2,000 times
+  // per bake with an identical verdict. The verdicts are all still emitted; a run is emitted once
+  // with its repeat count, which is the same information in ~three orders of magnitude less log.
+  var _vacGlowLens = { last: null, n: 0 };
+  var _vacNightLights = { last: null, n: 0 };
+  var _vacGlowSpriteStage = { last: null, n: 0 };
+  var _vacGlowSpriteOff = { last: null, n: 0 };
+  function _vacLog(st, line, note) {
+    if (line !== st.last) {
+      if (st.n > 0) console.log(st.last.split(' ')[0] + ' repeats=' + st.n + ' (identical, suppressed' + (st.note ? ' — ' + st.note : '') + ')');
+      console.log(line);
+      st.last = line; st.n = 0; st.note = note;
+    } else {
+      st.n++;
+      // Bounded heartbeat — a run that never ends (the bake exits mid-run) must still prove the
+      // code is running and say how long the run is. §VAC V2: compress, never drop.
+      if (st.n % 250 === 0) console.log(line.split(' ')[0] + ' still identical — repeats=' + st.n + (note ? ' (' + note + ')' : ''));
+    }
+  }
+  // §VAC V2 — flush any open run at a REAL still exit, so the last run is never lost to the end of
+  // the log. Called from _teardownStillRefine's !keepStaging branch (a bake-frame cancel passes
+  // keepStaging=true and must NOT flush — that is the middle of a run, not the end of one).
+  function _vacFlushStillTags() {
+    var _all = [_vacGlowLens, _vacNightLights, _vacGlowSpriteStage, _vacGlowSpriteOff, _vacGroundWetness];
+    for (var _vi = 0; _vi < _all.length; _vi++) {
+      var st = _all[_vi];
+      if (st.n > 0 && st.last) console.log(st.last.split(' ')[0] + ' repeats=' + st.n + ' (identical, suppressed — flushed at still exit)');
+      st.last = null; st.n = 0;
+    }
+  }
   function _teardownStillRefine(reason, keepStaging) {
     A._stillRefineActive = false;
     A._stillRefineBusy = false;   // §CINEMA_ROW_BUSY safety net — any exit path clears "processing"
+    if (!keepStaging) _vacFlushStillTags();   // §VAC V2 — end of a real still, close any open run
     if (_stillRefineRAF) { cancelAnimationFrame(_stillRefineRAF); _stillRefineRAF = null; }
     if (A._taaPass) { A._taaPass.accumulate = false; A._taaPass.accumulateIndex = -1; }
     _stopStillAOPhase(reason);  // §PHOTO_AO: disable the still-only AO pass on ANY exit path
@@ -4172,9 +4220,13 @@ async function setupEffects(A, renderer, scene, camera) {
     // quad's geometry (position/size/yaw) is built ONLY from fixture world data + the TM-visibility
     // gate, never from A.camera — an unchanged visible set means an unchanged quad, byte-identical
     // to what is already staged. §R10, CPE_4D_PERF_MEM_FINDINGS.md §7.
+    // §VAC V2 / §R14.1: MEASURED s5_hospital.log — 1,740 of this tag's 1,770 firings were the
+    // identical `skip (count unchanged 1273)`. The guard is CORRECT and is not being changed; it
+    // just said so 1,740 times. Run-length reported now.
     if (keepStaging && (_glowLensMeshRect || _glowLensMeshRound) &&
         _glowVisibleFixtureCount(A._tmIsVisible) === _glowLensStagedCount) {
-      console.log('§GLOW_LENS_QUAD skip (count unchanged ' + _glowLensStagedCount + ')');
+      _vacLog(_vacGlowLens, '§GLOW_LENS_QUAD skip (count unchanged ' + _glowLensStagedCount + ')',
+        'the stage-keep guard held; no dispose+rebuild');
     } else {
       _glowLensOff();
     }
@@ -4535,7 +4587,13 @@ async function setupEffects(A, renderer, scene, camera) {
     _glowPoints.renderOrder = 999;       // after opaque geometry, so additive lands on a finished frame
     _glowPoints.name = '__glowSprites';
     A.scene.add(_glowPoints);
-    console.log('§PHOTO_GLOW_SPRITE staged ' + pos.length + '/' + allPos.length + ' sprites (' + (pos.length - exits) +
+    // §VAC V2 / §R14.1: MEASURED s5_hospital.log — 1,730 `staged` lines paired with 1,730
+    // `removed`, but only ELEVEN distinct count-runs across the whole film
+    // (57→9→19→21→24→26→35→36→46→55→57). ⚠ The WORK is not redundant and is NOT being changed:
+    // sprite positions carry a camera-dependent GLOW_EYE_OFFSET nudge (see the k = GLOW_EYE_OFFSET
+    // / d line above), which is exactly why §GLOW_LENS_QUAD earned a stage-keep guard and this did
+    // not. The defect is the log, not the rebuild — so the line is run-length reported, not gated.
+    _vacLog(_vacGlowSpriteStage, '§PHOTO_GLOW_SPRITE staged ' + pos.length + '/' + allPos.length + ' sprites (' + (pos.length - exits) +
       ' luminaires gain ' + GLOW_GAIN + ', ' + exits + ' exit signs gain ' + GLOW_EXIT_GAIN +
       ' x' + GLOW_EXIT_SIZE + ' size — §GLOW_EXIT_SOFT, below the bloom threshold on purpose)' +
       ', 1 draw call, 0 scene materials touched' +
@@ -4550,7 +4608,8 @@ async function setupEffects(A, renderer, scene, camera) {
     A.scene.remove(_glowPoints);
     _glowPoints.geometry.dispose();
     _glowPoints.material.dispose();
-    console.log('§PHOTO_GLOW_SPRITE removed ' + n + ' sprites');
+    _vacLog(_vacGlowSpriteOff, '§PHOTO_GLOW_SPRITE removed ' + n + ' sprites',
+      'the per-frame teardown half of the staged/removed pair — see §VAC V2 at the staged line');
     _glowPoints = null;
   }
   A._glowSpriteCount = function() {
@@ -4811,9 +4870,14 @@ async function setupEffects(A, renderer, scene, camera) {
       A._nightNearFadeFloor = A._nightNearFadeFloorStill;   // §NIGHT_NEAR_FADE — no proximity penalty
       A._nightPLScale = A._nightPLScaleStill || 1;          // §STAGED_PL_CUT — staging-only intensity cut
       A._nightUpdateLights();
-      console.log('§NIGHT_STILL_LIGHTS raised to ' + A._nightLights.length +
+      // §VAC V2 / §R14.1: MEASURED s5_hospital.log — 2,026 firings, ONE distinct line
+      // (`raised to 200 lights, near-fade floor 1 …`). The re-raise itself is required every
+      // frame (the still budget is handed back to nav on every teardown, just below), so the
+      // WORK stays; only the identical line is run-length reported.
+      _vacLog(_vacNightLights, '§NIGHT_STILL_LIGHTS raised to ' + A._nightLights.length +
         ' lights, near-fade floor ' + A._nightNearFadeFloorStill + ' (was 0.3), plScale ' +
-        A._nightPLScale + ' (§STAGED_PL_CUT) for the still');
+        A._nightPLScale + ' (§STAGED_PL_CUT) for the still',
+        'the still budget is re-raised every frame; the values did not change');
     }
     A._composerEnabled = true;   // teardown RECOMPUTES from SSAO/Outline state (§GI_HANDOFF_GHOST_FIX) — no save needed
     A._taaPass.accumulate = true;

--- a/viewer/main.js
+++ b/viewer/main.js
@@ -872,9 +872,16 @@ async function initViewer() {
       _rafId = null;
       if (!_idleLogged) {
         _idleCycles = (_idleCycles || 0) + 1;
+        // §VAC / §R14.1 (bim-compiler prompts/CPE_4D_PERF_MEM_STUDY.md): this tag is the ONE of
+        // the nine audited that was already compliant — its mechanism is unchanged here. What was
+        // wrong is that the line INVITED a misread, and got one: §R13.9 recorded "165 park + 165
+        // wake pairs" from s5_hospital.log as if that were the event count. It is the SAMPLE
+        // count — `cycles=4050` on the last line is the real number of park/wake cycles during
+        // that bake, ~2 per exported frame. Saying the sample rate and the running total on the
+        // line itself is the whole fix; `(throttled: every 25th)` did not make that readable.
         if (_idleCycles <= 3 || _idleCycles % 25 === 0)
-          console.log('§IDLE_GATE park — rAF chain stopped (self-parking, 0 frames) cycles=' + _idleCycles +
-            (_idleCycles > 3 ? ' (throttled: every 25th)' : ''));
+          console.log('§IDLE_GATE park — rAF chain stopped (self-parking, 0 frames) parks=' + _idleCycles +
+            (_idleCycles > 3 ? ' (1-in-25 sample; every park is counted in parks=, only the line is sampled)' : ''));
         _idleLogged = true;
       }
       return;
@@ -934,7 +941,8 @@ async function initViewer() {
         if (APP._cpeViewfinderRender) APP._cpeViewfinderRender();
         _needsRender = false;
         if (_idleLogged) {
-          if ((_idleCycles || 0) <= 3 || (_idleCycles || 0) % 25 === 0) console.log('§IDLE_GATE wake cycles=' + (_idleCycles || 0));
+          // §VAC — same 1-in-25 sample as the park line above; parks= is the true event count.
+          if ((_idleCycles || 0) <= 3 || (_idleCycles || 0) % 25 === 0) console.log('§IDLE_GATE wake parks=' + (_idleCycles || 0) + ' (1-in-25 sample)');
           _idleLogged = false;
         }
       } else if (!_idleLogged) {

--- a/viewer/scene.js
+++ b/viewer/scene.js
@@ -206,6 +206,12 @@ async function setupScene(A) {
   _pmrem.compileCubemapShader();
   var _sky = null;
   var _sunVec = new THREE.Vector3();
+  // §VAC V3 — both arms of §ENVMAP_STOMP_GUARD are counted, so "100% skips" has a denominator.
+  // The sampled line prints every 100th call; the EXACT totals are always readable here, so the
+  // in-flight tail (< 100 calls since the last line) is compressed, never dropped. Same pattern as
+  // time_machine.js's window.__tmTrav — a diagnostic hook a probe or witness can read directly.
+  var _envSkips = 0, _envRegens = 0;
+  A._envmapStompStats = function() { return { skips: _envSkips, regens: _envRegens }; };
   // §MEMLEAK_PMREM_DISPOSE (2026-08-14): _pmrem.fromScene() allocates a brand-new
   // WebGLRenderTarget (backing texture + framebuffer) on every call — it is NOT reused/pooled
   // internally by THREE.PMREMGenerator, and three.js never garbage-collects WebGL resources on
@@ -299,10 +305,25 @@ async function setupScene(A) {
           // silently swapping every material's reflection source frame-to-frame and reading as an
           // alternating bright/dark movie. Every OTHER updateSky() caller (plain nav, Time Machine)
           // is unaffected — this flag is only ever true during a staged photoshoot.
+          // §VAC V2+V3 / §R14.1 (bim-compiler prompts/CPE_4D_PERF_MEM_STUDY.md): MEASURED on
+          // s5_hospital.log — 906 firings, 100% of them the identical `skipped procedural regen`,
+          // and the regen arm two lines up logged NOTHING. "100% skips" with no denominator cannot
+          // distinguish "the guard saved us 906 times" from "the regen arm was never reachable."
+          // Both arms are counted now, and the skip line is run-length reported: printed on the
+          // first skip of a run and then every 100th, always carrying the running skip/regen split
+          // so the ratio is readable without grepping the whole log. Nothing is dropped — the
+          // counters ARE the signal. (906 over a 2,680 s bake is the 2,000 ms A._envMapThrottle
+          // firing roughly every 3 s, not per frame; the volume was honest, the denominator was not.)
           if (!A._envMapHdriActive) {
+            _envRegens++;
             _setEnvMap(_pmrem.fromScene(_sky));
+            if (_envRegens === 1 || _envRegens % 100 === 0)
+              console.log('§ENVMAP_STOMP_GUARD regen ran (HDRI inactive) — regens=' + _envRegens + ' skips=' + _envSkips);
           } else {
-            console.log('§ENVMAP_STOMP_GUARD skipped procedural regen — HDRI active');
+            _envSkips++;
+            if (_envSkips === 1 || _envSkips % 100 === 0)
+              console.log('§ENVMAP_STOMP_GUARD skipped procedural regen — HDRI active; skips=' + _envSkips +
+                ' regens=' + _envRegens + ' (1-in-100 sample; every call is counted, only the line is sampled)');
           }
         } catch(e) {}
         A._envMapThrottle = false;

--- a/viewer/sw.js
+++ b/viewer/sw.js
@@ -31,7 +31,7 @@
 // installed service worker keeps serving the affine without this bump (§CRISIS LESSON 4). Paired
 // with _GANTT_CACHE_VERSION 37→38 (the IDB kernel_ops self-heal) in the same commit.
 // DEPLOY: bump CACHE_VERSION on every OCI upload. Old caches are purged on activate.
-const CACHE_VERSION = 'v1122';   // bump on each deploy; per-change detail is the git commit message.
+const CACHE_VERSION = 'v1123';   // bump on each deploy; per-change detail is the git commit message.
 // MERGE NOTE (2026-09-01, third of the day, same standing rule: KEEP BOTH notes, take the HIGHER
 // version, each separate change gets its OWN bump):
 // v1119 (2026-09-01) §WALL_SIDE_AND_LIGHT_FLOOR: streaming.js class-keyed material.side (census-

--- a/viewer/tests/witness_vacuous_tag_guards.js
+++ b/viewer/tests/witness_vacuous_tag_guards.js
@@ -1,0 +1,363 @@
+#!/usr/bin/env node
+// WITNESS — vacuous_tag_guards: the nine per-frame `§` tags of §R13.9, and whether each can now
+// report its own failure.
+// Spec: bim-compiler prompts/CPE_4D_PERF_MEM_STUDY.md §R14_VACUOUS_TAG_AUDIT (queue item A-7).
+//
+// ISSUE THIS PROVES OR DISPROVES — CLAUDE.md rule 4, "a witness that cannot report its own failure
+// is not a witness." §R13_BAKE_FRAME_MINING found nine `§` tags that fire on every bake frame while
+// judging nothing, the worst being §SHADOW_FRONTIER_AT_CAPTURE: 286 firings, every one carrying
+// `singleMesh_matched=0`. This witness proves three things a reader would otherwise have to take on
+// trust:
+//   (a) that §SHADOW_FRONTIER_AT_CAPTURE's zeros were an EMPTY POPULATION and not a BROKEN MATCHER
+//       — the distinction the item exists for, because stamping VACUOUS on a broken lookup would
+//       hide a live defect behind a compliant-looking log line;
+//   (b) that every tag whose population can be empty now prints the word VACUOUS at its own emit
+//       site in the SHIPPED source (grepped, not asserted);
+//   (c) that the run-length compression applied to the repeated tags is LOSSLESS — proved by
+//       extracting the SHIPPED `_vacLog` out of viewer/effects.js, executing it against the real
+//       2,027-frame Hospital series, and reconstructing the original per-line counts exactly.
+//
+// POPULATION: one row per audited tag (9), built from two real sources, no fixtures invented here —
+//   1. the SHIPPED source files in this worktree (viewer/{effects,scene,main,time_machine,
+//      cinema_maxq}.js), read and grepped at their real emit sites;
+//   2. tests/fixtures/vac_tag_series_s5_hospital.json — the run-length-encoded, ORDER-PRESERVING
+//      per-tag line series extracted from s5_hospital.log (Hospital MaxQ bake, commit e1369b7a,
+//      sw v1120, real GPU, 2,027 frames, 41,705 lines, 2026-09-01). The RLE expands back to the
+//      byte-exact original series; it exists so this witness outlives that 4.1 MB scratchpad log.
+//
+// NO BAKE, NO BROWSER, NO PROBE was run to produce this — user directive 2026-09-02. Every number
+// is read off the shipped source or off the archived series.
+//
+// Command: node viewer/tests/witness_vacuous_tag_guards.js
+'use strict';
+const fs = require('fs');
+const path = require('path');
+const { Witness } = require('../../witness_kit/contract');
+
+const ROOT = path.resolve(__dirname, '..', '..');
+const SRC = f => fs.readFileSync(path.join(ROOT, 'viewer', f), 'utf8');
+const FIXTURE = path.join(ROOT, 'tests', 'fixtures', 'vac_tag_series_s5_hospital.json');
+
+// ── §W-VACUOUS-SELF: this witness must be able to say INCONCLUSIVE about ITSELF. If the archived
+// series is not on disk there is nothing to judge, and a PASS here would be exactly the defect the
+// witness was written to close. Exit 2, never 0.
+if (!fs.existsSync(FIXTURE)) {
+  console.log('§WITNESS_VACUOUS_TAG_GUARDS INCONCLUSIVE — archived series absent at ' + FIXTURE +
+    '; nothing was judged. This is NOT a pass.');
+  process.exit(2);
+}
+const FX = JSON.parse(fs.readFileSync(FIXTURE, 'utf8'));
+
+// ── Extract and EXECUTE the shipped _vacLog, rather than reimplementing it here. A reimplementation
+// would prove that this file is lossless, which is not the claim. ────────────────────────────────
+function loadShippedVacLog() {
+  const src = SRC('effects.js');
+  const start = src.indexOf('function _vacLog(st, line, note) {');
+  if (start < 0) throw new Error('_vacLog not found in viewer/effects.js — the treatment is not shipped');
+  // brace-match to the end of the function
+  let depth = 0, i = src.indexOf('{', start), end = -1;
+  for (; i < src.length; i++) {
+    if (src[i] === '{') depth++;
+    else if (src[i] === '}') { depth--; if (depth === 0) { end = i + 1; break; } }
+  }
+  if (end < 0) throw new Error('_vacLog body did not brace-match');
+  const body = src.slice(start, end);
+  return new Function('console', body + '; return _vacLog;');
+}
+const makeVacLog = loadShippedVacLog();
+
+// Reconstruct the original occurrence count from what a run-length reporter emitted: each distinct
+// line print is 1 occurrence, each `repeats=N` accounts for N more. Heartbeats ("still identical")
+// re-report an IN-FLIGHT count and must NOT be added, or the reconstruction would double-count.
+// If this reconstruction ever misses the original total, the compression dropped signal — which is
+// the half of §VAC V2 that can silently regress, so it is asserted rather than assumed.
+function reconstruct(emitted) {
+  let recon = 0;
+  for (const l of emitted) {
+    if (/ still identical — repeats=/.test(l)) continue;
+    const m = /(?:^|\s)repeats=(\d+)/.exec(l);
+    if (m) recon += Number(m[1]); else recon += 1;
+  }
+  return recon;
+}
+
+// Replay one tag's real series through the SHIPPED _vacLog (extracted above) and report what it
+// would emit. This EXECUTES the shipped function; it does not model it.
+function replay(rle) {
+  const emitted = [];
+  const vacLog = makeVacLog({ log: l => emitted.push(l) });
+  const st = { last: null, n: 0 };
+  let total = 0;
+  for (const [line, count] of rle) for (let k = 0; k < count; k++) { total++; vacLog(st, line); }
+  // Flush the open run exactly as _vacFlushStillTags does at a real still exit.
+  if (st.n > 0 && st.last) emitted.push(st.last.split(' ')[0] + ' repeats=' + st.n + ' (identical, suppressed — flushed at still exit)');
+  return { emitted: emitted.length, reconstructed: reconstruct(emitted), total };
+}
+
+// §GROUP_SPARK_TICK's treatment is inline in time_machine.js, not a callable function, so its rule
+// is SIMULATED here rather than executed — stated plainly so the claim is not overread. The
+// simulation is faithful on this series because the shipped verdict is built from exactly the
+// fields that make the archived lines distinct (playing / cand / frontier / recent); roll and decay
+// were constant across the whole bake (roll=0 on 2,027/2,027, decay=1.00). The heartbeat cadence is
+// the shipped one: keyed on the tick counter, not on the repeat count.
+function simulateGroupSparkRule(rle) {
+  const emitted = []; let last = null, n = 0, tick = 0, total = 0;
+  for (const [line, count] of rle) for (let k = 0; k < count; k++) {
+    total++; tick++;
+    if (line !== last) {
+      if (n > 0) emitted.push('§GROUP_SPARK_TICK repeats=' + n + ' (identical verdict, suppressed)');
+      emitted.push(line); last = line; n = 0;
+    } else {
+      n++;
+      if (tick % 500 === 0) emitted.push('§GROUP_SPARK_TICK still identical — repeats=' + n);
+    }
+  }
+  if (n > 0) emitted.push('§GROUP_SPARK_TICK repeats=' + n + ' (identical verdict, suppressed)');
+  return { emitted: emitted.length, reconstructed: reconstruct(emitted), total };
+}
+
+// ── The nine rows ────────────────────────────────────────────────────────────────────────────────
+const effects = SRC('effects.js');
+const scene = SRC('scene.js');
+const main = SRC('main.js');
+const tm = SRC('time_machine.js');
+const maxq = SRC('cinema_maxq.js');
+
+// COMMENTS ARE STRIPPED BEFORE ANY REGION CHECK. First draft of this witness did not, and the
+// falsification arm caught it: deleting the VACUOUS literal from §SHADOW_FRONTIER_AT_CAPTURE's
+// actual emit statement still passed C2, because the explanatory comment block above it contains
+// the word "VACUOUS". That is a scope-blind witness — it passed while the defect sat inside the
+// window it was inspecting — which is the third failure mode CLAUDE.md rule 4 names alongside
+// no-op and vacuous. The check now sees only executable source.
+function stripComments(src) {
+  return src
+    .replace(/\/\*[\s\S]*?\*\//g, ' ')   // block comments
+    .replace(/(^|[^:'"`\\])\/\/[^\n]*/g, '$1');  // line comments (: guard keeps http:// intact)
+}
+// A tag's emit region = the COMMENT-STRIPPED shipped source within N chars of its emit site;
+// "can say VACUOUS" means the literal appears in code there, so a reader of the log can tell
+// 0-because-nothing-to-judge apart from 0-because-all-clean.
+function regionHas(src, anchor, needle, span) {
+  const code = stripComments(src);
+  const i = code.indexOf(anchor);
+  if (i < 0) return false;
+  return code.slice(Math.max(0, i - (span || 2500)), i + (span || 2500)).includes(needle);
+}
+
+const S = FX.series, F = FX.facts;
+const rows = [
+  {
+    tag: '§SHADOW_FRONTIER_AT_CAPTURE', tagBase: '§SHADOW_FRONTIER_AT_CAPTURE',
+    file: 'viewer/cinema_maxq.js', treatment: 'GUARD+FIX',
+    diagnosis: 'empty-population',
+    firedBefore: S.SHADOW_FRONTIER_AT_CAPTURE.total,
+    canSayVacuous: regionHas(maxq, "'§SHADOW_FRONTIER_AT_CAPTURE frame='", 'VACUOUS'),
+    // the FIX half: the third forEach outcome (in neither index) is now counted
+    extraFixShipped: maxq.includes('unmatched=') && maxq.includes('_fUnmatched++'),
+    // Volume is unchanged BY DESIGN — this tag fires only when something is under construction
+    // (286 of 2,027 frames, self-throttling already). Its defect was the CONTENT of the line.
+    losslessOnRealSeries: true, emittedAfter: S.SHADOW_FRONTIER_AT_CAPTURE.total,
+  },
+  {
+    tag: '§SHADOW_FRONTIER', tagBase: '§SHADOW_FRONTIER',
+    file: 'viewer/time_machine.js', treatment: 'GUARD',
+    diagnosis: 'empty-population',
+    firedBefore: S.SHADOW_FRONTIER.total,
+    canSayVacuous: regionHas(tm, "'§SHADOW_FRONTIER casters='", 'VACUOUS'),
+    // Volume unchanged by design: already a 1-in-60-tick sample. Content was the defect.
+    extraFixShipped: false, losslessOnRealSeries: true, emittedAfter: S.SHADOW_FRONTIER.total,
+  },
+  {
+    tag: '§GROUP_SPARK_TICK', tagBase: '§GROUP_SPARK_TICK',
+    file: 'viewer/time_machine.js', treatment: 'GUARD+FIX',
+    diagnosis: 'dead-throttle-and-vacuous',
+    firedBefore: S.GROUP_SPARK_TICK.total,
+    canSayVacuous: regionHas(tm, "'§GROUP_SPARK_TICK '", 'VACUOUS'),
+    // the FIX half: the log no longer rides `_gspRoll % 10`, a counter frozen at 0 in a bake
+    extraFixShipped: !/_gspRoll % 10 === 0[\s\S]{0,40}console\.log\('§GROUP_SPARK_TICK/.test(tm) &&
+      tm.includes('_gspTick++') && tm.includes('var _gspTick = 0;'),
+    losslessOnRealSeries: null, emittedAfter: null,   // filled by simulateGroupSparkRule below
+  },
+  {
+    tag: '§GROUND_WETNESS_OVERRIDE', tagBase: '§GROUND_WETNESS_OVERRIDE', file: 'viewer/effects.js', treatment: 'GUARD',
+    diagnosis: 'repeated-identical-verdict',
+    firedBefore: S.GROUND_WETNESS_OVERRIDE.total,
+    canSayVacuous: true,   // V2 tag: its guard is the repeat roll-up, not a VACUOUS label
+    // Routed through the shared _vacLog, so it inherits the bounded heartbeat. An earlier draft of
+    // this treatment used its own inline change-only rule, which on THIS series (one distinct line,
+    // 2,028 firings, run never ends) would have emitted exactly 1 line and never reported the 2,027
+    // repeats — a silent signal DROP dressed as compression. C3 below is what caught it.
+    extraFixShipped: /_vacLog\(_vacGroundWetness,/.test(effects),
+    losslessOnRealSeries: null, emittedAfter: null,   // filled by the shipped-_vacLog replay below
+  },
+  {
+    tag: '§NIGHT_STILL_LIGHTS', tagBase: '§NIGHT_STILL_LIGHTS', file: 'viewer/effects.js', treatment: 'GUARD',
+    diagnosis: 'repeated-identical-verdict',
+    firedBefore: S.NIGHT_STILL_LIGHTS.total, canSayVacuous: true, extraFixShipped: false,
+    losslessOnRealSeries: null, emittedAfter: null,
+  },
+  {
+    tag: '§PHOTO_GLOW_SPRITE staged', tagBase: '§PHOTO_GLOW_SPRITE', file: 'viewer/effects.js', treatment: 'GUARD',
+    diagnosis: 'repeated-identical-verdict',
+    firedBefore: S.PHOTO_GLOW_SPRITE_staged.total, canSayVacuous: true, extraFixShipped: false,
+    losslessOnRealSeries: null, emittedAfter: null,
+  },
+  {
+    tag: '§PHOTO_GLOW_SPRITE removed', tagBase: '§PHOTO_GLOW_SPRITE', file: 'viewer/effects.js', treatment: 'GUARD',
+    diagnosis: 'repeated-identical-verdict',
+    firedBefore: S.PHOTO_GLOW_SPRITE_removed.total, canSayVacuous: true, extraFixShipped: false,
+    losslessOnRealSeries: null, emittedAfter: null,
+  },
+  {
+    tag: '§GLOW_LENS_QUAD skip', tagBase: '§GLOW_LENS_QUAD', file: 'viewer/effects.js', treatment: 'GUARD',
+    diagnosis: 'repeated-identical-verdict',
+    firedBefore: S.GLOW_LENS_QUAD_skip.total, canSayVacuous: true, extraFixShipped: false,
+    losslessOnRealSeries: null, emittedAfter: null,
+  },
+  {
+    tag: '§ENVMAP_STOMP_GUARD', tagBase: '§ENVMAP_STOMP_GUARD', file: 'viewer/scene.js', treatment: 'GUARD',
+    diagnosis: 'no-denominator',
+    firedBefore: S.ENVMAP_STOMP_GUARD.total, canSayVacuous: true,
+    // V3: the OTHER arm is counted now, so "100% skips" has a denominator
+    // V3: the OTHER arm is counted, AND the exact running totals are exposed for direct read, so
+    // the < 100-call tail between sampled lines is compressed rather than lost.
+    extraFixShipped: scene.includes('_envRegens++') && scene.includes('_envSkips++') &&
+      scene.includes("'§ENVMAP_STOMP_GUARD regen ran") && scene.includes('A._envmapStompStats = function()'),
+    losslessOnRealSeries: true,
+    emittedAfter: 1 + Math.floor(S.ENVMAP_STOMP_GUARD.total / 100),
+  },
+  {
+    tag: '§IDLE_GATE', tagBase: '§IDLE_GATE', file: 'viewer/main.js', treatment: 'WORDING',
+    diagnosis: 'already-compliant',
+    firedBefore: S.IDLE_GATE.total, canSayVacuous: true,
+    extraFixShipped: main.includes('1-in-25 sample') && main.includes("'§IDLE_GATE park"),
+    losslessOnRealSeries: true, emittedAfter: S.IDLE_GATE.total,
+  },
+];
+
+// Replay the four effects.js V2 tags through the SHIPPED _vacLog and fill in the measured results.
+const REPLAY = {
+  '§GROUND_WETNESS_OVERRIDE': 'GROUND_WETNESS_OVERRIDE',
+  '§NIGHT_STILL_LIGHTS': 'NIGHT_STILL_LIGHTS',
+  '§PHOTO_GLOW_SPRITE staged': 'PHOTO_GLOW_SPRITE_staged',
+  '§PHOTO_GLOW_SPRITE removed': 'PHOTO_GLOW_SPRITE_removed',
+  '§GLOW_LENS_QUAD skip': 'GLOW_LENS_QUAD_skip',
+};
+for (const r of rows) {
+  const key = REPLAY[r.tag];
+  if (!key) continue;
+  const res = replay(S[key].rle);
+  r.emittedAfter = res.emitted;
+  r.losslessOnRealSeries = (res.reconstructed === res.total && res.total === r.firedBefore);
+  console.log('  §VAC_REPLAY ' + r.tag + ' original=' + res.total + ' emitted=' + res.emitted +
+    ' reconstructed=' + res.reconstructed + ' lossless=' + r.losslessOnRealSeries + ' (shipped _vacLog EXECUTED)');
+}
+{
+  const r = rows.find(x => x.tag === '§GROUP_SPARK_TICK');
+  const res = simulateGroupSparkRule(S.GROUP_SPARK_TICK.rle);
+  r.emittedAfter = res.emitted;
+  r.losslessOnRealSeries = (res.reconstructed === res.total && res.total === r.firedBefore);
+  console.log('  §VAC_REPLAY ' + r.tag + ' original=' + res.total + ' emitted=' + res.emitted +
+    ' reconstructed=' + res.reconstructed + ' lossless=' + r.losslessOnRealSeries +
+    ' (rule SIMULATED — the treatment is inline, not a callable function)');
+}
+
+// ── Standing facts from the archived bake, printed so the verdict is readable without the fixture ─
+console.log('  §VAC_EVIDENCE ' + F.shadow_frontier_idx_line);
+console.log('  §VAC_EVIDENCE §BATCHED_FAIL firings=' + F.batched_fail_count +
+  ' | at_capture firings=' + F.at_capture_firings +
+  ' singleMesh_matched=0 on=' + F.at_capture_singleMesh_matched_zero +
+  ' batchObjsContainingFrontier>0 on=' + F.at_capture_batchObjs_nonzero);
+console.log('  §VAC_EVIDENCE ' + F.tm_shadow_inherit_line +
+  ' | §GROUP_SPARK_TICK roll=0 on ' + F.group_spark_roll_zero + '/' + S.GROUP_SPARK_TICK.total +
+  ' firings (dead throttle) | §PERF_TRAVERSE same expression, ' + F.perf_traverse_firings + ' firings (named, NOT changed)');
+console.log('  §VAC_EVIDENCE §IDLE_GATE max cycles=' + F.idle_gate_max_cycles +
+  ' against ' + S.IDLE_GATE.total + ' logged lines — the lines are a 1-in-25 sample, not the event count');
+
+const schema = {
+  type: 'object',
+  required: ['tag', 'tagBase', 'file', 'treatment', 'diagnosis', 'firedBefore', 'canSayVacuous', 'emittedAfter'],
+  properties: {
+    tag: { type: 'string', pattern: '^§' },
+    tagBase: { type: 'string', pattern: '^§' },
+    file: { type: 'string', pattern: '^viewer/' },
+    treatment: { enum: ['GUARD', 'FIX', 'GUARD+FIX', 'REMOVE', 'WORDING'] },
+    diagnosis: { enum: ['empty-population', 'broken-matcher', 'repeated-identical-verdict',
+                        'dead-throttle-and-vacuous', 'no-denominator', 'already-compliant'] },
+    firedBefore: { type: 'integer', minimum: 1 },
+    canSayVacuous: { const: true },
+    emittedAfter: { type: 'integer', minimum: 1 },
+    losslessOnRealSeries: { const: true },
+    extraFixShipped: { type: 'boolean' },
+  },
+};
+
+Witness('vacuous_tag_guards')
+  .population(() => rows)
+  .schema(schema)
+
+  // C1 — all nine of §R13.9's tags are accounted for, none quietly dropped, none substituted.
+  //      §PHOTO_GLOW_SPRITE is ONE tag with TWO emit sites (staged/removed, 3,502 firings between
+  //      them), so the row count is 10 and the distinct-tag count is 9. The list is pinned by name
+  //      rather than by count so a swapped tag cannot pass as a covered one.
+  .invariant('C1 all-nine-tags-audited (§R13.9 list, by name, none dropped or substituted)', rs => {
+    const want = ['§GROUP_SPARK_TICK', '§GROUND_WETNESS_OVERRIDE', '§NIGHT_STILL_LIGHTS',
+      '§PHOTO_GLOW_SPRITE', '§GLOW_LENS_QUAD', '§ENVMAP_STOMP_GUARD', '§IDLE_GATE',
+      '§SHADOW_FRONTIER', '§SHADOW_FRONTIER_AT_CAPTURE'].sort();
+    const got = Array.from(new Set(rs.map(r => r.tagBase))).sort();
+    return got.length === 9 && want.every((w, i) => w === got[i]);
+  })
+
+  // C2 — every tag whose zeros can be structurally forced now prints VACUOUS at its own emit site
+  //      in the SHIPPED source. This is the CLAUDE.md rule-4 obligation.
+  .invariant('C2 every empty-population tag can say VACUOUS in shipped source',
+    rs => rs.filter(r => r.diagnosis === 'empty-population' || r.diagnosis === 'dead-throttle-and-vacuous')
+            .every(r => r.canSayVacuous === true))
+
+  // C3 — the compression is LOSSLESS, proved by executing the shipped _vacLog against the real
+  //      2,027-frame series. "Never silently drop the signal" is the half of V2 that can regress.
+  .invariant('C3 run-length compression is lossless on the real 2,027-frame series',
+    rs => rs.every(r => r.losslessOnRealSeries === true))
+
+  // C4 — and it is not a no-op: every repeated tag emits strictly fewer lines than it used to.
+  //      A treatment that changed nothing must be visible as a failure here, not read as a pass.
+  .invariant('C4 repeated-verdict tags emit strictly fewer lines than before',
+    rs => rs.filter(r => r.diagnosis === 'repeated-identical-verdict' ||
+                         r.diagnosis === 'no-denominator' ||
+                         r.diagnosis === 'dead-throttle-and-vacuous')
+            .every(r => r.emittedAfter < r.firedBefore))
+
+  // C5 — THE DISTINCTION THE ITEM EXISTS FOR. §SHADOW_FRONTIER_AT_CAPTURE's 286 zero-matches were
+  //      an empty population, not a broken lookup, and all four facts must hold together:
+  //        the single-mesh index is empty and says so;   all guids landed in the group index;
+  //        no BatchedMesh fallback ever fired;           the batch half judged on every firing.
+  //      If any one of these flips, the diagnosis is wrong and this must FAIL rather than let a
+  //      VACUOUS label hide a live matcher defect.
+  .invariant('C5 SHADOW_FRONTIER_AT_CAPTURE = empty population, NOT a broken matcher', () =>
+    F.shadow_frontier_idx_meshGuids === 0 &&
+    F.shadow_frontier_idx_groupGuids > 0 &&
+    F.batched_fail_count === 0 &&
+    /multi_draw=on/.test(F.renderer_caps_line || '') &&
+    F.at_capture_singleMesh_matched_zero === F.at_capture_firings &&
+    F.at_capture_batchObjs_nonzero === F.at_capture_firings)
+
+  // C6 — the two FIX halves are actually shipped, not just described: the unmatched= counter on
+  //      §SHADOW_FRONTIER_AT_CAPTURE, and §GROUP_SPARK_TICK's replacement for the dead throttle.
+  .invariant('C6 both FIX treatments present in shipped source (unmatched=, live tick counter)',
+    rs => rs.filter(r => r.treatment === 'GUARD+FIX').every(r => r.extraFixShipped === true))
+
+  // C7 — the dead throttle really was dead: roll=0 on every one of the 2,027 archived firings.
+  .invariant('C7 §GROUP_SPARK_TICK throttle was dead in the bake path (roll=0 on 100% of firings)',
+    () => F.group_spark_roll_zero === S.GROUP_SPARK_TICK.total && S.GROUP_SPARK_TICK.total > 1000)
+
+  // redControl — a witness that cannot fail is not a witness. Claim the worst tag was a broken
+  // matcher that got a VACUOUS label anyway (the exact defect this item was warned against), and
+  // drop the losslessness guarantee. C2/C3 and the schema must both reject it.
+  .redControl(rs => {
+    const broken = rs.map(r => Object.assign({}, r));
+    broken[0].diagnosis = 'broken-matcher';
+    broken[0].canSayVacuous = false;
+    broken[0].losslessOnRealSeries = false;
+    return broken;
+  })
+  .run();

--- a/viewer/time_machine.js
+++ b/viewer/time_machine.js
@@ -904,7 +904,12 @@
   //      Here: sparks exist ONLY during playback; stop decays to zero; scrub draws none.
   //      The only state that can persist is zero.
   var _gspTexture = null, _gspPool = [], _gspActive = 0;
-  var _gspRoll = 0;            // re-roll index — advances once per playback tick
+  var _gspRoll = 0;            // re-roll index — advances once per PLAYBACK tick (frozen at 0 in a
+                               // bake: see §VAC / §R14.1 at the §GROUP_SPARK_TICK log below)
+  var _gspTick = 0;            // §VAC — advances on EVERY _gspEmit, playing or not; the log's own
+                               // sample counter, replacing the dead `_gspRoll % 10` throttle
+  var _gspLastVerdict = null;  // §VAC V2 — last §GROUP_SPARK_TICK verdict, for run-length reporting
+  var _gspRepeats = 0;         // §VAC V2 — identical verdicts suppressed since _gspLastVerdict
   var _gspDecay = 1;           // 1 while playing; ramps to 0 on stop
   var _gspDecayTimer = null;
   var _gspCand = [];           // flat [x,y,z,...] collected during the traverse
@@ -1013,11 +1018,40 @@
     _gspActive = 0;
     // Unconditional tick log — MUST fire even on the early-return paths, otherwise a zero-spark
     // result is indistinguishable from "the code never ran" (that ambiguity is exactly what let
-    // #866 ship believing it was verified).
-    if (_gspRoll % 10 === 0) {
-      console.log('§GROUP_SPARK_TICK playing=' + !!isPlaying + ' cand=' + (_gspCand.length / 3) +
-                  ' (frontier=' + _gspFrontierN + ' recent=' + _gspRecentN + ')' +
-                  ' roll=' + _gspRoll + ' decay=' + _gspDecay.toFixed(2));
+    // #866 ship believing it was verified). That requirement is KEPT: the tick is still reported
+    // on every path, it is just no longer reported once per frame with an identical verdict.
+    //
+    // §VAC / §R14.1 — the throttle this line used to carry was DEAD in the bake path.
+    // It read `_gspRoll % 10 === 0`, intending a 1-in-10 sample. `_gspRoll++` happens in exactly
+    // one place — playTick() (search "§GROUP_SPARK: one re-roll per playback tick"), behind
+    // `if (!_playing) return;`. A MaxQ bake never calls playTick(); it drives renderAtTime()
+    // directly. So _gspRoll is frozen at 0, `0 % 10 === 0` is always true, and 1-in-10 silently
+    // became 1-in-1. MEASURED, s5_hospital.log: 2,027 firings over 2,027 frames, every one
+    // carrying `roll=0`. (The same dead expression also gates §PERF_TRAVERSE below — named in
+    // §R14.1, deliberately NOT changed here: that one is a real per-frame measurement other
+    // sections quote.) Fixed with a counter that advances on every emit, playing or not.
+    //
+    // §VAC V1+V2 — and the verdict itself was vacuous: 1,681 of those 2,027 firings read
+    // `playing=false cand=0 (frontier=0 recent=0)`, i.e. nothing to light and no playback to
+    // light it during. A run of identical verdicts is now printed ONCE with its repeat count;
+    // the count is the signal, so nothing is dropped.
+    _gspTick++;
+    var _gspVerdict = (!isPlaying || !_gspCand.length)
+      ? 'VACUOUS (' + (!isPlaying ? 'not playing' : 'cand=0 — no frontier/recent candidates this tick') +
+        ') playing=' + !!isPlaying + ' cand=' + (_gspCand.length / 3) +
+        ' (frontier=' + _gspFrontierN + ' recent=' + _gspRecentN + ')'
+      : 'playing=true cand=' + (_gspCand.length / 3) +
+        ' (frontier=' + _gspFrontierN + ' recent=' + _gspRecentN + ')' +
+        ' roll=' + _gspRoll + ' decay=' + _gspDecay.toFixed(2);
+    if (_gspVerdict !== _gspLastVerdict) {
+      if (_gspRepeats > 0) console.log('§GROUP_SPARK_TICK repeats=' + _gspRepeats + ' (identical verdict, suppressed)');
+      console.log('§GROUP_SPARK_TICK ' + _gspVerdict + ' tick=' + _gspTick);
+      _gspLastVerdict = _gspVerdict; _gspRepeats = 0;
+    } else {
+      _gspRepeats++;
+      // Never let a long identical run go completely silent — a bounded heartbeat proves the code
+      // is still running (the #866 ambiguity above), without one line per frame.
+      if (_gspTick % 500 === 0) console.log('§GROUP_SPARK_TICK still ' + _gspVerdict + ' — repeats=' + _gspRepeats + ' tick=' + _gspTick);
     }
     // Scrub / paused / not playing → NO sparks at all. Scrubbing is a state-diff read; flashing
     // VFX competes with it (user: "the appreciation is in the quick diff in states").
@@ -1659,10 +1693,28 @@
       }
     }
     // §SHADOW_FRONTIER — log every 60 ticks
+    // §VAC V1 / §R14.1 (bim-compiler prompts/CPE_4D_PERF_MEM_STUDY.md): this line printed
+    // "casters=0 receivers=0" on all 33 firings of the 2,027-frame Hospital bake, and BOTH of its
+    // counters are structurally unreachable in that run — so the zeros were never a judgement.
+    //   (a) _shadowCasters/_shadowReceivers only increment behind `if (app._shadowOn)` (:1463 and
+    //       the promotion pass directly above); that run logged §TM_SHADOW_INHERIT shadowOn=false.
+    //   (b) both counters live in the SINGLE-MESH branch (see the §PERF_INCR Phase 2 comment near
+    //       :1342). On a device that took the fast batched path there are no individually-meshed
+    //       elements at all — §SHADOW_FRONTIER_IDX measured meshGuids=0 groupGuids=63182 on the
+    //       same building, and §BATCHED_FAIL never fired.
+    // The log line sits OUTSIDE the `if (app._shadowOn …)` block on purpose (a zero must still be
+    // reportable), so it has to name WHICH predicate is empty rather than print a bare 0.
     _shadowLogTick++;
     if (_shadowLogTick >= 60) {
       _shadowLogTick = 0;
-      console.log('§SHADOW_FRONTIER casters=' + _shadowCasters + ' receivers=' + _shadowReceivers);
+      if (!app._shadowOn) {
+        console.log('§SHADOW_FRONTIER VACUOUS — shadowOn=false, the casters/receivers counters are gated off; 0 means "not asked", not "none found"');
+      } else if (!_placedMeshes.length && !_frontierCentroids.length) {
+        console.log('§SHADOW_FRONTIER VACUOUS — shadowOn=true but the single-mesh branch placed 0 meshes and 0 frontier centroids (batched/instanced scene); these counters cannot see batched geometry');
+      } else {
+        console.log('§SHADOW_FRONTIER casters=' + _shadowCasters + ' receivers=' + _shadowReceivers +
+          ' (single-mesh branch only; placedMeshes=' + _placedMeshes.length + ' frontierCentroids=' + _frontierCentroids.length + ')');
+      }
     }
 
     // §S260c: Cinematic Director — storyboard-driven camera (Film Studio mode)


### PR DESCRIPTION
## §VAC — the nine per-frame `§` tags of §R13.9 can now report their own failure

Queue item **A-7**. Spec: `bim-compiler prompts/CPE_4D_PERF_MEM_STUDY.md` **§R14_VACUOUS_TAG_AUDIT**.

CLAUDE.md rule 4 — *"a witness that cannot report its own failure is not a witness."* `§R13_BAKE_FRAME_MINING` mined a 2,027-frame Hospital bake (`s5_hospital.log`, `e1369b7a`, sw v1120, real GPU, 41,705 lines) and found nine per-frame tags firing while judging nothing, or repeating one identical verdict thousands of times.

**No bake, no browser, no probe was run** (user directive 2026-09-02). Evidence is that archived log plus the code. **No behaviour changed** — nothing rendered, staged, torn down or scheduled moves; only what is printed.

### The decisive question, answered per tag

Stamping `VACUOUS` on a **broken lookup** would hide a live defect behind a compliant-looking line, so every tag was tested against that distinction first. **7 GUARD · 2 GUARD+FIX · 0 REMOVE.**

| tag | fired | diagnosis | treatment |
|---|---|---|---|
| `§SHADOW_FRONTIER_AT_CAPTURE` | 286 | **empty population** | GUARD + **FIX** (`unmatched=`) |
| `§GROUP_SPARK_TICK` | 2,027 | **dead throttle** + vacuous | GUARD + **FIX** (live tick counter) |
| `§SHADOW_FRONTIER` | 33 | empty population (×2 causes) | GUARD |
| `§GROUND_WETNESS_OVERRIDE` | 2,028 | 1 distinct line | GUARD (run-length) |
| `§NIGHT_STILL_LIGHTS` | 2,026 | 1 distinct line | GUARD (run-length) |
| `§PHOTO_GLOW_SPRITE` (staged+removed) | 3,502 | 11 count-runs | GUARD (run-length) |
| `§GLOW_LENS_QUAD skip` | 1,770 | 1,740 identical | GUARD (run-length) |
| `§ENVMAP_STOMP_GUARD` | 906 | 100% skips, **no denominator** | GUARD + V3 (count both arms) |
| `§IDLE_GATE` | 330 | **already compliant** | wording only |

### `§SHADOW_FRONTIER_AT_CAPTURE`: empty population, NOT a broken matcher

Three independent facts, all read off the archived log:

1. **The index the matcher queries is itself empty and says so** — `§SHADOW_FRONTIER_IDX built gen=2814 meshGuids=0 groupGuids=63182`. All 63,182 streamed guids landed in the group index. The matcher is a `Map.get` against a Map of size 0.
2. **The single-mesh population is a FALLBACK that never fired.** The three `streaming.js` sites that put `userData.guid` on a lone `THREE.Mesh` are `:2069` (BatchedMesh ctor threw), `:2143` (BatchedMesh unavailable), `:2438` (oversized spill). The log has `§RENDERER_CAPS multi_draw=on` and `§BATCHED_FAIL` count **0**.
3. **The other half of the same line judges normally** — `batchObjsContainingFrontier` non-zero and `batchCastShadowTrue` equal to it on **286/286** firings.

→ **GUARD**, not fix. But the same read found a real hole, and *that* half is a **FIX**: the `forEach` always had a third outcome — a guid in **neither** index — and never counted it, so `frontierGuids=10 batchObjs=4` could not distinguish dedup from lookup miss. `unmatched=` is a counter on an existing else-branch. It will attribute the **63,182 streamed vs 63,417 placed** gap on the next bake.

### `§GROUP_SPARK_TICK`: the throttle was dead in the bake path

`_gspRoll % 10 === 0` intended a 1-in-10 sample. `_gspRoll++` happens in **one place** — `playTick()`, behind `if (!_playing) return;`. A bake drives `renderAtTime()` directly, so `_gspRoll` is frozen at 0 and 1-in-10 silently became 1-in-1. Measured: `roll=0` on **2,027/2,027** firings. The **same dead expression gates `§PERF_TRAVERSE`** (also 2,027) — named in §R14.1 and **deliberately not changed**; it is a real measurement other sections quote.

### `§IDLE_GATE` — the one that was already right

Mechanism untouched. Its 165 park + 165 wake lines are a **1-in-25 sample of 4,050+ real cycles**, and §R13.9 read them as the event count. Wording only, so the line cannot invite that again.

### Measured — W-VACUOUS-TAG-GUARDS 10/10, redControl green

Replaying the real archived series through the **shipped `_vacLog`** (extracted from `effects.js` and *executed*, not modelled). Every one **lossless**:

```
§GROUND_WETNESS_OVERRIDE   2,028 -> 10 lines    reconstructed 2,028
§NIGHT_STILL_LIGHTS        2,026 -> 10          reconstructed 2,026
§PHOTO_GLOW_SPRITE staged  1,751 -> 24          reconstructed 1,751
§PHOTO_GLOW_SPRITE removed 1,751 -> 24          reconstructed 1,751
§GLOW_LENS_QUAD skip       1,740 -> 29          reconstructed 1,740
§GROUP_SPARK_TICK          2,027 -> 467         reconstructed 2,027
```

**Two source-level red arms both turned the witness red:** deleting `unmatched=` failed C6; deleting `VACUOUS` from the emit statement failed C2. ⚠ The **first draft of C2 passed that second arm** — it was reading my own comment block. The region check now strips comments before grepping. A scope-blind witness is the same rule-4 defect it was written to close.

⚠ An earlier draft of `§GROUND_WETNESS_OVERRIDE`'s guard used its own inline change-only rule; on this series it would have emitted **1** line and never reported the 2,027 repeats — a silent **drop** dressed as compression. **C3 caught it.** It goes through `_vacLog` like the rest now.

### Compatibility

- `witness_glow_lens_stage_keep.js` asserts `ft.skip > 0` and reads `§GLOW_LENS_QUAD staged rect=` / `removed` — all still emitted verbatim. (Browser/bake witness; **not run**, per the no-bake directive — checked by reading its assertions.)
- `witness_tour_wake.js` / `tests/probe_idle_blank.js` match on the `§IDLE_GATE park` prefix, unchanged.
- `viewer/tests/witness_vacuous_tag_guards.js` is auto-discovered by `tests/run_witness_suite.js` (headless class): `§SUITE_SUMMARY green=1 new_red=0`.
- `sw.js` `CACHE_VERSION` **v1122 → v1123** (precached viewer files changed).
- `node --check` clean on all five product files; eslint clean (the 3 `VideoEncoder` `no-undef` in `cinema_maxq.js` are pre-existing on `origin/main`, lines 830-892, nowhere near this diff).

`tests/fixtures/vac_tag_series_s5_hospital.json` is the archived log's per-tag line series, run-length encoded and order-preserving, so the witness outlives that 4.1 MB scratchpad file. **The next bake anyone runs is the live confirmation; it rides free.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RTX9gUq3tQoytC1vthLmcq
