### PR TITLE
fix(4d): §W_D0_ATTRIBUTION — all 8 played-layer DAY-0 FAILs attributed, 3 of them the witness's own defects

### DIFF
--- a/scripts/cache_4d_run.js
+++ b/scripts/cache_4d_run.js
@@ -178,11 +178,21 @@ function build(bld, force) {
         // compare "storeys the model declares" against "bands the schedule invents" without a
         // tolerance constant anywhere. Absent on some shipped DBs (Duplex/Hospital have no
         // spatial_structure table at all) — absent must be REPORTED as absent, never guessed.
+        //
+        // ⚠ §STOREY_PROVENANCE (2026-09-02, queue B-1 / bim-compiler 4D_MODEL_INTEGRITY.md §J.6.2
+        // W3). `object_type` is persisted with the row because these are NOT always what a reader
+        // assumes. MEASURED on the shipped fleet: 6 of 6 Terminal and 3 of 3 HHS IfcBuildingStorey
+        // rows carry object_type='COMPILED' with STC_* guids — they are compile_rooms.py output,
+        // not an IFC declaration. A claim that compares "bands the schedule uses" against these and
+        // calls the difference "levels the schedule invented" is comparing against a derived
+        // artifact. It cannot say so unless the provenance travels with the row, so it does.
         try {
-          const q = db.exec("SELECT name,center_z,size_z FROM spatial_structure WHERE type='IfcBuildingStorey'");
+          const q = db.exec("SELECT name,center_z,size_z,object_type FROM spatial_structure WHERE type='IfcBuildingStorey'");
           if (q.length) {
-            const c = q[0].columns, ni = c.indexOf('name'), zi = c.indexOf('center_z'), si = c.indexOf('size_z');
-            storeys = q[0].values.map(v => ({ name: v[ni], center_z: v[zi], size_z: v[si] }));
+            const c = q[0].columns, ni = c.indexOf('name'), zi = c.indexOf('center_z'),
+              si = c.indexOf('size_z'), oi = c.indexOf('object_type');
+            storeys = q[0].values.map(v => ({ name: v[ni], center_z: v[zi], size_z: v[si],
+              object_type: oi >= 0 ? v[oi] : null }));
           }
         } catch (e) { storeys = null; }   // no table / no columns — reported, not invented
         db.close();

--- a/viewer/tests/witness_day0_attribution.js
+++ b/viewer/tests/witness_day0_attribution.js
@@ -1,0 +1,294 @@
+#!/usr/bin/env node
+// witness_day0_attribution.js — §W_D0A: THE EIGHT DAY-0 FAILS, EACH PINNED TO ITS CAUSE.
+//
+// ⚠ DO NOT REMOVE — SCOPE. bim-compiler prompts/AGENT_QUEUE.md item B-1, written up as
+// prompts/4D_MODEL_INTEGRITY.md §J.6. Read the log after every run (project Log Mandate).
+//
+// WHY IT EXISTS. §W_D0 says `claims=16 PASS=5 FAIL=8 INCONCLUSIVE=3 RED` on the played layer. Those
+// eight FAILs were attributed by hand: 3 witness defects (fixed in witness_day0_integrity.js), 3
+// modelling facts, 1 real defect whose fix sits on an unmerged PR, 1 absolute-threshold scope limit.
+// **An attribution written only in prose decays into a claim nobody can re-check** — which is the
+// exact failure this lane keeps paying for (§J.2's three retractions were all prose). So every
+// attribution that can be stated as a number is a CLAIM here, judged off the persisted cache.
+//
+// This witness does NOT re-assert that the eight FAILs exist (that is §W_D0's job and duplicating it
+// would be two judges of one fact). It asserts the CAUSES, so that the day a cause stops being true
+// — a rates.js override lands, the source IFC is re-extracted, §GROUNDWORK_SLAB changes — the
+// attribution in §J.6 goes red instead of quietly becoming fiction.
+//
+// CLAIMS (each independently PASS / FAIL / INCONCLUSIVE; a 0 over an empty population is never PASS):
+//   A1 GROUNDWORK OWNS THE SEQ SPLIT  every day-0 element with phase='Substructure' and seq!==1 is a
+//      §GROUNDWORK_SLAB promotion (ScheduleGate.groundworkSlabs, the shipped owner). If one is not,
+//      C2's seq-vs-phase disagreement has a SECOND cause and §J.6.1 #4 is incomplete.
+//   A2 #1551 OWNS DUPLEX'S DAY-0 DEFECT  Duplex's day-0 by-phase intruders and its hanging element
+//      are all matched by the three name-override patterns PR #1551 declares, AND those patterns hit
+//      exactly the fleet counts §J.6 records. A rates.js edit that moves either fails here.
+//   A3 HHS's OPENING IS A MODEL FACT  HHS models ZERO seq-1 elements, and every element §W_D0 C3
+//      calls hanging on it is waiting on a support in a LATER phase that lives in a DIFFERENT task —
+//      i.e. §F's class, outside §TPL_LAYER_ORDER's within-task scope (§H.3). Not a solvable ordering.
+//   A4 TERMINAL'S OPENING MEP IS A PHANTOM STOREY  the band carrying Terminal's early MEP is a
+//      4-element band sitting below the model's own 1st-percentile base_z, and Substructure is a
+//      building-scope phase, so it instantiates there and that band's MEP Final follows it.
+//   A5 C1 HAS NO IFC-DECLARED BASELINE  every IfcBuildingStorey row in every cached DB that has any
+//      is object_type='COMPILED'. C1 therefore compares the schedule against a DERIVED storey set on
+//      every building in the fleet, and deriveStoreyMergeMap cannot run on any of them.
+//   A6 DUPLEX'S EARLY MEP IS UNDER-SLAB WORK ON A SHORT PROGRAMME  every in-window MEP element is on
+//      the foundation storey, and the 3-day window is a double-digit percentage of the programme.
+//
+// Reads the persisted cache (scripts/cache_4d_run.js) and selects the PLAYED layer through
+// CACHE.layerOf(). No pipeline re-run, no browser, no bake.
+//
+// RED CONTROL: `W_D0A_RED=1 node viewer/tests/witness_day0_attribution.js` corrupts A1's population
+// (one promoted element removed from the owner's answer) and the run MUST go RED. A witness that
+// cannot be made to fail has not been shown to be able to fail.
+'use strict';
+const path = require('path');
+const ROOT = path.join(__dirname, '..', '..');
+const SG = require(path.join(ROOT, 'viewer', 'schedule_gate.js')); global.ScheduleGate = SG;
+const SS = require(path.join(ROOT, 'viewer', 'support_sweep.js'));
+const CACHE = require(path.join(ROOT, 'scripts', 'cache_4d_run.js'));
+
+const DAY_MS = 86400000;
+const RED = !!process.env.W_D0A_RED;
+const BUILDINGS = ['Duplex', 'HHS_Office_Federated', 'Hospital', 'Terminal'];
+
+// The three patterns PR #1551 declares (viewer/rates.js SEQUENCE_NAME_OVERRIDES on
+// refs/pull/1551/head). Reproduced here as the WITNESS's own reference copy, deliberately: this file
+// must be able to say "the defect #1551 targets is still live" while #1551 is unmerged, and it must
+// go red if a LATER edit changes which elements those patterns reach. Not an executed rule table.
+const PR1551 = [
+  { id: 'foundation_wall_substructure', classes: ['IfcWall', 'IfcWallStandardCase'], re: /\bfoundation\b/i },
+  { id: 'stair_member_architecture', classes: ['IfcMember'], re: /^\s*stair\b/i },
+  { id: 'finish_floor_finishes', classes: ['IfcSlab'], re: /\bfinish(ed)?[ _-]?floor\b/i },
+];
+// MEASURED 2026-09-02 off this cache and recorded in §J.6.1 #3. Locked so a rates.js change that
+// moves any of them fails loudly rather than silently invalidating the attribution.
+const PR1551_FLEET = {
+  foundation_wall_substructure: { Duplex: 7, HHS_Office_Federated: 0, Hospital: 28, Terminal: 0 },
+  stair_member_architecture: { Duplex: 4, HHS_Office_Federated: 0, Hospital: 0, Terminal: 0 },
+  finish_floor_finishes: { Duplex: 14, HHS_Office_Federated: 0, Hospital: 0, Terminal: 0 },
+};
+
+const verdicts = [];
+function claim(id, scope, pop, bad, detail, layer) {
+  const v = pop === 0 ? 'INCONCLUSIVE' : (bad === 0 ? 'PASS' : 'FAIL');
+  verdicts.push(v);
+  console.log('§W_D0A ' + id + ' ' + String(scope).padEnd(22) + v.padEnd(13) +
+    'layer=' + String(layer).padEnd(9) + 'judged=' + String(pop).padEnd(7) +
+    'bad=' + String(bad).padEnd(6) + (detail || ''));
+  return v;
+}
+
+// load(bld) — the cache, the played layer, and the day-0 slice, in one place.
+function load(bld) {
+  const r = CACHE.read(bld);
+  if (!r) { console.log('§W_D0A CACHE_MISS ' + bld + ' — run: node scripts/cache_4d_run.js ' + bld); return null; }
+  const L = CACHE.layerOf(r);
+  if (L.missing) {
+    console.log('§W_D0A CACHE_LAYER_MISSING ' + bld + ' layer=' + L.id +
+      ' — rebuild: node scripts/cache_4d_run.js --force ' + bld + '. Not substituting the other layer.');
+    return null;
+  }
+  const sched = L.map, els = r.els;
+  const t0 = Math.min.apply(null, Object.keys(sched).map(g => sched[g].s));
+  const day0 = els.filter(e => sched[e.guid] && sched[e.guid].s <= t0 + DAY_MS);
+  return { r: r, els: els, sched: sched, t0: t0, day0: day0, layer: L.id };
+}
+
+const D = {};
+BUILDINGS.forEach(b => { D[b] = load(b); });
+const have = BUILDINGS.filter(b => D[b]);
+console.log('§W_D0A_INPUT buildings=' + have.length + '/' + BUILDINGS.length +
+  ' elements=' + have.reduce((a, b) => a + D[b].els.length, 0) +
+  ' layer=' + (have.length ? D[have[0]].layer : 'none') + (RED ? '  ⚠ RED CONTROL ARMED' : ''));
+
+// ── A1 §GROUNDWORK_SLAB OWNS THE ENTIRE seq-vs-phase SPLIT ────────────────────────────────────────
+// The owner is ScheduleGate.groundworkSlabs (schedule_gate.js:201) — called, never re-derived (§I).
+{
+  let pop = 0, bad = 0; const detail = [], off = {};
+  have.forEach(b => {
+    const els = D[b].els;
+    // groundworkSlabs takes the gate's own element shape: it reads cls/phase/seq/base_z + bbox.
+    const items = els.map(e => ({ guid: e.guid, cls: e.cls, seq: e.seq, phase: e.phase,
+      base_z: e.bz, top_z: e.tz, x0: e.x0, x1: e.x1, y0: e.y0, y1: e.y1 }));
+    // §GROUNDWORK_SLAB runs on the PRE-promotion phases; the cache stores the POST-promotion ones.
+    // Re-deriving the pre-state would be inventing an input, so the membership question is asked the
+    // only honest way available from the persisted run: an element is a promotion iff its phase is
+    // Substructure while its class rule's own sequence is not 1. groundworkSlabs is still CALLED, on
+    // the post-state, as the corroborating owner — an element it still elects is unambiguous.
+    const gw = SG.groundworkSlabs(items.map(x => x.phase === 'Substructure' && x.seq !== 1
+      ? Object.assign({}, x, { phase: 'Superstructure' }) : x));
+    // RED CONTROL: drop ONE real member from the owner's answer. If the claim still passes, it is
+    // not actually reading the owner and the PASS above means nothing.
+    if (RED) { const k = D[b].day0.filter(e => e.phase === 'Substructure' && e.seq !== 1 && gw[e.guid])[0]; if (k) delete gw[k.guid]; }
+    D[b].day0.forEach(e => {
+      if (!(e.phase === 'Substructure' && e.seq !== 1)) return;
+      pop++;
+      if (!gw[e.guid]) { bad++; off[b + '/' + e.cls] = (off[b + '/' + e.cls] || 0) + 1; }
+    });
+    const n = D[b].day0.filter(e => e.phase === 'Substructure' && e.seq !== 1).length;
+    if (n) detail.push(b + ':' + n);
+  });
+  claim('A1_GROUNDWORK_OWNS_SEQ_SPLIT', 'fleet', pop, bad,
+    'day0 elements with phase=Substructure & seq!==1 {' + detail.join(' ') + '}' +
+    ' — every one must be elected by ScheduleGate.groundworkSlabs (§I owner)' +
+    (bad ? '  NOT_ELECTED{' + Object.entries(off).map(([k, n]) => k + ':' + n).join(' ') + '}' : ''),
+    have.length ? D[have[0]].layer : 'n/a');
+}
+
+// ── A2 PR #1551 OWNS DUPLEX'S DAY-0 DEFECT, AND STILL HITS THE SAME FLEET POPULATION ──────────────
+{
+  const dx = D.Duplex;
+  let pop = 0, bad = 0; const unmatched = [], counts = [];
+  if (dx) {
+    // (a) every Duplex day-0 element that is impure BY PHASE, plus the one §W_D0 C3 calls hanging,
+    //     must be matched by one of #1551's three patterns under its class gate.
+    const G = SS.contactGraph(dx.els), DES = SS.designatedSupport(dx.els, G);
+    const placed = {}; dx.day0.forEach(e => placed[e.guid] = 1);
+    const idx = {}; dx.els.forEach((e, i) => idx[e.guid] = i);
+    const targets = dx.day0.filter(e => e.phase !== 'Substructure');
+    dx.day0.forEach(e => {
+      const i = idx[e.guid];
+      if (e.seq === 1 || G.grounded[i]) return;
+      const d = DES[i];
+      if (d >= 0 && !placed[dx.els[d].guid] && targets.indexOf(e) < 0) targets.push(e);
+    });
+    targets.forEach(e => {
+      pop++;
+      const hit = PR1551.some(p => p.classes.indexOf(e.cls) >= 0 && p.re.test(e.name || ''));
+      if (!hit) { bad++; unmatched.push(e.cls + ' "' + (e.name || '').slice(0, 40) + '"'); }
+    });
+    // (b) the fleet population those three patterns reach must still be what §J.6 recorded.
+    PR1551.forEach(p => {
+      have.forEach(b => {
+        const n = D[b].els.filter(e => p.classes.indexOf(e.cls) >= 0 && p.re.test(e.name || '')).length;
+        const want = PR1551_FLEET[p.id][b];
+        pop++;
+        if (n !== want) { bad++; unmatched.push(p.id + '@' + b + ' ' + n + '!=' + want); }
+        if (n) counts.push(p.id.slice(0, 14) + '@' + b.slice(0, 8) + '=' + n);
+      });
+    });
+  }
+  claim('A2_PR1551_OWNS_DUPLEX  ', 'Duplex+fleet', pop, bad,
+    'Duplex day0 defects matched by #1551 patterns; fleet reach locked {' + counts.join(' ') + '}' +
+    (bad ? '  MISMATCH[' + unmatched.slice(0, 6).join(' | ') + ']' : ''),
+    dx ? dx.layer : 'n/a');
+}
+
+// ── A3 HHS's OPENING IS A MODEL FACT, NOT AN ORDERING THE SCHEDULER COULD FIX ─────────────────────
+{
+  const h = D.HHS_Office_Federated;
+  let pop = 0, bad = 0; const why = [];
+  if (h) {
+    const seq1 = h.els.filter(e => e.seq === 1).length;
+    pop++;
+    if (seq1 !== 0) { bad++; why.push('HHS models ' + seq1 + ' seq-1 elements, so the ground exemption CAN fire — §J.6.1 #6 is wrong'); }
+    else why.push('seq1=0 (no substructure modelled: the shipped `T.seq !== 1` exemption can never fire)');
+    // every hanging element must be waiting on a LATER-phase support in a DIFFERENT task
+    const G = SS.contactGraph(h.els), DES = SS.designatedSupport(h.els, G);
+    const placed = {}; h.day0.forEach(e => placed[e.guid] = 1);
+    const taskOf = {};
+    (h.r.tasks || []).forEach(t => t.guids.forEach(g => {
+      if (taskOf[g] == null || t.sDays < taskOf[g].s) taskOf[g] = { id: t.id, s: t.sDays };
+    }));
+    h.els.forEach((e, i) => {
+      if (!placed[e.guid] || e.seq === 1 || G.grounded[i]) return;
+      const d = DES[i]; if (d < 0 || placed[h.els[d].guid]) return;
+      pop++;
+      const S = h.els[d];
+      const later = S.seq > e.seq;
+      const crossTask = taskOf[e.guid] && taskOf[S.guid] && taskOf[e.guid].id !== taskOf[S.guid].id;
+      if (!(later && crossTask)) { bad++; why.push(e.cls + '<-' + S.cls + ' later=' + later + ' crossTask=' + crossTask); }
+      else why.push(e.cls + '(seq' + e.seq + ')<-' + S.cls + '(seq' + S.seq + ') across ' +
+        taskOf[e.guid].id + '->' + taskOf[S.guid].id);
+    });
+  }
+  claim('A3_HHS_OPENING_IS_MODEL', 'HHS_Office_Fed', pop, bad,
+    why.slice(0, 4).join(' | '), h ? h.layer : 'n/a');
+}
+
+// ── A4 TERMINAL'S EARLY MEP SITS ON A PHANTOM STOREY ──────────────────────────────────────────────
+{
+  const t = D.Terminal;
+  let pop = 0, bad = 0; const why = [];
+  if (t) {
+    const win = t.t0 + 3 * DAY_MS;
+    const earlyMep = t.els.filter(e => /^MEP/.test(e.phase || '') && t.sched[e.guid] && t.sched[e.guid].s <= win);
+    const storeys = {}; earlyMep.forEach(e => storeys[SG.collapsePhase(e.storey)] = 1);
+    const names = Object.keys(storeys);
+    pop++;
+    if (names.length !== 1) { bad++; why.push('early MEP spans ' + names.length + ' bands ' + JSON.stringify(names)); }
+    else {
+      const band = names[0];
+      const members = t.els.filter(e => SG.collapsePhase(e.storey) === band);
+      const zs = t.els.map(e => e.bz).sort((a, b) => a - b);
+      const p01 = zs[Math.floor(zs.length * 0.01)];
+      const bandMin = Math.min.apply(null, members.map(e => e.bz));
+      pop += 2;
+      if (members.length !== earlyMep.length) { bad++; why.push('band "' + band + '" holds ' + members.length + ' elements but only ' + earlyMep.length + ' are the early MEP — it is not a phantom band of exactly those'); }
+      if (!(bandMin < p01)) { bad++; why.push('band min base_z ' + bandMin.toFixed(2) + ' is NOT below the model p01 ' + p01.toFixed(2) + ' — it is not below the building'); }
+      why.push('band "' + band + '" n=' + members.length + ' = the whole early-MEP set; minBaseZ=' +
+        bandMin.toFixed(3) + 'm vs model p01=' + p01.toFixed(2) + 'm p50=' + zs[Math.floor(zs.length / 2)].toFixed(2) + 'm');
+      const subTask = (t.r.tasks || []).filter(x => x.phase === 'Substructure' && x.storey === band)[0];
+      if (subTask) why.push('building-scope Substructure instantiated HERE: ' + subTask.id + ' guids=' + subTask.guids.length + ' days ' + subTask.sDays + '-' + subTask.eDays);
+    }
+  }
+  claim('A4_TERMINAL_PHANTOM_LVL ', 'Terminal', pop, bad, why.join(' | '), t ? t.layer : 'n/a');
+}
+
+// ── A5 C1 HAS NO IFC-DECLARED BASELINE ANYWHERE IN THE FLEET ──────────────────────────────────────
+{
+  let pop = 0, bad = 0; const why = [];
+  have.forEach(b => {
+    const st = D[b].r.storeys;
+    if (!st || !st.length) { why.push(b + ':spatial_structure ABSENT'); return; }
+    pop += st.length;
+    const comp = st.filter(s => s.object_type === 'COMPILED').length;
+    if (comp !== st.length) { bad += (st.length - comp); why.push(b + ':' + (st.length - comp) + ' of ' + st.length + ' NOT compiled — an IFC-declared baseline exists here'); }
+    else why.push(b + ':' + comp + '/' + st.length + ' COMPILED');
+    // corroboration from the run's OWN log — deriveStoreyMergeMap could not run
+    if (D[b].r.log.indexOf('§S18_STOREY_MERGE_FAIL') < 0) { pop++; bad++; why.push(b + ':§S18_STOREY_MERGE_FAIL ABSENT from the log — the merge DID run, contradicting §J.6.3'); }
+  });
+  claim('A5_C1_BASELINE_COMPILED ', 'fleet', pop, bad,
+    why.join(' | ') + ' — C1 compares scheduled bands against compile_rooms.py output, not an IFC declaration',
+    have.length ? D[have[0]].layer : 'n/a');
+}
+
+// ── A6 DUPLEX'S EARLY MEP IS UNDER-SLAB WORK ON A SHORT PROGRAMME ─────────────────────────────────
+{
+  const dx = D.Duplex;
+  let pop = 0, bad = 0; const why = [];
+  if (dx) {
+    const win = dx.t0 + 3 * DAY_MS;
+    const early = dx.els.filter(e => /^MEP/.test(e.phase || '') && dx.sched[e.guid] && dx.sched[e.guid].s <= win);
+    const st = {}; early.forEach(e => st[e.storey || '_'] = (st[e.storey || '_'] || 0) + 1);
+    const bands = Object.keys(st);
+    pop++;
+    if (bands.length !== 1) { bad++; why.push('spans ' + bands.length + ' storeys ' + JSON.stringify(st)); }
+    else why.push('all ' + early.length + ' on storey "' + bands[0] + '"');
+    // the foundation storey is the LOWEST band by median base_z — extracted, not named by hand
+    const byBand = {};
+    dx.els.forEach(e => { const k = e.storey || '_'; (byBand[k] = byBand[k] || []).push(e.bz); });
+    const mids = Object.keys(byBand).map(k => {
+      const z = byBand[k].slice().sort((a, b) => a - b); return { k: k, mid: z[Math.floor(z.length / 2)] };
+    }).sort((a, b) => a.mid - b.mid);
+    pop++;
+    if (bands.length === 1 && bands[0] !== mids[0].k) { bad++; why.push('storey "' + bands[0] + '" is NOT the lowest band (that is "' + mids[0].k + '")'); }
+    else why.push('which IS the lowest band (median base_z ' + mids[0].mid.toFixed(3) + 'm)');
+    let end = dx.t0; for (const g in dx.sched) if (dx.sched[g].e > end) end = dx.sched[g].e;
+    const prog = (end - dx.t0) / DAY_MS;
+    pop++;
+    if (!(prog < 20)) { bad++; why.push('programme is ' + prog.toFixed(2) + 'd — no longer short, the scope argument in §J.6.1 #7 must be re-measured'); }
+    else why.push('programme=' + prog.toFixed(2) + 'd so the 3d window is ' + (3 / prog * 100).toFixed(1) + '% of it');
+    why.push('belowGrade(base_z<0)=' + early.filter(e => e.bz < 0).length + '/' + early.length);
+  }
+  claim('A6_DUPLEX_UNDERSLAB_MEP ', 'Duplex', pop, bad, why.join(' | '), dx ? dx.layer : 'n/a');
+}
+
+const fail = verdicts.filter(v => v === 'FAIL').length;
+const inc = verdicts.filter(v => v === 'INCONCLUSIVE').length;
+console.log('§W_D0A_VERDICT layer=' + (process.env.LAYER || 'played') +
+  ' claims=' + verdicts.length + ' PASS=' + (verdicts.length - fail - inc) +
+  ' FAIL=' + fail + ' INCONCLUSIVE=' + inc + '  ' +
+  (fail ? 'RED' : inc ? 'NOT GREEN — a claim judged nothing; an empty population is not a pass' : 'GREEN'));
+process.exit(fail ? 1 : 0);

--- a/viewer/tests/witness_day0_integrity.js
+++ b/viewer/tests/witness_day0_integrity.js
@@ -38,6 +38,31 @@
 // is VOID as a statement about the film (queue item A-0). The layer is now selected through
 // CACHE.layerOf() and PRINTED ON EVERY LINE — `LAYER=display` re-points this witness at the old map
 // deliberately, and it still says so. C1 is band geometry and is layer-independent by construction.
+//
+// ⚠ §W_D0_ATTRIBUTION (2026-09-02, queue item B-1; bim-compiler prompts/4D_MODEL_INTEGRITY.md §J.6).
+// The eight played-layer FAILs were attributed one by one and THREE OF THEM WERE THIS FILE'S OWN
+// DEFECTS, each against a row of the §I ownership table. Fixed here, and every fix is ADDITIVE —
+// the four buildings' verdict letters are unchanged by all three (measured A/B before writing):
+//   W1  C2 judged `seq === 1` while its own detail line printed `phase`. Those are different
+//       relations by construction: §GROUNDWORK_SLAB (schedule_gate.js:201) promotes an element's
+//       PHASE to Substructure and deliberately leaves its seq — 236 elements fleet-wide (Terminal
+//       233, Hospital 2, Duplex 1). Terminal's 9 "intruders" are 9 of those, in the FIRST task,
+//       with day-0 phase purity 245/245. C2 now reports BOTH relations and fails on EITHER, so
+//       Duplex's genuinely-misclassified 13mm ceramic tile is still counted and Terminal's
+//       foundation beams are NAMED as promotions instead of appearing as anonymous intruders.
+//   W2  C3 elected its own support — §I says the OWNER is support_sweep.js:432 _designatedSupport
+//       and the "never" column is literally "elect a support yourself". Walking raw contacts let a
+//       waste pipe count as a stair stringer's bearing (Duplex: all 3 of its bearing candidates are
+//       IfcFlowSegment at bz -0.47/-0.63 — §S26.2's own worked example). Now calls the owner, and
+//       PRINTS which element was elected, so a hanging is self-attributing. The old inline count is
+//       kept and printed beside it: a future divergence between the two must be visible, not silent.
+//   W3  C1's "declared" side is not declared. 6 of 6 Terminal and 3 of 3 HHS IfcBuildingStorey rows
+//       carry object_type='COMPILED' with STC_* guids — compile_rooms.py output, not an IFC
+//       declaration — and NEITHER DB has an `elevation` column, so deriveStoreyMergeMap (the §I
+//       owner of "are two storey names one floor?") cannot run on any building in the fleet.
+//       ⚠ C1's VERDICT LOGIC IS DELIBERATELY UNTOUCHED (it was verified valid and layer-independent
+//       and this change does not re-litigate it). Only the DETAIL gained `declaredBy=`, so the claim
+//       can state the limit of its own input without changing what it judges.
 'use strict';
 const path = require('path'), os = require('os');
 const ROOT = path.join(__dirname, '..', '..');
@@ -117,11 +142,20 @@ function run(bld) {
   }
   const declared = r.storeys ? r.storeys.length : null;
   const excess = declared == null ? 0 : Math.max(0, bands.length - declared);
+  // §W_D0_ATTRIBUTION W3 — PROVENANCE, DETAIL ONLY. The verdict math above and below is unchanged.
+  // A row written by compile_rooms.py (object_type='COMPILED', STC_* guid) is a DERIVED artifact,
+  // not something "the IFC declares", and this claim's whole premise is the latter. It cannot say
+  // that unless it prints it. Measured 2026-09-02: Terminal 6/6 and HHS 3/3 are COMPILED.
+  const compiled = r.storeys ? r.storeys.filter(s => s.object_type === 'COMPILED').length : 0;
+  const provenance = declared == null ? '' :
+    ' declaredBy=' + (compiled === declared
+      ? 'COMPILED:' + compiled + '/' + declared + '(compile_rooms.py, NOT an IFC declaration — this claim is judged against a DERIVED storey set; §J.6.2 W3)'
+      : compiled ? 'MIXED:' + compiled + '/' + declared + '-compiled' : 'IFC:' + declared + '/' + declared);
   out.push(claim('C1_BAND_MODEL ', bld, declared == null ? 0 : bands.length, excess + collide,
     (declared == null
       ? 'spatial_structure ABSENT from this DB — the model declares no storeys to check against'
       : 'declaredStoreys=' + declared + ' scheduledBands=' + bands.length + ' excess=' + excess) +
-    ' datumCollisions=' + collide +
+    ' datumCollisions=' + collide + provenance +
     (collisions.length ? ' [' + collisions.slice(0, 4).join(' | ') + ']' : ''), 'n/a-geometry'));
 
   // ── C2 DAY-0 PURITY + C3 DAY-0 SUPPORT ─────────────────────────────────────────────────────
@@ -129,49 +163,108 @@ function run(bld) {
   const placed = els.map(e => (sched[e.guid] && sched[e.guid].s <= cur) ? 1 : 0);
   const onScreen = placed.reduce((a, b) => a + b, 0);
   const modelsSub = els.some(e => e.seq === 1);
-  const phaseHist = {}; let impure = 0; const impureCls = {};
+  // §W_D0_ATTRIBUTION W1 — TWO RELATIONS, BOTH JUDGED, NEITHER ASSUMED TO BE THE OTHER.
+  // This claim used to read `seq === 1` and print `phase`, and those disagree BY CONSTRUCTION:
+  // §GROUNDWORK_SLAB (schedule_gate.js:201) is the shipped owner of "is this slab/beam groundwork"
+  // and it promotes PHASE to Substructure while deliberately leaving seq ("seq/resource unchanged").
+  // 236 elements fleet-wide are in that state. Reading only `seq` made Terminal's 9 promoted
+  // foundation beams look like intruders in a day 0 that is 245/245 Substructure by phase; reading
+  // only `phase` would have HIDDEN Duplex's 13mm "Finish Floor - Ceramic Tile", which §GROUNDWORK_SLAB
+  // promoted by mistake and PR #1551's finish_floor_finishes override exists to fix. So BOTH are
+  // judged and EITHER fails — the counts are reported separately so the log says which objected.
+  const phaseHist = {}; let impure = 0, promoted = 0; const impureCls = {}, promoCls = {};
   for (let i = 0; i < els.length; i++) {
     if (!placed[i]) continue;
     const ph = els[i].phase || '_UNPHASED';
     phaseHist[ph] = (phaseHist[ph] || 0) + 1;
     // Pure opening = Substructure. Where the building models NO Substructure at all, the lowest
     // Superstructure band is the legitimate opening (HHS models zero foundations — 4D_template.json
-    // says so explicitly and "_empty_ok": absent must be reported, never silently skipped).
-    const ok = modelsSub ? (els[i].seq === 1) : (els[i].seq <= 4);
-    if (!ok) { impure++; impureCls[els[i].cls] = (impureCls[els[i].cls] || 0) + 1; }
+    // says so explicitly and "_empty_ok": absent must be reported, never silently skipped). In that
+    // branch the two relations coincide by definition and the split below reads 0/0, correctly.
+    const okSeq = modelsSub ? (els[i].seq === 1) : (els[i].seq <= 4);
+    const okPhase = modelsSub ? (ph === 'Substructure') : (els[i].seq <= 4);
+    if (!okPhase) { impure++; impureCls[els[i].cls] = (impureCls[els[i].cls] || 0) + 1; }
+    else if (!okSeq) { promoted++; promoCls[els[i].cls + '(seq' + els[i].seq + '/' + els[i].resource + ')'] =
+      (promoCls[els[i].cls + '(seq' + els[i].seq + '/' + els[i].resource + ')'] || 0) + 1; }
   }
-  out.push(claim('C2_DAY0_PURITY', bld, onScreen, impure,
-    'modelsSubstructure=' + modelsSub + ' phases{' +
+  out.push(claim('C2_DAY0_PURITY', bld, onScreen, impure + promoted,
+    'modelsSubstructure=' + modelsSub + ' byPhase=' + impure + ' bySeqOnly=' + promoted + ' phases{' +
     Object.entries(phaseHist).sort((a, b) => b[1] - a[1]).map(([k, n]) => k + ':' + n).join(' ') + '}' +
-    (impure ? '  INTRUDERS{' + Object.entries(impureCls).sort((a, b) => b[1] - a[1]).slice(0, 6).map(([k, n]) => k + ':' + n).join(' ') + '}' : ''), LAY));
+    (impure ? '  INTRUDERS{' + Object.entries(impureCls).sort((a, b) => b[1] - a[1]).slice(0, 6).map(([k, n]) => k + ':' + n).join(' ') + '}' : '') +
+    (promoted ? '  §GROUNDWORK_SLAB-PROMOTED(phase=Substructure, seq left behind){' +
+      Object.entries(promoCls).sort((a, b) => b[1] - a[1]).slice(0, 6).map(([k, n]) => k + ':' + n).join(' ') + '}' : ''), LAY));
 
-  let judged = 0, hanging = 0; const hangCls = {};
+  // §W_D0_ATTRIBUTION W2 — CALL THE OWNER. §I: "which ONE thing supports T?" -> support_sweep.js:432
+  // _designatedSupport; the "never" column is "elect a support yourself". This claim used to walk raw
+  // contacts and accept ANY bearing/embedded one, which is how Duplex's day-0 stair stringer came to
+  // be judged against three waste/cold-water IfcFlowSegment at bz -0.47/-0.63 — §S26.2's own worked
+  // example of "an IfcFlowSegment under a wall bore that wall". _designatedSupport's pool election
+  // (schedule_gate.js:1323 supportPool) rejects exactly that and elects the IfcSlab instead.
+  // The old inline test is KEPT and PRINTED as a cross-check, never as the verdict: two judges of one
+  // physics that quietly diverge is the defect class this whole file exists to catch, so a divergence
+  // must be a number on the line. Measured 2026-09-02, they agree on all four (1/3/0/0).
+  const DES = SS.designatedSupport(els, G);
+  let judged = 0, hanging = 0, inlineHang = 0, desNone = 0, heldByCarrier = 0;
+  const hangCls = {}, hangBy = {};
   for (let i = 0; i < els.length; i++) {
     if (!placed[i]) continue;
     if (els[i].seq === 1 || G.grounded[i]) continue;      // shipped 1c + rests on soil
     judged++;
-    const T = els[i]; let held = 0;
+    const T = els[i];
+    let inlineHeld = 0;
     for (const j of (G.contacts[i] || [])) {
       const S = els[j];
       const bearing = (S.bz < T.bz - EPS && S.tz >= T.bz - GAP);
       const embedded = (S.bz <= T.bz + EPS && S.tz >= T.tz - EPS);
-      if ((bearing || embedded) && placed[j]) { held = 1; break; }
+      if ((bearing || embedded) && placed[j]) { inlineHeld = 1; break; }
     }
-    if (!held) { hanging++; hangCls[T.cls] = (hangCls[T.cls] || 0) + 1; }
+    if (!inlineHeld) inlineHang++;
+    const d = DES[i];
+    if (d < 0) { desNone++; continue; }   // §MIDAIR_DIRECTIONAL: nothing it depends on. Counted, so it is never silent.
+    const S = els[d];
+    const carrier = (S.bz >= T.tz - GAP && S.tz > T.tz + EPS);
+    if (!placed[d]) {
+      hanging++;
+      hangCls[T.cls] = (hangCls[T.cls] || 0) + 1;
+      const k = T.cls + '<-' + S.cls + '|seq' + S.seq + '|' + (S.phase || '_UNPHASED');
+      hangBy[k] = (hangBy[k] || 0) + 1;
+    } else if (carrier) heldByCarrier++;   // the owner says held, by something ABOVE. Reported, not hidden.
   }
   out.push(claim('C3_DAY0_SUPPORT', bld, judged, hanging,
-    (hanging ? 'hanging{' + Object.entries(hangCls).sort((a, b) => b[1] - a[1]).slice(0, 6).map(([k, n]) => k + ':' + n).join(' ') + '}' : 'nothing on screen is unheld'), LAY));
+    (hanging
+      ? 'hanging{' + Object.entries(hangCls).sort((a, b) => b[1] - a[1]).slice(0, 6).map(([k, n]) => k + ':' + n).join(' ') + '}' +
+        ' waitingOn{' + Object.entries(hangBy).sort((a, b) => b[1] - a[1]).slice(0, 6).map(([k, n]) => k + ':' + n).join(' ') + '}'
+      : 'nothing on screen is unheld') +
+    ' judge=_designatedSupport(§I owner) inlineAnyContact=' + inlineHang +
+    (inlineHang !== hanging ? ' ⚠ JUDGES DIVERGE' : '') +
+    ' desNone=' + desNone + ' heldByCarrierAbove=' + heldByCarrier, LAY));
 
   // ── C4 NO EARLY MEP ────────────────────────────────────────────────────────────────────────
   const mepCur = t0 + MEP_WINDOW_D * DAY_MS;
