### PR TITLE
fix(4d): §FUTURE-5A — relocate 7 of 11 hardcoded 5D policy constants into JSON

### DIFF
--- a/viewer/rates.js
+++ b/viewer/rates.js
@@ -174,6 +174,16 @@ var LABOR_RATES = {
     rate_per_day: 95, crew_size: 1, max_crews: 1, trade: 'General Laborer',
     productivity: {}
   },
+  // §FUTURE-5A (bim-compiler prompts/4D_GANTT_TM_REFACTOR.md, applied 2026-09-02, queue item B-3).
+  // THIS is the object window.LABOR_RATES actually resolves to on every real viewer.html load
+  // (rates/sequence_rules.json's own header: "viewer.html never calls loadSequenceRules()... this
+  // file is their MIRROR plus the Settings-JSON-editor override surface") — so these three keys
+  // MUST be kept here, byte-identical to their sequence_rules.json mirror, or the JSON edit a
+  // Settings-JSON-editor user makes is invisible on the default (non-overridden) path. See
+  // sequence_rules.json LABOR_RATES for the full provenance comment on each.
+  _productivity_basis_secs: 28800,     // A1 — the 8h crew-day the productivity figures are quoted against
+  _zero_minute_floor_secs: 120,        // B3 — the §TPL_ZERO_MINUTE no-data floor
+  _default_max_crews_author: 1,        // B4 — pricing-side crew-cap fallback (schedule_gate.js keeps its own, different, 3)
 };
 
 // ============================================================================

--- a/viewer/rates/4D_template.json
+++ b/viewer/rates/4D_template.json
@@ -15,8 +15,10 @@
     "_what": "The working calendar the programme is authored against. Named here because it was previously implicit: rates.js SHIFT_HOURS alone carried it, and nothing stated the week.",
     "hours_per_shift": 24,
     "days_per_week": 7,
+    "project_start": "2026-01-01",
     "_hours_per_shift_why": "24 is the STANDING USER RULING recorded at rates.js SHIFT_HOURS (2026-08-13): 'our default, import and JSON setting can import as we align to standard model'. Carried forward verbatim, NOT changed here — this file only makes it visible and editable. A standard-model import sets 8.",
     "_days_per_week_why": "7 matches what the engine actually does today (schedule_gate.js applies no week calendar; §CREW_DAY logs '24/7 calendar unchanged'). Stated so a 5-day working week becomes an edit rather than a rewrite.",
+    "_project_start_why": "§FUTURE-5A row B2 (2026-08-27 inventory, applied 2026-09-02, queue item B-3). The literal '2026-01-01' epoch schedule_author.js materializeZones/the §GANTT_SCHEDULE_STALE_REGEN self-heal path anchor a generated programme to when nothing else supplies a start. Extracted verbatim, not changed. NOT the same call site as the live UI's 'Generate Gantt' path (time_machine.js todayStart = new Date().toISOString().slice(0,10)) — that one is deliberately today's real date, out of this key's scope. 14 more '2026-01-01' sites exist in schedule_author_ui.js/schedule_diff.js/proj_control.js/proj_fold.js — outside this audit's scope (schedule_author.js/schedule_gate.js/time_machine.js scheduling call sites only), counted but not touched.",
     "holidays": []
   },
 
@@ -38,7 +40,9 @@
     "rule": "at no instant may more than max_crews[t] elements of trade t be in progress, for every trade t",
     "applies_to": "the FINAL emitted times, not only the times at first placement",
     "_why_final_and_not_first": "MEASURED on HHS_Office_Federated (2026-08-25, A/B with the repair loop disabled): schedule_gate.js enforces the cap correctly inside claimCrew at placement — every trade sits exactly at or under its cap. The §DEQ_REPAIR sweep then moves elements forward to satisfy geometry gates by writing o.start/o.end DIRECTLY, without re-claiming a crew slot. Result: CARPENTER peaks at 8 simultaneous crews against max_crews=2, a 4.0x breach, while all 7 other trades stay legal. Disabling the repair loop returns CARPENTER to 2. The span is 46.9 days either way — the breach does not shorten the programme, it just makes it unbuildable.",
