### PR TITLE
fix(4d): §TPL_MOVIE_BINDS_BARS stops claiming a map nobody plays + §DAYBATCH_* re-measured on the played layer

### DIFF
--- a/scripts/cache_4d_run.js
+++ b/scripts/cache_4d_run.js
@@ -9,14 +9,39 @@
 //
 //   witness.log — the FULL §-tagged log the shipped pipeline emitted. This is the primary
 //                 evidence, per the project Log Mandate. Read it; do not re-derive what it says.
-//   run.json    — elements (guid, cls, seq, phase, storey, name, bbox) + displaySchedule
-//                 (guid -> {s,e}) exactly as the run produced them.
+//   run.json    — elements (guid, cls, seq, phase, storey, name, bbox) + BOTH schedule layers,
+//                 each NAMED (see §CACHE_PLAYED_LAYER below), exactly as the run produced them.
+//
+// ══ §CACHE_PLAYED_LAYER (2026-09-02, bim-compiler prompts/4D_GANTT_TM_REFACTOR.md §FUTURE item 2
+//    §CACHE_PLAYED_LAYER, queue item A-9) — TWO LAYERS, BOTH NAMED, NEITHER ANONYMOUS ═══════════
+// This file used to persist exactly ONE schedule under the neutral key `sched`: materializeZones'
+// `displaySchedule`. §TM_REVEAL_SHIPPED then measured that viewer/time_machine.js has ZERO readers
+// of that map — the movie and the scrubber play kernel_ops timestamps written by injectGantt. So
+// every judge reading this cache (witness_day0_integrity, probe_tpl_reveal_spread,
+// probe_tpl_parallel_reveal, probe_tpl_calibration_scope, probe_stair_flight_support_pool) was
+// judging a map nobody plays, and NONE of them printed which map that was. The anonymity is the
+// defect: a judge that cannot name its own input cannot report being pointed at the wrong one
+// (PRIMAL LAW clause 4). Both layers are persisted now and `layerOf()` makes every reader say so.
+//
+//   play    — the instants kernel_ops carries = what the film and the Time Machine scrubber
+//             reveal each element at. Produced by the injectGantt mirror in
+//             scripts/lib/tm_played_layer.js (the live time_machine.js functions, sliced).
+//   sched   — materializeZones' displaySchedule (remapSolveToTasks). KEPT under its original key
+//             so no existing reader breaks, and aliased `display`. NOT read by time_machine.js.
+//
+// ⚠ A SECOND divergence fixed here at the same time: this file called materializeZones WITHOUT
+// `opts.displayRemap`, and that hook (schedule_author.js:728-736) is what sets display_authored=1
+// and what swaps the raw solve for the CPM display timeline BEFORE task windows are authored.
+// Measured on the pre-fix Hospital cache: no §ZONE_DISPLAY_AUTHORING, no §CELL_GATE, no §CPM_DISPLAY
+// in 29 log lines — the cached run was a third configuration the browser never runs. The hook is
+// wired in below; `schedules.display_authored` is READ from the DB, never assumed.
 //
 // CACHE KEY = building db (size+mtime) + the CONTENT of every input that can change the answer
-// (the five viewer modules, rates.js, 4D_template.json). Change any of them and the key changes,
-// so a stale cache is impossible — which matters here: this lane already lost hours to two
-// measurements that silently disagreed because they ran against different viewer checkouts
-// (4D_MODEL_INTEGRITY.md §H.4).
+// (the viewer modules, rates.js, 4D_template.json, and — since the played layer depends on them —
+// time_machine.js, gantt_model.js and the three §S50 CELL-gate modules). Change any of them and
+// the key changes, so a stale cache is impossible — which matters here: this lane already lost
+// hours to two measurements that silently disagreed because they ran against different viewer
+// checkouts (4D_MODEL_INTEGRITY.md §H.4).
 //
 // Usage:  node scripts/cache_4d_run.js Terminal Hospital        (build if missing)
 //         node scripts/cache_4d_run.js --force Terminal         (rebuild)
@@ -27,9 +52,36 @@ const HOME = os.homedir();
 const V = path.join(__dirname, '..', 'viewer');
 const BLD = process.env.BLD_DIR || path.join(HOME, 'bim-ootb', 'buildings');
 const ROOT = process.env.CACHE_4D_DIR || path.join(HOME, '.cache', 'bim4d');
