### PR TITLE
fix(4d): §GANTT_EDIT_CLAMP toast on the link-creation re-apply path

### DIFF
--- a/viewer/time_machine.js
+++ b/viewer/time_machine.js
@@ -7332,6 +7332,17 @@
         retimeTaskElements(app.db, byTask, res.moved, tasksBeforeLink);
         _tmResyncAfterRetime();   // §GANTT_RETIME_RESYNC — without this the canvas plays the OLD times
       }
+      // §FUTURE-5A item 6 (applied 2026-09-02, queue item B-3): the ONLY §GANTT_EDIT_CLAMP call
+      // site in this file with NO on-screen feedback at all — commitGanttDrag/openGanttProps'
+      // Apply already show `blockedBy`/`clampedTo` (the inline tm-gantt-tip pattern _tmSay itself
+      // wraps), but this re-apply-after-link call to moveTaskCascade never checked res.clamped, so
+      // a new link that ALSO clamps the successor left the user with only the earlier "Linked: ..."
+      // message and no word that the date shown isn't where the link math alone would have put it.
+      // res.blockedBy is the engine's own extracted binding predecessor (schedule_author.js
+      // _bindingPred) — never invented here.
+      if (res && res.clamped) {
+        _tmSay('Linked, but ' + succBar.taskId + ' clamped to ' + res.start + ' — blocked by ' + res.blockedBy, 3400);
+      }
     }
     // §GANTT_CPM_ANNOTATE (§S68) — OUTSIDE the moved-check on purpose: a new EDGE changes the graph,
     // so it changes float and criticality even when the clamp left every date exactly where it was.


### PR DESCRIPTION
## Summary
- Implements `4D_GANTT_TM_REFACTOR.md` §FUTURE item 6 / queue item B-3, Part 3 of 3.
- The reported gap ("blockedBy=TASK_X(FS) prints to console but never shows on screen") was already fixed on the two paths the original live test could have exercised — `commitGanttDrag` (mouse drag, since 2026-08-04) and `openGanttProps`' Apply (typed edit, since 2026-08-24) both already surface `res.clamped`/`res.blockedBy` via the shared `tm-gantt-tip` element (`_tmSay` is a named wrapper around that exact pattern) — verified by reading the code, not assumed.
- The real, confirmed gap: `linkGanttBars()` re-applies the successor through `moveTaskCascade` after creating a new dependency, but never checked `res.clamped`/`res.blockedBy` at all.
- Fix: when the re-apply clamps, call the shared `_tmSay` helper with `res.blockedBy` (the engine's own extracted binding predecessor — never invented).

## Test plan
- [x] All 8 witnesses that reference `linkGanttBars` pass, including the two that slice it out as raw source text
- [x] `eslint viewer modeller` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RTX9gUq3tQoytC1vthLmcq