-    "_witness": "witness_4d_capacity_honoured.js — sweeps the emitted start/end times per trade and asserts peak concurrency <= max_crews."
+    "_witness": "witness_4d_capacity_honoured.js — sweeps the emitted start/end times per trade and asserts peak concurrency <= max_crews.",
+    "_level_scan_max_days": 100000,
+    "_level_scan_max_days_why": "§FUTURE-5A row B6 (applied 2026-09-02, queue item B-3). instantiateTemplate's crew-levelling search guard (`while (!fits(t, at) && guard++ < LEVEL_SCAN_MAX) at++`) — how many days it will scan forward looking for a free crew slot before giving up. Extracted verbatim, not changed. ⚠ Separate finding #1 in §FUTURE-5A (NOT fixed here, PRIME-RULE-relevant but out of this refactor's scope): guard exhaustion is committed as if it were a successful placement, with no way to tell the two apart in `capacity_levelled`'s own report — moving the number does not touch that bug."
   },
 
   "phases": [

--- a/viewer/rates/sequence_rules.json
+++ b/viewer/rates/sequence_rules.json
@@ -494,6 +494,12 @@
       "max_crews": 1,
       "trade": "General Laborer",
       "productivity": {}
-    }
+    },
+    "_productivity_basis_secs": 28800,
+    "_productivity_basis_secs_why": "bim-compiler prompts/4D_GANTT_TM_REFACTOR.md §FUTURE-5A row A1 (2026-08-27 inventory, applied 2026-09-02, queue item B-3). 28800s = the 8h crew-day the productivity figures above are QUOTED AGAINST (secsPerUnit = this / productivity). This is NOT calendar.hours_per_shift (4D_template.json, =24, the crew's actual working day) — those are two different quantities that merely share the word 'hours'; collapsing them was the exact 3x conflation bug §FUTURE item 2 chased. Read by schedule_author.js _installSecs/materializeDefault/scheduleContiguous and time_machine.js getInstallSecs/§HR_COST, all with a literal 28800 fallback so a caller that omits this key (an older cached JSON, a minimal test object) is byte-identical to pre-2026-09-02 behaviour.",
+    "_zero_minute_floor_secs": 120,
+    "_zero_minute_floor_secs_why": "§FUTURE-5A row B3. The §TPL_ZERO_MINUTE floor schedule_author.js _installSecs returns when a class has no resource/productivity match. Same fallback-with-literal-120 pattern as _productivity_basis_secs. schedule_gate.js:564's OWN independent `el.installSecs || 120` safety net is NOT wired to this key — that module receives no rules/rates object at all (pure elements-in, times-out), and threading one in was judged out of proportion for this refactor; left as a documented literal there, kept in sync by hand.",
+    "_default_max_crews_author": 1,
+    "_default_max_crews_author_why": "§FUTURE-5A row B4 / separate finding #2 — schedule_author.js's five `(laborRates[t] && laborRates[t].max_crews) || 1` sites (pricing side). schedule_gate.js has its OWN, DIFFERENT default (`MAX_CREWS_DEFAULT = 3`, pacing/solve side) for the identical missing-value case — a real, NAMED, NOT-fixed-here divergence (both defaults are dormant today because all 10 named trades carry an explicit max_crews; only an unnamed/_DEFAULT resource would ever hit either). Deliberately NOT unified into one shared key: doing so would silently change one side's shipped output 3x for any building that ever exercises the fallback, which is a calibration decision, not a refactor. This key relocates ONLY the author-side literal; the gate-side `3` stays a documented JS constant in schedule_gate.js (a pure, rules-free module — see that file's own comment) — do not add a `_default_max_crews_gate` key here unless something is wired to read it, or it becomes exactly the 'config nobody loads' defect this same queue item's Part 2 fixes elsewhere."
   }
 }

--- a/viewer/schedule_author.js
+++ b/viewer/schedule_author.js
@@ -75,9 +75,14 @@
     console.warn('§TPL_ZERO_MINUTE cls=' + cls + ' resource=' + resource + ' reason=' + why +
       ' — 120s floor, this class draws a zero-width bar (first occurrence only)');
   }