-  let inWin = 0, mep = 0; const mepCls = {};
+  let inWin = 0, mep = 0, firstMep = Infinity; const mepCls = {}, mepStorey = {};
+  let progEnd = t0;
+  for (const g in sched) if (sched[g].e > progEnd) progEnd = sched[g].e;
   for (let i = 0; i < els.length; i++) {
-    const st = sched[els[i].guid]; if (!st || st.s > mepCur) continue;
+    const st = sched[els[i].guid]; if (!st) continue;
+    if (/^MEP/.test(els[i].phase || '') && st.s < firstMep) firstMep = st.s;
+    if (st.s > mepCur) continue;
     inWin++;
-    if (/^MEP/.test(els[i].phase || '')) { mep++; mepCls[els[i].cls] = (mepCls[els[i].cls] || 0) + 1; }
+    if (/^MEP/.test(els[i].phase || '')) {
+      mep++; mepCls[els[i].cls] = (mepCls[els[i].cls] || 0) + 1;
+      mepStorey[els[i].storey || '_'] = (mepStorey[els[i].storey || '_'] || 0) + 1;
+    }
   }
+  // §W_D0_ATTRIBUTION: MEP_WINDOW_D is an ABSOLUTE constant judged against programmes that span
+  // 13 -> 318 days across this fleet, so 3 days is 23.1% of Duplex and 0.9% of Hospital. That is not
+  // a reason to invent a proportional threshold (§J.0: a metric invented to fill a hole where a RULE
+  // should be is the square peg) — it is a reason for the claim to PRINT the scale it is judging at,
+  // so a reader can see whether a FAIL means "MEP is early" or "the programme is short".
+  const progDays = (progEnd - t0) / DAY_MS;
   out.push(claim('C4_NO_EARLY_MEP', bld, inWin, mep, 'window=' + MEP_WINDOW_D + 'd' +
-    (mep ? ' MEP{' + Object.entries(mepCls).map(([k, n]) => k + ':' + n).join(' ') + '}' : ''), LAY));
+    ' programmeDays=' + progDays.toFixed(2) + ' windowIs=' + (MEP_WINDOW_D / progDays * 100).toFixed(1) + '%ofProgramme' +
+    ' firstMEP=+' + (firstMep === Infinity ? 'none' : ((firstMep - t0) / DAY_MS).toFixed(2) + 'd') +
+    (mep ? ' MEP{' + Object.entries(mepCls).map(([k, n]) => k + ':' + n).join(' ') + '}' +
+      ' onStorey{' + Object.entries(mepStorey).sort((a, b) => b[1] - a[1]).slice(0, 4).map(([k, n]) => k + ':' + n).join(' ') + '}' : ''), LAY));
   return out;
 }
 


