### PR TITLE
test(cinema): witness_cpe_aim_retire GPU_REAL — swiftshader cannot load Hospital

### DIFF
--- a/witness_cpe_aim_retire.js
+++ b/witness_cpe_aim_retire.js
@@ -77,7 +77,12 @@ const fx = (v, n) => (v == null || !isFinite(v)) ? 'n/a' : v.toFixed(n == null ?
 
   const b = await puppeteer.launch({
     headless: 'new',
-    args: ['--use-gl=angle', '--use-angle=swiftshader', '--no-sandbox', '--enable-unsafe-swiftshader'],
+    args: process.env.GPU_REAL
+      // §CLI_BAKE_GL's own wiring (--gpu real): real NVIDIA GL through ANGLE's gl-egl backend, paired
+      // with __EGL_VENDOR_LIBRARY_FILENAMES in the environment. Same probe, no bake — swiftshader is
+      // 10-50x slower and could not finish a Hospital load in 50 min under concurrent load.
+      ? ['--use-gl=angle', '--use-angle=gl-egl', '--no-sandbox', '--ignore-gpu-blocklist']
+      : ['--use-gl=angle', '--use-angle=swiftshader', '--no-sandbox', '--enable-unsafe-swiftshader'],
     protocolTimeout: 1800000,
   });
   const p = await b.newPage();


### PR DESCRIPTION
Follow-up to #1619 (merged). Witness-only; no product code.

`GPU_REAL=1` selects the same real-GPU wiring `cli_silent_bake.js` already uses for `--gpu real` (`--use-angle=gl-egl` plus `__EGL_VENDOR_LIBRARY_FILENAMES=/usr/share/glvnd/egl_vendor.d/10_nvidia.json` in the environment). Default is unchanged (swiftshader), so every existing invocation behaves identically.

### Why — a negative result worth keeping
#1619's Hospital arm (`buildings/HospitalAjaibPath.db`, **the only real authored `cinema_path` on disk**) never completed:

| attempt | server | rasteriser | outcome |
|---|---|---|---|
| 1-3 | `python3 -m http.server` | swiftshader | no output — explained: `scripts/_fast_static_server.js`'s own header (§S78) documents this server as making "a Hospital/Clinic/even-Duplex page load take 180s+ / never complete" |
| 4 | `_fast_static_server.js` | swiftshader | ~50 min, renderer 250-370 % CPU, no output |
| 5 | `_fast_static_server.js` | **real RTX 4060** | **identical** — ~25 min, no output |

**So the bottleneck is NOT the static server and NOT the rasteriser.** That is measured, and it rules out the two obvious suspects for whoever picks this up. Remaining untested candidates: the 250 MB single-file DB through sql.js, and the ~6 `cinemaPathPlan()` rebuilds this witness performs on a 63 k-element model.

### Instrumentation gap this exposed
The witness prints only after its single `page.evaluate` returns, so an abandoned run leaves a **0-byte log and cannot say where it was**. Next session should emit per-stage progress (through the `p.on('console')` hook that already exists) before bisecting with `N=50 NT=50` to separate load cost from plan-rebuild cost.

### Scope
The shipped `§CPE_AIM_DEPTH_RETIRED` claim does **not** depend on this arm — HHS_Office and Duplex were each measured with a real depth-ON red control and each came out at **0.000°** against the look-ahead chord. But Hospital is genuinely **not** measured and is not claimed as done; the gap is written into bim-compiler `prompts/RESUME_2026-09-02_FILM_REVIEW.md` §AIM_RETIRED_DONE rather than left implied.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RTX9gUq3tQoytC1vthLmcq