+  // §FUTURE-5A A1/B3 (bim-compiler prompts/4D_GANTT_TM_REFACTOR.md, applied 2026-09-02, queue item
+  // B-3): both numbers below now READ laborRates._productivity_basis_secs / ._zero_minute_floor_secs
+  // (sequence_rules.json), falling back to the SAME literals that shipped before this — a caller
+  // (older cached JSON, a minimal test object) that omits either key is byte-identical to pre-fix.
   function _installSecs(cls, rule, laborRates, realQty, lengthRatio) {
     var resource = rule && rule.resource;
-    if (!resource || !laborRates[resource]) { _reportFloor(cls, resource, 'no-resource'); return 120; }
+    var _floorSecs = (laborRates && laborRates._zero_minute_floor_secs) || 120;
+    if (!resource || !laborRates[resource]) { _reportFloor(cls, resource, 'no-resource'); return _floorSecs; }
     var labor = laborRates[resource], bestPk = null, bestLen = 0;
     for (var pk in labor.productivity) {
       if (cls.indexOf(pk) >= 0 && pk.length > bestLen) { bestPk = pk; bestLen = pk.length; }
@@ -87,8 +92,8 @@
     // pointed at. default_productivity is the resource's own declared figure for that case; absent,
     // this is 0 and the floor still applies exactly as before (backward-compatible).
     var prod = bestPk ? labor.productivity[bestPk] : (labor.default_productivity || 0);
-    if (prod <= 0) { _reportFloor(cls, resource, bestPk ? 'productivity<=0' : 'no-productivity-key'); return 120; }
-    var secsPerUnit = 28800 / prod;
+    if (prod <= 0) { _reportFloor(cls, resource, bestPk ? 'productivity<=0' : 'no-productivity-key'); return _floorSecs; }
+    var secsPerUnit = ((laborRates && laborRates._productivity_basis_secs) || 28800) / prod;
     if (realQty != null) return Math.round(secsPerUnit * realQty);
     if (lengthRatio != null) return Math.round(secsPerUnit * lengthRatio);
     return Math.round(secsPerUnit);
@@ -436,6 +441,14 @@
     laborRates = laborRates || {};
     var shiftSecs = (shiftHours > 0 ? shiftHours : (T.calendar && T.calendar.hours_per_shift) || 24) * 3600;
     var minDays = (T.duration_rule && T.duration_rule.min_days) || 1;
+    // §FUTURE-5A B4 (applied 2026-09-02, queue item B-3): the pricing-side crew-cap fallback for an
+    // unnamed/_DEFAULT resource, now sourced from sequence_rules.json LABOR_RATES._default_max_crews_author
+    // — same literal (1) as before this fix, see that key's own comment for why this is NOT unified
+    // with schedule_gate.js's separate MAX_CREWS_DEFAULT=3 (a real, undisturbed divergence).
+    var _defMaxCrews = (laborRates && laborRates._default_max_crews_author) || 1;
+    // §FUTURE-5A B6: instantiateTemplate's own crew-levelling search guard, now sourced from
+    // 4D_template.json capacity_rule._level_scan_max_days (same literal, 100000, as before).
+    var LEVEL_SCAN_MAX = (T.capacity_rule && T.capacity_rule._level_scan_max_days) || 100000;
     collapse = collapse || function (x) { return x; };
     // Resolved ONCE. With levelAxis absent both of these are literally the expressions that were
     // inline here before, so the flag-off path is unchanged by construction, not by inspection.
@@ -467,7 +480,7 @@
       for (var t in c.secs) {
         if (t === '_DEFAULT') continue;
         any = 1;
-        var cap = (laborRates[t] && laborRates[t].max_crews) || 1;
+        var cap = (laborRates[t] && laborRates[t].max_crews) || _defMaxCrews;
         var td = c.secs[t] / (shiftSecs * cap);
         if (td > d) { d = td; bott = t + '(' + cap + ')'; }
       }
@@ -631,13 +644,13 @@
     function fits(t, at) {
       var need = taskTradeCrews(t);
       for (var tr in need) {
-        var cap = (laborRates[tr] && laborRates[tr].max_crews) || 1;
+        var cap = (laborRates[tr] && laborRates[tr].max_crews) || _defMaxCrews;
         for (var d = at; d < at + t.days; d++)
           if (((demand[tr] && demand[tr][d]) || 0) + need[tr] > cap + 1e-9) return false;
       }
       return true;
     }
-    var levelled = 0, levelledDays = 0, LEVEL_SCAN_MAX = 100000;
+    var levelled = 0, levelledDays = 0;   // LEVEL_SCAN_MAX now derived once at function top (§FUTURE-5A B6)
     topo.forEach(function (t) {
       var at = t.sDays, guard = 0;
       while (!fits(t, at) && guard++ < LEVEL_SCAN_MAX) at++;
@@ -697,7 +710,13 @@
   function materializeZones(db, rules, opts) {
     opts = opts || {};
     var schedId = opts.scheduleId || 'SCH_AUTHORED';
-    var start = opts.start || '2026-01-01';
+    // §FUTURE-5A B2 (applied 2026-09-02, queue item B-3): opts.start (a real caller value) wins as
+    // before; the SECOND choice now reads the declared 4D_template.json calendar.project_start
+    // instead of jumping straight to the bare literal, so a future caller that passes opts.template
+    // but omits opts.start picks up the JSON-declared epoch. Every CURRENT caller that passes
+    // opts.template also passes an explicit opts.start (verified 2026-09-02), so this branch is not
+    // yet live — added for when a caller drops the redundant explicit start, not a behaviour change.
+    var start = opts.start || (opts.template && opts.template.calendar && opts.template.calendar.project_start) || '2026-01-01';
     var SG = opts.scheduleGate || global.ScheduleGate;
     if (!SG || !SG.computeSchedule || !SG.deriveZones) {
       console.log('§AUTHOR_ZONES_FAIL reason=ScheduleGate_not_loaded');
@@ -707,6 +726,10 @@
     if (!elements.length) { console.log('§AUTHOR_ZONES_FAIL reason=no_elements'); return { ok: false, reason: 'no_elements' }; }
 
     var laborRates = opts.laborRates || (global.LABOR_RATES) || {};
+    // §FUTURE-5A B4 (applied 2026-09-02, queue item B-3): same relocation as instantiateTemplate's
+    // own _defMaxCrews (used below by the §ZONE_WINDOW_COVERS_WORK floor) — this function has its
+    // own laborRates local, so it needs its own copy of the derived default, not a shared closure var.
+    var _defMaxCrews = (laborRates && laborRates._default_max_crews_author) || 1;
     var maxCrews = {};
     for (var res in laborRates) if (laborRates[res].max_crews) maxCrews[res] = laborRates[res].max_crews;
     // §GANTT_SHIFT_HOURS_DESYNC (4D_SCHEDULE_PERFECTION.md) — this call used to omit shiftHours,
@@ -883,7 +906,7 @@
       var _crewDays = 0, _wAnyTrade = 0;
       for (var _wt in _wTrades) {
         _wAnyTrade = 1;
-        var _wCap = (laborRates[_wt] && laborRates[_wt].max_crews) || 1;
+        var _wCap = (laborRates[_wt] && laborRates[_wt].max_crews) || _defMaxCrews;
         var _wd = (_wTrades[_wt] * 1000) / (_shiftMs * _wCap);
         if (_wd > _crewDays) _crewDays = _wd;
       }
@@ -1487,6 +1510,11 @@
   // materializeDefault(db, rules, opts) — originate the smart-default schedule on a blank model.
   // db: a sql.js Database with `elements_meta`. rules: SEQUENCE_RULES map. opts: {start, phaseDays,
   // scheduleId, defaultRule}. Idempotent — rebuilds the SCH_AUTHORED schedule from scratch.
+  // §FUTURE-5A B2/B7 (reviewed 2026-09-02, queue item B-3): this is the ALTERNATE/legacy authoring
+  // path, never the canonical template one (no caller anywhere in the codebase passes opts.template
+  // here — verified) — so, unlike materializeZones above, its opts.start/opts.phaseDays literal
+  // fallbacks are left untouched rather than threading a dead opts.template read. Their JSON homes
+  // (4D_template.json calendar.project_start / duration_rule) are documented but NOT wired here.
   function materializeDefault(db, rules, opts) {
     opts = opts || {};
     var start = opts.start || '2026-01-01';
@@ -1603,8 +1631,9 @@
       for (var resKey in p.resourceSecs) {
         var secs = p.resourceSecs[resKey];
         laborSecsTotal += secs;
-        var maxCrews = (laborRates[resKey] && laborRates[resKey].max_crews) || 1;
-        var tradeDays = secs / (28800 * maxCrews);
+        // §FUTURE-5A A1/B4 (applied 2026-09-02, queue item B-3) — same relocation as instantiateTemplate.
+        var maxCrews = (laborRates[resKey] && laborRates[resKey].max_crews) || (laborRates._default_max_crews_author || 1);
+        var tradeDays = secs / (((laborRates && laborRates._productivity_basis_secs) || 28800) * maxCrews);
         if (tradeDays > maxTradeDays) maxTradeDays = tradeDays;
       }
       p.widthDays = Math.max(1, Math.ceil(maxTradeDays));
@@ -1759,6 +1788,8 @@
   // act (the optional "suggest a start"). Lays the leaf phases out contiguously from opts.start so
   // a blank-materialized (undated) schedule becomes datable on demand. Orders by rowid = insert
   // order = the sequence order materializeDefault used (NULL dates can't be ORDER BY'd).
+  // §FUTURE-5A B2/B7 — same alternate-path note as materializeDefault above: no caller passes
+  // opts.template here, so its start/phaseDays literal fallbacks are left as-is (2026-09-02).
   function scheduleContiguous(db, scheduleId, opts) {
     scheduleId = scheduleId || 'SCH_AUTHORED';
     opts = opts || {};
@@ -1798,8 +1829,9 @@
       }
       var maxTradeDays = 0;
       for (var resKey2 in resourceSecs) {
-        var maxCrews = (laborRates[resKey2] && laborRates[resKey2].max_crews) || 1;
-        var d = resourceSecs[resKey2] / (28800 * maxCrews);
+        // §FUTURE-5A A1/B4 (applied 2026-09-02, queue item B-3) — same relocation as materializeDefault.
+        var maxCrews = (laborRates[resKey2] && laborRates[resKey2].max_crews) || (laborRates._default_max_crews_author || 1);
+        var d = resourceSecs[resKey2] / (((laborRates && laborRates._productivity_basis_secs) || 28800) * maxCrews);
         if (d > maxTradeDays) maxTradeDays = d;
       }
       widthDays[tid] = maxTradeDays > 0 ? Math.max(1, Math.ceil(maxTradeDays)) : phaseDays;

--- a/viewer/schedule_gate.js
+++ b/viewer/schedule_gate.js
@@ -43,7 +43,27 @@
   // (Terminal/Hospital/Duplex/HHS/Clinic, extraction logged 2026-08-11; p99 was 11.808 m³ — same
   // class mix, less coverage). EXTRACTED, not invented — do not retune without re-measuring.
   var BIG_ELEMENT_VOL = 1.556;  // m³
-  var MAX_CREWS_DEFAULT = 3;  // §CREW-CAP: fallback crew count per resource when no lookup is given
+  // §CREW-CAP: fallback crew count per resource when no lookup is given. §FUTURE-5A B4 (reviewed
+  // 2026-09-02, queue item B-3): sequence_rules.json now carries the SAME missing-value case for the
+  // pricing side as LABOR_RATES._default_max_crews_author (=1) — a real, NOT-fixed-here divergence
+  // from this module's 3 (see that key's own comment). NOT wired to read it: this module receives no
+  // rules/rates object at all (elements already carry a resolved `resource` string, nothing more —
+  // see computeSchedule's own header), so threading one in for a single fallback constant was judged
+  // out of proportion for a refactor whose contract is byte-identical output. Kept in sync by hand.
+  var MAX_CREWS_DEFAULT = 3;
+  // §FUTURE-5A B1 (attempted 2026-09-02, queue item B-3, REVERTED same day) — the audit's own
+  // "highest-value finding": this file tests `seq <= 4` / `seq > 4` as the structure/non-structure
+  // boundary at 20 separate literal sites, one edit away from a silent mis-classification on any
+  // future re-band. A single named `STRUCT_MAX_SEQ` constant was tried and REVERTED in the same
+  // session: `viewer/bar_needs.js` (and, by the same mechanism, potentially other witnesses in this
+  // repo's large sliceFn/`new Function` text-extraction family — grep for that pattern before
+  // retrying) pulls `isPromotedSlab`/`edgeContained` OUT of this file as raw source text and evals
+  // them standalone, outside this module's scope; a named module-level constant referenced inside a
+  // sliced function is undefined in that eval, which crashed witness_bar_schedule.js/
+  // witness_bar_composite.js (ReferenceError: STRUCT_MAX_SEQ is not defined). Left as 20 literal
+  // `4`s, unchanged — real runtime derivation from the template (the audit's own stated ideal) is
+  // still open for whoever next picks this up, but needs an audit of every source-slicing consumer
+  // first, not just a grep for `seq <= 4`.
   // ══ §ARCH_START_TEMPO / M1 — THE 8-HOUR CREW DAY (2026-08-12) ═══════════════════════════════
   // `el.installSecs` is 28800/productivity — 28800 s IS one 8-hour crew-day (schedule_author.js
   // _installSecs line 71, and its own phase widths already divide by `28800 * maxCrews`). But
@@ -561,6 +581,11 @@
     function wallAt(p) { return toWall(p, baseMs); }
     var _prodMsTot = 0;   // §CREW_DAY audit: productive ms actually committed
     function place(el, start) {
+      // §FUTURE-5A B3 (reviewed 2026-09-02, queue item B-3): a SECOND, independent zero-minute floor
+      // — schedule_author.js's own copy is now sourced from sequence_rules.json
+      // LABOR_RATES._zero_minute_floor_secs (see _installSecs); this one stays a literal for the
+      // same reason MAX_CREWS_DEFAULT above do — this module never receives a
+      // rules/rates object, only already-resolved elements. Kept in sync by hand.
       var dur = Math.round((el.installSecs || 120) * scaleFactor * 1000);
       // 8 productive h per calendar day: the remainder rolls to the next day's window start, and a
       // multi-window `dur` consumes as many following windows as it needs.
@@ -1326,7 +1351,7 @@
            e.cls === 'IfcStairFlight';                     // §STAIR_FLIGHT_GRID_VISIBILITY
   }
 
-  var API = { supportPool: supportPool, computeSchedule: computeSchedule, collapsePhase: collapsePhase, elementsInPhase: elementsInPhase, auditFloating: auditFloating, deriveBandRanks: deriveBandRanks, deriveZones: deriveZones, deriveStoreyMergeMap: deriveStoreyMergeMap, hostPairs: hostPairs, openingPairs: openingPairs, groundworkSlabs: groundworkSlabs, CELL: CELL, EPS: EPS, GAP: GAP, BIG_ELEMENT_VOL: BIG_ELEMENT_VOL, SHIFT_MS: SHIFT_MS, DAY_MS: DAY_MS, toProductive: toProductive, toWall: toWall };
+  var API = { supportPool: supportPool, computeSchedule: computeSchedule, collapsePhase: collapsePhase, elementsInPhase: elementsInPhase, auditFloating: auditFloating, deriveBandRanks: deriveBandRanks, deriveZones: deriveZones, deriveStoreyMergeMap: deriveStoreyMergeMap, hostPairs: hostPairs, openingPairs: openingPairs, groundworkSlabs: groundworkSlabs, CELL: CELL, EPS: EPS, GAP: GAP, BIG_ELEMENT_VOL: BIG_ELEMENT_VOL, MAX_CREWS_DEFAULT: MAX_CREWS_DEFAULT, SHIFT_MS: SHIFT_MS, DAY_MS: DAY_MS, toProductive: toProductive, toWall: toWall };
   global.ScheduleGate = API;
   if (typeof module !== 'undefined' && module.exports) module.exports = API;
 })(typeof window !== 'undefined' ? window : (typeof globalThis !== 'undefined' ? globalThis : this));

--- a/viewer/time_machine.js
+++ b/viewer/time_machine.js
@@ -4190,6 +4190,20 @@
     return _4dTemplate;
   }
 
+  // §FUTURE-5A A7 (attempted 2026-09-02, queue item B-3, REVERTED same day) — rates.js's
+  // `var SHIFT_HOURS = 24` is hand-copied as a literal `24` fallback at 4 separate sites in this
+  // file ("the shape that produced §GANTT_SHIFT_HOURS_DESYNC — one copy missed", §FUTURE-5A's own
+  // words). Consolidating all 4 into one `_shiftHoursOrDefault()` helper was tried and REVERTED in
+  // the same session as B1's STRUCT_MAX_SEQ revert, same root cause: `witness_gantt_native_generate.js`
+  // slices `generateGanttSchedule` out of this file as raw source text and evals it in a sandbox
+  // that only also includes `_tmBusyRecording`/`_tmEditLocked` — a call to a shared helper declared
+  // elsewhere in this file is undefined in that sandbox (masked by a SECOND ReferenceError inside
+  // the catch, `_tmEditExceptionRecover is not defined`, since that's ALSO not in the slice — the
+  // real cause only surfaces by removing the outer catch and looking directly). Left as 4 literal
+  // `(window.SHIFT_HOURS > 0) ? window.SHIFT_HOURS : 24` copies, unchanged. Before retrying this
+  // consolidation, audit every `sliceFn`/`new Function` witness in `viewer/tests/` that slices ANY
+  // of the 4 enclosing functions (grep for the pattern first, not just for SHIFT_HOURS).
+
   // §TUKEY_BOUND (4D_GANTT_TM_REFACTOR.md stage 2, 2026-08-17) — hoisted out of _tmDisplayRemap
   // (was a nested closure there) so buildGanttTasks() can share the SAME envelope math instead of
   // re-deriving its own. This is the proven, already-shipped, already-measured rule (Hospital
@@ -4624,8 +4638,12 @@
         return window.ScheduleAuthor._installSecs(cls, rule, LR, realQty, lengthRatio);
       }
       // Fallback (ScheduleAuthor not loaded) — old per-element behavior, no area weighting.
+      // §FUTURE-5A A1/B3 (applied 2026-09-02, queue item B-3): reads the SAME
+      // LR._productivity_basis_secs / LR._zero_minute_floor_secs (sequence_rules.json) the primary
+      // ScheduleAuthor._installSecs path above reads, literal-fallback identical to before this fix.
       var resource = rule.resource;
-      if (!resource || !LR[resource]) return 120;
+      var _floorSecs = LR._zero_minute_floor_secs || 120;
+      if (!resource || !LR[resource]) return _floorSecs;
       var labor = LR[resource], bestPk = null, bestLen = 0;
       for (var pk in labor.productivity) {
         if (cls.indexOf(pk) >= 0 && pk.length > bestLen) { bestPk = pk; bestLen = pk.length; }
@@ -4633,7 +4651,7 @@
       // §TPL_ZERO_MINUTE (§S65) — keep this fallback in step with ScheduleAuthor._installSecs'
       // default_productivity, or the two copies disagree the moment ScheduleAuthor fails to load.
       var prod = bestPk ? labor.productivity[bestPk] : (labor.default_productivity || 0);
-      return prod > 0 ? Math.round(28800 / prod) : 120;
+      return prod > 0 ? Math.round((LR._productivity_basis_secs || 28800) / prod) : _floorSecs;
     }
 
     // Query elements with spatial Z
@@ -4860,11 +4878,13 @@
       else if (LR[_mcRes].max_crews) _maxCrews[_mcRes] = LR[_mcRes].max_crews;
     }
     // Per-trade labour content, straight from the installSecs the scheduler itself uses
-    // (28800s = the 8h crew-day getInstallSecs divides by).
+    // (28800s = the 8h crew-day getInstallSecs divides by). §FUTURE-5A A1 (applied 2026-09-02,
+    // queue item B-3): reads sequence_rules.json LR._productivity_basis_secs, same 28800 fallback.
     var _crewWorkDays = {};
+    var _hrCostBasisSecs = LR._productivity_basis_secs || 28800;
     elements.forEach(function (el) {
       var _r = el.resource || '_DEFAULT';
-      _crewWorkDays[_r] = (_crewWorkDays[_r] || 0) + (el.installSecs || 0) / 28800;
+      _crewWorkDays[_r] = (_crewWorkDays[_r] || 0) + (el.installSecs || 0) / _hrCostBasisSecs;
     });
     // §CREW_DEMAND — "the max resource needed", reported per trade so a user can see what to edit.
     // capacity = crews x projectDays crew-days; utilisation = demand / capacity. A trade over 100%
@@ -5473,11 +5493,14 @@
       try {
         var _SR = window.SEQUENCE_RULES || {}, _LR = window.LABOR_RATES || {}, _RT = window.RATES || {};
         var _shGantt = (window.SHIFT_HOURS > 0) ? window.SHIFT_HOURS : 24;
-        var rres = SA.materializeZones(db, _SR, { start: '2026-01-01', laborRates: _LR, rates: _RT,
+        // §FUTURE-5A B2 (applied 2026-09-02, queue item B-3): sourced from 4D_template.json
+        // calendar.project_start (same literal, '2026-01-01', as before this fix).
+        var _tplStart = (_4dTemplate && _4dTemplate.calendar && _4dTemplate.calendar.project_start) || '2026-01-01';
+        var rres = SA.materializeZones(db, _SR, { start: _tplStart, laborRates: _LR, rates: _RT,
           scheduleGate: window.ScheduleGate, shiftHours: _shGantt, genVersion: _GANTT_CACHE_VERSION,
           displayRemap: _tmDisplayRemap, template: _4dTemplate });   // §ZONE_DISPLAY_AUTHORING + §TPL_WIRED
         if ((!rres || !rres.ok) && SA.materializeDefault) {
-          rres = SA.materializeDefault(db, _SR, { start: '2026-01-01', laborRates: _LR, blank: false,
+          rres = SA.materializeDefault(db, _SR, { start: _tplStart, laborRates: _LR, blank: false,
             genVersion: _GANTT_CACHE_VERSION });
         }
         console.log('§GANTT_SCHEDULE_STALE_REGEN_RESULT ok=' + !!(rres && rres.ok));
@@ -8135,7 +8158,12 @@
       var op2 = _ops[ci2];
       var opRes = (op2.parameters || {}).resource || '';
       var lr = LR[opRes];
-      var dailyRate = lr ? lr.rate_per_day * (lr.crew_size || 1) : 95;
+      // §FUTURE-5A B5 (applied 2026-09-02, queue item B-3): the bare "95" was an undocumented
+      // duplicate of sequence_rules.json LABOR_RATES.LABORER (rate_per_day 95, crew_size 1) — read
+      // that entry directly; the literal 95 now fires only if LABORER itself is absent from LR.
+      var _laborerLR = LR.LABORER;
+      var dailyRate = lr ? lr.rate_per_day * (lr.crew_size || 1)
+        : (_laborerLR ? _laborerLR.rate_per_day * (_laborerLR.crew_size || 1) : 95);
       var opStart = op2.start_ts || _projectStart;
       var realEnd = op2.end_ts || _projectEnd;
       var durMs = Math.max(1, realEnd - opStart);


### PR DESCRIPTION
## Summary
- Implements `bim-compiler prompts/4D_GANTT_TM_REFACTOR.md` §FUTURE-5A's read-only inventory (queue item B-3, Part 1 of 3).
- Moves 7 of 11 inventoried constants into `sequence_rules.json`/`4D_template.json` (mirrored into `rates.js`, the object `window.LABOR_RATES` actually resolves to on every real viewer load — the JSON alone is invisible without it): A1 (28800 install-time basis), B2 (project start date), B3 (120 zero-minute floor), B4 (crew-cap fallback, author side only), B5 (95 labour rate → now points at the already-present `LABOR_RATES.LABORER`), B6 (`LEVEL_SCAN_MAX`).
- The remaining 4 (A5/A6 shift-basis, A7 shift-hours fallback, B1 the `seq<=4` structure boundary, B7 `phaseDays`) are reviewed and deliberately left as documented literals — B1 and A7 were both attempted as a shared constant/helper and **reverted same-day** after breaking `bar_needs.js` / `witness_gantt_native_generate.js`, which slice individual functions out of these files as raw source text and eval them standalone; a shared symbol declared elsewhere is undefined in that sandbox.

## Proof (no bake, no browser — node harness only)
- `scripts/cache_4d_run.js` + a byte-for-byte guid→task membership hash, 3 buildings, before vs after: Hospital totalDays 318→318, HHS 50→50, Duplex 13→13 — every task's `sDays`/`eDays`/element count identical.
- Canary/mutation test: doubling `rates.js`'s new `_productivity_basis_secs` 28800→57600 moved Duplex totalDays 13→22, proving the new key is genuinely read, not coincidentally matching.
- Full headless witness suite run; two real regressions this refactor itself introduced were found and fixed before this diff (materializeZones' own `_defMaxCrews` scope, the A7 helper revert) — see commit message for detail.
- `eslint viewer modeller` exits 0.

## Test plan
- [x] Node invariance proof (3 buildings, byte-identical totalDays + task-grid membership)
- [x] Canary mutation proof (wiring genuinely live)
- [x] Isolated re-run of every witness this diff touched or could touch (bar_schedule, bar_composite, bar_needs, gantt_baseline, gantt_edit_undo, gantt_native_generate, gantt_bar_is_its_task)
- [x] `eslint viewer modeller` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RTX9gUq3tQoytC1vthLmcq