### PR TITLE
fix(witness): §W_PROGRESS — a killed cinema/aim run now names the last stage it finished

### DIFF
--- a/viewer/tests/fixtures/progress_fixture.js
+++ b/viewer/tests/fixtures/progress_fixture.js
@@ -1,0 +1,82 @@
+#!/usr/bin/env node
+// viewer/tests/fixtures/progress_fixture.js — the subject under test for
+// viewer/tests/witness_progress_flush.js. Spec: bim-compiler
+// prompts/WITNESS_INTERFACE_FRAMEWORK.md §W_PROGRESS.
+//
+// ⚠ NOT A WITNESS. It asserts nothing. It exists to be KILLED: it reproduces, in miniature and in
+// about two seconds, the exact shape that produced the 0-byte log — a real puppeteer browser, a real
+// page, and ONE long `await page.evaluate(...)` that would otherwise print nothing until it returns.
+// The witness runs it twice (progress ON and, as the red control, `W_PROGRESS=0`), SIGKILLs both,
+// and reads the two logs.
+//
+// It deliberately loads `about:blank` and no building: the claim under test is about the HARNESS's
+// ability to narrate a long wait, not about anything the viewer computes. Coupling it to a building
+// load would make a fast, always-runnable check into a slow, flaky one and would test the wrong thing.
+//
+// Env: RUN_MS  how long the in-page loop runs before the fixture would exit on its own (default
+//              120000 — long enough that the witness's kill always lands INSIDE the evaluate).
+//      W_PROGRESS=0            red control: disables every progress write.
+//      W_PROGRESS_BEAT_MS      heartbeat interval, so the witness can observe one in seconds.
+//      BROWSER_PID_FILE        where to record chrome's pid, so the killer can reap it — see below.
+//
+// ⚠ WHY THE PID FILE EXISTS. Puppeteer spawns chrome `detached`, i.e. in its OWN process group, so
+// SIGKILLing this process's group does NOT take chrome with it — measured here, 3 orphaned chrome
+// trees left behind on the first run of the acceptance witness. The pid is written OUTSIDE the
+// progress channel on purpose: the red-control arm runs with W_PROGRESS=0 and would otherwise leave
+// an unreapable browser precisely because the reporting is off.
+'use strict';
+const fs = require('fs');
+const path = require('path');
+const puppeteer = require('/home/red1/bim-compiler/node_modules/puppeteer');
+const Progress = require(path.join(__dirname, '..', '..', '..', 'witness_kit', 'progress.js'));
+
+const RUN_MS = +(process.env.RUN_MS || 120000);
+
+process.on('unhandledRejection', (e) => { console.error('UNHANDLED: ' + ((e && e.stack) || e)); process.exit(1); });
+
+(async () => {
+  const pr = Progress('PROGRESS_FIXTURE');
+
+  pr.stage('launch-browser');
+  const b = await puppeteer.launch({
+    headless: 'new',
+    args: ['--no-sandbox', '--disable-dev-shm-usage'],
+    protocolTimeout: 1800000,
+  });
+
+  const bp = b.process && b.process();
+  if (process.env.BROWSER_PID_FILE && bp && bp.pid) {
+    try { fs.writeFileSync(process.env.BROWSER_PID_FILE, String(bp.pid)); } catch (e) { /* reaper will report */ }
+  }
+
+  pr.stage('open-page');
+  const p = await b.newPage();
+  // The SAME hook every cinema/aim witness already installs, kept here so the fixture exercises the
+  // real mechanism: product lines are collected, progress lines are forwarded and NOT collected.
+  const logs = [];
+  const { isProgress } = pr.attach(p);
+  p.on('console', (m) => { const t = m.text(); if (!isProgress(t)) logs.push(t); });
+  await p.goto('about:blank', { waitUntil: 'domcontentloaded', timeout: 60000 });
+
+  pr.stage('long-evaluate');
+  // ONE long evaluate — the shape that goes silent. The page narrates itself through console.log;
+  // puppeteer delivers those events while this await is still pending, which is the whole claim.
+  await p.evaluate(async (runMs, prefix) => {
+    const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+    const t0 = Date.now();
+    let i = 0;
+    // A product-shaped line too, so the witness can prove progress lines are separated from the
+    // product §-log rather than polluting it.
+    console.log('§FIXTURE_PRODUCT_LINE this is not progress');
+    while (Date.now() - t0 < runMs) {
+      i++;
+      console.log(prefix + 'in-page-step-' + i);
+      await sleep(1000);
+    }
+    return i;
+  }, RUN_MS, Progress.pageLine(''));
+
+  pr.stage('teardown');
+  await p.close(); await b.close();
+  pr.end(`productLines=${logs.length}`);
+})();

