### PR TITLE
fix(erp-fsm): recover 3 DocumentEngine tail blocks the FSM oracle's parse window hid (§P4-DEFECT)

### DIFF
--- a/erp/ad_docfsm.js
+++ b/erp/ad_docfsm.js
@@ -141,7 +141,9 @@
   // never silently inherits the generic union (the exact error the per-table narrowing exists to kill).
   // Optional per-table fields (H2_ISOMORPH_TAIL — defaults preserve the six walked tables exactly):
   //   block: which Completed-narrowing arm applies ('inout'|'invoice'|'payment'|'journal'|'alloc'|'cash'|
-  //          'bankstmt'); absent = the movement-style arm for the original six, generic-only for the tail.
+  //          'bankstmt'|'rma'|'banktransfer'|'depositbatch'); absent = generic-only fall-through. The last
+  //          three were ADDED by ERP_IDEMPIERE_UX_PARITY.md §P6 — they are real getValidActions arms that
+  //          sat past the oracle's old parse window (:1248), so both sides wrongly said "fall-through".
   //   vo:    per-fromStatus void OUTCOME map (parsed from the class's voidIt); absent = the H-2 default
   //          (unprocessed→VO, processed→RE reversal delegation).
   //   rc/ra: false when the class's reverseCorrectIt/reverseAccrualIt can never return true; absent = true.
@@ -171,10 +173,11 @@
            vo: { DR: 'VO', IP: 'VO', IN: 'VO', AP: 'VO', NA: 'VO', CO: 'VO' } },
         // MBankStatement.voidIt:506-602 voids unprocessed AND completed (period-gated :679), never sets
         // RE; RC:629-645/RA:650-666 always false; reActivateIt:670-696 period+doctype gated → true
-    661: { name: 'M_RMA',           reActivate: false, rc: false, ra: false,
+    661: { name: 'M_RMA',           reActivate: false, rc: false, ra: false, block: 'rma',
            vo: { DR: 'VO', IP: 'VO', IN: 'VO', AP: 'VO', NA: 'VO', CO: 'VO' } },
-        // generic-only (no getValidActions block); MRMA.voidIt:681-754 → VO (live-shipment data gate
-        // :686-690, named); RC:760/RA:781/RE:802 always false
+        // getValidActions:1302-1309 (IDEMPIERE-98 "Implement void for completed RMAs") → CO offers Void,
+        // UNGATED; MRMA.voidIt:681-754 → VO (live-shipment data gate :686-690, named); RC:760/RA:781/RE:802
+        // always false. §P6: was modelled generic-only — the block is real, the oracle just could not see it.
     702: { name: 'M_Requisition',   reActivate: false, rc: false, ra: false,
            vo: { DR: 'VO', IP: 'VO', IN: 'VO', AP: 'VO', NA: 'VO', CO: 'VO' } },
         // generic-only; MRequisition.voidIt:401-418 delegates closeIt→true→VO; RC:480/RA:501 always
@@ -183,14 +186,17 @@
            vo: { DR: 'VO', IP: 'VO', IN: 'VO', AP: 'VO', NA: 'VO', CO: 'VO' } },
         // generic-only; MTimeExpense.voidIt:433-451 delegates closeIt→true→VO; RC:480/RA:502/RE:524 false
     // 0-seed classes (FSM source-parse only — stored-replay honestly n/a, H2_ISOMORPH_TAIL table):