### PR DESCRIPTION
## What

Queue item **B-1**. `§W_D0` read **`claims=16 PASS=5 FAIL=8 INCONCLUSIVE=3 RED`** on the played layer with **no FAIL attributed to a cause**. All eight are attributed here, off the persisted cache (`origin/main` @ `99e260e8`, four buildings, **119,568 elements**, no bake, no browser). Spec: bim-compiler `prompts/4D_MODEL_INTEGRITY.md` **§J.6**.

**3 witness defects · 3 modelling facts · 1 real defect (fix on unmerged #1551) · 1 scope limit.**

## The attribution

| # | claim · building | bad | cause | class |
|---|---|---|---|---|
| 1 | C1 HHS | excess=1 | extra band `Roof Level`, n=45 (22 IfcFlowSegment, 10 IfcFlowFitting, 7 IfcSlab, 5 proxy, 1 ECD; bz 0.90–14.32 m). HHS `spatial_structure` = **3 rows, 3/3 `object_type='COMPILED'`, `STC_*`** — `compile_rooms.py`, not an IFC declaration | witness (W3) |
| 2 | C1 Terminal | excess=16, collisions=5 | **22 collapsed storey strings across 3 parallel naming systems** (Malay `Aras *`, English `NN … FLOOR LEVEL`, `Ceiling Level *`) vs **6 rows, 6/6 COMPILED, all Malay**. `deriveStoreyMergeMap` **cannot run** — reads `r.elevation`, the column does not exist | modelling fact |
| 3 | C2 Duplex | 3 | `IfcWallStandardCase "Basic Wall:Foundation - Concrete (435mm)"` · `IfcMember "Stair:Residential…"` · `IfcSlab "Floor:Finish Floor - Ceramic Tile"` (**13 mm** thick) = exactly PR **#1551**'s three unmerged overrides. Re-measured: `IfcWall* /foundation/` Duplex 7/56 Hospital 28/1310 else 0; `IfcMember ^Stair` Duplex 4/4, 0 of 9,019 elsewhere; `IfcSlab /finish floor/` Duplex 14/21, 0 elsewhere | **real defect, fix unmerged** |
| 4 | C2 Terminal | 9 | 9 × `IfcBeam "M_Concrete-Foundation Beam"`, **`phase='Substructure'`**, in `TASK_Substructure_00_Aras_Asas`, `seq=3`/STEEL_ERECTOR. Day-0 phase purity **245/245**. §GROUNDWORK_SLAB promotes phase, leaves seq — **236 elements fleet-wide** | witness (W1) |
| 5 | C3 Duplex | 1 | same stair stringer; its **only 3 bearing candidates are `IfcFlowSegment`** waste/cold-water pipes at bz −0.47/−0.63 — §S26.2's own worked example | witness (W2) + #1551 |
| 6 | C3 HHS | 3 | HHS **models zero seq-1 elements** (`{2:257,3:1450,4:274,5:825,6:464,7:2666,8:133,9:727,10:43}`), so `T.seq !== 1` can never fire. The 65×53 m ground slab has **3 bearing contacts of 6,193** (2 `IfcStairFlight` seq 6 @+264 h, 1 pipe @+816 h); `grounded=0` because **one single pipe** at bz −4.700 lies in its footprint. Other 2 = 30 mm `IfcSlab` stair treads on that same seq-6 flight | modelling fact + §F cross-task (outside §H.3's within-task scope) |
| 7 | C4 Duplex | 83 | 83 MEP Rough-in, **all on `T/FDN`**, 39 below grade (bz to −0.762) vs Substructure slab top **+0.013** — under-slab plumbing at day 2.00 of a **13.00-day** programme. The 3-day window is **23.1 %** of Duplex vs **0.9 %** of Hospital | witness scope (absolute window, 13→318 d) |
| 8 | C4 Terminal | 4 | the 4 `IfcFlowTerminal` **are the entire `00 Aras Asas` band**; 3 sit at bz ≈ 0.2 m vs model **p01 = 14.43 m, p50 = 34.36 m**. Substructure is `scope: building` → instantiates there (`TASK_Substructure_00_Aras_Asas`, 469 guids, days 0–2), so that band's MEP Final follows at days 2–3 | modelling fact |

Hospital contributes **zero** FAILs on the played layer.

## The three witness defects — each against an §I row

- **W1 `C2` judged `seq`, printed `phase`.** §GROUNDWORK_SLAB (`schedule_gate.js:201`) promotes `phase` and *deliberately leaves* `seq`. Now judges **both**, fails on **either**, so Duplex's genuinely misclassified 13 mm ceramic tile is still counted (`byPhase=2 bySeqOnly=1`) and Terminal's beams are named `§GROUNDWORK_SLAB-PROMOTED{IfcBeam(seq3/STEEL_ERECTOR):9}`.
- **W2 `C3` elected its own support.** §I OWNER = `support_sweep.js:432 _designatedSupport`; the "never" column is literally *"elect a support yourself"*. Now calls the owner and prints `waitingOn{IfcMember<-IfcSlab|seq4}`. **A/B measured before writing: counts identical on all four (1/3/0/0).** The old inline count is kept beside it with a `⚠ JUDGES DIVERGE` marker, plus `desNone=` and `heldByCarrierAbove=` — which surfaced 1 HHS element the owner calls held by something *above* it, previously invisible.
- **W3 `C1`'s "declared" side is not declared.** Cache now persists `object_type`; C1 prints `declaredBy=COMPILED:6/6(…)`. **C1's verdict logic is deliberately untouched** — detail only.

## Nothing was weakened

`§W_D0_VERDICT` is **`claims=16 PASS=5 FAIL=8 INCONCLUSIVE=3 RED` before and after, on BOTH layers.** Every fix is additive.

## New witness — `§W_D0A`

`viewer/tests/witness_day0_attribution.js`: **`claims=6 PASS=6 FAIL=0 INCONCLUSIVE=0 GREEN`**; red control `W_D0A_RED=1` (drops one member from the owner's answer) → **RED, `bad=2`**. It locks the causes so the attribution cannot decay into prose: §GROUNDWORK_SLAB owns the whole seq/phase split (10 day-0 elements, 0 unelected); #1551's patterns still reach exactly Duplex 7/4/14 + Hospital 28; HHS has 0 seq-1 and every hanging waits on a later-phase support in a **different task**; Terminal's early MEP is a 4-element band below p01; no IFC-declared storey baseline exists fleet-wide; Duplex's early MEP is under-slab work on a 13-day programme.

## ⛔ Correction to `4D_MODEL_INTEGRITY.md` §I

The row *"are two storey names one floor?"* claimed `deriveStoreyMergeMap` **✅ RUNS as of 2026-08-27 (Terminal 23 names → 15 bands)**. Measured against the shipped bytes: `§S18_STOREY_MERGE_FAIL no such column: elevation` on **Terminal AND HHS**, `no such table` on Duplex and Hospital — **it runs on nothing in the fleet.** `compile_rooms.py` writes `center_z` and no `elevation`. Row corrected in place.

## Measured, deliberately NOT shipped (§J.6.4)

1. **§GROUNDWORK_SLAB prices 21 promoted `IfcBeam` as STEEL_ERECTOR** (Terminal 20 + Hospital 1). Its own comment says *"seq/resource unchanged (CONCRETE_GANG already)"* — true for `IfcSlab`, false for `IfcBeam`. Fixing it changes duration/crew → dates → a **U-8-class ruling**.
2. **Widening `stair_member_architecture` to `IfcSlab`** would close C3 HHS (`IfcSlab ^Stair` = HHS **4/83**, 0 elsewhere) — but it appends to the same array PR **#1551** appends to, and moves `IfcSlab` out of `supportPool`. **Land #1551 first.**

## Checks

`node --check` on all three files · `./node_modules/.bin/eslint viewer modeller scripts` **exit 0** (repo's own install, not `npx` — see the phantom-`VideoEncoder` trap) · `witness_cache_layer_attribution` **claims=5 PASS=5 GREEN** with the new reader discovered and passing C4 · no shipped runtime file touched (`viewer/tests` + `scripts` only) so **no `sw.js` bump**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RTX9gUq3tQoytC1vthLmcq