--- a/viewer/tests/witness_progress_flush.js
+++ b/viewer/tests/witness_progress_flush.js
@@ -1,0 +1,227 @@
+#!/usr/bin/env node
+// witness_progress_flush.js — §W_PROGRESS: a killed witness must still name where it got to.
+//
+// ⚠ DO NOT REMOVE — SCOPE. bim-compiler prompts/AGENT_QUEUE.md item A-16b, specified in
+// prompts/WITNESS_INTERFACE_FRAMEWORK.md §W_PROGRESS. Read the log after every run (Log Mandate).
+//
+// THE ISSUE IT PROVES OR DISPROVES. The cinema/aim witnesses do all their work inside ONE long
+// `await page.evaluate(...)` and print only after it returns, so a run redirected to a file holds a
+// **0-byte log** for its entire duration. On 2026-09-02 that ambiguity was resolved the wrong way
+// twice — a COMPLETED Hospital run was reported as "never measured", and a rasteriser attribution
+// was asserted off the same absence. Both were retracted. CLAUDE.md clause 4 ("a witness that cannot
+// report its own failure is not a witness") is extended by §W_PROGRESS to liveness: silence must be
+// distinguishable from "still working". This file is the acceptance test for that, and it tests it
+// the only honest way — by KILLING a real run and reading what survived on disk.
+//
+// CLAIMS (each PASS / FAIL / INCONCLUSIVE; a claim whose run never happened is never PASS):
+//   P1 A KILLED RUN NAMES ITS LAST COMPLETED STAGE. SIGKILL (uncatchable — no exit handler can
+//      rescue this) a real fixture mid-flight; the log must be non-empty, must carry at least one
+//      completed-stage line, and its last ENTERed stage must be un-DONE, i.e. it names exactly where
+//      the process was when it died.
+//   P2 IN-PAGE PROGRESS CROSSES THE `p.on('console')` HOOK DURING THE EVALUATE. The mechanism the
+//      spec names must actually carry: at least one line the PAGE emitted from inside the long
+//      evaluate must be on disk before the kill. Without this, only the node side is proven and the
+//      long silent stretch — the one that caused the false report — is still silent.
+//   P3 A HUNG RUN IS DISTINGUISHABLE FROM A DEAD ONE. An open stage that outlives the heartbeat
+//      interval must emit heartbeats. Stage lines alone cannot do this: a stage that never completes
+//      leaves the same last line whether the process is working or gone.
+//   P4 RED CONTROL — THE DEFECT IS STILL REPRODUCIBLE. The IDENTICAL fixture with `W_PROGRESS=0`,
+//      killed identically, must produce the **0-byte log**. If it does not, this witness is not
+//      measuring what it claims and P1-P3 prove nothing (§W-REDCONTROL).
+//   P5 THE FIVE CINEMA/AIM WITNESSES ARE ACTUALLY WIRED. A static check of the shipped files, with
+//      comment lines STRIPPED FIRST — a check that can be satisfied by a file's own prose is one of
+//      the checks-that-cannot-fail this queue caught three of on 2026-09-02.
+//
+// NO BUILDING, NO BAKE, NO SERVER. The fixture loads about:blank. The claim is about the harness's
+// ability to narrate a long wait; coupling it to a building load would test something else and make
+// a 30-second check into a 40-minute one.
+//
+// Usage: node viewer/tests/witness_progress_flush.js     (~35 s: two killed fixture runs)
+'use strict';
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+const { spawn } = require('child_process');
+
+const ROOT = path.join(__dirname, '..', '..');
+const FIXTURE = path.join(ROOT, 'viewer', 'tests', 'fixtures', 'progress_fixture.js');
+const KILL_AFTER = +(process.env.KILL_AFTER_MS || 14000);
+const BEAT_MS = +(process.env.BEAT_MS || 3000);
+
+const checks = [];
+const INC = [];
+const P = (label, ok, detail) => checks.push({ label, ok, detail });
+const I = (label, why) => INC.push({ label, why });
+
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+
+// runAndKill — start the fixture in its OWN process group, let it work, then SIGKILL the whole
+// group. The group matters: puppeteer's chrome is a child, and killing only node would strand it.
+async function runAndKill(tag, env) {
+  const log = path.join(os.tmpdir(), `wprogress_${tag}_${process.pid}.log`);
+  const pidFile = path.join(os.tmpdir(), `wprogress_${tag}_${process.pid}.browserpid`);
+  [log, pidFile].forEach((f) => { try { fs.unlinkSync(f); } catch (e) { /* first run */ } });
+  const fd = fs.openSync(log, 'w');
+  const child = spawn(process.execPath, [FIXTURE], {
+    detached: true,
+    stdio: ['ignore', fd, fd],
+    env: Object.assign({}, process.env, env, { BROWSER_PID_FILE: pidFile }),
+  });
+  fs.closeSync(fd);
+  let exited = null;
+  child.on('exit', (code, sig) => { exited = { code, sig }; });
+  await sleep(KILL_AFTER);
+  const aliveBeforeKill = exited === null;
+  let killed = false;
+  try { process.kill(-child.pid, 'SIGKILL'); killed = true; } catch (e) { /* already gone */ }
+  // ⚠ REAP CHROME SEPARATELY. Puppeteer launches the browser `detached`, so it sits in its OWN
+  // process group and the group kill above does NOT reach it — measured: the first run of this
+  // witness left 3 orphaned chrome trees. The fixture records the pid for exactly this.
+  let reaped = 'none', bpid = 0;
+  try {
+    bpid = +fs.readFileSync(pidFile, 'utf8').trim();
+    if (bpid > 0) { try { process.kill(-bpid, 'SIGKILL'); reaped = 'group'; } catch (e) { process.kill(bpid, 'SIGKILL'); reaped = 'pid'; } }
+  } catch (e) { reaped = 'no-pid-file'; }
+  await sleep(1500);
+  // Verified, not assumed: a kill(pid, 0) that does NOT throw means the browser is still running.
+  let orphan = false;
+  if (bpid > 0) { try { process.kill(bpid, 0); orphan = true; } catch (e) { orphan = false; } }
+  let size = 0, text = '';
+  try { size = fs.statSync(log).size; text = fs.readFileSync(log, 'utf8'); } catch (e) { /* none */ }
+  try { fs.unlinkSync(pidFile); } catch (e) { /* already gone */ }
+  console.log(`§W_PROGRESS_RUN tag=${tag} aliveAtKill=${aliveBeforeKill} killedGroup=${killed} ` +
+    `browserPid=${bpid || 'n/a'} reapedBrowser=${reaped} orphanLeft=${orphan} logBytes=${size} ` +
+    `lines=${text ? text.trim().split('\n').length : 0} exitedEarly=${JSON.stringify(exited)}`);
+  return { log, size, text, aliveBeforeKill, exited, reaped, orphan, bpid };
+}
+
+(async () => {
+  if (!fs.existsSync(FIXTURE)) {
+    console.log('§W_PROGRESS_VERDICT INCONCLUSIVE — fixture missing at ' + FIXTURE + '; nothing was judged.');
+    process.exit(1);
+  }
+
+  const ON = await runAndKill('on', { W_PROGRESS_BEAT_MS: String(BEAT_MS), RUN_MS: '120000' });
+  const OFF = await runAndKill('off', { W_PROGRESS: '0', W_PROGRESS_BEAT_MS: String(BEAT_MS), RUN_MS: '120000' });
+
+  const lines = ON.text ? ON.text.split('\n').filter(Boolean) : [];
+  const enters = lines.filter((l) => /§W_PROGRESS \S+ ENTER stage=/.test(l))
+    .map((l) => l.match(/ENTER stage=(\S+)/)[1]);
+  const dones = lines.filter((l) => /§W_PROGRESS \S+ DONE stage=/.test(l))
+    .map((l) => l.match(/DONE stage=(\S+)/)[1]);
+  const pageLines = lines.filter((l) => /§W_PROGRESS \S+ PAGE /.test(l));
+  const beats = lines.filter((l) => /§W_PROGRESS \S+ HEARTBEAT /.test(l));
+
+  // A fixture that never reached the kill (chrome failed to launch, node crashed) judges NOTHING.
+  // Saying PASS or FAIL off such a run is exactly the false-absence this whole item is about.
+  const vacuous = !ON.aliveBeforeKill;
+  if (vacuous) {
+    const why = `the ON fixture exited BEFORE the ${KILL_AFTER}ms kill (${JSON.stringify(ON.exited)}), ` +
+      `so nothing was killed mid-flight. Log said: ${(ON.text || '(empty)').slice(0, 300)}`;
+    I('P1 a killed run names its last completed stage', why);
+    I('P2 in-page progress crosses the p.on(console) hook', why);
+    I('P3 a hung run is distinguishable from a dead one', why);
+  } else {
+    // ── P1 ──────────────────────────────────────────────────────────────────────────────────────
+    const openStage = enters.filter((s) => dones.indexOf(s) < 0);
+    P('P1 a SIGKILLed run still names the last stage it completed',
+      ON.size > 0 && dones.length >= 1 && openStage.length >= 1,
+      `log ${ON.size} bytes, ${lines.length} lines. COMPLETED stages [${dones.join(' → ')}] ` +
+      `(each with its own duration on the line). Killed INSIDE [${openStage.join(' ')}] — entered, ` +
+      `never DONE, which is what pins where the process was. SIGKILL is uncatchable, so every one ` +
+      `of these lines was already on disk when it landed: that is the fs.writeSync(1) requirement, ` +
+      `not a shutdown handler.`);
+
+    // ── P2 ──────────────────────────────────────────────────────────────────────────────────────
+    P('P2 the PAGE narrates itself through the existing p.on(console) hook, during the evaluate',
+      pageLines.length >= 2,
+      `${pageLines.length} forwarded in-page progress lines on disk before the kill` +
+      (pageLines.length ? ` (first: "${pageLines[0].slice(0, 90)}", last: "${pageLines[pageLines.length - 1].slice(0, 90)}")` : '') +
+      `. These were emitted from INSIDE the still-pending await page.evaluate() — the stretch that ` +
+      `was previously silent for the whole run.`);
+
+    // ── P3 ──────────────────────────────────────────────────────────────────────────────────────
+    // Expected count is derived from the measured window, not chosen: the heartbeat can only fire
+    // once a stage is open, so the fixture's launch time is subtracted rather than guessed at.
+    P('P3 an open stage HEARTBEATS, so a hung run is distinguishable from a dead one',
+      beats.length >= 1,
+      `${beats.length} heartbeat lines at ${BEAT_MS}ms over a ${KILL_AFTER}ms run` +
+      (beats.length ? `, last: "${beats[beats.length - 1].slice(0, 120)}"` : '') +
+      `. Without these, a stage that never completes leaves an identical last line whether the ` +
+      `process is working or gone.`);
+  }
+
+  // ── P4 red control ────────────────────────────────────────────────────────────────────────────
+  if (!OFF.aliveBeforeKill) {
+    I('P4 RED CONTROL — the 0-byte log is still reproducible with progress off',
+      `the OFF fixture exited before the kill (${JSON.stringify(OFF.exited)}), so its empty log ` +
+      `proves nothing — an empty log from a process that died at second 3 is the very ambiguity ` +
+      `under test.`);
+  } else {
+    P('P4 RED CONTROL — with W_PROGRESS=0 the SAME run leaves the 0-byte log (the defect is real)',
+      OFF.size === 0,
+      `progress OFF: ${OFF.size} bytes after ${KILL_AFTER}ms of identical work, killed identically ` +
+      `— against ${ON.size} bytes with it ON. This is the before/after of the defect A-16 was ` +
+      `misread from, measured rather than asserted. A non-zero here would mean P1-P3 pass for some ` +
+      `other reason and this witness cannot fail.`);
+  }
+
+  // ── P5 wiring ─────────────────────────────────────────────────────────────────────────────────
+  // COMMENTS ARE STRIPPED FIRST, deliberately. `witness_cpe_aim_retire.js` documents this mechanism
+  // in prose; a grep that matched that prose would pass on a file with zero instrumentation — the
+  // "a witness reading its own comment block" trap this queue caught on 2026-09-02.
+  {
+    const targets = ['witness_cpe_aim_retire.js', 'witness_cpe_corr_brush.js', 'witness_cpe_aim_pin.js',
+      'witness_cpe_stick_hold.js', 'witness_cpe_hose.js'];
+    const rows = []; let bad = 0, judged = 0;
+    targets.forEach((f) => {
+      const fp = path.join(ROOT, f);
+      if (!fs.existsSync(fp)) { rows.push(f + ':ABSENT'); bad++; judged++; return; }
+      const code = fs.readFileSync(fp, 'utf8').split('\n')
+        .filter((l) => !/^\s*(\/\/|\*|\/\*)/.test(l)).join('\n');
+      const req = /require\([^)]*witness_kit[/'"\\ ,.]*progress/.test(code) ||
+        /progress\.js'\)\)/.test(code);
+      const nStage = (code.match(/\.stage\(/g) || []).length;
+      const nAttach = (code.match(/\.attach\(/g) || []).length;
+      judged++;
+      if (!(req && nStage >= 3 && nAttach >= 1)) { bad++; }
+      rows.push(`${f.replace('witness_cpe_', '').replace('.js', '')}:req=${req ? 1 : 0} stages=${nStage} attach=${nAttach}`);
+    });
+    if (!judged) {
+      I('P5 the five cinema/aim witnesses are wired to §W_PROGRESS', 'no target file was found to judge');
+    } else {
+      P('P5 all five cinema/aim witnesses are WIRED (code, not comments — comment lines stripped first)',
+        bad === 0,
+        `${judged - bad}/${judged} carry a real require + >=3 stage() calls + attach(): ${rows.join(' | ')}. ` +
+        `Comment lines are removed before matching so a file that only TALKS about progress fails here.`);
+    }
+  }
+
+  // ── P6 hygiene ────────────────────────────────────────────────────────────────────────────────
+  // This witness KILLS things, so it owes an account of what it left running. Puppeteer spawns
+  // chrome `detached` — its own process group — so the group kill above does not reach it; the
+  // first run of this file left 3 orphaned chrome trees behind. Reported as a claim rather than a
+  // comment, because a leak that is only described in prose comes back.
+  {
+    const arms = [{ t: 'on', r: ON }, { t: 'off', r: OFF }].filter((a) => a.r.bpid > 0);
+    if (!arms.length) {
+      I('P6 the kill leaves no orphaned browser', 'neither arm recorded a browser pid — nothing to check');
+    } else {
+      P('P6 both killed arms leave NO orphaned chrome (verified by kill(pid,0), not assumed)',
+        arms.every((a) => !a.r.orphan),
+        arms.map((a) => `${a.t}: pid=${a.r.bpid} reap=${a.r.reaped} stillAlive=${a.r.orphan}`).join(' | ') +
+        `. The pid file is written OUTSIDE the progress channel on purpose — the OFF arm has no log ` +
+        `at all, so a reaper reading the log could never clean up the red control.`);
+    }
+  }
+
+  console.log('');
+  checks.forEach((c) => console.log(`  ${c.ok ? 'PASS' : 'FAIL'} ${c.label}\n        ${c.detail}`));
+  INC.forEach((c) => console.log(`  INCONCLUSIVE ${c.label}\n        ${c.why}`));
+  const pass = checks.filter((c) => c.ok).length, fail = checks.length - pass;
+  console.log(`\n§W_PROGRESS_VERDICT claims=${checks.length + INC.length} PASS=${pass} FAIL=${fail} ` +
+    `INCONCLUSIVE=${INC.length}  ` +
+    (fail ? 'RED' : INC.length ? 'NOT GREEN — a claim judged nothing; an empty population is not a pass' : 'GREEN'));
+  [ON.log, OFF.log].forEach((f) => { try { fs.unlinkSync(f); } catch (e) { /* already gone */ } });
+  process.exit(fail || checks.length === 0 ? 1 : 0);
+})();

--- a/witness_cpe_aim_pin.js
+++ b/witness_cpe_aim_pin.js
@@ -11,28 +11,41 @@
 //             Save/the bake already consume, no second table (guardrail 4).
 //   G-PIN-3   position untouched: the pinned band's CENTRE (`c`) is bit-identical before/after.
 const puppeteer = require('/home/red1/bim-compiler/node_modules/puppeteer');
+// §W_PROGRESS (bim-compiler prompts/WITNESS_INTERFACE_FRAMEWORK.md) — the editor open below waits up
+// to 5 min on `#cpe-ok` and the streaming wait is unbounded on a large building; both used to print
+// nothing at all, which is the ambiguity AGENT_QUEUE.md A-16b names.
+const Progress = require('./witness_kit/progress.js');
 
 const PORT = process.env.PORT || 8470;
 const BUILDINGS = (process.env.BLDS || 'Duplex').split(',');
 const sleep = ms => new Promise(r => setTimeout(r, ms));
+const pr = Progress('CPE_AIM_PIN');
 
 async function openEditor(browser, BLD) {
+  pr.stage(`${BLD}/open-page`);
   const page = await browser.newPage();
   await page.setViewport({ width: 1200, height: 700 });
   const logs = [];
-  page.on('console', m => logs.push(m.text()));
+  // §W_PROGRESS rides this same hook; its own lines are kept out of `logs`.
+  const { isProgress } = pr.attach(page);
+  page.on('console', m => { const t = m.text(); if (!isProgress(t)) logs.push(t); });
   page.on('pageerror', e => logs.push('PAGEERROR ' + e.message));
+  pr.stage(`${BLD}/goto-viewer`);
   await page.goto(`http://localhost:${PORT}/viewer/viewer.html?db=/buildings/${BLD}_extracted.db`,
     { waitUntil: 'domcontentloaded', timeout: 60000 });
+  pr.stage(`${BLD}/wait-APP-ready`);
   await page.waitForFunction(
     () => window.APP && window.APP.cinemaPathEditor && window.APP.startMaxQualityOrbit && window.APP._composer,
     { timeout: 120000 });
   await sleep(9000);
+  pr.stage(`${BLD}/wait-element-transforms`);
   await page.waitForFunction(() => {
     try { const r = window.APP.dbQuery('SELECT COUNT(*) FROM element_transforms'); return r && r[0][0] > 0; }
     catch (e) { return false; }
   }, { timeout: 60000, polling: 2000 });
+  pr.stage(`${BLD}/open-editor`);
   await page.evaluate(() => { window.APP.startMaxQualityOrbit({ preview: false, fps: 1, editor: true }); });
+  // up to 5 minutes, previously silent
   await page.waitForSelector('#cpe-ok', { timeout: 300000 });
   await sleep(800);
   return { page, logs };
@@ -50,6 +63,7 @@ async function gates(browser, BLD) {
   const checks = [];
   const P = (n, ok, d) => checks.push({ n, ok, d });
   const { page, logs } = await openEditor(browser, BLD);
+  pr.stage(`${BLD}/gates`);
 
   const setup = await page.evaluate(() => {
     const cpe = window.APP.cinemaPathEditor;
@@ -171,6 +185,8 @@ async function gates(browser, BLD) {
 }
 
 (async () => {
+  pr.note(`port=${PORT} buildings=${BUILDINGS.join(',')}`);
+  pr.stage('launch-browser');
   const browser = await puppeteer.launch({
     headless: 'new',
     protocolTimeout: 900000,
@@ -185,6 +201,7 @@ async function gates(browser, BLD) {
     summary.push({ BLD, pass: checks.every(c => c.ok), n: checks.filter(c => c.ok).length, t: checks.length });
   }
   await browser.close();
+  pr.end(`allPass=${allPass}`);
   console.log(`\n${'='.repeat(78)}`);
   summary.forEach(s => console.log(`${s.pass ? 'PASS' : 'FAIL'}  ${s.BLD}  (${s.n}/${s.t})`));
   console.log(allPass ? '\nWITNESS PASS' : '\nWITNESS FAIL');

--- a/witness_cpe_aim_retire.js
+++ b/witness_cpe_aim_retire.js
@@ -48,6 +48,12 @@
 //   PORT=<port> BLD=<building> OUT=<file.json> [BASE=<other-arm.json>] node witness_cpe_aim_retire.js
 const fs = require('fs');
 const puppeteer = require('/home/red1/bim-compiler/node_modules/puppeteer');
+// §W_PROGRESS (bim-compiler prompts/WITNESS_INTERFACE_FRAMEWORK.md). This file's whole measurement
+// used to happen inside ONE `await p.evaluate(...)` that printed nothing until it returned, so a
+// Hospital run held a 0-BYTE LOG for tens of minutes — and on 2026-09-02 that silence was read as
+// "never measured" for a run that had in fact completed (AGENT_QUEUE.md A-16, retracted). Stages
+// below are written UNBUFFERED, so a killed run still names where it got to.
+const Progress = require('./witness_kit/progress.js');
 
 const PORT = process.env.PORT || 8533;
 const BLD = process.env.BLD || 'Duplex';
@@ -75,6 +81,10 @@ const fx = (v, n) => (v == null || !isFinite(v)) ? 'n/a' : v.toFixed(n == null ?
   const INC = [];
   const I = (label, why) => { INC.push({ label, why }); };
 
+  const pr = Progress(`CPE_AIM_RETIRE/${BLD}`);
+  pr.note(`port=${PORT} db=${DB} secs=${SECS} N=${N} NT=${NT} out=${OUT} base=${BASE || '(none)'} gpu=${process.env.GPU_REAL ? 'real' : 'swiftshader'}`);
+
+  pr.stage('launch-browser');
   const b = await puppeteer.launch({
     headless: 'new',
     args: process.env.GPU_REAL
@@ -93,22 +103,37 @@ const fx = (v, n) => (v == null || !isFinite(v)) ? 'n/a' : v.toFixed(n == null ?
   // is kept so A-6 can assert the ABSENCE of the retired rule's own lines against a non-zero count
   // of lines actually scanned (an absence measured over an empty log is vacuous).
   const logs = [];
-  p.on('console', m => logs.push(m.text()));
+  // §W_PROGRESS rides this SAME hook — no second channel is opened. `isProgress` keeps the witness's
+  // own progress lines OUT of `logs`, because A-6 counts `logs.length` as the denominator of an
+  // absence test and padding it with this file's own output would inflate that evidence.
+  const { isProgress } = pr.attach(p);
+  p.on('console', m => { const t = m.text(); if (!isProgress(t)) logs.push(t); });
 
+  pr.stage('goto-viewer');
   await p.goto(`http://localhost:${PORT}/viewer/viewer.html?db=${DB}`,
     { waitUntil: 'domcontentloaded', timeout: 240000 });
+  pr.stage('wait-APP-ready');
   await p.waitForFunction(() => window.APP && window.APP.camera && typeof window.APP.cinemaPathPlan === 'function',
     { timeout: 300000 });
+  pr.stage('wait-stream-start');
   await p.waitForFunction(() => window.APP.streaming === true || (window.APP.streamQueue || []).length > 0,
     { timeout: 240000, polling: 250 }).catch(() => {});
+  // THE LONG ONE — Hospital streams 63,182 elements here and this single await has run for tens of
+  // minutes. The heartbeat is what makes that distinguishable from a dead process.
+  pr.stage('wait-stream-drain');
   await p.waitForFunction(() => !window.APP.streaming || (window.APP.streamIdx >= (window.APP.streamQueue || []).length),
     { timeout: 1200000, polling: 1000 }).catch(() => {});
+  pr.stage('wait-element-transforms');
   await p.waitForFunction(() => {
     try { const r = window.APP.dbQuery('SELECT COUNT(*) FROM element_transforms'); return r && r[0][0] > 0; }
     catch (e) { return false; }
   }, { timeout: 240000, polling: 2000 }).catch(() => {});
 
-  const res = await p.evaluate(async (N, NT, SECS) => {
+  pr.stage('measure(in-page)');
+  const res = await p.evaluate(async (N, NT, SECS, PP) => {
+    // Page-side progress: one console.log per sub-phase of the measurement, forwarded by the hook
+    // above while THIS await is still pending. Without it the longest stretch of the run is silent.
+    const W = (s) => { try { console.log(PP + s); } catch (e) { /* console gone */ } };
     const A = window.APP;
     const nrm = (g) => {
       const dx = g.target.x - g.pos.x, dy = g.target.y - g.pos.y, dz = g.target.z - g.pos.z;
@@ -144,6 +169,7 @@ const fx = (v, n) => (v == null || !isFinite(v)) ? 'n/a' : v.toFixed(n == null ?
     //    lazy loader (_cpeLoadFromDb) and uses the building DB's own cinema_path table if it has
     //    one. Which source was used is REPORTED, never assumed — a derived fallback measured as if
     //    it were the user's stored path would be a different claim entirely.
+    W('build-stored-plan');
     const plan0 = await A.cinemaPathPlan(SECS);
     if (!plan0) return { fail: 'no plan built' };
     const staged = (A._getCinemaPathEdit && A._getCinemaPathEdit()) || null;
@@ -178,9 +204,11 @@ const fx = (v, n) => (v == null || !isFinite(v)) ? 'n/a' : v.toFixed(n == null ?
     // override plan measures two different routes, not one route with and without a feature).
     const mkOv = (extra) => Object.assign(JSON.parse(JSON.stringify(ovBase)), extra || {});
 
+    W('build-base-plan bandSrc=' + bandSrc + ' bands=' + ((ovBase.bands || []).length));
     const planBase = await A.cinemaPathPlan(SECS, mkOv({ aimCorrections: [] }));
     if (!planBase) return { fail: 'no base plan built' };
     const base = sampleWalk();
+    W('sampled-base-walk n=' + base.length);
     // ── the look-ahead chord, reconstructed EXACTLY as _lookAhead computes it ──────────────────
     // effects.js:8000 `var _AH_FRAC = 0.15, _ahN = 240` and :8028
     // `_outPos(_ahAtArc(_ahArcAt(u) + _AH_FRAC * _ahL))`. BOTH constants matter: an earlier cut of
@@ -215,7 +243,9 @@ const fx = (v, n) => (v == null || !isFinite(v)) ? 'n/a' : v.toFixed(n == null ?
       const L = Math.hypot(dx, dy, dz);
       chord.push(L > 0 ? { x: dx / L, y: dy / L, z: dz / L } : null);
     }
+    W('reconstructed-lookahead-chord');
     const film = sampleFilm(planBase);
+    W('sampled-film n=' + film.length);
     const zones = A._cpePinZonesDebug ? JSON.parse(JSON.stringify(A._cpePinZonesDebug())) : null;
     const beats = planBase.beats ? JSON.parse(JSON.stringify(planBase.beats)) : null;
     const nBands = (ovBase.bands || []).length;
@@ -223,6 +253,7 @@ const fx = (v, n) => (v == null || !isFinite(v)) ? 'n/a' : v.toFixed(n == null ?
     // 2. A-3 — a pin on ONE band. Target offset from that band's own centre so the aim change is
     //    unambiguous; same construction witness_cpe_aim_pin.js already uses (this gate is about the
     //    AIM MATH, not the raycast UI).
+    W('A-3 pin arm');
     let pinRes = null;
     if (nBands >= 2) {
       const bi = Math.min(1, nBands - 1);
@@ -270,6 +301,7 @@ const fx = (v, n) => (v == null || !isFinite(v)) ? 'n/a' : v.toFixed(n == null ?
     //    witness_cpe_corr_brush.js uses, which is what put the entry gaze near-antipodal on Hospital
     //    and exposed the §CPE_CORR_BRANCH 2*pi flip. Changing it would un-exercise that defect.
     const mid = base[Math.floor(N / 2)];
+    W('A-4 correction arm');
     let corrRes = null;
     if (mid && mid.g) {
       const yaw = Math.atan2(mid.g.z, mid.g.x) + Math.PI / 3;
@@ -289,6 +321,7 @@ const fx = (v, n) => (v == null || !isFinite(v)) ? 'n/a' : v.toFixed(n == null ?
         let stepOff = null;
         A._cpeCorrBranchOff = true;
         try {
+          W('A-4b branch-OFF A/B arm');
           const planOff = await mkCorrPlan();
           if (planOff) {
             const off = sampleWalk();
@@ -328,12 +361,14 @@ const fx = (v, n) => (v == null || !isFinite(v)) ? 'n/a' : v.toFixed(n == null ?
       base: base.map((s, i) => ({ e3: s.e3, g: s.g, pos: s.pos, chord: chord[i] })),
       film, pin: pinRes, corr: corrRes,
     };
-  }, N, NT, SECS);
+  }, N, NT, SECS, Progress.pageLine(''));
+  pr.stage('teardown+derive');
 
   await p.close(); await b.close();
 
   if (res && res.fail) {
     console.log(`§WITNESS_CPE_AIM_RETIRE INCONCLUSIVE — ${res.fail}; nothing was judged.`);
+    pr.end('bailed: ' + res.fail);
     process.exitCode = 1; return;
   }
 
@@ -611,5 +646,6 @@ const fx = (v, n) => (v == null || !isFinite(v)) ? 'n/a' : v.toFixed(n == null ?
   console.log(`\n§WITNESS_CPE_AIM_RETIRE arm=${res.arm} building=${res.building} ` +
     `pass=${pass} fail=${fail} inconclusive=${INC.length} ran=${checks.length}`);
   if (!checks.length) console.log('§WITNESS_CPE_AIM_RETIRE INCONCLUSIVE — no gate was judged.');
+  pr.end(`pass=${pass} fail=${fail} inconclusive=${INC.length}`);
   process.exitCode = (fail > 0 || checks.length === 0) ? 1 : 0;
 })();

--- a/witness_cpe_corr_brush.js
+++ b/witness_cpe_corr_brush.js
@@ -49,6 +49,9 @@
 // G-FRZ-1/2/4 are UNAFFECTED and still judge the freeze: it is kept deliberately, because the
 // from-direction can still move where a window overlaps a pinned zone or the _openU seam blend.
 const puppeteer = require('/home/red1/bim-compiler/node_modules/puppeteer');
+// §W_PROGRESS (bim-compiler prompts/WITNESS_INTERFACE_FRAMEWORK.md) — this file has the same
+// single-long-evaluate shape that left a 0-byte log for a whole Hospital run on 2026-09-02.
+const Progress = require('./witness_kit/progress.js');
 const PORT = process.env.PORT || 8533, BLD = process.env.BLD || 'Duplex';
 // Walk length is NOT a property of the building — it scales with the film duration the planner is
 // given. Measured on Hospital: 60 s -> 39.43 m. So the duration is a parameter of this measurement
@@ -58,6 +61,9 @@ const N = 900;   // arc samples
 process.on('unhandledRejection', e => { console.error('UNHANDLED: ' + (e && e.stack || e)); process.exit(1); });
 
 (async () => {
+  const pr = Progress(`CPE_CORR_BRUSH/${BLD}`);
+  pr.note(`port=${PORT} secs=${SECS_IN} N=${N}`);
+  pr.stage('launch-browser');
   const b = await puppeteer.launch({ headless: 'new',
     args: ['--use-gl=angle', '--use-angle=swiftshader', '--no-sandbox', '--enable-unsafe-swiftshader'],
     protocolTimeout: 1800000 });
@@ -67,18 +73,29 @@ process.on('unhandledRejection', e => { console.error('UNHANDLED: ' + (e && e.st
   // the runtime's own statement of which branch it resolved per stroke; echo it into this witness's
   // log rather than re-deriving it here.
   const pageLog = [];
+  // §W_PROGRESS rides the SAME hook; progress lines are excluded from pageLog so this witness's own
+  // output never becomes evidence about the product's.
+  const { isProgress } = pr.attach(p);
   p.on('console', m => { const t = m.text();
+    if (isProgress(t)) return;
     if (/§CPE_CORR_BRANCH|§CINEMA_GAZE_SENSE|§CPE_WALK_BUDGET|§CPE_AIM_DEPTH_FREEZE/.test(t)) pageLog.push(t); });
+  pr.stage('goto-viewer');
   await p.goto(`http://localhost:${PORT}/viewer/viewer.html?db=/buildings/${BLD}_extracted.db`,
     { waitUntil: 'domcontentloaded', timeout: 180000 });
+  pr.stage('wait-APP-ready');
   await p.waitForFunction(() => window.APP && window.APP.camera && typeof window.APP.cinemaPathPlan === 'function',
     { timeout: 240000 });
+  pr.stage('wait-stream-start');
   await p.waitForFunction(() => window.APP.streaming === true || (window.APP.streamQueue || []).length > 0,
     { timeout: 180000, polling: 250 }).catch(() => {});
+  // THE LONG ONE — up to 15 min on a large building, previously entirely silent.
+  pr.stage('wait-stream-drain');
   await p.waitForFunction(() => !window.APP.streaming || (window.APP.streamIdx >= (window.APP.streamQueue || []).length),
     { timeout: 900000, polling: 1000 }).catch(() => {});
 
-  const r = await p.evaluate(async (N, SECS_IN) => {
+  pr.stage('measure(in-page)');
+  const r = await p.evaluate(async (N, SECS_IN, PP) => {
+    const W = (s) => { try { console.log(PP + s); } catch (e) { /* console gone */ } };
     const A = window.APP;
     const sample = () => {
       const out = [];
@@ -95,6 +112,7 @@ process.on('unhandledRejection', e => { console.error('UNHANDLED: ' + (e && e.st
       }
       return out;
     };
+    W('baseline-plan');
     // 1. baseline plan, no corrections
     // signature is (durationSec, ov) — an earlier cut of this witness passed the ov as the FIRST
     // arg and the planner threw `durationSec.toFixed is not a function`. 60 s is the editor's own
@@ -115,6 +133,7 @@ process.on('unhandledRejection', e => { console.error('UNHANDLED: ' + (e && e.st
     const turnOverlap = (A._cpeBeat3GazeDebug(0) || {}).turnOverlap;
     const base = sample();
     const arcLen = base[0].arcLen;
+    W('correction-arm');
     // 2. one correction, anchored mid-walk, aimed 60 deg off the baseline gaze there
     const mid = base[Math.floor(N / 2)];
     const yaw = Math.atan2(mid.z, mid.x) + Math.PI / 3;          // +60 deg in yaw
@@ -177,6 +196,7 @@ process.on('unhandledRejection', e => { console.error('UNHANDLED: ' + (e && e.st
           clearOn: cOn, clearOff: cOff };
       } else deadEnd = { firingN: 0 };
     }
+    W('branch-OFF A/B arm');
     // 3. THE SAME correction with §CPE_CORR_BRANCH switched OFF — i.e. the naive short-way yaw this
     //    branch replaced. This is the A/B that makes G-BR-6 name its issue: without it the gate would
     //    only assert a number, with no evidence that the number was ever otherwise.
@@ -197,7 +217,8 @@ process.on('unhandledRejection', e => { console.error('UNHANDLED: ' + (e && e.st
         { pos: g.pos, dir: dir, rampF: 0.04, holdF: 0.12, decayF: 0.18 }] });
     }
     return { base, corr, frzOff, clearRows, deadEnd, ab, arcLen, rec, dir, turnOverlap, ok: true };
-  }, N, SECS_IN);
+  }, N, SECS_IN, Progress.pageLine(''));
+  pr.stage('derive+judge');
 
   console.log('='.repeat(90) + `\n§CPE_CORR_BOUNDED witness — ${BLD}, one correction, ${N} arc samples\n` + '='.repeat(90));
   if (r.fail) { console.log('  INCONCLUSIVE — ' + r.fail + '; nothing was judged.'); await b.close(); process.exit(1); }
@@ -534,5 +555,6 @@ process.on('unhandledRejection', e => { console.error('UNHANDLED: ' + (e && e.st
       : 'the branch fix DOES change this plan, so a failing gate here may be attributable to it — investigate.'));
   }
   await b.close();
+  pr.end(`pass=${pass}/${G.length}`);
   process.exit(pass === G.length ? 0 : 1);
 })();

--- a/witness_cpe_hose.js
+++ b/witness_cpe_hose.js
@@ -40,6 +40,9 @@
 //   B2  the re-key is REVERSIBLE: tmRestoreDerivedOrder puts every timestamp back exactly, so a
 //       bake cannot leave the user's timeline re-ordered.
 const puppeteer = require('/home/red1/bim-compiler/node_modules/puppeteer');
+// §W_PROGRESS (bim-compiler prompts/WITNESS_INTERFACE_FRAMEWORK.md) — same single-long-evaluate shape
+// as the rest of the cinema family; it printed nothing until the very end (AGENT_QUEUE.md A-16b).
+const Progress = require('./witness_kit/progress.js');
 
 const PORT = process.env.PORT || 8421;
 const BUILDINGS = (process.env.BLDS || 'Duplex,Hospital_3').split(',');
@@ -47,6 +50,9 @@ const FPS = 15, DUR = 24;
 const sleep = ms => new Promise(r => setTimeout(r, ms));
 
 (async () => {
+  const pr = Progress('CPE_HOSE');
+  pr.note(`port=${PORT} buildings=${BUILDINGS.join(',')} fps=${FPS} dur=${DUR}`);
+  pr.stage('launch-browser');
   const browser = await puppeteer.launch({
     headless: 'new', protocolTimeout: 900000,
     args: ['--use-gl=angle', '--use-angle=swiftshader', '--no-sandbox', '--enable-unsafe-swiftshader'],
@@ -55,16 +61,23 @@ const sleep = ms => new Promise(r => setTimeout(r, ms));
   const summary = [];
 
   for (const BLD of BUILDINGS) {
+    pr.stage(`${BLD}/open-page`);
     const page = await browser.newPage();
     await page.setViewport({ width: 1200, height: 700 });
     const logs = [];
-    page.on('console', m => logs.push(m.text()));
+    // §W_PROGRESS rides this same hook; its own lines are kept out of `logs`.
+    const { isProgress } = pr.attach(page);
+    page.on('console', m => { const t = m.text(); if (!isProgress(t)) logs.push(t); });
     page.on('pageerror', e => logs.push('PAGEERROR ' + e.message));
+    pr.stage(`${BLD}/goto-viewer`);
     await page.goto(`http://localhost:${PORT}/viewer/viewer.html?db=/buildings/${BLD}_extracted.db`,
       { waitUntil: 'domcontentloaded', timeout: 60000 });
+    pr.stage(`${BLD}/wait-APP-ready`);
     await page.waitForFunction(() => window.APP && window.APP.cinemaPathPlan && window.APP.cinemaHoseApply,
       { timeout: 180000 });
     await sleep(9000);
+    // THE LONG ONE — element_transforms streaming, previously silent.
+    pr.stage(`${BLD}/wait-element-transforms`);
     await page.waitForFunction(() => {
       try { const r = window.APP.dbQuery('SELECT COUNT(*) FROM element_transforms'); return r && r[0][0] > 0; }
       catch (e) { return false; }
@@ -74,13 +87,16 @@ const sleep = ms => new Promise(r => setTimeout(r, ms));
     const checks = [];
     const P = (n, ok, d) => { checks.push({ n, ok, d }); if (!ok) allPass = false; };
 
-    const res = await page.evaluate(async (dur, fps) => {
+    pr.stage(`${BLD}/measure(in-page)`);
+    const res = await page.evaluate(async (dur, fps, PP) => {
+      const W = (s) => { try { console.log(PP + s); } catch (e) { /* console gone */ } };
       const A = window.APP;
       if (typeof A.loadNavigate === 'function' && !A._navigateLoaded) { try { await A.loadNavigate(); } catch (e) {} }
       if (typeof A.ensureRooms === 'function') { try { await A.ensureRooms({}); } catch (e) {} }
       A._cinemaPathEdit = null;
       const out = {};
 
+      W('H1/H2 falloff law');
       // ── H1/H2: the falloff law, on a synthetic OUT-AND-BACK polyline ────────────────────────
       // Out along +x for 100 m, then back along a line 0.5 m away. Point at s=0.25 (out leg) and
       // its near-twin on the return leg are 0.5 m apart in SPACE and 0.5 apart in ARC LENGTH.
@@ -121,6 +137,7 @@ const sleep = ms => new Promise(r => setTimeout(r, ms));
       };
       out.h2 = { span10: spanOf(0.10), span30: spanOf(0.30), span02: spanOf(0.02) };
 
+      W('H3 ops reach the real plan');
       // ── H3: the ops reach the real plan ────────────────────────────────────────────────────
       const planBase = A.cinemaPathPlan(dur, null);
       const bands = A.cinemaSeedBands(planBase.waypoints, planBase.pathLen);
@@ -152,6 +169,7 @@ const sleep = ms => new Promise(r => setTimeout(r, ms));
         return best;
       };
 
+      W('S1/S2/S3 stick spawn');
       // ── S1/S2/S3: §CPE_STICK — spawn a band at an arbitrary point on the walk ───────────────
       // S1 is the load-bearing claim and the one that can fail silently: a freshly dropped stick is
       // a NO-OP. If the seeder's tangent or centre is even slightly off the curve, the film JUMPS
@@ -215,6 +233,7 @@ const sleep = ms => new Promise(r => setTimeout(r, ms));
                   return (stick.d.x * tx + stick.d.y * ty + stick.d.z * tz) / tl;
                 })() };
 
+      W('R1/R2 reopen');
       // ── R1/R2: §CPE_REOPEN_DOUBLE — re-opening an authored path must not multiply the bands ──
       // The user's report: "it seems to dupe more bars upon alt-c cancel and resume". The mechanism
       // is reciprocal fan-out — cinemaSeedBands emits ONE band per waypoint, cinemaBandWaypoints
@@ -340,6 +359,7 @@ const sleep = ms => new Promise(r => setTimeout(r, ms));
         probeGone: typeof A._probeAimDepth === 'undefined',
       };
 
+      W('B1/B2 mode D');
       // ── B1/B2: mode D ──────────────────────────────────────────────────────────────────────
       out.b = { skipped: null };
       if (typeof window.tmActivateForBake === 'function') {
@@ -367,7 +387,8 @@ const sleep = ms => new Promise(r => setTimeout(r, ms));
         }
       } else out.b.skipped = 'time_machine.js not loaded';
       return out;
-    }, DUR, FPS);
+    }, DUR, FPS, Progress.pageLine(''));
+    pr.stage(`${BLD}/gates`);
 
     // ── H1: THE LAW ─────────────────────────────────────────────────────────────────────────
     P('H1 W-HOSE-ARC: grab point moved', res.h1.grabMoved > 11.9,
@@ -473,5 +494,6 @@ const sleep = ms => new Promise(r => setTimeout(r, ms));
   for (const s of summary) console.log(`${s.pass ? '✅' : '❌'} ${s.BLD}`);
   console.log(allPass ? '✅ ALL PASS' : '❌ FAILURES ABOVE');
   await browser.close();
+  pr.end(`allPass=${allPass}`);
   process.exit(allPass ? 0 : 1);
 })();

--- a/witness_cpe_stick_hold.js
+++ b/witness_cpe_stick_hold.js
@@ -40,12 +40,18 @@
 //   G-SH-8  no regression: naturalTotal == sum(naturalSec.*), replan deterministic, and a path with
 //           every hold 0 is BYTE-IDENTICAL to the same path planned with no hold field at all.
 const puppeteer = require('/home/red1/bim-compiler/node_modules/puppeteer');
+// §W_PROGRESS (bim-compiler prompts/WITNESS_INTERFACE_FRAMEWORK.md) — Hospital is the FIRST building
+// in the default list here, so the silent stretch A-16b names is the first thing this witness does.
+const Progress = require('./witness_kit/progress.js');
 
 const PORT = process.env.PORT || 8450;
 const BUILDINGS = (process.env.BLDS || 'Hospital,Duplex').split(',');
 const sleep = ms => new Promise(r => setTimeout(r, ms));
 
 (async () => {
+  const pr = Progress('CPE_STICK_HOLD');
+  pr.note(`port=${PORT} buildings=${BUILDINGS.join(',')}`);
+  pr.stage('launch-browser');
   const browser = await puppeteer.launch({
     headless: 'new', protocolTimeout: 900000,
     args: ['--use-gl=angle', '--use-angle=swiftshader', '--no-sandbox', '--enable-unsafe-swiftshader'],
@@ -55,23 +61,32 @@ const sleep = ms => new Promise(r => setTimeout(r, ms));
 
   for (const BLD of BUILDINGS) {
     console.log(`\n${'='.repeat(78)}\n${BLD}\n${'='.repeat(78)}`);
+    pr.stage(`${BLD}/open-page`);
     const page = await browser.newPage();
     await page.setViewport({ width: 1200, height: 700 });
     const logs = [];
-    page.on('console', m => logs.push(m.text()));
+    // §W_PROGRESS rides this same hook; its own lines are kept out of `logs`.
+    const { isProgress } = pr.attach(page);
+    page.on('console', m => { const t = m.text(); if (!isProgress(t)) logs.push(t); });
     page.on('pageerror', e => logs.push('PAGEERROR ' + e.message));
+    pr.stage(`${BLD}/goto-viewer`);
     await page.goto(`http://localhost:${PORT}/viewer/viewer.html?db=/buildings/${BLD}_extracted.db`,
       { waitUntil: 'domcontentloaded', timeout: 120000 });
+    pr.stage(`${BLD}/wait-APP-ready`);
     await page.waitForFunction(() => window.APP && window.APP.cinemaPathPlan && window.APP.dbQuery,
       { timeout: 300000 });
     await sleep(9000);
+    // THE LONG ONE — up to 5 min of element_transforms streaming, previously silent.
+    pr.stage(`${BLD}/wait-element-transforms`);
     await page.waitForFunction(() => {
       try { const r = window.APP.dbQuery('SELECT COUNT(*) FROM element_transforms'); return r && r[0][0] > 0; }
       catch (e) { return false; }
     }, { timeout: 300000, polling: 3000 });
 
     const DUR = 40, HOLD = 1.0;
-    const res = await page.evaluate(async (DUR, HOLD) => {
+    pr.stage(`${BLD}/measure(in-page)`);
+    const res = await page.evaluate(async (DUR, HOLD, PP) => {
+      const W = (s) => { try { console.log(PP + s); } catch (e) { /* console gone */ } };
       const A = window.APP;
       const out = { err: null };
       const norm = v => { const L = Math.hypot(v.x, v.y, v.z) || 1; return { x: v.x/L, y: v.y/L, z: v.z/L }; };
@@ -83,6 +98,7 @@ const sleep = ms => new Promise(r => setTimeout(r, ms));
 
         // A real 3-band path near the building, derived from the plan's own waypoints — the same
         // shape the editor seeds, so the "last stick" is band index 1 (length-2).
+        W('derive-bands');
         const planD = A.cinemaPathPlan(DUR);
         const s0 = planD.waypoints[0];
         // ⚠ A DOG-LEG, not a straight line — and this is a MEASURED correction to this file, not a
@@ -101,6 +117,7 @@ const sleep = ms => new Promise(r => setTimeout(r, ms));
             c: L.c, d: L.d, len: 10, hold: holds[i] || 0, _stick: i > 0 && i < 2,
           }));
         };
+        W('plan-nohold+hold arms');
         const planNoHold = A.cinemaPathPlan(DUR, { bands: mkBands([0, 0, 0]) });
         const planHold   = A.cinemaPathPlan(DUR, { bands: mkBands([0, HOLD, 0]) });
         out.noHold = { out: planNoHold.naturalSec.out, total: planNoHold.naturalTotal,
@@ -181,6 +198,7 @@ const sleep = ms => new Promise(r => setTimeout(r, ms));
         }
         // ── G-SH-8: all-holds-zero must equal a plan built with no hold field at all.
         const bandsNoField = mkBands([0,0,0]).map(b2 => { const c = { ...b2 }; delete c.hold; return c; });
+        W('G-SH-8 no-field / zero-hold identity arms');
         const planNoField = A.cinemaPathPlan(DUR, { bands: bandsNoField });
         const planZero2   = A.cinemaPathPlan(DUR, { bands: mkBands([0,0,0]) });
         let poseDiff = 0;
@@ -201,7 +219,8 @@ const sleep = ms => new Promise(r => setTimeout(r, ms));
           total: planHold.naturalTotal };
       } catch (e) { out.err = e.message + ' | ' + (e.stack || '').split('\n').slice(0,3).join(' / '); }
       return out;
-    }, DUR, HOLD);
+    }, DUR, HOLD, Progress.pageLine(''));
+    pr.stage(`${BLD}/gates`);
 
     const checks = [];
     const P = (n, ok, d) => { checks.push({ n, ok }); if (!ok) allPass = false;
@@ -382,6 +401,7 @@ const sleep = ms => new Promise(r => setTimeout(r, ms));
   }
 
   await browser.close();
+  pr.end(`allPass=${allPass}`);
   console.log(`\n${'='.repeat(78)}\n§CPE_STICK_HOLD WITNESS: ${summary.join(' | ')} — ${allPass ? 'PASS' : 'FAIL'}\n${'='.repeat(78)}`);
   process.exit(allPass ? 0 : 1);
 })();

--- a/witness_kit/progress.js
+++ b/witness_kit/progress.js
@@ -1,0 +1,165 @@
+// witness_kit/progress.js — §W_PROGRESS. Spec: bim-compiler
+// prompts/WITNESS_INTERFACE_FRAMEWORK.md §W_PROGRESS (queue item A-16b).
+//
+// THE ISSUE IT PROVES OR DISPROVES. A witness whose work happens inside one long
+// `await page.evaluate(...)` prints NOTHING until that call returns. Redirected to a file, the run
+// holds a **0-byte log** for its whole duration — and a 0-byte log at minute 40 is indistinguishable
+// from a 0-byte log because the process died at second 3. On 2026-09-02 that ambiguity was resolved
+// the wrong way twice: a completed Hospital run was reported as "never measured" and the absence was
+// reported instead of re-checked (AGENT_QUEUE.md A-16, retracted). CLAUDE.md clause 4 says a witness
+// that cannot report its own FAILURE is not a witness; this module is the same rule applied to
+// LIVENESS — silence must be distinguishable from "still working".
+//
+// THREE STATES, exactly parallel to PASS / FAIL / INCONCLUSIVE:
+//   a STAGE line      — this much definitely finished, and how long it took.
+//   a HEARTBEAT line  — still working, and here is the stage it is inside.
+//   nothing at all    — the process is gone; the last STAGE line names how far it got.
+//
+// WHY fs.writeSync AND NOT console.log. Node buffers stdout when it is a pipe. A SIGKILL then
+// discards exactly the lines that mattered, which is the defect this file exists to remove. Every
+// write here is a synchronous write to fd 1 (and, if OUT is given, to that file too), so a line that
+// has been emitted is on disk before the next statement runs.
+//
+// WHY THE PAGE SIDE NEEDS NO NEW PLUMBING. Every witness in this family already installs
+// `p.on('console', ...)` to keep the product's shipped §-log (CLAUDE.md rule 3). In-page progress
+// rides that same hook: the page emits a tagged console.log, `attach()` recognises the tag and
+// forwards it immediately. Nothing new is opened; what was missing is that nothing emitted, and that
+// the node side buffered.
+//
+// RED CONTROL. `W_PROGRESS=0` disables every write. viewer/tests/witness_progress_flush.js runs the
+// same fixture with and without it and asserts the OFF arm really does produce the 0-byte log — a
+// progress reporter that could not be turned off would leave "the log is non-empty" unfalsifiable.
+'use strict';
+const fs = require('fs');
+
+const TAG = '§W_PROGRESS';
+// Any console line from the page starting with this prefix is progress, not product output.
+const PAGE_PREFIX = TAG + ' ';
+
+/**
+ * Progress(name, opts) — an unbuffered, stage-and-heartbeat progress reporter for a long witness.
+ *
+ * @param {string} name - short witness name, printed on every line so interleaved runs are readable.
+ * @param {{ beatMs?: number, out?: string, enabled?: boolean }} [opts]
+ *   beatMs  heartbeat interval in ms (default 15000, env W_PROGRESS_BEAT_MS).
+ *   out     optional extra file to append every line to, opened in append mode and written
+ *           synchronously (for a caller that does not redirect stdout).
+ *   enabled default true; forced false by `W_PROGRESS=0`. This is the red control.
+ * @returns {{stage:(l:string)=>void, note:(s:string)=>void, attach:(page:object)=>object,
+ *            end:(s?:string)=>void, enabled:boolean, tag:string}}
+ */
+function Progress(name, opts) {
+  const o = opts || {};
+  const enabled = o.enabled === false ? false : process.env.W_PROGRESS !== '0';
+  const beatMs = +(o.beatMs || process.env.W_PROGRESS_BEAT_MS || 15000);
+  const t0 = Date.now();
+  let cur = null, curAt = t0, beat = null, ended = false;
+  let fd = null;
+  if (enabled && o.out) { try { fd = fs.openSync(o.out, 'a'); } catch (e) { fd = null; } }
+
+  const secs = (ms) => (ms / 1000).toFixed(1);
+  function emit(line) {
+    if (!enabled) return;
+    const s = line.endsWith('\n') ? line : line + '\n';
+    // fd 1 direct: survives a SIGKILL, unlike a buffered console.log on a pipe.
+    try { fs.writeSync(1, s); } catch (e) { /* EPIPE — the reader went away, keep going */ }
+    if (fd != null) { try { fs.writeSync(fd, s); } catch (e) { /* full disk / closed */ } }
+  }
+
+  function armBeat() {
+    if (!enabled || beat) return;
+    beat = setInterval(() => {
+      if (ended || !cur) return;
+      emit(`${TAG} ${name} HEARTBEAT stage=${cur} openFor=${secs(Date.now() - curAt)}s ` +
+        `total=${secs(Date.now() - t0)}s (still working — this line is what distinguishes a hung run from a dead one)`);
+    }, beatMs);
+    // NEVER hold the process open: a heartbeat that outlives the work would turn a finished witness
+    // into a hang, which is the very failure mode this file is about.
+    if (beat.unref) beat.unref();
+  }
+
+  const api = {
+    enabled,
+    tag: TAG,
+    /**
+     * Close the open stage (printing its duration) and open a new one. The CLOSING line is the
+     * evidence a kill leaves behind: it names the last thing that definitely finished.
+     * @param {string} label - stage name.
+     */
+    stage(label) {
+      const now = Date.now();
+      if (cur) emit(`${TAG} ${name} DONE stage=${cur} took=${secs(now - curAt)}s total=${secs(now - t0)}s`);
+      cur = label; curAt = now;
+      emit(`${TAG} ${name} ENTER stage=${label} total=${secs(now - t0)}s`);
+      armBeat();
+    },
+    /**
+     * A free-form progress note inside the current stage (a count, a detected value). Not a stage
+     * boundary — use it for things a reader needs to see before the run can finish.
+     * @param {string} s - the note.
+     */
+    note(s) {
+      emit(`${TAG} ${name} NOTE stage=${cur || '-'} total=${secs(Date.now() - t0)}s ${s}`);
+    },
+    /**
+     * Forward the PAGE's own progress lines through the `p.on('console')` hook that every witness in
+     * this family already installs. Puppeteer delivers Runtime.consoleAPICalled events while the
+     * outer `await page.evaluate()` is still pending, so this is what makes a long in-page run
+     * narrate itself. Returns a predicate so the caller can keep progress lines OUT of the product
+     * log it scans (an absence test must not count the witness's own lines).
+     * @param {object} page - a puppeteer Page.
+     * @returns {{isProgress:(text:string)=>boolean}}
+     */
+    attach(page) {
+      if (page && page.on) {
+        page.on('console', (m) => {
+          let t = '';
+          try { t = m.text(); } catch (e) { return; }
+          if (t.indexOf(PAGE_PREFIX) === 0) {
+            emit(`${TAG} ${name} PAGE ${t.slice(PAGE_PREFIX.length)} total=${secs(Date.now() - t0)}s`);
+          }
+        });
+      }
+      return { isProgress: (t) => typeof t === 'string' && t.indexOf(PAGE_PREFIX) === 0 };
+    },
+    /**
+     * Close the last stage and stop the heartbeat. Safe to call twice.
+     * @param {string} [summary] - optional trailing text.
+     */
+    end(summary) {
+      if (ended) return;
+      const now = Date.now();
+      if (cur) emit(`${TAG} ${name} DONE stage=${cur} took=${secs(now - curAt)}s total=${secs(now - t0)}s`);
+      emit(`${TAG} ${name} END total=${secs(now - t0)}s${summary ? ' ' + summary : ''}`);
+      ended = true; cur = null;
+      if (beat) { clearInterval(beat); beat = null; }
+      if (fd != null) { try { fs.closeSync(fd); } catch (e) { /* already closed */ } fd = null; }
+    },
+  };
+
+  // A witness killed by SIGTERM/SIGINT can still say where it was. SIGKILL cannot be caught — which
+  // is exactly why every line above is written synchronously rather than relying on this.
+  if (enabled) {
+    ['SIGTERM', 'SIGINT'].forEach((sig) => {
+      process.on(sig, () => {
+        emit(`${TAG} ${name} ABORTED signal=${sig} stage=${cur || '-'} ` +
+          `openFor=${secs(Date.now() - curAt)}s total=${secs(Date.now() - t0)}s`);
+        process.exit(130);
+      });
+    });
+  }
+
+  return api;
+}
+
+/**
+ * The snippet a page-side `evaluate` calls to narrate itself. Kept here, next to the node-side
+ * reader, so the tag can never drift between the two halves.
+ * @param {string} label - stage name to report from inside the page.
+ * @returns {string} the exact console.log text the node side recognises.
+ */
+Progress.pageLine = (label) => PAGE_PREFIX + label;
+Progress.TAG = TAG;
+
+module.exports = Progress;
+module.exports.Progress = Progress;


### PR DESCRIPTION
## The defect (AGENT_QUEUE.md **A-16b**)

The five cinema/aim witnesses do all their work inside ONE `await page.evaluate(...)` and print only after it returns. Redirected to a file, a run holds a **0-byte log** for its entire duration — and a 0-byte log at minute 40 is indistinguishable from a 0-byte log because the process died at second 3.

On 2026-09-02 that ambiguity was resolved the wrong way **twice**: a *completed* Hospital run was reported as "never measured", and a rasteriser attribution was asserted off the same absence. Both were retracted (A-16).

CLAUDE.md clause 4 — *a witness that cannot report its own failure is not a witness* — extended to **liveness**: silence must be distinguishable from "still working".

## The fix — the hook that already existed

Exactly as the queue item named it: forward per-stage progress through the `p.on('console')` hook these files **already install** for the shipped §-log. No second channel is opened.

`witness_kit/progress.js` adds the node half:

| | |
|---|---|
| **stage lines** | `ENTER` / `DONE stage=… took=…s`, via **`fs.writeSync(1, …)` and never `console.log`** — node buffers stdout on a pipe and a SIGKILL then discards exactly the lines that mattered |
| **heartbeat** | names the OPEN stage + how long it has been open (default 15 s, `unref`'d so it can never hold a finished run open). This is what separates *hung* from *dead* |
| **`attach(page)`** | forwards in-page `§W_PROGRESS` lines and returns an `isProgress` predicate, so the witness's own output stays **out** of the product log it scans (`witness_cpe_aim_retire.js` A-6 uses `logs.length` as an absence denominator) |
| **`W_PROGRESS=0`** | turns it all off — the red control below |

Wired into all five: `witness_cpe_aim_retire.js`, `witness_cpe_corr_brush.js`, `witness_cpe_aim_pin.js`, `witness_cpe_stick_hold.js`, `witness_cpe_hose.js`.

## Acceptance test — it kills a run and reads what survived

`viewer/tests/witness_progress_flush.js` spawns a real puppeteer fixture, SIGKILLs it mid-flight (uncatchable — no shutdown handler can rescue it), and reads the log. **MEASURED on this branch:**

```
§W_PROGRESS_RUN tag=on  aliveAtKill=true killedGroup=true reapedBrowser=group orphanLeft=false logBytes=1801 lines=22
§W_PROGRESS_RUN tag=off aliveAtKill=true killedGroup=true reapedBrowser=group orphanLeft=false logBytes=0    lines=0
§W_PROGRESS_VERDICT claims=6 PASS=6 FAIL=0 INCONCLUSIVE=0  GREEN
```

- **P1** killed at 14.0 s → completed stages `[launch-browser → open-page]`, killed **inside** `[long-evaluate]` — entered, never DONE, which is what pins where it died.
- **P2** **13 forwarded in-page lines** on disk before the kill, emitted from inside the still-pending `evaluate` — the stretch that used to be silent for the whole run.
- **P3** 4 heartbeats at 3 s.
- **P4 RED CONTROL** — identical fixture, identical kill, `W_PROGRESS=0` → **0 bytes**. The defect still reproduces, so P1-P3 are not passing for some other reason.
- **P5** all five files really wired — **comment lines stripped before matching**, because a grep that matches a file's own prose is the *check that cannot fail* class this queue caught three of on 2026-09-02. Verified negatively: the same predicate against `origin/main`'s uninstrumented `witness_cpe_aim_retire.js` reads `req=false stages=0` → FAIL.
- **P6** exists because the **first** run of this witness leaked 3 orphaned chrome trees — puppeteer spawns the browser `detached`, in its own process group, so the group kill does not reach it. The fixture records the browser pid **outside** the progress channel (the red-control arm has no log at all), the witness reaps it, and P6 verifies with `kill(pid,0)` rather than assuming.

Any claim whose fixture never reached the kill prints **INCONCLUSIVE**, never PASS.

## Scope / safety

**No product code is touched** — harness only, so no measured number can move. Every existing `§`-line keeps its exact text; progress is a new tag, not a rewrite. No bake, no building, no server: the fixture loads `about:blank`, and the whole check runs in ~35 s.

`eslint viewer modeller witness_kit <the five>` via the repo's own install — **own exit code 0**.

Spec: `bim-compiler prompts/WITNESS_INTERFACE_FRAMEWORK.md` §W_PROGRESS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RTX9gUq3tQoytC1vthLmcq