-    200246: { name: 'C_BankTransfer', reActivate: false, rc: false, ra: false,
+    200246: { name: 'C_BankTransfer', reActivate: false, rc: false, ra: false, block: 'banktransfer',
               vo: { DR: 'VO', IP: 'VO', IN: 'VO', AP: 'VO', NA: 'VO', CO: 'VO' } },
-        // MBankTransfer.voidIt:315-337 voids child payments→true→VO; RC:356-374/RA:379-397 reverse child
-        // payments yet RETURN FALSE (the parsed quirk); reActivateIt:402-415 always false
-    200056: { name: 'C_DepositBatch', reActivate: true, rc: false, ra: false,
+        // getValidActions:1313-1320 → CO offers Void, UNGATED; MBankTransfer.voidIt:315-337 voids child
+        // payments→true→VO; RC:356-374/RA:379-397 reverse child payments yet RETURN FALSE (the parsed
+        // quirk); reActivateIt:402-415 always false
+    200056: { name: 'C_DepositBatch', reActivate: true, rc: false, ra: false, block: 'depositbatch',
               vo: { DR: 'VO', IP: 'VO', IN: 'VO', AP: 'VO', NA: 'VO', CO: 'VO' } },
-        // MDepositBatch.voidIt:203-257 terminal-reject + bank-statement-line gate → VO; RC:552/RA:558
-        // stubs return false; reActivateIt:564-598 gated → true
+        // getValidActions:1323-1330 → CO offers Void + ReActivate, BOTH UNGATED (this arm carries no
+        // canReactivateThisDocType test, unlike invoice/payment/journal/bankstmt — do NOT gate it on
+        // iscanbereactivated); MDepositBatch.voidIt:203-257 terminal-reject + bank-statement-line gate → VO;
+        // RC:552/RA:558 stubs return false; reActivateIt:564-598 gated → true
     623: { name: 'M_ProjectIssue', reActivate: false },
         // MProjectIssue delegates to DocActionDelegate (:377-417) and REGISTERS Reverse_Correct/Accrual
         // callables (doReverse, :126-127) → RC/RA→RE and void = the H-2 default delegation (delegate
@@ -240,8 +246,14 @@
         a.push('VO');
       } else if (blk === 'bankstmt') {                                  // BankStatement :1185-1198 (periodOpen frames BOTH)
         if (po) { if (canReact) a.push('RE'); a.push('VO'); }
+      } else if (blk === 'rma') {                                       // RMA :1302-1309 (IDEMPIERE-98) — CO→Void
+        a.push('VO');                                                   // UNGATED: no periodOpen/canReact test
+      } else if (blk === 'banktransfer') {                              // BankTransfer :1313-1320 — CO→Void
+        a.push('VO');                                                   // UNGATED
+      } else if (blk === 'depositbatch') {                              // DepositBatch :1323-1330 — CO→Void+ReActivate
+        a.push('VO', 'RE');                                             // BOTH UNGATED (no canReactivateThisDocType)
       }
-      // no block (M_RMA / M_Requisition / S_TimeExpense / the 0-seed tail) = generic-only:
+      // no block (M_Requisition / S_TimeExpense / M_ProjectIssue / the FA tail) = generic-only:
       // getValidActions falls through, completed docs offer just the :1050-1053 Close.
     }
     return a;

--- a/erp/sw.js
+++ b/erp/sw.js
@@ -10,7 +10,7 @@
 // init-bubble must be INSTANT, ERP_INIT_BUBBLE_INSTANT.md); network-first for non-precached .js (fresh on
 // deploy); cache-first for precached assets/.wasm/images. Freshness on deploy is carried by the SW version
 // bump (skipWaiting+clients.claim precache the new shell), so SWR strands a user at most one load post-deploy.
-const CACHE_VERSION = 'v772';   // bump on each deploy; per-change detail is the git commit message.
+const CACHE_VERSION = 'v773';   // bump on each deploy; per-change detail is the git commit message.
 // v772 (rebase of PR #203 onto origin/main) §INTEG-WIRE-B: disposable-host persistence in-app
 // (erp_replica_client.js + erp_persist_ui.js) — back the books up to a SIGNED snapshot the user
 // owns (signed by the edge key), restore on a FRESH device -> replay recomputes tip == signed


### PR DESCRIPTION
## The defect (found by the §P4 audit, not by a failing witness)

`bim-compiler/scripts/docfsm_oracle.js` parses iDempiere's `DocumentEngine.getValidActions` **at runtime** — that runtime parse is the whole reason the FSM witnesses aren't tautologies of our own tables. But its marker list terminated at `_end = 'else if (AD_Table_ID == I_PP_Cost_Collector.Table_ID)'` (**:1248**). The method actually carries **18 `AD_Table_ID ==` arms**, and **six** live at or after that line, so the oracle never saw them.

Three of those six are in our `DOC_FAMILY`, and `ad_docfsm.js` modelled them as generic fall-through. `W-GENERIC-TAIL-FSM` reported `fixtures=333 diff=0` because **both sides shared the same blind spot** — and its `§FALSIFIER-A` actively asserted the *wrong* behaviour as correct: *"VO@CO on RMA … implemented in the class yet NEVER offered"*. iDempiere **does** offer it.

This is exactly the failure mode `CLAUDE.md` PRIMAL LAW §4 names: **a witness that cannot report its own failure**.

## Blast radius: ZERO, measured

The only seeded `m_rma` row is `DocStatus=IP`; `c_banktransfer` and `c_depositbatch` **are not tables in `ad_seed.db`**. No completed document of any affected table exists, so no user could currently see a wrong action bar. This is correctness of the **truth instrument**, not a live user-facing bug — stated so it isn't inflated.

## The fix

Only the legal **SET** at `DocStatus=CO` was short. The transitions were already right (`DOC_FAMILY[661].vo.CO='VO'`, `[200056].reActivate=true`), so this is a `block` arm, **not** new transition logic:

| table | id | was | now | source |
|---|---|---|---|---|
| `M_RMA` | 661 | `[CL]` | **`[CL,VO]`** | `getValidActions:1302-1309` (IDEMPIERE-98, "Implement void for completed RMAs") |
| `C_BankTransfer` | 200246 | `[CL]` | **`[CL,VO]`** | `getValidActions:1313-1320` |
| `C_DepositBatch` | 200056 | `[CL]` | **`[CL,VO,RE]`** | `getValidActions:1323-1330` |

All three arms are **UNGATED**. The `C_DepositBatch` `RE` in particular carries **no `canReactivateThisDocType` test**, unlike the invoice/payment/journal/bankstmt arms — so the arm must not consult `iscanbereactivated`. Three separate arms rather than one shared arm, because iDempiere writes three separate blocks and each carries its own line cite.

The companion oracle + witness fix lands in `bim-compiler` (`scripts/docfsm_oracle.js`, `scripts/poc_generic_tail_fsm.js`). The new parse window ends at the **text** anchor `'if (po instanceof DocOptions)'` (:1333, the customization hook that ends the if/else chain) — a text marker, never a hard-coded line number. Proven non-disruptive: all 11 pre-existing slices are **byte-identical** after the change (`§P6_SLICE_IDENTITY generic_identical=true changedOldSlices=[]`), so the nine sibling witnesses that index a named `byTable` key are untouched.

## Witness evidence — RED then GREEN (Log Mandate: logs read, not exit codes)

Oracle fixed **first**, engine deliberately left short, so the blind spot had to surface:

```
§HARDEN surface=M_RMA.docaction.legal         status=CO engine=[CL] oracle=[CL,VO]    diff=SET-MISMATCH
§HARDEN surface=C_BankTransfer.docaction.legal status=CO engine=[CL] oracle=[CL,VO]    diff=SET-MISMATCH
§HARDEN surface=C_DepositBatch.docaction.legal status=CO engine=[CL] oracle=[CL,RE,VO] diff=SET-MISMATCH
   🔴 242 legal-set fixtures ... — setDiffs=6
🔴 W-GENERIC-TAIL-FSM FAIL (1)
```

`setDiffs=6` = 3 tables × 2 gate corners, all at `CO`. Then the engine fix in this PR:

```
§HARDEN surface=M_RMA.docaction.legal         status=CO engine=[CL,VO]    oracle=[CL,VO](BLOCK MRMA)          diff=0
§HARDEN surface=C_BankTransfer.docaction.legal status=CO engine=[CL,VO]    oracle=[CL,VO](BLOCK MBankTransfer) diff=0
§HARDEN surface=C_DepositBatch.docaction.legal status=CO engine=[CL,RE,VO] oracle=[CL,RE,VO](BLOCK MDepositBatch) diff=0
§HARDEN surface=M_Requisition.docaction.legal  status=CO engine=[CL]       oracle=[CL](GENERIC)                diff=0
   🟢 242 legal-set fixtures ... — setDiffs=0
🟢 W-GENERIC-TAIL-FSM PASS
```

**`§FALSIFIER-A` rewritten**, now two arms load-bearing in *opposite* directions — so neither a re-regression nor an over-correction can pass:

```
§FALSIFIER-A1 action=VO from=CO table=661 ok=true  to=VO legal=[CL,VO]  (must be ok=true to=VO)
§FALSIFIER-A2 action=VO from=CO table=702 ok=false reason=illegal-action (must be ok=false illegal-action)
```

A1 fires if the per-table block is ever dropped again; A2 (`M_Requisition`, genuinely block-less) fires if the correction ever leaks into the fall-through classes.

**12/12 FSM witnesses green**, including `W-AD-DOCFSM-LIVE` re-run against this worktree's engine (`ERP_ROOT=/tmp/wt-fsm-oracle/erp`, real DOM, real clicks):

`W-MORDER-FSM` · `W-MINOUT-FSM` · `W-MINVOICE-FSM` · `W-MPAYMENT-FSM` · `W-MINVENTORY-FAMILY-FSM` · `W-MJOURNAL-FSM` · `W-MALLOCHDR-FSM` · `W-MCASH-FSM` · `W-MBANKSTMT-FSM` · `W-GENERIC-TAIL-FSM` · `W-DOCFSM` · `W-AD-DOCFSM-LIVE`

## Notes

- `erp/ad_docfsm.js` stays **byte-identical** to `bim-compiler/build/erp/ad_docfsm.js` (both now `fdf16f960504d1656259c4a14de9b467`, was `461e339c0acbe17c3b725eb541f19b67`).
- `erp/sw.js` `CACHE_VERSION` v772 → v773, same PR.
- Spec written before code: `bim-compiler/prompts/ERP_IDEMPIERE_UX_PARITY.md` **§P6**.
- No `ad_seed.db` regeneration. None of `crud_overlay.js` / `crud_core.js` / `crud_ops.json` / `idempiere.html` touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)