+const TMP = require(path.join(__dirname, 'lib', 'tm_played_layer.js'));
 
 const INPUTS = ['schedule_gate.js', 'schedule_author.js', 'support_sweep.js', 'cpm_schedule.js',
-                'rates.js', 'rates/4D_template.json'];
+                'rates.js', 'rates/4D_template.json',
+                // §CACHE_PLAYED_LAYER: the played layer is produced by these — a change to any of
+                // them changes what the movie reveals, so it must change the cache key too.
+                'time_machine.js', 'gantt_model.js', 'location_axis.js',
+                'lib/room_walker.js', 'lib/level_deriver.js'];
+
+// ── LAYERS — self-describing, so a judge can print what it judged without knowing this file ──────
+const LAYERS = {
+  played: { key: 'play',
+    desc: 'PLAYED — kernel_ops timestamps written by injectGantt (_tmTilePlayWithinTasks -> ' +
+          '_tmRescaleToTaskWindow). THIS is what the film and the Time Machine scrubber reveal.' },
+  display: { key: 'sched',
+    desc: 'DISPLAY(unplayed) — materializeZones displaySchedule (remapSolveToTasks). ' +
+          'viewer/time_machine.js has ZERO readers of it (§TM_REVEAL_SHIPPED, 2026-09-02).' },
+};
+
+// layerOf(run, id) — the ONE accessor every cache reader selects through. Throws on an unknown id
+// (W-CLA-5: no silent default), and reports MISSING rather than substituting the other layer when a
+// cache predates §CACHE_PLAYED_LAYER.
+function layerOf(run, id) {
+  const want = id || process.env.LAYER || 'played';
+  const L = LAYERS[want];
+  if (!L) throw new Error('§CACHE_LAYER_UNKNOWN "' + want + '" — known layers: ' + Object.keys(LAYERS).join(', '));
+  const map = run ? run[L.key] : null;
+  if (!map) return { id: want, key: L.key, map: null, desc: L.desc, missing: true };
+  return { id: want, key: L.key, map: map, desc: L.desc, missing: false };
+}
 
 function codeKey() {
   const h = crypto.createHash('sha1');
@@ -42,12 +94,17 @@ function dbKey(file) {
 }
 function dirFor(bld) { return path.join(ROOT, bld, codeKey() + '_' + dbKey(path.join(BLD, bld + '_extracted.db'))); }
 
-// read(bld) — what every downstream probe should call. Returns {els, sched, tasks, log, dir} or null.
+// read(bld) — what every downstream probe should call. Returns {els, play, sched, tasks, log, dir}
+// or null. SELECT A LAYER WITH layerOf(run) — never reach for `.sched` directly; that key is the
+// unplayed map and reading it unnamed is the defect §CACHE_PLAYED_LAYER removed.
 function read(bld) {
   const d = dirFor(bld);
   if (!fs.existsSync(path.join(d, 'run.json'))) return null;
   const j = JSON.parse(fs.readFileSync(path.join(d, 'run.json'), 'utf8'));
-  return { els: j.els, sched: j.sched, storeys: j.storeys || null, tasks: j.tasks || null, log: fs.readFileSync(path.join(d, 'witness.log'), 'utf8'), dir: d };
+  return { els: j.els, play: j.play || null, sched: j.sched, display: j.sched,
+    playStats: j.playStats || null, storeys: j.storeys || null, tasks: j.tasks || null,
+    dbFile: j.dbFile || null, builtAt: j.builtAt || null,
+    log: fs.readFileSync(path.join(d, 'witness.log'), 'utf8'), dir: d };
 }
 
 function build(bld, force) {
@@ -63,7 +120,14 @@ function build(bld, force) {
   const SA = require(path.join(V, 'schedule_author.js'));
   const SS = require(path.join(V, 'support_sweep.js')); global.SupportSweep = SS;
   const CP = require(path.join(V, 'cpm_schedule.js')); global.CpmSchedule = CP;
+  const GM = require(path.join(V, 'gantt_model.js')); global.GanttModel = GM;
+  // §S50: the CELL gate resolves these on globalThis exactly like a browser window would. Without
+  // them the run silently takes the GRAPH path — a configuration the browser does not run.
+  globalThis.RoomWalker = require(path.join(V, 'lib', 'room_walker.js'));
+  globalThis.LevelDeriver = require(path.join(V, 'lib', 'level_deriver.js'));
+  globalThis.LocationAxis = require(path.join(V, 'location_axis.js'));
   const T = JSON.parse(fs.readFileSync(path.join(V, 'rates', '4D_template.json'), 'utf8'));
+  const tmSrc = fs.readFileSync(path.join(V, 'time_machine.js'), 'utf8');
   const sb = { console: { log() {}, warn() {}, error() {} } };
   vm.createContext(sb); vm.runInContext(fs.readFileSync(path.join(V, 'rates.js'), 'utf8'), sb);
 
@@ -75,16 +139,25 @@ function build(bld, force) {
       // TEE, not suppress: the §-log is the evidence, so it goes to the file AND to the terminal.
       console.log = function () { const s = Array.prototype.join.call(arguments, ' '); lines.push(s); _l(s); };
       console.warn = function () { const s = Array.prototype.join.call(arguments, ' '); lines.push(s); _w(s); };
-      let els = null, sched = null, storeys = null, tasks = null, err = null;
+      let els = null, sched = null, play = null, playStats = null, storeys = null, tasks = null, err = null;
       try {
         const db = new SQL.Database(new Uint8Array(fs.readFileSync(file)));
+        // §CACHE_PLAYED_LAYER — the live time_machine.js functions, sliced (never re-typed).
+        const tmsb = TMP.buildSandbox({ tmSrc: tmSrc, SA: SA, SG: SG, CP: CP, GM: GM, SS: SS,
+          LABOR_RATES: sb.LABOR_RATES, console: console });
         const base = { start: '2026-01-01', laborRates: sb.LABOR_RATES, rates: sb.RATES,
           nameOverrides: sb.SEQUENCE_NAME_OVERRIDES, defaultRule: sb.SEQUENCE_DEFAULT,
-          scheduleGate: SG, shiftHours: T.calendar.hours_per_shift, template: T, db: db };
-        els = SA._buildScheduleElements(db, sb.SEQUENCE_RULES, base).map(e => ({
+          scheduleGate: SG, shiftHours: T.calendar.hours_per_shift, template: T, db: db,
+          // §ZONE_DISPLAY_AUTHORING — the hook every real UI call site passes. Without it this run
+          // authors windows from the RAW solve and never runs the CPM display pass, i.e. it is not
+          // the configuration the browser runs (§CACHE_PLAYED_LAYER header).
+          displayRemap: tmsb._tmDisplayRemap };
+        const rawEls = SA._buildScheduleElements(db, sb.SEQUENCE_RULES, base);
+        els = rawEls.map(e => ({
           guid: e.guid, cls: e.cls, seq: e.seq, phase: e.phase, storey: e.storey, name: e.name || '',
           resource: e.resource, installSecs: e.installSecs,
           x0: e.x0, x1: e.x1, y0: e.y0, y1: e.y1, bz: e.base_z, tz: e.top_z }));
+        globalThis.APP = { db: db };          // §S50 CELL gate reads the db through APP, as the viewer does
         const res = SA.materializeZones(db, sb.SEQUENCE_RULES, base);
         sched = res && res.displaySchedule;
         // task grid (id, window, member guids) — needed to compute reveal-time-within-task-window,
@@ -92,6 +165,15 @@ function build(bld, force) {
         // guid belongs to only exists on `res.tasks` (in-memory here, never written back to the db).
         if (res && res.tasks) tasks = res.tasks.map(t => ({ id: t.id, sDays: t.sDays, eDays: t.eDays,
           phase: t.phase, storey: t.storey, guids: t.guids }));
+        // ── THE PLAYED LAYER — injectGantt's write path, mirrored (scripts/lib/tm_played_layer.js).
+        // These are the instants kernel_ops carries, i.e. what the film and the scrubber reveal.
+        if (res && res.tasks) {
+          const mp = TMP.mirrorInjectGantt({ sb: tmsb, elements: rawEls, tasks: tasks, db: db,
+            startISO: base.start, applyTiling: true, log: console.log });
+          if (mp.ok) { play = mp.play; playStats = mp.stats; }
+          else console.log('§CACHE_PLAY_FAIL ' + bld + ' ' + mp.reason + ' — the played layer is NOT persisted for this run');
+        }
+        delete globalThis.APP;
         // The IFC's OWN declared spatial structure, persisted alongside the run so a witness can
         // compare "storeys the model declares" against "bands the schedule invents" without a
         // tolerance constant anywhere. Absent on some shipped DBs (Duplex/Hospital have no
@@ -112,14 +194,25 @@ function build(bld, force) {
       fs.mkdirSync(d, { recursive: true });
       fs.writeFileSync(path.join(d, 'witness.log'), lines.join('\n') + '\n');
       fs.writeFileSync(path.join(d, 'run.json'), JSON.stringify({ bld: bld, builtAt: new Date().toISOString(),
-        codeKey: codeKey(), els: els, sched: flat, storeys: storeys, tasks: tasks }));
+        codeKey: codeKey(), dbFile: path.basename(file), els: els,
+        sched: flat, play: play, playStats: playStats, storeys: storeys, tasks: tasks }));
       console.log('§CACHE_BUILT ' + bld + ' n=' + els.length + ' scheduled=' + Object.keys(flat).length +
         ' logLines=' + lines.length + ' declaredStoreys=' + (storeys ? storeys.length : 'ABSENT') + ' -> ' + d);
+      // §CACHE_LAYERS — the cache says, in its own log, which maps it carries and which one plays.
+      console.log('§CACHE_LAYERS ' + bld +
+        ' played=' + (play ? Object.keys(play).length : 'MISSING') +
+        ' display=' + Object.keys(flat).length +
+        (playStats ? ' tiled=' + playStats.tiled + '/' + playStats.total +
+          ' clamped=' + playStats.clamped + ' uncovered=' + playStats.uncovered +
+          ' display_authored=' + playStats.displayAuthored : '') +
+        ' — "played" is what the film/scrubber reveal (kernel_ops); "display" is remapSolveToTasks, ' +
+        'which viewer/time_machine.js does not read. Select with CACHE.layerOf(run).');
       return read(bld);
     });
 }
 
-module.exports = { read: read, build: build, dirFor: dirFor, codeKey: codeKey };
+module.exports = { read: read, build: build, dirFor: dirFor, codeKey: codeKey,
+  layerOf: layerOf, LAYERS: LAYERS };
 
 if (require.main === module) {
   const args = process.argv.slice(2);

--- a/scripts/lib/tm_played_layer.js
+++ b/scripts/lib/tm_played_layer.js
@@ -1,0 +1,182 @@
+// tm_played_layer.js — THE PLAYED LAYER, IN NODE. ONE OWNER, NO SECOND COPY.
+//
+// ⚠ DO NOT REMOVE — SCOPE (bim-compiler prompts/4D_GANTT_TM_REFACTOR.md §FUTURE item 2,
+// 2026-09-02 §CACHE_PLAYED_LAYER §H). Read the log after every run (project Log Mandate).
+//
+// WHAT "PLAYED" MEANS, AND WHY IT NEEDS A MODULE.
+// materializeZones returns `displaySchedule` (= ScheduleAuthor.remapSolveToTasks,
+// schedule_author.js:965) and scripts/cache_4d_run.js used to persist ONLY that — but
+// viewer/time_machine.js has ZERO readers of it (grep: the only reference repo-wide is its own
+// return statement, schedule_author.js:1476). The instants the Time Machine scrubber and the baked
+// film actually reveal an element at (`op.start_ts <= cursor`, time_machine.js:169-170, 2576) are
+// written by injectGantt from
+//     _displayTimeline(_twItems)                (CpmSchedule.run, time_machine.js ~4838)
+//     -> _tmTilePlayWithinTasks(...)            (§TM_REVEAL_TILED, ~4254, PR #1605)
+//     -> _tmRescaleToTaskWindow(guid, s)        (affine fallback, ~4971)
+//     -> kernel_ops.timestamp / _end_ts
+// scripts/probe_tm_reveal_shipped.js (PR #1605) proved this chain can be replicated in node by
+// SLICING the live functions out of time_machine.js — no browser, no bake, nothing re-typed. That
+// slicing + mirror lives HERE now, so the probe and the cache cannot drift apart: two independent
+// replications of the played layer would be the same defect class this whole section exists to
+// remove. time_machine.js is READ, never edited.
+//
+// EXPORTS
+//   sliceFn(src, name)          brace-matched source slice, by function name
+//   buildSandbox(deps)          a vm context holding the live TM functions
+//   mirrorInjectGantt(opts)     the injectGantt write-path mirror -> { play, disp, cap, ... }
+'use strict';
+const fs = require('fs'), path = require('path'), vm = require('vm');
+
+const DAY_MS = 86400000;
+
+// The exact set injectGantt's play path depends on. Sliced verbatim; if time_machine.js renames one
+// of these the slice throws by name instead of silently producing a different map.
+const TM_FNS = ['_tukeyBound', '_displayTimelineRemember', '_displayTimeline', '_tmDisplayRemap',
+                '_tmRescaleToTaskWindow'];
+
+function sliceFn(src, name) {
+  const idx = src.indexOf('function ' + name + '(');
+  if (idx < 0) throw new Error(name + ' not found in time_machine.js');
+  let d = 0, open = false;
+  for (let i = idx; i < src.length; i++) {
+    if (src[i] === '{') { d++; open = true; }
+    else if (src[i] === '}') { d--; if (open && d === 0) return src.slice(idx, i + 1); }
+  }
+  throw new Error('unbalanced braces for ' + name);
+}
+
+// buildSandbox({ tmSrc, SA, SG, CP, GM, SS, LABOR_RATES, console })
+// `window` is supplied because the shipped `_tmTilePlayWithinTasks` resolves ScheduleAuthor through
+// `window` only — the same seam every real UI call site in time_machine.js uses.
+function buildSandbox(d) {
+  const sb = {
+    window: { LABOR_RATES: d.LABOR_RATES, GanttModel: d.GM, ScheduleAuthor: d.SA },
+    ScheduleGate: d.SG, CpmSchedule: d.CP, GanttModel: d.GM, ScheduleAuthor: d.SA,
+    _midairAudit: d.SS && d.SS.midairAudit,
+    console: d.console || console,
+    // Free variables `_tmRescaleToTaskWindow` closes over inside injectGantt. `_tiledPlay` is set by
+    // mirrorInjectGantt when applyTiling is on; left null it yields the PRE-#1605 affine, which is
+    // what the A/B probe's red control needs.
+    _cap: null, _winGroups: {}, _tiledPlay: null, _rawScheduleRemember: null,
+  };
+  vm.createContext(sb);
+  const missing = [];
+  const code = ['var _CPM_DISPLAY = true;']
+    .concat(TM_FNS.map(n => sliceFn(d.tmSrc, n)))
+    .concat([
+      // Optional so this module still runs against a pre-#1605 revision (then applyTiling is a no-op
+      // and says so, rather than pretending the tiling ran).
+      (d.tmSrc.indexOf('function _tmTilePlayWithinTasks(') >= 0
+        ? sliceFn(d.tmSrc, '_tmTilePlayWithinTasks')
+        : (missing.push('_tmTilePlayWithinTasks'), 'var _tmTilePlayWithinTasks = null;')),
+      'this._tmDisplayRemap = _tmDisplayRemap; this._displayTimeline = _displayTimeline;',
+      'this._tmRescaleToTaskWindow = _tmRescaleToTaskWindow; this._tmTilePlayWithinTasks = _tmTilePlayWithinTasks;',
+      'this.__getRaw = function () { return _rawScheduleRemember; };',
+    ]).join('\n');
+  vm.runInContext(code, sb);
+  sb.__missing = missing;
+  return sb;
+}
+
+// readDisplayAuthored(db) — the SAME query injectGantt runs (time_machine.js:4967). Never assumed:
+// a schedule whose windows we did not author keeps the affine, and this must be able to say so.
+function readDisplayAuthored(db) {
+  try {
+    const r = db.exec('SELECT 1 FROM schedules WHERE display_authored=1 LIMIT 1');
+    return !!(r.length && r[0].values.length);
+  } catch (e) { return false; }   // legacy DB without the column — affine stays, reported by caller
+}
+
+// mirrorInjectGantt({ sb, elements, tasks, db, startISO, applyTiling, log })
+//
+// Verbatim mirror of injectGantt's write path (time_machine.js ~4930-5010), in order:
+//   _twItems (from the raw schedule the displayRemap hook remembered)
+//   -> _displayTimeline  -> _cap {win, guidTask}  -> _winGroups
+//   -> _tmTilePlayWithinTasks(disp, cap, display_authored)
+//   -> _tmRescaleToTaskWindow per element   == the instants kernel_ops carries
+//
+// Returns { play, disp, win, guidTask, stats }. `play`/`disp` are guid -> {s,e} (ms epoch).
+function mirrorInjectGantt(o) {
+  const sb = o.sb, elements = o.elements, baseMs = Date.parse(o.startISO);
+  const log = o.log || function () {};
+  const raw = sb.__getRaw();
+  if (!raw || !raw.map) return { ok: false, reason: 'displayRemap hook did not remember a raw schedule — was opts.displayRemap passed to materializeZones?' };
+
+  const twItems = elements.map(el => {
+    const ts = raw.map[el.guid];
+    return { guid: el.guid, s: ts ? ts.start : baseMs, e: ts ? ts.end : baseMs + 60000,
+      bz: el.base_z != null ? el.base_z : el.bz, tz: el.top_z != null ? el.top_z : el.tz,
+      x0: el.x0, x1: el.x1, y0: el.y0, y1: el.y1,
+      cls: el.cls, seq: el.seq, phase: el.phase, storey: el.storey, resource: el.resource };
+  });
+  const dt = sb._displayTimeline(twItems);   // mutates .s/.e in place, exactly as injectGantt relies on
+  const disp = {};
+  twItems.forEach(it => { disp[it.guid] = { start: it.s, end: it.e }; });
+  let schedEnd = baseMs;
+  for (const g in disp) if (disp[g].end > schedEnd) schedEnd = disp[g].end;
+
+  // _cap mirror: the persisted task rows, guid -> its EARLIEST claiming task (injectGantt's rule)
+  const win = {}, guidTask = {};
+  const tasks = o.tasks;
+  if (!Array.isArray(tasks) || !tasks.length)
+    return { ok: false, reason: 'no task grid — materializeZones returned no res.tasks, so no element has a dated window' };
+  {
+    tasks.forEach(t => {
+      win[t.id] = { s: baseMs + t.sDays * DAY_MS, e: baseMs + t.eDays * DAY_MS, name: t.id,
+        sDays: t.sDays, eDays: t.eDays, phase: t.phase, storey: t.storey };
+      t.guids.forEach(g => { if (!guidTask[g] || win[t.id].s < win[guidTask[g]].s) guidTask[g] = t.id; });
+    });
+    const winGroups = {};
+    elements.forEach(el => {
+      const s = disp[el.guid] || { start: schedEnd, end: schedEnd + 60000 };
+      const tid = guidTask[el.guid];
+      if (tid == null || !win[tid]) return;
+      const g = winGroups[tid] || (winGroups[tid] = { min: Infinity, max: -Infinity });
+      if (s.start < g.min) g.min = s.start;
+      if (s.end > g.max) g.max = s.end;
+    });
+    sb._cap = { base: baseMs, win: win, guidTask: guidTask };
+    sb._winGroups = winGroups;
+
+    const displayAuthored = o.db ? readDisplayAuthored(o.db) : false;
+    let tiledMap = null;
+    if (o.applyTiling) {
+      if (typeof sb._tmTilePlayWithinTasks === 'function') {
+        tiledMap = sb._tmTilePlayWithinTasks(disp, sb._cap, displayAuthored);
+      } else {
+        log('§TM_PLAYED_LAYER tiling UNAVAILABLE — this time_machine.js revision has no ' +
+            '_tmTilePlayWithinTasks (pre-#1605); the played layer below is the affine, not the tiling');
+      }
+    }
+    // bind(tiles) — the write loop, verbatim. Run once per variant; the CPM display pass above is
+    // NOT repeated (it is one-shot: _displayTimeline._last is consumed), so the A/B columns are two
+    // views of ONE run, which is the only way an A/B here is honest.
+    function bind(tiles) {
+      sb._tiledPlay = tiles;
+      const map = {}; let clamped = 0, tiled = 0, uncovered = 0;
+      elements.forEach(el => {
+        const s = disp[el.guid] || { start: schedEnd, end: schedEnd + 60000 };
+        const b = sb._tmRescaleToTaskWindow(el.guid, s);
+        if (b.clamped) clamped++; else if (guidTask[el.guid] == null) uncovered++;
+        if (b.tiled) tiled++;
+        map[el.guid] = { s: b.start, e: b.end };
+      });
+      return { map: map, clamped: clamped, tiled: tiled, uncovered: uncovered };
+    }
+    // The AFFINE column (pre-#1605 behaviour) is only produced on request — an A/B probe needs it,
+    // the cache does not.
+    const affine = o.wantAffine ? bind(null) : null;
+    const r = bind(tiledMap);
+    const stats = { total: elements.length, clamped: r.clamped, tiled: r.tiled, uncovered: r.uncovered,
+      displayAuthored: displayAuthored, cpm: dt && dt.cpm, midair: dt && dt.midair,
+      applyTiling: !!o.applyTiling, tilingAvailable: typeof sb._tmTilePlayWithinTasks === 'function' };
+    log('§TM_PLAYED_LAYER total=' + stats.total + ' clamped=' + r.clamped + ' tiled=' + r.tiled +
+        ' uncovered=' + r.uncovered + ' display_authored=' + displayAuthored +
+        ' cpm=' + stats.cpm + ' midair=' + stats.midair +
+        ' (mirrors §TM_ELEMENT_WINDOW_BIND — these are the instants kernel_ops carries)');
+    return { ok: true, play: r.map, affine: affine ? affine.map : null, tiledMap: tiledMap,
+      disp: disp, win: win, guidTask: guidTask, winGroups: winGroups, twItems: twItems, stats: stats };
+  }
+}
+
+module.exports = { sliceFn, buildSandbox, mirrorInjectGantt, readDisplayAuthored, TM_FNS, DAY_MS };

--- a/scripts/probe_daybatch_played.js
+++ b/scripts/probe_daybatch_played.js
@@ -1,0 +1,145 @@
+#!/usr/bin/env node
+// probe_daybatch_played.js — §DAYBATCH_*, RE-MEASURED ON THE LAYER THE FILM ACTUALLY PLAYS.
+//
+// ⚠ DO NOT REMOVE — SCOPE (bim-compiler prompts/GANTT_ACCURACY.md §BUILDUP_DAY_BATCH_FEASIBILITY,
+// re-measured 2026-09-02 under queue item A-0; layer machinery: 4D_GANTT_TM_REFACTOR.md
+// §CACHE_PLAYED_LAYER). Read the log after every run (project Log Mandate).
+//
+// WHY THIS EXISTS. §BUILDUP_DAY_BATCH_FEASIBILITY's original numbers were computed by session
+// scratchpad scripts over the cache's `sched` key = materializeZones' displaySchedule — the map
+// §TM_REVEAL_SHIPPED then measured that viewer/time_machine.js NEVER READS. Its NO-GO verdict and
+// its "no real day-buckets exist" finding survive that (both are properties of a continuous
+// schedule, true of either map), but every WITHIN-TASK magnitude it published described a layer
+// nobody plays. Those magnitudes are re-measured here, on the persisted PLAYED layer, by a probe
+// that lives in the repo instead of a scratchpad — so the next session reads a § line instead of
+// re-deriving it (CLAUDE.md, PRIMAL LAW clause 5).
+//
+// Usage: node scripts/probe_daybatch_played.js [Building ...]      (default Hospital Duplex)
+//        LAYER=display node scripts/probe_daybatch_played.js ...   (the old, unplayed map)
+//        FRAMES=3118 ...                                           (film frame count, default 3118)
+'use strict';
+const path = require('path');
+const CACHE = require(path.join(__dirname, 'cache_4d_run.js'));
+const DAY_MS = 86400000;
+const FRAMES = process.env.FRAMES ? Number(process.env.FRAMES) : 3118;
+
+function pct(sorted, p) { return sorted[Math.min(sorted.length - 1, Math.floor(sorted.length * p))]; }
+function cv(a) {
+  if (a.length < 2) return null;
+  const m = a.reduce((x, y) => x + y, 0) / a.length;
+  const v = a.reduce((s, x) => s + (x - m) * (x - m), 0) / a.length;
+  return { mean: m, cv: m ? Math.sqrt(v) / m : null };
+}
+
+function run(bld) {
+  const r = CACHE.read(bld);
+  if (!r) { console.log('§DAYBATCH_PLAYED bld=' + bld + ' INCONCLUSIVE — no cache, run: node scripts/cache_4d_run.js ' + bld); return; }
+  const L = CACHE.layerOf(r);
+  console.log('§DAYBATCH_LAYER bld=' + bld + ' layer=' + L.id + ' key=' + L.key + ' — ' + L.desc);
+  if (L.missing) {
+    console.log('§DAYBATCH_PLAYED bld=' + bld + ' INCONCLUSIVE — layer=' + L.id + ' ABSENT from this cache ' +
+      '(predates §CACHE_PLAYED_LAYER). Rebuild: node scripts/cache_4d_run.js --force ' + bld +
+      '. NOT falling back to the other layer: that substitution is the defect A-9 removed.');
+    return;
+  }
+  const M = L.map, LAY = L.id, els = r.els, tasks = r.tasks || [];
+  const guids = Object.keys(M);
+  if (!guids.length) { console.log('§DAYBATCH_PLAYED bld=' + bld + ' layer=' + LAY + ' VACUOUS — the layer is empty'); return; }
+
+  // ── 1. ties: are completions discrete day-buckets, or continuous instants? ──────────────────
+  const ends = guids.map(g => M[g].e);
+  const tally = {}; ends.forEach(e => { tally[e] = (tally[e] || 0) + 1; });
+  const distinct = Object.keys(tally).length;
+  let largest = 0; for (const k in tally) if (tally[k] > largest) largest = tally[k];
+  console.log('§DAYBATCH_TIES bld=' + bld + ' layer=' + LAY + ' distinctEnds=' + distinct + '/' + ends.length +
+    ' largestExactTie=' + largest +
+    ' — a real day-bucket would show large exact ties; distinct instants mean the schedule is continuous');
+
+  // ── 2. intraday: do completions pile at midnight? ───────────────────────────────────────────
+  const t0 = Math.min.apply(null, guids.map(g => M[g].s));
+  const hour = new Array(24).fill(0);
+  let nearMidnight = 0;
+  ends.forEach(e => {
+    const off = e - t0;
+    const h = Math.floor((off % DAY_MS) / 3600000);
+    hour[Math.max(0, Math.min(23, h))]++;
+    const intoDay = ((off % DAY_MS) + DAY_MS) % DAY_MS;
+    if (intoDay < 60000 || intoDay > DAY_MS - 60000) nearMidnight++;
+  });
+  const hMin = Math.min.apply(null, hour), hMax = Math.max.apply(null, hour);
+  console.log('§DAYBATCH_INTRADAY bld=' + bld + ' layer=' + LAY + ' hourHistogram min=' + hMin + ' max=' + hMax +
+    ' uniformExpected=' + Math.round(ends.length / 24) +
+    ' endsWithin1minOfDayBoundary=' + nearMidnight + '/' + ends.length +
+    ' (' + (100 * nearMidnight / ends.length).toFixed(2) + '%) — 24/7 calendar, so a day boundary is not a shift change');
+
+  // ── 3. the biggest task: successive-completion gaps, and the per-day rate ───────────────────
+  const byTask = {};
+  tasks.forEach(t => { byTask[t.id] = t.guids.filter(g => M[g]); });
+  const big = Object.keys(byTask).sort((a, b) => byTask[b].length - byTask[a].length).slice(0, 4);
+  big.forEach((tid, i) => {
+    const gs = byTask[tid]; if (gs.length < 20) return;
+    const es = gs.map(g => M[g].e).sort((a, b) => a - b);
+    const gaps = []; for (let k = 1; k < es.length; k++) gaps.push(es[k] - es[k - 1]);
+    gaps.sort((a, b) => a - b);
+    if (i === 0) console.log('§DAYBATCH_GAPS bld=' + bld + ' layer=' + LAY + ' task=' + tid + ' n=' + gs.length +
+      ' successiveCompletionGap p50=' + pct(gaps, 0.5) + 'ms(' + (pct(gaps, 0.5) / 60000).toFixed(2) + 'min)' +
+      ' p90=' + (pct(gaps, 0.9) / 60000).toFixed(2) + 'min max=' + (gaps[gaps.length - 1] / 3600000).toFixed(2) + 'h' +
+      ' — a smooth drip has a small p50; a daily clump would show p50~0 with a 24h max');
+    const perDay = {};
+    es.forEach(e => { const d = Math.floor((e - t0) / DAY_MS); perDay[d] = (perDay[d] || 0) + 1; });
+    const c = cv(Object.values(perDay));
+    console.log('§DAYBATCH_TASK_DAYRATE bld=' + bld + ' layer=' + LAY + ' task=' + tid + ' n=' + gs.length +
+      ' days=' + Object.keys(perDay).length + ' meanPerDay=' + (c ? c.mean.toFixed(1) : 'n/a') +
+      ' CV=' + (c && c.cv != null ? c.cv.toFixed(2) : 'n/a') +
+      ' — a per-day count is the BINNING of a continuous layout, not a schedule structure');
+  });
+
+  // ── 4. frames: worst-frame pop on a calendar-linear cursor ──────────────────────────────────
+  const starts = guids.map(g => M[g].s);
+  const pStart = Math.min.apply(null, starts), pEnd = Math.max.apply(null, guids.map(g => M[g].e));
+  const step = (pEnd - pStart) / FRAMES;
+  const per = new Array(FRAMES).fill(0);
+  const frameOf = {};
+  guids.forEach(g => { let f = Math.floor((M[g].s - pStart) / step); if (f >= FRAMES) f = FRAMES - 1; if (f < 0) f = 0; per[f]++; frameOf[g] = f; });
+  let worst = -1, worstF = -1;
+  per.forEach((c, i) => { if (c > worst) { worst = c; worstF = i; } });
+  const mean = guids.length / FRAMES;
+  console.log('§DAYBATCH_FRAMES bld=' + bld + ' layer=' + LAY + ' frames=' + FRAMES +
+    ' projectDays=' + ((pEnd - pStart) / DAY_MS).toFixed(1) +
+    ' mean=' + mean.toFixed(1) + '/frame worst=' + worst + ' at f' + worstF +
+    ' = ' + (worst / mean).toFixed(1) + 'x mean, day ' + ((worstF * step) / DAY_MS).toFixed(1));
+
+  // ── 5. what is IN the worst frame — the short-element-run clustering claim ───────────────────
+  const elBy = {}; els.forEach(e => { elBy[e.guid] = e; });
+  const gTask = {}; tasks.forEach(t => t.guids.forEach(g => { if (gTask[g] == null) gTask[g] = t.id; }));
+  const inWorst = guids.filter(g => frameOf[g] === worstF);
+  const byT = {}; inWorst.forEach(g => { const t = gTask[g] || '_none'; byT[t] = (byT[t] || 0) + 1; });
+  const topT = Object.keys(byT).sort((a, b) => byT[b] - byT[a])[0];
+  const widths = inWorst.filter(g => (gTask[g] || '_none') === topT).map(g => (M[g].e - M[g].s) / 1000).sort((a, b) => a - b);
+  const taskAll = (byTask[topT] || []).map(g => (M[g].e - M[g].s) / 1000).sort((a, b) => a - b);
+  const isecs = inWorst.filter(g => (gTask[g] || '_none') === topT && elBy[g]).map(g => elBy[g].installSecs).sort((a, b) => a - b);
+  const isecsAll = (byTask[topT] || []).filter(g => elBy[g]).map(g => elBy[g].installSecs).sort((a, b) => a - b);
+  console.log('§DAYBATCH_BURST_MIX bld=' + bld + ' layer=' + LAY + ' worstFrame=f' + worstF +
+    ' dominatedBy=' + topT + ' (' + byT[topT] + '/' + inWorst.length + ' of the frame)' +
+    ' burstWidth p50=' + (widths.length ? widths[Math.floor(widths.length / 2)].toFixed(0) : 'n/a') + 's' +
+    ' vs taskWidth p50=' + (taskAll.length ? taskAll[Math.floor(taskAll.length / 2)].toFixed(0) : 'n/a') + 's' +
+    ' | installSecs p50 burst=' + (isecs.length ? isecs[Math.floor(isecs.length / 2)] : 'n/a') +
+    ' vs task=' + (isecsAll.length ? isecsAll[Math.floor(isecsAll.length / 2)] : 'n/a') +
+    ' — the duration-weighted tiling packs a short-duration run denser than the task mean');
+
+  // ── 6. day-batching prediction (labelled a PREDICTION, computed from the measured per-day mix) ─
+  const perDayAll = {};
+  ends.forEach(e => { const d = Math.floor((e - t0) / DAY_MS); perDayAll[d] = (perDayAll[d] || 0) + 1; });
+  const dayCounts = Object.values(perDayAll).sort((a, b) => a - b);
+  const maxDay = dayCounts[dayCounts.length - 1];
+  const overs = dayCounts.filter(c => c > worst).length;
+  console.log('§DAYBATCH_PULSE_PREDICTION bld=' + bld + ' layer=' + LAY +
+    ' framesPerDay=' + (FRAMES / ((pEnd - pStart) / DAY_MS)).toFixed(2) +
+    ' perDay p50=' + pct(dayCounts, 0.5) + ' p90=' + pct(dayCounts, 0.9) + ' max=' + maxDay +
+    ' -> predictedWorstFrameIfBatched=' + maxDay + ' = ' + (maxDay / mean).toFixed(1) + 'x mean' +
+    ' (today ' + (worst / mean).toFixed(1) + 'x) daysWhoseFullCountExceedsCurrentWorstFrame=' + overs + '/' + dayCounts.length +
+    ' — PREDICTION, not a measurement of a built thing');
+}
+
+const list = process.argv.slice(2).filter(a => a[0] !== '-');
+(list.length ? list : ['Hospital', 'Duplex']).forEach(b => { run(b); console.log(''); });

--- a/scripts/probe_tm_reveal_shipped.js
+++ b/scripts/probe_tm_reveal_shipped.js
@@ -16,6 +16,11 @@
 // So this probe mirrors THAT chain, slicing the live functions out of time_machine.js by brace
 // matching (same discipline as witness_tm_element_window_bind.js) — never re-typed.
 //
+// §CACHE_PLAYED_LAYER (2026-09-02, queue item A-9): that slicing + mirror now lives in
+// scripts/lib/tm_played_layer.js and is SHARED with scripts/cache_4d_run.js, which persists the
+// played layer into ~/.cache/bim4d. Two independent node replications of the played layer would be
+// the same defect class this section exists to remove, so there is exactly one.
+//
 // Per task it prints: the decile histogram of op.start inside the task's own window (the film's
 // reveal distribution), the CPM group's raw span vs its Tukey-fenced core span (how much of the
 // window the outlier-free mass is squashed into), and the outliers by name.
@@ -44,17 +49,9 @@ globalThis.LevelDeriver = require(path.join(V, 'lib', 'level_deriver.js'));
 globalThis.LocationAxis = require(path.join(V, 'location_axis.js'));
 const T = JSON.parse(fs.readFileSync(path.join(V, 'rates', '4D_template.json'), 'utf8'));
 const tmSrc = fs.readFileSync(path.join(V, 'time_machine.js'), 'utf8');
+// §CACHE_PLAYED_LAYER — the ONE owner of "the played layer, in node" (slicing + injectGantt mirror).
+const TMP = require(path.join(__dirname, 'lib', 'tm_played_layer.js'));
 
-function sliceFn(src, name) {
-  const idx = src.indexOf('function ' + name + '(');
-  if (idx < 0) throw new Error(name + ' not found in time_machine.js');
-  let d = 0, open = false;
-  for (let i = idx; i < src.length; i++) {
-    if (src[i] === '{') { d++; open = true; }
-    else if (src[i] === '}') { d--; if (open && d === 0) return src.slice(idx, i + 1); }
-  }
-  throw new Error('unbalanced braces for ' + name);
-}
 function executedRules() {
   const sb = { console: { log() {}, warn() {}, error() {} } };
   vm.createContext(sb);
@@ -75,41 +72,12 @@ function deciles(vals) {
   return h.map(c => +(100 * c / Math.max(1, vals.length)).toFixed(1));
 }
 
-function buildSandbox(R) {
-  const sb = {
-    window: { LABOR_RATES: R.LABOR_RATES, GanttModel: GM, ScheduleAuthor: SA },
-    ScheduleGate: SG, CpmSchedule: CP, GanttModel: GM, ScheduleAuthor: SA,
-    _midairAudit: SS.midairAudit,
-    console: console,
-    // _tiledPlay stays null here so `_tmRescaleToTaskWindow` yields the PRE-FIX affine map (the
-    // "SHIPPED-affine" label below = what played before §TM_REVEAL_TILED); the CANDIDATE map is the
-    // shipped tiling function itself when the revision has it.
-    _cap: null, _winGroups: {}, _tiledPlay: null, _rawScheduleRemember: null,
-  };
-  vm.createContext(sb);
-  const code = [
-    'var _CPM_DISPLAY = true;',
-    sliceFn(tmSrc, '_tukeyBound'),
-    sliceFn(tmSrc, '_displayTimelineRemember'),
-    sliceFn(tmSrc, '_displayTimeline'),
-    sliceFn(tmSrc, '_tmDisplayRemap'),
-    sliceFn(tmSrc, '_tmRescaleToTaskWindow'),
-    // §TM_REVEAL_TILED — optional so the probe still runs against a pre-fix revision (then the
-    // CANDIDATE is computed by calling the verb directly, which is what the shipped function does).
-    (tmSrc.indexOf('function _tmTilePlayWithinTasks(') >= 0 ? sliceFn(tmSrc, '_tmTilePlayWithinTasks') : 'var _tmTilePlayWithinTasks = null;'),
-    'this._tmDisplayRemap = _tmDisplayRemap; this._displayTimeline = _displayTimeline;',
-    'this._tmRescaleToTaskWindow = _tmRescaleToTaskWindow; this._tmTilePlayWithinTasks = _tmTilePlayWithinTasks;',
-    'this.__getRaw = function () { return _rawScheduleRemember; };',
-  ].join('\n');
-  vm.runInContext(code, sb);
-  return sb;
-}
-
 async function runBuilding(bld, SQL, R) {
   const dbf = resolveDbFile(bld);
   if (!fs.existsSync(dbf.path)) { console.log('§TM_REVEAL_SHIPPED_SKIP ' + bld + ' — no db'); return null; }
   const db = new SQL.Database(new Uint8Array(fs.readFileSync(dbf.path)));
-  const sb = buildSandbox(R);
+  const sb = TMP.buildSandbox({ tmSrc: tmSrc, SA: SA, SG: SG, CP: CP, GM: GM, SS: SS,
+    LABOR_RATES: R.LABOR_RATES, console: console });
   const SHIFT = T.calendar.hours_per_shift;
   const base = { start: START, laborRates: R.LABOR_RATES, rates: R.RATES,
     nameOverrides: R.SEQUENCE_NAME_OVERRIDES, defaultRule: R.SEQUENCE_DEFAULT,
@@ -125,69 +93,26 @@ async function runBuilding(bld, SQL, R) {
     ' elements=' + elements.length + ' tasks=' + res.tasks.length + ' totalDays=' + res.totalDays +
     ' materializeMs=' + (Date.now() - t0));
 
-  // ── injectGantt mirror: _twItems -> _displayTimeline (REUSE branch replays the hook's CPM) ──
-  const raw = sb.__getRaw();
-  if (!raw || !raw.map) { console.log('§TM_REVEAL_SHIPPED_FAIL ' + bld + ' hook did not remember the raw schedule'); db.close(); delete globalThis.APP; return null; }
+  // ── injectGantt mirror — scripts/lib/tm_played_layer.js, the SHARED owner (§CACHE_PLAYED_LAYER).
+  // wantAffine:true gives BOTH columns off ONE run: `affine` = the pre-#1605 per-task affine (the A
+  // column and the red control), `play` = the shipped path with §TM_REVEAL_TILED applied. The CPM
+  // display pass runs once and is shared by both, which is the only way this A/B is honest.
   const baseMs = Date.parse(START);
-  const twItems = elements.map(el => {
-    const ts = raw.map[el.guid];
-    return { guid: el.guid, s: ts ? ts.start : baseMs, e: ts ? ts.end : baseMs + 60000,
-      bz: el.base_z, tz: el.top_z, x0: el.x0, x1: el.x1, y0: el.y0, y1: el.y1,
-      cls: el.cls, seq: el.seq, phase: el.phase, storey: el.storey, resource: el.resource };
-  });
-  const dt = sb._displayTimeline(twItems);
+  const mp = TMP.mirrorInjectGantt({ sb: sb, elements: elements, tasks: res.tasks, db: db,
+    startISO: START, applyTiling: true, wantAffine: true, log: console.log });
   delete globalThis.APP;
-  console.log('§TM_REVEAL_SHIPPED_DISPLAY ' + bld + ' cpm=' + (dt && dt.cpm) + ' midair=' + (dt && dt.midair) +
+  if (!mp.ok) { console.log('§TM_REVEAL_SHIPPED_FAIL ' + bld + ' ' + mp.reason); db.close(); return null; }
+  const disp = mp.disp, win = mp.win, guidTask = mp.guidTask, twItems = mp.twItems, winGroups = mp.winGroups;
+  const op = mp.affine, opFix = mp.play, tiled = mp.tiledMap;
+  console.log('§TM_REVEAL_SHIPPED_DISPLAY ' + bld + ' cpm=' + mp.stats.cpm + ' midair=' + mp.stats.midair +
     ' (cpm=reuse means injectGantt replayed the hook\'s CPM timeline, exactly as the browser cold-open does)');
-  const disp = {};
-  twItems.forEach(it => { disp[it.guid] = { start: it.s, end: it.e }; });
-  let schedEnd = baseMs;
-  for (const g in disp) if (disp[g].end > schedEnd) schedEnd = disp[g].end;
-
-  // ── _cap mirror: template task windows (the persisted `tasks` rows), guid -> earliest task ──
-  const win = {}, guidTask = {};
-  res.tasks.forEach(t => {
-    win[t.id] = { s: baseMs + t.sDays * DAY_MS, e: baseMs + t.eDays * DAY_MS, name: t.id, sDays: t.sDays, eDays: t.eDays,
-      phase: t.phase, storey: t.storey };
-    t.guids.forEach(g => { if (!guidTask[g] || win[t.id].s < win[guidTask[g]].s) guidTask[g] = t.id; });
-  });
-  sb._cap = { win: win, guidTask: guidTask };
-  // _winGroups — verbatim shape of time_machine.js injectGantt (~4872-4880)
-  const winGroups = {};
-  elements.forEach(el => {
-    const s = disp[el.guid] || { start: schedEnd, end: schedEnd + 60000 };
-    const tid = guidTask[el.guid];
-    if (tid == null || !win[tid]) return;
-    const g = winGroups[tid] || (winGroups[tid] = { min: Infinity, max: -Infinity });
-    if (s.start < g.min) g.min = s.start;
-    if (s.end > g.max) g.max = s.end;
-  });
-  sb._winGroups = winGroups;
-  const op = {};
-  let clamped = 0, uncovered = 0;
-  elements.forEach(el => {
-    const s = disp[el.guid] || { start: schedEnd, end: schedEnd + 60000 };
-    const b = sb._tmRescaleToTaskWindow(el.guid, s);
-    if (b.clamped) clamped++; else if (guidTask[el.guid] == null) uncovered++;
-    op[el.guid] = { s: b.start, e: b.end };
-  });
-  console.log('§TM_REVEAL_SHIPPED_BIND ' + bld + ' total=' + elements.length + ' clamped=' + clamped + ' uncovered=' + uncovered +
+  console.log('§TM_REVEAL_SHIPPED_BIND ' + bld + ' total=' + mp.stats.total + ' clamped=' + mp.stats.clamped +
+    ' uncovered=' + mp.stats.uncovered + ' tiled=' + mp.stats.tiled + ' display_authored=' + mp.stats.displayAuthored +
     ' (mirrors §TM_ELEMENT_WINDOW_BIND)');
-
-  // ── CANDIDATE (A/B): the tiling verb schedule_author already owns, applied in CPM order ──
-  // ScheduleAuthor.remapSolveToTasks(solve, tasks, startISO, layerOf=null): one band per task, members
-  // ordered by the solve's own start (here: the CPM display time the movie plays TODAY, so every
-  // ordering CPM established survives — monotone, ties on guid), each element's width = its own CPM
-  // duration, tiled edge-to-edge across the task's window. No number invented; no window moved.
+  console.log('§TM_REVEAL_SHIPPED_CANDIDATE ' + bld + ' source=' +
+    (mp.stats.tilingAvailable ? 'time_machine.js _tmTilePlayWithinTasks (shipped)'
+      : '⛔ NONE — this revision has no _tmTilePlayWithinTasks, so the CANDIDATE column equals the affine'));
   const capTasks = res.tasks.map(t => ({ id: t.id, sDays: t.sDays, eDays: t.eDays, guids: t.guids.filter(g => guidTask[g] === t.id) }));
-  // Prefer the SHIPPED function (sliced out of time_machine.js) so the CANDIDATE column measures the
-  // code that ships, not a re-derivation; a pre-fix revision falls back to calling the verb directly.
-  const tiled = (typeof sb._tmTilePlayWithinTasks === 'function')
-    ? sb._tmTilePlayWithinTasks(disp, { base: baseMs, win: win, guidTask: guidTask }, true)
-    : SA.remapSolveToTasks(disp, capTasks, START, null).schedule;
-  console.log('§TM_REVEAL_SHIPPED_CANDIDATE ' + bld + ' source=' + (typeof sb._tmTilePlayWithinTasks === 'function' ? 'time_machine.js _tmTilePlayWithinTasks (shipped)' : 'ScheduleAuthor.remapSolveToTasks (direct call, pre-fix revision)'));
-  const opFix = {};
-  elements.forEach(el => { const t = tiled[el.guid]; opFix[el.guid] = t ? { s: t.start, e: t.end } : op[el.guid]; });
   let pStart0 = Infinity, pEnd0 = -Infinity;
   elements.forEach(e => { if (op[e.guid].s < pStart0) pStart0 = op[e.guid].s; if (op[e.guid].e > pEnd0) pEnd0 = op[e.guid].e; });
 

--- a/scripts/probe_tpl_calibration_scope.js
+++ b/scripts/probe_tpl_calibration_scope.js
@@ -73,6 +73,16 @@ function run(bld) {
   const c = CACHE.read(bld);
   if (!c) { console.log('§TPL_CALIB_SCOPE bld=' + bld + ' INCONCLUSIVE — no current cache (run scripts/cache_4d_run.js ' + bld + ')'); return null; }
   if (!c.els || !c.els.length) { console.log('§TPL_CALIB_SCOPE bld=' + bld + ' INCONCLUSIVE — cache has no elements'); return null; }
+  // §CACHE_PLAYED_LAYER (2026-09-02, queue item A-9) — every cache reader must name the layer it
+  // judged. This one is layer-INDEPENDENT and says so: it re-instantiates the TEMPLATE from the
+  // cached ELEMENTS (installSecs) and checks its arms against the shipped §AUTHOR_TPL totalDays in
+  // the cached LOG. It reads neither schedule map, so no re-pointing was needed — but "I read no
+  // layer" is itself an attribution, and an unstated one is what let a whole class of measurement
+  // judge the wrong map for four weeks.
+  console.log('§TPL_CALIB_LAYER bld=' + bld + ' layer=NONE — this probe judges cached ELEMENTS ' +
+    '(installSecs) + the shipped §AUTHOR_TPL log line; it reads neither the played nor the display ' +
+    'schedule map, so its numbers are unaffected by §CACHE_PLAYED_LAYER. cacheHasPlayedLayer=' +
+    (c.play ? 'yes' : 'NO (rebuild with --force)'));
 
   // ── arms ────────────────────────────────────────────────────────────────────────────────────
   const base = arm(c.els, SHIFT_H, 1);                                   // shipped, as deployed

--- a/scripts/probe_tpl_parallel_reveal.js
+++ b/scripts/probe_tpl_parallel_reveal.js
@@ -34,7 +34,13 @@
 //       must never read as a pass.
 //
 // NON-INVENT: reads the persisted cache_4d_run.js run (element reveal times exactly as the shipped
-// materializeZones produced them, plus the shipped task grid). Nothing is re-solved or authored.
+// pipeline produced them, plus the shipped task grid). Nothing is re-solved or authored.
+//
+// ⚠ WHICH LAYER (§CACHE_PLAYED_LAYER, 2026-09-02, queue item A-9). "Reveal AT THE SAME TIME during
+// movie playback" is a question about the map the movie plays — so it is asked of the PLAYED layer
+// (kernel_ops), not materializeZones' displaySchedule, which viewer/time_machine.js never reads
+// (§TM_REVEAL_SHIPPED). Selected through CACHE.layerOf() and named on every line below;
+// `LAYER=display` re-points this probe at the old map deliberately, and it still says so.
 'use strict';
 const path = require('path');
 const CACHE = require(path.join(__dirname, 'cache_4d_run.js'));
@@ -46,7 +52,15 @@ function run(bld, startISO) {
     console.log('§TPL_PARALLEL_REVEAL bld=' + bld + ' INCONCLUSIVE — no cached task grid'); return false;
   }
   const base = Date.parse(startISO || '2026-01-01');
-  const sched = c.sched, tasks = c.tasks;
+  const L = CACHE.layerOf(c);
+  console.log('§TPL_PARALLEL_REVEAL_LAYER bld=' + bld + ' layer=' + L.id + ' key=' + L.key + ' — ' + L.desc);
+  if (L.missing) {
+    console.log('§TPL_PARALLEL_REVEAL bld=' + bld + ' INCONCLUSIVE — layer=' + L.id + ' ABSENT from this cache ' +
+      '(predates §CACHE_PLAYED_LAYER). Rebuild: node scripts/cache_4d_run.js --force ' + bld +
+      '. NOT falling back to the other layer: that substitution is the defect A-9 removed.');
+    return false;
+  }
+  const sched = L.map, tasks = c.tasks, LAY = L.id;
 
   // ── P1: every element sits inside its own task's ABSOLUTE window ─────────────────────────────
   let inWin = 0, outWin = 0, worstMs = 0, judged = 0;
@@ -59,7 +73,7 @@ function run(bld, startISO) {
       if (off > 0) { outWin++; if (off > worstMs) worstMs = off; } else inWin++;
     });
   });
-  console.log('§TPL_REVEAL_ABSOLUTE bld=' + bld + ' elementsInsideOwnTaskWindow=' + inWin + '/' + judged +
+  console.log('§TPL_REVEAL_ABSOLUTE bld=' + bld + ' layer=' + LAY + ' elementsInsideOwnTaskWindow=' + inWin + '/' + judged +
     ' outside=' + outWin + ' worstOffsetDays=' + (worstMs / DAY).toFixed(3) +
     ' — ' + (judged === 0 ? 'VACUOUS (nothing judged)'
       : outWin === 0 ? 'PASS: reveal times are absolute project-timeline instants placed by each task\'s OWN window'
@@ -73,12 +87,12 @@ function run(bld, startISO) {
     if (ov > 0) pairs.push({ a: a, b: b, ov: ov, sameLevel: a.storey === b.storey });
   }
   const crossLevel = pairs.filter(p => !p.sameLevel);
-  console.log('§TPL_REVEAL_CONCURRENCY bld=' + bld + ' overlappingTaskPairs=' + pairs.length +
+  console.log('§TPL_REVEAL_CONCURRENCY bld=' + bld + ' layer=' + LAY + ' overlappingTaskPairs=' + pairs.length +
     ' (crossLevel=' + crossLevel.length + ' sameLevel=' + pairs.filter(p => p.sameLevel).length +
     ') of ' + (tasks.length * (tasks.length - 1) / 2) + ' pairs — sameLevel MUST stay 0 ' +
     '(witness_4d_template_instantiation no-same-level-phase-overlap)');
   if (!crossLevel.length) {
-    console.log('§TPL_PARALLEL_REVEAL bld=' + bld + ' VACUOUS — no two task windows intersect, so P2 judged nothing');
+    console.log('§TPL_PARALLEL_REVEAL bld=' + bld + ' layer=' + LAY + ' VACUOUS — no two task windows intersect, so P2 judged nothing');
     return false;
   }
 
@@ -98,7 +112,7 @@ function run(bld, startISO) {
       .map(s => ({ t: tag, ts: s.s, te: s.e }));
     const A = pick(p.a, 'A'), B = pick(p.b, 'B');
     if (!A.length || !B.length) {
-      console.log('§TPL_REVEAL_INTERLEAVE bld=' + bld + ' ' + p.a.id + ' | ' + p.b.id +
+      console.log('§TPL_REVEAL_INTERLEAVE bld=' + bld + ' layer=' + LAY + ' ' + p.a.id + ' | ' + p.b.id +
         ' VACUOUS — one side contributes no element inside the shared range (nA=' + A.length + ' nB=' + B.length + ')');
       allPass = false; return;
     }
@@ -139,7 +153,7 @@ function run(bld, startISO) {
     // itself makes available to co-occur.
     const ok = alt > 1 && bothActive === Math.min(aBins, bBins);
     if (!ok) allPass = false;
-    console.log('§TPL_REVEAL_DEADAIR bld=' + bld + ' pair=' + p.a.id + '|' + p.b.id +
+    console.log('§TPL_REVEAL_DEADAIR bld=' + bld + ' layer=' + LAY + ' pair=' + p.a.id + '|' + p.b.id +
       ' binsActive A=' + aBins + '/' + BINS + ' B=' + bBins + '/' + BINS + ' both=' + bothActive +
       ' — ' + (bothActive === Math.min(aBins, bBins)
         ? 'every slice the sparser task occupies is SHARED (no serialisation); ' +
@@ -147,7 +161,7 @@ function run(bld, startISO) {
         : 'a slice has one task active while the other is ALSO capable of being active — genuine serialisation'));
     const rng = arr => (Math.min.apply(null, arr.map(x => x.ts)) - base) / DAY;
     const rngE = arr => (Math.max.apply(null, arr.map(x => x.ts)) - base) / DAY;
-    console.log('§TPL_REVEAL_INTERLEAVE bld=' + bld +
+    console.log('§TPL_REVEAL_INTERLEAVE bld=' + bld + ' layer=' + LAY +
       ' A=' + p.a.id + '[' + p.a.sDays + ',' + p.a.eDays + ']' +
       ' B=' + p.b.id + '[' + p.b.sDays + ',' + p.b.eDays + ']' +
       ' sharedWindowDays=[' + ((s0 - base) / DAY).toFixed(1) + ',' + ((e0 - base) / DAY).toFixed(1) + ']' +
@@ -162,7 +176,7 @@ function run(bld, startISO) {
         : 'FAIL: ' + (BINS - bothActive) + ' slice(s) of the shared window have only ONE task revealing'));
   });
 
-  console.log('§TPL_PARALLEL_REVEAL bld=' + bld + ' ' + (outWin === 0 && allPass ? 'PASS' : 'FAIL') +
+  console.log('§TPL_PARALLEL_REVEAL bld=' + bld + ' layer=' + LAY + ' ' + (outWin === 0 && allPass ? 'PASS' : 'FAIL') +
     ' — absolute=' + (outWin === 0) + ' interleaved=' + allPass);
   return outWin === 0 && allPass;
 }

--- a/scripts/probe_tpl_reveal_spread.js
+++ b/scripts/probe_tpl_reveal_spread.js
@@ -3,9 +3,15 @@
 // ⚠ DO NOT REMOVE — SCOPE. Spec-First (CLAUDE.md): measure the CURRENT distribution before any code
 // change. Reads the persisted cache (bim-ootb/scripts/cache_4d_run.js) — never re-invokes the
 // pipeline. Question: for a task spanning [task_sDays, task_eDays], where does each of its elements'
-// reveal timestamp (displaySchedule[guid].s, from §TPL_MOVIE_BINDS_BARS) fall inside that window,
-// normalized to [0,1]? A histogram skewed toward 0 is "crammed at the start"; a flat histogram is
-// "spread across the bar" (the fixed shape).
+// reveal timestamp fall inside that window, normalized to [0,1]? A histogram skewed toward 0 is
+// "crammed at the start"; a flat histogram is "spread across the bar" (the fixed shape).
+//
+// ⚠ WHICH LAYER (§CACHE_PLAYED_LAYER, 2026-09-02, queue item A-9). This probe used to read the
+// cache's `sched` key = materializeZones' displaySchedule, which §TM_REVEAL_SHIPPED measured that
+// viewer/time_machine.js NEVER READS. Every number it published before this date — the aggregate
+// deciles [12.8,9.7,...] and the §TPL_REVEAL_SPREAD_WORST MEP-Final first-decile skew — described a
+// map the film does not play and is VOID (queue item A-0). It now selects through CACHE.layerOf()
+// and prints `layer=` on every line; `LAYER=display` re-points it at the old map deliberately.
 'use strict';
 const path = require('path');
 const CACHE = require(path.join(__dirname, 'cache_4d_run.js'));
@@ -14,6 +20,15 @@ const bld = process.argv[2] || 'Hospital';
 const run = CACHE.read(bld);
 if (!run) { console.log('§TPL_REVEAL_SPREAD_FAIL bld=' + bld + ' — no cache, run: node scripts/cache_4d_run.js ' + bld); process.exit(1); }
 if (!run.tasks) { console.log('§TPL_REVEAL_SPREAD_FAIL bld=' + bld + ' — cache has no tasks field, rebuild with --force'); process.exit(1); }
+const L = CACHE.layerOf(run);
+console.log('§TPL_REVEAL_SPREAD_LAYER bld=' + bld + ' layer=' + L.id + ' key=' + L.key + ' — ' + L.desc);
+if (L.missing) {
+  console.log('§TPL_REVEAL_SPREAD_FAIL bld=' + bld + ' layer=' + L.id + ' ABSENT — this cache predates ' +
+    '§CACHE_PLAYED_LAYER. Rebuild: node scripts/cache_4d_run.js --force ' + bld +
+    '. NOT falling back to the other layer: that substitution is the defect A-9 removed.');
+  process.exit(1);
+}
+const SCHED = L.map;
 
 const BUCKETS = 10;
 const hist = new Array(BUCKETS).fill(0);
@@ -27,7 +42,7 @@ for (const t of run.tasks) {
   const tHist = new Array(BUCKETS).fill(0);
   let tN = 0;
   for (const g of t.guids) {
-    const sc = run.sched[g];
+    const sc = SCHED[g];
     if (!sc) { skipped++; continue; }
     let pos = wSpan > 0 ? (sc.s - wS) / wSpan : 0;
     if (pos < 0) pos = 0; if (pos > 1) pos = 1;
@@ -40,17 +55,17 @@ for (const t of run.tasks) {
 }
 
 perTask.sort((a, b) => b.firstDecilePct - a.firstDecilePct);
-console.log('§TPL_REVEAL_SPREAD_WORST bld=' + bld + ' top5-by-firstDecilePct=' +
+console.log('§TPL_REVEAL_SPREAD_WORST bld=' + bld + ' layer=' + L.id + ' top5-by-firstDecilePct=' +
   JSON.stringify(perTask.slice(0, 5)));
 
 const pct = hist.map(c => (100 * c / n).toFixed(1));
-console.log('§TPL_REVEAL_SPREAD bld=' + bld + ' tasks=' + run.tasks.length + ' n=' + n + ' skipped=' + skipped +
+console.log('§TPL_REVEAL_SPREAD bld=' + bld + ' layer=' + L.id + ' tasks=' + run.tasks.length + ' n=' + n + ' skipped=' + skipped +
   ' decileCounts=[' + hist.join(',') + '] decilePct=[' + pct.join(',') + ']' +
   ' — decile 0 = first 10% of the task own window, decile 9 = last 10%; a flat 10.0 each = uniform spread');
 
 // Simple skew signal: share of elements landing in the FIRST decile vs a uniform-spread expectation
 // of 10%. This is the number item 2's "crammed at the start" claim is actually about.
 const first = parseFloat(pct[0]);
-console.log('§TPL_REVEAL_SPREAD_SKEW bld=' + bld + ' firstDecilePct=' + first.toFixed(1) +
+console.log('§TPL_REVEAL_SPREAD_SKEW bld=' + bld + ' layer=' + L.id + ' firstDecilePct=' + first.toFixed(1) +
   ' uniformExpected=10.0 ratio=' + (first / 10).toFixed(2) + 'x' +
   (first > 20 ? ' — CRAMMED (>2x uniform)' : first > 12 ? ' — mild skew' : ' — roughly uniform'));

--- a/viewer/schedule_author.js
+++ b/viewer/schedule_author.js
@@ -1468,9 +1468,17 @@
          : _mv === 0 ? 'FAIL pass ran but moved nothing — a no-op that looks like a success'
          : _inv === 0 ? 'PASS' : 'FAIL support order still violated inside a task'));
     } catch (e) { console.log('§TPL_LAYER_SELFCHECK_ERROR ' + e.message); }
+    // ⚠ WORDING CORRECTED 2026-09-02 (bim-compiler 4D_GANTT_TM_REFACTOR.md §TM_REVEAL_SHIPPED,
+    // queue item A-0). This line used to end "every element now PLAYS inside the bar that claims
+    // it". That was never true of THIS map: `displaySchedule` is returned below and
+    // viewer/time_machine.js has ZERO readers of it (the only reference repo-wide is the return
+    // statement a few lines down). What the film and the scrubber play is kernel_ops, written by
+    // injectGantt — since #1605 by §TM_REVEAL_TILED, which calls this same verb with its own
+    // arguments. The counts are unchanged; only the false half of the sentence is.
     console.log('§TPL_MOVIE_BINDS_BARS remapped=' + _rm.mapped + '/' + elements.length +
       ' degenerateTasksSpreadEvenly=' + _rm.degenerateTasks +
-      ' — every element now plays inside the bar that claims it');
+      ' — every element is REMAPPED inside the bar that claims it (this is `displaySchedule`;' +
+      ' time_machine.js does not read it — the played layer is kernel_ops, §TM_REVEAL_TILED)');
     return { ok: true, scheduleId: schedId, zoneCount: inst.tasks.length, edgeCount: inst.edges.length,
              totalDays: inst.totalDays, templateVersion: T.meta.version, reports: inst.reports,
              tasks: inst.tasks, displaySchedule: _rm.schedule };

--- a/viewer/tests/probe_stair_flight_support_pool.js
+++ b/viewer/tests/probe_stair_flight_support_pool.js
@@ -32,6 +32,11 @@ const VB = process.env.VIEWER_B || path.join(ROOT, 'viewer');
 // upstream of them). So the BEFORE run is the correct shared input for both sides, and taking it
 // from A's key is what makes A and B provably see byte-identical elements.
 const CACHE = require(path.join(VA, '..', 'scripts', 'cache_4d_run.js'));
+// §CACHE_PLAYED_LAYER — layerOf is a PURE selector over the persisted run object (no viewer state in
+// it), so it is taken from THIS checkout, not from VIEWER_A: VIEWER_A may deliberately be an older
+// tree that predates the two-layer cache, and a missing selector must not silently become "read
+// whatever key happens to be there".
+const SEL = require(path.join(ROOT, 'scripts', 'cache_4d_run.js'));
 
 const SGA = require(path.join(VA, 'schedule_gate.js'));
 const SGB = require(path.join(VB, 'schedule_gate.js'));
@@ -77,9 +82,30 @@ function quietCount(fn) {
 
 let anyDelta = 0, rows = [];
 for (const bld of BUILDINGS) {
-  const r = CACHE.read(bld);
+  // The cached run keyed on VIEWER_A is the preferred input (see the note on CACHE above). If that
+  // checkout predates §CACHE_PLAYED_LAYER its run carries no played layer — then, and only then,
+  // this falls back to THIS checkout's cache key. That is still ONE run feeding BOTH sides, so the
+  // byte-identical-input invariant holds; what it must never do is silently read the other LAYER.
+  let r = CACHE.read(bld), keyedOn = 'VIEWER_A';
+  if (r && !r.play) { const r2 = SEL.read(bld); if (r2 && r2.play) { r = r2; keyedOn = 'this checkout (VIEWER_A cache predates §CACHE_PLAYED_LAYER)'; } }
+  if (!r && SEL.read(bld)) { r = SEL.read(bld); keyedOn = 'this checkout (no VIEWER_A-keyed cache)'; }
   if (!r) { console.log('§STAIR_POOL CACHE_MISS ' + bld + ' — run: node scripts/cache_4d_run.js ' + bld); continue; }
-  const els = remapEls(r.els), sched = remapSched(r.sched);
+  console.log('§STAIR_POOL_CACHE ' + bld.padEnd(22) + 'keyedOn=' + keyedOn + ' dir=' + r.dir);
+  // §CACHE_PLAYED_LAYER (2026-09-02, queue item A-9) — the layer is SELECTED and NAMED, never
+  // implicit. This probe asks "does the audit see a stair flight as support", which is a question
+  // about the times the schedule actually presents; the PLAYED layer (kernel_ops) is what the
+  // viewer's own _buildXraySupportCache audits, so that is the default. `LAYER=display` re-points
+  // it at materializeZones' unread displaySchedule deliberately, and it still says so on every line.
+  const L = SEL.layerOf(r);
+  console.log('§STAIR_POOL_LAYER ' + bld.padEnd(22) + 'layer=' + L.id + ' key=' + L.key + ' — ' + L.desc);
+  if (L.missing) {
+    console.log('§STAIR_POOL ' + bld.padEnd(22) + 'INCONCLUSIVE — layer=' + L.id + ' ABSENT from this cache ' +
+      '(predates §CACHE_PLAYED_LAYER). Rebuild: node scripts/cache_4d_run.js --force ' + bld +
+      '. NOT falling back to the other layer: that substitution is the defect A-9 removed.');
+    continue;
+  }
+  const LAY = L.id;
+  const els = remapEls(r.els), sched = remapSched(L.map);
 
   // VACUITY GUARD — does auditFloating judge ANYTHING on this input? Break the schedule for every
   // element (start everything a day before the earliest start) and demand a non-zero floating
@@ -91,7 +117,7 @@ for (const bld of BUILDINGS) {
   for (const g of Object.keys(sched)) shake[g] = { start: t0 - 86400000, end: sched[g].end };
   const shakeN = quietCount(() => SGA.auditFloating(els, shake, null, null)).v;
   if (shakeN === 0) {
-    console.log('§STAIR_POOL ' + bld.padEnd(22) + 'VACUOUS — auditFloating returned 0 on a schedule where ' +
+    console.log('§STAIR_POOL ' + bld.padEnd(22) + 'VACUOUS layer=' + LAY + ' — auditFloating returned 0 on a schedule where ' +
       'EVERY element starts before its supports finish. It is judging nothing (field-name mismatch?); no verdict is possible.');
     continue;
   }
@@ -157,7 +183,7 @@ for (const bld of BUILDINGS) {
   }
 
   const verdict = flights.length === 0 ? 'VACUOUS' : (A.v === B.v && newlySeen.length === 0 ? 'NO-OP' : 'CHANGED');
-  console.log('§STAIR_POOL ' + bld.padEnd(22) + verdict.padEnd(9) +
+  console.log('§STAIR_POOL ' + bld.padEnd(22) + verdict.padEnd(9) + 'layer=' + LAY + ' ' +
     'stairFlights=' + String(flights.length).padEnd(6) + 'seq=' + JSON.stringify(flightSeqs).padEnd(6) +
     ' floating ' + A.v + ' -> ' + B.v + ' (delta ' + (B.v - A.v >= 0 ? '+' : '') + (B.v - A.v) + ')' +
     ' newlyVisible=' + newlySeen.length + ' nowClean=' + nowClean.length +
@@ -172,6 +198,6 @@ for (const bld of BUILDINGS) {
 
 const judged = rows.filter(r => r.flights > 0).length;
 const regress = rows.filter(r => r.nowClean > 0).length;
-console.log('§STAIR_POOL VERDICT=' + (judged === 0 ? 'INCONCLUSIVE — no building in this run has a stair flight'
+console.log('§STAIR_POOL VERDICT layer=' + (process.env.LAYER || 'played') + ' =' + (judged === 0 ? 'INCONCLUSIVE — no building in this run has a stair flight'
   : (regress ? 'REGRESSION on ' + regress + ' building(s)' : (anyDelta ? 'CHANGED on ' + anyDelta + '/' + judged + ' buildings with flights' : 'NO-OP across ' + judged + ' buildings with flights'))));
 process.exit(regress ? 1 : 0);

--- a/viewer/tests/witness_4d_movie_binds_bars.js
+++ b/viewer/tests/witness_4d_movie_binds_bars.js
@@ -1,5 +1,9 @@
 #!/usr/bin/env node
-// WITNESS — §TPL_MOVIE_BINDS_BARS: the movie plays inside the bars the 4D template authored.
+// WITNESS — §TPL_MOVIE_BINDS_BARS: every element is REMAPPED inside the bar the 4D template
+// authored. ⚠ NOT "the movie plays inside the bars" (the original title, corrected 2026-09-02,
+// queue item A-0): this judges `displaySchedule`, and viewer/time_machine.js has ZERO readers of
+// that map (§TM_REVEAL_SHIPPED). The bar-binding of the PLAYED layer is W-RWB
+// (witness_tm_reveal_within_bar.js, §TM_REVEAL_TILED) — that is the witness for the film.
 // Spec: bim-compiler prompts/4D_SCHEDULE_PERFECTION.md §S70.
 //
 // WHICH LAYER THIS PROVES (WITNESS_INTERFACE_FRAMEWORK.md §CRISIS LESSON 1):

--- a/viewer/tests/witness_cache_layer_attribution.js
+++ b/viewer/tests/witness_cache_layer_attribution.js
@@ -1,0 +1,186 @@
+#!/usr/bin/env node
+// witness_cache_layer_attribution.js — W-CLA. EVERY JUDGE NAMES THE LAYER IT JUDGES.
+//
+// ⚠ DO NOT REMOVE — SCOPE (bim-compiler prompts/4D_GANTT_TM_REFACTOR.md §FUTURE item 2,
+// 2026-09-02 §CACHE_PLAYED_LAYER §I; queue item A-9). Read the log after every run (Log Mandate).
+//
+// THE DEFECT THIS EXISTS TO KEEP DEAD. §TM_REVEAL_SHIPPED measured that viewer/time_machine.js has
+// ZERO readers of materializeZones' `displaySchedule` — the film and the Time Machine scrubber play
+// kernel_ops timestamps written by injectGantt. scripts/cache_4d_run.js nevertheless persisted only
+// that unplayed map, under the neutral key `sched`, and every cache reader inherited it silently.
+// Same task, same run: the cache read [9.8,10.1,10,9.7,10.5,10.2,9.5,10.2,9.9,10] while the played
+// layer was [18.4,17.8,17.8,18.4,17.5,8.8,1.1,0,0,0.2]. Four weeks of measurement judged a map
+// nobody plays, and NOT ONE of those judges printed which map that was. The anonymity is the
+// defect (PRIMAL LAW clause 4): a judge that cannot name its own input cannot report being pointed
+// at the wrong one. C4 below is the claim that actually holds that line.
+//
+// CLAIMS (each independently PASS / FAIL / INCONCLUSIVE; a 0 over an empty population is never a PASS):
+//   C1 BOTH LAYERS      every current-code cached run carries `play` AND `sched`, same guid coverage.
+//   C2 NOT THE SAME MAP the two layers genuinely differ (anti-vacuous: if they were equal,
+//                       re-pointing every judge would be a no-op dressed as a fix).
+//   C3 PLAYED IN WINDOW every played interval lies inside the task window that claims it — the
+//                       invariant _tmRescaleToTaskWindow exists to hold.
+//   C4 READERS NAME IT  every file that calls CACHE.read( either selects through layerOf( or
+//                       explicitly declares `layer=NONE` (it judges no schedule map), AND emits
+//                       `layer=` on a § line. A new reader that does neither FAILS here.
+//   C5 NO SILENT DEFAULT layerOf throws on an unknown id, and reports MISSING on a pre-§CACHE_
+//                       PLAYED_LAYER cache instead of substituting the other layer.
+//
+// Reads the persisted cache and the repo's own source text. No pipeline re-run, no browser, no bake.
+'use strict';
+const fs = require('fs'), path = require('path');
+const ROOT = path.join(__dirname, '..', '..');
+const CACHE = require(path.join(ROOT, 'scripts', 'cache_4d_run.js'));
+
+const BUILDINGS = process.argv.slice(2).filter(a => a[0] !== '-').length
+  ? process.argv.slice(2).filter(a => a[0] !== '-')
+  : ['Duplex', 'HHS_Office_Federated', 'Hospital', 'Terminal'];
+const DAY_MS = 86400000;
+
+const verdicts = [];
+function claim(id, scope, pop, bad, detail) {
+  const v = pop === 0 ? 'INCONCLUSIVE' : (bad === 0 ? 'PASS' : 'FAIL');
+  verdicts.push(v);
+  console.log('§W_CLA ' + id.padEnd(20) + scope.padEnd(24) + v.padEnd(13) +
+    'judged=' + String(pop).padEnd(8) + 'bad=' + String(bad).padEnd(6) + (detail || ''));
+  return v;
+}
+function deciles(vals) {
+  const h = new Array(10).fill(0);
+  vals.forEach(p => { let b = Math.floor(Math.max(0, Math.min(1, p)) * 10); if (b > 9) b = 9; h[b]++; });
+  return h.map(c => +(100 * c / Math.max(1, vals.length)).toFixed(1));
+}
+
+// ── the cached runs actually available ──────────────────────────────────────────────────────────
+const runs = [];
+for (const b of BUILDINGS) {
+  const r = CACHE.read(b);
+  if (!r) { console.log('§W_CLA CACHE_MISS       ' + b.padEnd(24) + '— run: node scripts/cache_4d_run.js ' + b); continue; }
+  runs.push({ bld: b, r: r });
+}
+console.log('§W_CLA_POPULATION cachedRuns=' + runs.length + '/' + BUILDINGS.length +
+  ' [' + runs.map(x => x.bld).join(', ') + ']  codeKey=' + CACHE.codeKey());
+
+// ── C1 BOTH LAYERS ──────────────────────────────────────────────────────────────────────────────
+{
+  let bad = 0; const detail = [];
+  runs.forEach(x => {
+    const P = CACHE.layerOf(x.r, 'played'), D = CACHE.layerOf(x.r, 'display');
+    const nP = P.map ? Object.keys(P.map).length : 0, nD = D.map ? Object.keys(D.map).length : 0;
+    if (!P.map || !D.map || nP !== nD) { bad++; detail.push(x.bld + ' played=' + (P.map ? nP : 'MISSING') + ' display=' + (D.map ? nD : 'MISSING')); }
+    else detail.push(x.bld + ' ' + nP);
+  });
+  claim('C1_BOTH_LAYERS', 'cached runs', runs.length, bad, detail.join(' | '));
+}
+
+// ── C2 NOT THE SAME MAP (anti-vacuous) ──────────────────────────────────────────────────────────
+{
+  let judged = 0, bad = 0;
+  runs.forEach(x => {
+    const P = CACHE.layerOf(x.r, 'played').map, D = CACHE.layerOf(x.r, 'display').map;
+    if (!P || !D || !x.r.tasks) return;
+    judged++;
+    const base = Date.parse('2026-01-01');
+    let shared = 0, differ = 0;
+    const posP = [], posD = [];
+    x.r.tasks.forEach(t => {
+      const wS = base + t.sDays * DAY_MS, wE = base + t.eDays * DAY_MS, span = wE - wS;
+      t.guids.forEach(g => {
+        if (!P[g] || !D[g]) return;
+        shared++;
+        if (P[g].s !== D[g].s) differ++;
+        if (span > 0) { posP.push((P[g].s - wS) / span); posD.push((D[g].s - wS) / span); }
+      });
+    });
+    const dP = deciles(posP), dD = deciles(posD);
+    const sameVec = JSON.stringify(dP) === JSON.stringify(dD);
+    const pct = shared ? 100 * differ / shared : 0;
+    const isBad = shared === 0 || pct < 1 || sameVec;
+    if (isBad) bad++;
+    console.log('§W_CLA_LAYER_DIFF ' + x.bld.padEnd(24) + 'sharedGuids=' + shared +
+      ' differentStart=' + differ + ' (' + pct.toFixed(1) + '%)' +
+      ' played.decilePct=[' + dP.join(',') + ']' +
+      ' display.decilePct=[' + dD.join(',') + ']' +
+      (isBad ? '  ⛔ the two layers are indistinguishable here — re-pointing the judges would be a no-op'
+             : '  — these are different maps; a judge reading the wrong one gets different answers'));
+  });
+  claim('C2_LAYERS_DIFFER', 'runs with both layers', judged, bad,
+    'a same-map result would make every re-pointing vacuous — this is the claim that refuses that');
+}
+
+// ── C3 PLAYED IS IN-WINDOW ──────────────────────────────────────────────────────────────────────
+{
+  let judged = 0, bad = 0; const detail = [];
+  runs.forEach(x => {
+    const P = CACHE.layerOf(x.r, 'played').map;
+    if (!P || !x.r.tasks) return;
+    const base = Date.parse('2026-01-01');
+    let n = 0, out = 0, worst = 0;
+    x.r.tasks.forEach(t => {
+      const wS = base + t.sDays * DAY_MS, wE = base + t.eDays * DAY_MS;
+      t.guids.forEach(g => {
+        const p = P[g]; if (!p) return;
+        n++;
+        const off = Math.max(wS - p.s, p.e - wE, 0);
+        if (off > 1) { out++; if (off > worst) worst = off; }   // >1ms: float rounding is not a defect
+      });
+    });
+    judged += n; bad += out;
+    detail.push(x.bld + ' ' + (n - out) + '/' + n + (out ? ' worstOffsetDays=' + (worst / DAY_MS).toFixed(3) : ''));
+  });
+  claim('C3_PLAYED_IN_WIN', 'element-task pairs', judged, bad, detail.join(' | '));
+}
+
+// ── C4 EVERY CACHE READER NAMES ITS LAYER (the actual DONE-WHEN) ─────────────────────────────────
+{
+  // Discover the readers by grep, not by a hand-maintained list — a list would go stale exactly when
+  // it matters (a new probe added, never re-pointed), which is the failure mode this claim exists for.
+  const dirs = [path.join(ROOT, 'scripts'), path.join(ROOT, 'viewer', 'tests')];
+  const readers = [];
+  dirs.forEach(d => {
+    if (!fs.existsSync(d)) return;
+    fs.readdirSync(d).filter(f => f.endsWith('.js')).forEach(f => {
+      const p = path.join(d, f), src = fs.readFileSync(p, 'utf8');
+      if (src.indexOf('CACHE.read(') < 0) return;
+      if (f === 'cache_4d_run.js' || f === path.basename(__filename)) return;
+      readers.push({ file: path.relative(ROOT, p), src: src });
+    });
+  });
+  let bad = 0;
+  readers.forEach(x => {
+    const selects = /\.layerOf\(/.test(x.src);
+    // A reader that genuinely judges NO schedule map (it reads only `els`/`log`) is not required to
+    // select a layer — but it IS required to say so, out loud, in a § line: `layer=NONE`. Silence is
+    // exactly what let a whole class of measurement judge the wrong map for four weeks, so an
+    // abstention has to be stated, not inferred from the absence of a lookup.
+    const abstains = /layer=NONE/.test(x.src);
+    // "names it in the output" = a § line carrying layer= .
+    const names = /§[A-Z0-9_]+[^\n]*layer=/i.test(x.src) || /'layer='/.test(x.src);
+    const ok = (selects || abstains) && names;
+    if (!ok) bad++;
+    console.log('§W_CLA_READER ' + x.file.padEnd(48) + 'selectsViaLayerOf=' + (selects ? 'yes' : 'NO ') +
+      ' declaresLayerNONE=' + (abstains ? 'yes' : 'NO ') + ' printsLayer=' + (names ? 'yes' : 'NO ') +
+      (ok ? '' : '  ⛔ this judge cannot say which layer it judged'));
+  });
+  claim('C4_READERS_NAME_IT', 'cache-reading files', readers.length, bad,
+    'discovered by grep for CACHE.read( over scripts/ + viewer/tests/ — a reader added later and ' +
+    'neither re-pointed nor declaring layer=NONE fails here, which is the point');
+}
+
+// ── C5 NO SILENT DEFAULT ────────────────────────────────────────────────────────────────────────
+{
+  let n = 0, bad = 0;
+  n++; try { CACHE.layerOf({ play: {}, sched: {} }, 'no-such-layer'); bad++; console.log('§W_CLA_DEFAULT unknown-id did NOT throw'); }
+  catch (e) { console.log('§W_CLA_DEFAULT unknown-id throws: ' + e.message); }
+  n++;
+  const legacy = CACHE.layerOf({ sched: { g: { s: 1, e: 2 } } }, 'played');
+  if (!legacy.missing || legacy.map !== null) { bad++; console.log('§W_CLA_DEFAULT legacy cache SUBSTITUTED a layer — ' + JSON.stringify(legacy)); }
+  else console.log('§W_CLA_DEFAULT legacy cache (no `play` key) reports missing=true, map=null — no substitution');
+  claim('C5_NO_SILENT_DEF', 'layerOf contract', n, bad, 'unknown id must throw; a missing layer must not fall back');
+}
+
+const fail = verdicts.filter(v => v === 'FAIL').length, inc = verdicts.filter(v => v === 'INCONCLUSIVE').length;
+console.log('§W_CLA_SUMMARY claims=' + verdicts.length + ' PASS=' + (verdicts.length - fail - inc) +
+  ' FAIL=' + fail + ' INCONCLUSIVE=' + inc + '  ' +
+  (fail ? 'RED' : inc ? 'NOT GREEN — a claim judged nothing; an empty population is not a pass' : 'GREEN'));
+process.exit(fail ? 1 : 0);

--- a/viewer/tests/witness_day0_integrity.js
+++ b/viewer/tests/witness_day0_integrity.js
@@ -29,6 +29,15 @@
 // The judge is REQUIRED from viewer/support_sweep.js and never re-derived here (4D_MODEL_INTEGRITY
 // §G.0). The ground exemption is the SHIPPED one, schedule_gate.js:1210 `T.seq !== 1`.
 // Input is the PERSISTED run (scripts/cache_4d_run.js) — the pipeline is not re-run per witness.
+//
+// ⚠ WHICH LAYER (§CACHE_PLAYED_LAYER, 2026-09-02, queue item A-9). C2/C3/C4 are questions about
+// WHEN AN ELEMENT APPEARS ON SCREEN, so they must be asked of the map the screen actually plays.
+// Until this date they read the cache's `sched` key = materializeZones' displaySchedule, and
+// §TM_REVEAL_SHIPPED measured that viewer/time_machine.js has ZERO readers of that map. Those
+// verdicts described a layer nobody plays: the fleet table `claims=13 PASS=4 FAIL=5 INCONCLUSIVE=4`
+// is VOID as a statement about the film (queue item A-0). The layer is now selected through
+// CACHE.layerOf() and PRINTED ON EVERY LINE — `LAYER=display` re-points this witness at the old map
+// deliberately, and it still says so. C1 is band geometry and is layer-independent by construction.
 'use strict';
 const path = require('path'), os = require('os');
 const ROOT = path.join(__dirname, '..', '..');
@@ -43,9 +52,12 @@ const DAY_MS = 86400000;
 const MEP_WINDOW_D = process.env.MEP_WINDOW_D ? Number(process.env.MEP_WINDOW_D) : 3;
 
 // A claim that cannot say INCONCLUSIVE is not a claim. `pop` is the population it judged.
-function claim(id, bld, pop, bad, detail) {
+// `layer` is the map it judged it ON — a claim that cannot name its own input cannot report being
+// pointed at the wrong one (§CACHE_PLAYED_LAYER).
+function claim(id, bld, pop, bad, detail, layer) {
   const verdict = pop === 0 ? 'INCONCLUSIVE' : (bad === 0 ? 'PASS' : 'FAIL');
   console.log('§W_D0 ' + id + ' ' + bld.padEnd(22) + verdict.padEnd(13) +
+    'layer=' + String(layer).padEnd(9) +
     'judged=' + String(pop).padEnd(7) + 'bad=' + String(bad).padEnd(7) + (detail || ''));
   return verdict;
 }
@@ -53,7 +65,16 @@ function claim(id, bld, pop, bad, detail) {
 function run(bld) {
   const r = CACHE.read(bld);
   if (!r) { console.log('§W_D0 CACHE_MISS ' + bld + ' — run: node scripts/cache_4d_run.js ' + bld); return ['INCONCLUSIVE']; }
-  const els = r.els, sched = r.sched;
+  const L = CACHE.layerOf(r);
+  console.log('§W_D0_LAYER ' + bld.padEnd(22) + 'layer=' + L.id + ' key=' + L.key +
+    ' — ' + L.desc + (L.missing ? '  ⛔ ABSENT from this cache' : ''));
+  if (L.missing) {
+    console.log('§W_D0 CACHE_LAYER_MISSING ' + bld + ' layer=' + L.id +
+      ' — this cache predates §CACHE_PLAYED_LAYER. Rebuild: node scripts/cache_4d_run.js --force ' + bld +
+      '. NOT falling back to the other layer: that substitution is the defect A-9 removed.');
+    return ['INCONCLUSIVE'];
+  }
+  const els = r.els, sched = L.map, LAY = L.id;
   const EPS = SG.EPS, GAP = SG.GAP;
   const G = SS.contactGraph(els);
   if (!G.ok) { console.log('§W_D0 JUDGE_UNAVAILABLE ' + bld); return ['INCONCLUSIVE']; }
@@ -101,7 +122,7 @@ function run(bld) {
       ? 'spatial_structure ABSENT from this DB — the model declares no storeys to check against'
       : 'declaredStoreys=' + declared + ' scheduledBands=' + bands.length + ' excess=' + excess) +
     ' datumCollisions=' + collide +
-    (collisions.length ? ' [' + collisions.slice(0, 4).join(' | ') + ']' : '')));
+    (collisions.length ? ' [' + collisions.slice(0, 4).join(' | ') + ']' : ''), 'n/a-geometry'));
 
   // ── C2 DAY-0 PURITY + C3 DAY-0 SUPPORT ─────────────────────────────────────────────────────
   const cur = t0 + DAY_MS;
@@ -122,7 +143,7 @@ function run(bld) {
   out.push(claim('C2_DAY0_PURITY', bld, onScreen, impure,
     'modelsSubstructure=' + modelsSub + ' phases{' +
     Object.entries(phaseHist).sort((a, b) => b[1] - a[1]).map(([k, n]) => k + ':' + n).join(' ') + '}' +
-    (impure ? '  INTRUDERS{' + Object.entries(impureCls).sort((a, b) => b[1] - a[1]).slice(0, 6).map(([k, n]) => k + ':' + n).join(' ') + '}' : '')));
+    (impure ? '  INTRUDERS{' + Object.entries(impureCls).sort((a, b) => b[1] - a[1]).slice(0, 6).map(([k, n]) => k + ':' + n).join(' ') + '}' : ''), LAY));
 
   let judged = 0, hanging = 0; const hangCls = {};
   for (let i = 0; i < els.length; i++) {
@@ -139,7 +160,7 @@ function run(bld) {
     if (!held) { hanging++; hangCls[T.cls] = (hangCls[T.cls] || 0) + 1; }
   }
   out.push(claim('C3_DAY0_SUPPORT', bld, judged, hanging,
-    (hanging ? 'hanging{' + Object.entries(hangCls).sort((a, b) => b[1] - a[1]).slice(0, 6).map(([k, n]) => k + ':' + n).join(' ') + '}' : 'nothing on screen is unheld')));
+    (hanging ? 'hanging{' + Object.entries(hangCls).sort((a, b) => b[1] - a[1]).slice(0, 6).map(([k, n]) => k + ':' + n).join(' ') + '}' : 'nothing on screen is unheld'), LAY));
 
   // ── C4 NO EARLY MEP ────────────────────────────────────────────────────────────────────────
   const mepCur = t0 + MEP_WINDOW_D * DAY_MS;
@@ -150,14 +171,15 @@ function run(bld) {
     if (/^MEP/.test(els[i].phase || '')) { mep++; mepCls[els[i].cls] = (mepCls[els[i].cls] || 0) + 1; }
   }
   out.push(claim('C4_NO_EARLY_MEP', bld, inWin, mep, 'window=' + MEP_WINDOW_D + 'd' +
-    (mep ? ' MEP{' + Object.entries(mepCls).map(([k, n]) => k + ':' + n).join(' ') + '}' : '')));
+    (mep ? ' MEP{' + Object.entries(mepCls).map(([k, n]) => k + ':' + n).join(' ') + '}' : ''), LAY));
   return out;
 }
 
 const all = [];
 for (const b of BUILDINGS) { all.push.apply(all, run(b)); console.log(''); }
 const fail = all.filter(v => v === 'FAIL').length, inc = all.filter(v => v === 'INCONCLUSIVE').length;
-console.log('§W_D0_VERDICT claims=' + all.length + ' PASS=' + (all.length - fail - inc) +
+console.log('§W_D0_VERDICT layer=' + (process.env.LAYER || 'played') +
+  ' claims=' + all.length + ' PASS=' + (all.length - fail - inc) +
   ' FAIL=' + fail + ' INCONCLUSIVE=' + inc + '  ' +
   (fail ? 'RED' : inc ? 'NOT GREEN — a claim judged nothing; an empty population is not a pass' : 'GREEN'));
 process.exit(fail ? 1 : 0);


### PR DESCRIPTION
Queue item **A-0** (void-number sweep), the code half. **Stacked on #1607** (§CACHE_PLAYED_LAYER) — the new probe selects its layer through `CACHE.layerOf()`, so review/merge #1607 first.

## 1. The false claim, struck at its source

`schedule_author.js`'s `§TPL_MOVIE_BINDS_BARS` line ended **"every element now PLAYS inside the bar that claims it"**. That was never true of this map: it describes `displaySchedule`, returned four lines below, and `viewer/time_machine.js` has **zero readers** of it (§TM_REVEAL_SHIPPED, #1605). The counts are unchanged; only the false half of the sentence is.

`witness_4d_movie_binds_bars.js`'s own title said the same thing and is corrected the same way, pointing at **W-RWB** (`witness_tm_reveal_within_bar.js`) as the witness that actually judges the played layer.

## 2. `scripts/probe_daybatch_played.js`

`§BUILDUP_DAY_BATCH_FEASIBILITY`'s within-task numbers were produced by session **scratchpad** scripts over the unplayed map. They are re-measured here by a probe that lives in the repo, on a **selected, named** layer — so the next session reads a `§` line instead of re-deriving it.

### Measured, Hospital, played vs the void originals (3,118 frames)

| | void (unplayed map) | re-measured (played) |
|---|---|---|
| `§DAYBATCH_FRAMES` worst | 94 @f1250 = 4.6x mean | **142 @f1504 = 7.0x mean** (day 153.4) |
| `§DAYBATCH_GAPS` p50 | 631,738 ms (10.5 min) | **691,392 ms (11.52 min)**, p90 14.40 min |
| `§DAYBATCH_TASK_DAYRATE` CV | 0.21-0.31 | **0.28-0.40** |
| `§DAYBATCH_BURST_MIX` | 45 s vs 632 s; isecs 114 | **77 s vs 691 s**; isecs 214 vs 1920 |
| `§DAYBATCH_PULSE_PREDICTION` | 399 = 19.7x, 299/319 days | **528 = 26.1x, 235/319 days** |

## What survives — measured, not assumed

- **No real day-buckets exist**: `distinctEnds 63,178/63,182`, `largestExactTie=2`, 0.20% of ends within 1 min of a day boundary.
- **The NO-GO on day-batching**: predicted 26.1x vs today's 7.0x — still ~3.7x worse. Duplex agrees (540.6x vs 30.7x).
- **The short-element-run clustering lever also survives** — the worst frame is 115/142 from ONE task, burst width p50 77 s against that task's 691 s. Only its *magnitudes* were void; the lever stands. It was deliberately **not** struck.

## Note on the cache key

`schedule_author.js` is a `cache_4d_run.js` INPUT, so the log-string change rotates the codeKey. All four caches were rebuilt on the new key in this session (~3 min, node only) and every judge re-run green against it.

No bake, no browser, no `cli_silent_bake.js`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RTX9gUq3tQoytC1vthLmcq