### PR TITLE
feat(erp): iDempiere parity — AD_Val_Rule reaches the live FK pickers (§P3)

### DIFF
--- a/erp/ad_parser.js
+++ b/erp/ad_parser.js
@@ -288,7 +288,13 @@
       '       c.DefaultValue as ColDefault ';
     var EXT = ', f.AD_Reference_ID as FieldRef, COALESCE(f.AD_Reference_Value_ID, c.AD_Reference_Value_ID) as RefValue, ' +
       '       COALESCE(NULLIF(f.ReadOnlyLogic, \'\'), c.ReadOnlyLogic) as ROLogic, ' +
-      '       COALESCE(NULLIF(f.MandatoryLogic, \'\'), c.MandatoryLogic) as MLogic ';
+      '       COALESCE(NULLIF(f.MandatoryLogic, \'\'), c.MandatoryLogic) as MLogic, ' +
+      // §P3 (ERP_IDEMPIERE_UX_PARITY.md §P3-EXTRACT E4 — W-PARITY-VALRULE): the lookup's AD_Val_Rule. The
+      // AD_Field_v view is explicit that the FIELD wins over the COLUMN — "COALESCE(f.ad_val_rule_id,
+      // c.ad_val_rule_id) AS AD_Val_Rule_ID", with validationcode joined on that same COALESCE
+      // (migration/iD10/postgresql/202209141520_IDEMPIERE-5396.sql:7,14). Same precedence this function
+      // already applies to DefaultValue / AD_Reference_ID / AD_Reference_Value_ID, not a new convention.
+      '       COALESCE(NULLIF(f.AD_Val_Rule_ID, \'\'), c.AD_Val_Rule_ID) as ValRule ';
     var TAIL = 'FROM AD_Field f ' +
       'JOIN AD_Column c ON f.AD_Column_ID = c.AD_Column_ID ' +
       'WHERE f.AD_Tab_ID = ? AND f.IsActive = \'Y\' ' +
@@ -322,6 +328,7 @@
         readOnlyLogic: o.ROLogic || null,                    // §P2.1 — now reaches foldCrudSpec → effectiveFlags
         mandatoryLogic: o.MLogic || null,
         referenceValueId: (o.RefValue != null && o.RefValue !== '') ? o.RefValue : null,   // §P2.1 — the List/Table reference value (AD_Ref_List key)
+        valRuleId: (o.ValRule != null && o.ValRule !== '') ? o.ValRule : null,             // §P3 — the lookup's AD_Val_Rule (field over column, AD_Field_v)
         isMandatory: (o.IsMandatory || o.ColMandatory) === 'Y',
         isReadOnly: o.IsReadOnly === 'Y',
         defaultValue: o.DefaultValue || o.ColDefault,

--- a/erp/ad_valrule.js
+++ b/erp/ad_valrule.js
@@ -1,0 +1,139 @@
+// Copyright (c) 2025-2026 Redhuan D. Oon <red1org@gmail.com>
+// SPDX-License-Identifier: MIT
+// ad_valrule.js — AD_Val_Rule SQL-where interpreter (W-VALRULE). The "AD_Val_Rule" leg of the coverage
+// matrix: read AD_Val_Rule.Code (Type S = a SQL where-clause fragment), substitute @Context@/@Field@
+// tokens, and APPLY the clause as a real WHERE against the bound table for list/FK filtering — exactly
+// how iDempiere's MValRule appends the where-clause to a lookup query. Self-contained, no kernel dep
+// (mirrors ad_process.js / ad_access.js / ad_evaluator.js shape).
+//
+// SEAM (pinned in docs/ERP_BACKEND_SEPARATION.md §3 ❷): a val-rule VALIDATES / FILTERS — given a field +
+// context it decides which values are LEGAL (a where-clause over a candidate set). It is the READ verb. It
+// must NOT derive a value (that is the callout, A-3). This module returns a boolean/row-set, never a value
+// map. It extends ad_evaluator.js (boolean display/readonly/mandatory logic) as a DISTINCT sibling surface —
+// SQL-validation ≠ boolean logic — it does not replace it.
+//
+// EXTRACT, DON'T INVENT: the where-clause IS the AD data (build/erp/ad_full.db: ad_val_rule, lowercase). We
+// run it verbatim (after token substitution) against the real db; we never author or rewrite a rule. An
+// unresolved token / unsafe clause is reported DEFERRED (explicit), never silently passed. (AD_Rule is a
+// SEPARATE surface — 4 SQL ruletype-Q Fact_Reconciliation rules, n/a-in-seed; not this module's concern.)
+// Determinism: read-only query, no Date.now/Math.random. Implementing ERP_COVERAGE_MATRIX.md §AD_Val_Rule
+// (ranked GAP #7) — Witness: W-VALRULE
+(function (global) {
+  'use strict';
+
+  // ── classify a clause: what can we evaluate headless, and what must be deferred? ───────────────────────
+  // unsafe  = multi-statement / comment markers (defensive — these are AD-authored, but we only ever embed
+  //           the fragment inside a SELECT…WHERE, so reject anything that could break out of that context).
+  function classify(code) {
+    if (code == null || String(code).trim() === '') return 'empty';
+    var c = String(code);
+    if (/;|--|\/\*|\bunion\b/i.test(c)) return 'unsafe';     // never embed a breakout fragment
+    if (/@SQL=/i.test(c)) return 'sql-token';                // dynamic subselect token — named-deferred
+    if (c.indexOf('@') >= 0) return 'token';                 // @Field@/@#Global@ context tokens present
+    return 'static';                                         // a literal where-clause, directly applicable
+  }
+
+  // tokens present in a clause, e.g. "AD_Tab.AD_Table_ID=@AD_Table_ID@" -> ["AD_Table_ID"] (strips @#…@/@…@).
+  function tokensIn(code) {
+    var out = [], m, re = /@([#$]?[A-Za-z0-9_]+)@/g;
+    while ((m = re.exec(String(code)))) out.push(m[1]);
+    return out;
+  }
+
+  // quote a value SQL-style: numbers bare, everything else single-quoted (escaped). RETAINED as public API
+  // for callers that need to build a literal — it is deliberately NOT the val-rule substitution path (see
+  // envValue/substitute below; using it there was ERP_IDEMPIERE_UX_PARITY.md §P3-DEFECT).
+  function quote(v) {
+    if (v == null) return 'NULL';
+    if (typeof v === 'number' || (/^-?\d+(\.\d+)?$/.test(String(v)))) return String(v);
+    return "'" + String(v).replace(/'/g, "''") + "'";
+  }
+
+  // envValue — the substitution semantics of Env.parseContext(…, forSQL=true), EXTRACTED from the source, not
+  // assumed (Env.java:1636-1639, and its own javadoc :1540-1543): the context value is appended VERBATIM with
+  // only ' -> '' escaping. It is NOT wrapped in quotes — the RULE AUTHOR writes them, which is why 25 of the
+  // 332 Type-S rules read  IsSOTrx='@IsSOTrx@' . Auto-quoting those emitted  ''Y''  — a SQL syntax error, so
+  // the filter could not run at all (measured: 6 of the 43 in-seed val-rule fields on the five document tabs).
+  // An EMPTY value is not a value: Env.java:1641-1645 treats it as an unparsable token and returns "" for the
+  // WHOLE expression; MLookup.java:1128-1140 then clears the lookup — no rows, NOT an unfiltered list.
+  function envValue(v) {
+    if (v == null) return '';
+    var s = String(v);
+    return s.indexOf("'") >= 0 ? s.replace(/'/g, "''") : s;
+  }
+
+  // substitute(code, ctx) -> { sql, unresolved:[] }. ctx keys may be bare ("AD_Table_ID") or global
+  // ("#AD_Client_ID"); a token with no ctx value — or an EMPTY one (Env: same thing) — is LEFT in place and
+  // recorded unresolved, so the caller defers rather than filtering on a half-substituted clause.
+  function substitute(code, ctx) {
+    ctx = ctx || {};
+    var unresolved = [];
+    var sql = String(code).replace(/@([#$]?[A-Za-z0-9_]+)@/g, function (whole, name) {
+      var key = name.replace(/^[#$]/, '');
+      var hit = Object.prototype.hasOwnProperty.call(ctx, name) ? name
+              : (Object.prototype.hasOwnProperty.call(ctx, key) ? key : null);
+      var sv = hit === null ? '' : envValue(ctx[hit]);
+      if (sv === '') { unresolved.push(name); return whole; }
+      return sv;
+    });
+    return { sql: sql, unresolved: unresolved };
+  }
+
+  // inferTable — a qualified clause "C_Invoice.IsPaid<>'Y'" names its table; bare clauses ("IsSOTrx='Y'")
+  // rely on the caller-bound table (opts.table). Returns lowercase table name or null.
+  function inferTable(code) {
+    var m = /([A-Za-z_][A-Za-z0-9_]*)\s*\./.exec(String(code));
+    return m ? m[1].toLowerCase() : null;
+  }
+
+  // evalValRule(db, valRuleId, opts) — the full interpreter.
+  //   opts.ctx        : context map for token substitution
+  //   opts.table      : bound lookup table (fallback when the clause is unqualified)
+  //   opts.candidatePk: {col, id} — membership test: is THIS row admitted by the filter?
+  // Returns { id, name, type, code, sql, table, rows, ok, member?, deferred?, unresolved? }.
+  function evalValRule(db, valRuleId, opts) {
+    opts = opts || {};
+    var row = db.prepare('SELECT ad_val_rule_id,name,type,code FROM ad_val_rule WHERE ad_val_rule_id=?').get(valRuleId);
+    if (!row) throw new Error('no ad_val_rule ' + valRuleId);
+    var base = { id: row.ad_val_rule_id, name: row.name, type: row.type, code: row.code };
+
+    var kind = classify(row.code);
+    if (kind !== 'static' && kind !== 'token')
+      return Object.assign(base, { ok: false, deferred: kind });   // empty/unsafe/sql-token → explicit defer
+
+    var sub = substitute(row.code, opts.ctx);
+    if (sub.unresolved.length)
+      return Object.assign(base, { ok: false, deferred: 'unresolved-tokens', unresolved: sub.unresolved, sql: sub.sql });
+
+    var table = opts.table || inferTable(row.code);
+    if (!table)
+      return Object.assign(base, { ok: false, deferred: 'no-bound-table', sql: sub.sql });
+
+    // APPLY the where-clause as a real filter (the MValRule semantics). Read-only.
+    var n = db.prepare('SELECT COUNT(*) AS n FROM ' + table + ' WHERE ' + sub.sql).get().n;
+    var out = Object.assign(base, { sql: sub.sql, table: table, rows: n, ok: true });
+
+    // membership test: does a specific candidate row survive the filter? (list/FK admission)
+    if (opts.candidatePk && opts.candidatePk.col) {
+      var hit = db.prepare('SELECT 1 AS m FROM ' + table + ' WHERE ' + opts.candidatePk.col + '=? AND (' + sub.sql + ')').get(opts.candidatePk.id);
+      out.member = !!hit;
+    }
+    return out;
+  }
+
+  // coverageScan(db) — classify all Type-S rules: directly applicable (static) vs token-bearing vs deferred.
+  function coverageScan(db) {
+    var rows = db.prepare("SELECT ad_val_rule_id,code FROM ad_val_rule WHERE type='S'").all();
+    var tally = { total: rows.length, static: 0, token: 0, 'sql-token': 0, unsafe: 0, empty: 0 };
+    rows.forEach(function (r) { tally[classify(r.code)]++; });
+    return tally;
+  }
+
+  var API = {
+    classify: classify, tokensIn: tokensIn, substitute: substitute, quote: quote, envValue: envValue,
+    inferTable: inferTable, evalValRule: evalValRule, coverageScan: coverageScan
+  };
+  if (typeof module !== 'undefined' && module.exports) module.exports = API;   // node witness
+  if (typeof window !== 'undefined') window.AdValRule = API;                    // browser
+  else if (global) global.AdValRule = API;
+})(typeof globalThis !== 'undefined' ? globalThis : this);

--- a/erp/crud_core.js
+++ b/erp/crud_core.js
@@ -153,6 +153,12 @@
         break;
       case 'fk':
         if (!isFinite(Number(val))) return 'type:fk';
+        // §P3 (ERP_IDEMPIERE_UX_PARITY.md §P3-SPEC P3.6 — W-PARITY-VALRULE): the save-side half of the
+        // AD_Val_Rule. f.admitted is the id-set the interpreter's own where-clause returned when the picker
+        // was built (crud_overlay.populateRefs), so the OFFERED set and the ACCEPTED set are the same set by
+        // construction and cannot drift apart. Absent map (no rule on this column, or the arm degraded and
+        // said so in the log) → unchanged behaviour, never a blanket reject.
+        if (f.admitted && !Object.prototype.hasOwnProperty.call(f.admitted, String(val))) return 'valrule:not-admitted';
         break;
       case 'string':
         if (V.regex && !new RegExp(V.regex).test(String(val))) return 'regex:' + (V.valRule || V.regex);
@@ -742,6 +748,11 @@
         else if (!/[@()]/.test(ds)) spec.default = d;
       }
       if (type === 'fk') spec.ref = String(f.columnName).toLowerCase().replace(/_id$/, '');
+      // §P3 (ERP_IDEMPIERE_UX_PARITY.md §P3-SPEC P3.3 — Witness: W-PARITY-VALRULE): carry the lookup's
+      // AD_Val_Rule id so the picker can filter to the rows the rule admits (MLookupFactory.java:122-125 —
+      // the rule's Code IS the lookup's ValidationCode). The fold stays PURE: no db, no engine call here;
+      // crud_overlay.populateRefs runs the interpreter (ad_valrule.js) when it has a real db handle.
+      if (f.valRuleId != null && String(f.valRuleId) !== '') spec.valruleid = f.valRuleId;
       // §P2 (W-PARITY-REFLIST): a List column's option set is its AD_Reference_Value_ID's AD_Ref_List rows. The
       // fold stays PURE — the host supplies opts.refList(id) → [{value,name}] (ADParser.resolveReference, active
       // rows, ordered per AD_Reference.IsOrderByValue). optionList keeps that order for rendering; options is the
@@ -787,7 +798,13 @@
       var o = {}; for (k in cf) if (Object.prototype.hasOwnProperty.call(cf, k)) o[k] = cf[k];
       var ad = byCol[String(cf.col).toLowerCase()];
       if (ad) {
-        ['displaylogic', 'readonlylogic', 'mandatorylogic'].forEach(function (lk) {
+        // §P3 (ERP_IDEMPIERE_UX_PARITY.md §P3-SPEC P3.3): `valruleid` joins the three AD logic strings as a
+        // LAYERED key. It is additive — no curated field has ever carried one — and it does not touch the
+        // attributes §IMPL F3 pinned deliberately (type/required/readonly/default/validation/ref). Without
+        // this, a lookup that is BOTH curated and val-ruled kept the unfiltered picker: measured 2026-09-02,
+        // c_order.C_BPartner_ID (curated, rule 230) offered all 113 partners instead of the 42 iDempiere
+        // admits, while the same rule bit correctly on every non-curated column.
+        ['displaylogic', 'readonlylogic', 'mandatorylogic', 'valruleid'].forEach(function (lk) {
           if ((o[lk] == null || String(o[lk]).trim() === '') && ad[lk] != null && String(ad[lk]).trim() !== '') o[lk] = ad[lk];
         });
         if (o.seq == null && ad.seq != null) o.seq = ad.seq;

--- a/erp/crud_overlay.js
+++ b/erp/crud_overlay.js
@@ -429,10 +429,11 @@
          '<button class=cfb id=cfCancel>Cancel</button><button class="cfb cfsave" id=cfSave>' + (verb === 'create' ? 'Create' : 'Save') + '</button></div>';
     fhost = form; _inlineHost = null;                           // modal mount (Glass/Gravity ring path)
     form.innerHTML = h; form.className = 'open';
-    populateRefs(e);
+    populateRefs(e, orig);                                      // §P3 — orig is the window context the @token@ feed reads
     applyAdLogic(e);                                            // §AD-LOGIC-LIVE — initial show/hide/enable/require off the AD
     var body = form.querySelector('.cfbody');                   // …and re-apply on every edit so the form REACTS like iDempiere
-    if (body) { body.addEventListener('input', function () { applyAdLogic(e); }); body.addEventListener('change', function () { applyAdLogic(e); }); }
+    if (body) { body.addEventListener('input', function () { applyAdLogic(e); });
+                body.addEventListener('change', function () { applyAdLogic(e); populateRefs(e, orig, { valRuleOnly: true }); }); }
     // §CRUD-CALLOUT (S2/J4) — on a create form, a field change fires the AD callout (price/defaults FILL like
     //   iDempiere: e.g. C_BPartner_ID → bill-to + price list). Fires AFTER applyAdLogic; derived siblings filled.
     if (verb === 'create' && body) body.addEventListener('change', function (ev) {
@@ -554,9 +555,57 @@
     }
     return '<input class=cfi type="' + t + '" data-col="' + f.col + '" value="' + esc(v) + '"' + ro + (f.readonly ? ' title="derived — read-only"' : '') + '>';
   }
+  // ── §P3 AD_Val_Rule (ERP_IDEMPIERE_UX_PARITY.md §IMPL-P3 — Witness: W-PARITY-VALRULE) ────────────────────
+  // _valRuleCtx — the @token@ context feed, and the ONLY new logic this item adds; the evaluator itself is the
+  // already-witnessed build/erp/ad_valrule.js (W-VALRULE), run verbatim below. iDempiere's window context is
+  // EVERY column of the row under edit plus the Env globals, so the RECORD comes first and the globals fill
+  // only what it lacks. AD tokens are CamelCase and our rows are lowercase, so that case mapping lives HERE —
+  // it is our storage detail, not the engine's — resolved against the rule's own token list.
+  // A token whose value is absent OR EMPTY is deliberately left OUT, so the engine reports it unresolved and
+  // the E3 arm fires (Env.java:1641-1645 + MLookup.java:1128-1140: an unparsable token empties the clause and
+  // the lookup is CLEARED). Never defaulted to something plausible — that would offer rows iDempiere hides.
+  function _valRuleCtx(code, e, rec) {
+    var VR = global.AdValRule, low = {}, k;
+    if (rec) for (k in rec) if (rec[k] != null) low[String(k).toLowerCase()] = rec[k];
+    var vals = gatherVals(e);
+    for (k in vals) if (vals[k] != null && String(vals[k]) !== '') low[String(k).toLowerCase()] = vals[k];
+    var app = global.APP || {};
+    var fill = function (n, v) { if (v != null && String(v) !== '' && (low[n] == null || String(low[n]) === '')) low[n] = v; };
+    fill('ad_client_id', app.clientId); fill('ad_org_id', app.orgId);
+    fill('ad_user_id', app.actor); fill('salesrep_id', app.actor); fill('date', today());
+    // the per-window Sales/Purchase signal idempiere.html already extracts from the active AD_Tab's own
+    // WhereClause — reuse it, do NOT write a second reader (_docCtx owns this question).
+    if (app._createIsSOTrx === 'Y' || app._createIsSOTrx === 'N') fill('issotrx', app._createIsSOTrx);
+    var ctx = {};
+    ((VR && VR.tokensIn(code)) || []).forEach(function (tok) {
+      var v = low[String(tok).toLowerCase().replace(/^[#$]/, '')];
+      if (v != null && String(v) !== '') ctx[tok] = v;
+    });
+    return ctx;
+  }
+  // _valRuleFilter — run the SHIPPED interpreter through the SAME better-sqlite3 shim the beforeSave hooks
+  // use (_mvB3), so the witnessed engine executes verbatim in the browser and there is no second evaluator.
+  function _valRuleFilter(db, f, e, rec) {
+    var VR = global.AdValRule;
+    if (!VR || f.valruleid == null || !f.ref) return null;
+    var b3 = _mvB3(db), row = null;
+    try { row = b3.prepare('SELECT ad_val_rule_id,name,type,code FROM ad_val_rule WHERE ad_val_rule_id=?').get(Number(f.valruleid)); } catch (e0) {}
+    if (!row || row.code == null) return { verdict: 'no-rule-row', id: f.valruleid, ctx: {} };
+    var ctx = _valRuleCtx(row.code, e, rec), res;
+    try { res = VR.evalValRule(b3, Number(f.valruleid), { ctx: ctx, table: f.ref }); }
+    catch (e1) { return { verdict: 'engine-error:' + String((e1 && e1.message) || e1).slice(0, 60), id: f.valruleid, name: row.name, ctx: ctx }; }
+    if (!res.ok) return { verdict: res.deferred, id: res.id, name: res.name, unresolved: res.unresolved || [], ctx: ctx };
+    return { verdict: 'applied', id: res.id, name: res.name, sql: res.sql, ctx: ctx };
+  }
+
   // list options from __meta; fk options from the ref table via the page bundle (truth-bound).
-  function populateRefs(e) {
+  // rec (§P3) = the row under edit, the window context the @token@ feed reads. opts.valRuleOnly re-runs ONLY
+  // the val-rule'd fk pickers (a dependent lookup refresh, e.g. C_BPartner_ID → C_BPartner_Location_ID) —
+  // a full re-run would reset every list select back to its render-time data-cur and lose the user's choice.
+  function populateRefs(e, rec, opts) {
+    var only = !!(opts && opts.valRuleOnly);
     (e.fields || []).forEach(function (f) {
+      if (only && !(f.type === 'fk' && f.valruleid != null && !f.readonly)) return;
       var el = fhost.querySelector('[data-col="' + f.col + '"]'); if (!el || el.tagName !== 'SELECT') return;
       if (f.type === 'list') {
         // W-CRUD-DOCSTATUS render arm: the record's CURRENT value must render SELECTED (pre-fix the select
@@ -597,14 +646,56 @@
         withBundle(function (db) {
           try {
             var t = f.ref, pk = t + '_id', nameCol = recHasCol(db, t, 'name') ? 'name' : (recHasCol(db, t, 'documentno') ? 'documentno' : pk);
-            var res = db.exec('SELECT ' + pk + ',' + nameCol + ' FROM ' + t + ' ORDER BY ' + pk + ' LIMIT 200');
-            if (!res.length) return;
-            // §P2/§P1 (§IMPL F5): a lookup ALWAYS offers an empty choice when the field is not mandatory or has no
-            // value yet — pre-fix an empty fk landed on row 1 and cleanVals persisted it on CREATE (harmless at 8
-            // curated fields, catastrophic at 81: a payment against the first invoice/charge/project…).
+            // ── §P3 (§P3-SPEC P3.4 — W-PARITY-VALRULE): narrow the candidate set to exactly the rows this
+            // column's AD_Val_Rule admits. MLookupFactory.java:122-125 — the rule's Code IS the lookup's
+            // ValidationCode, appended to the lookup query; that is all this does.
+            var vr = _valRuleFilter(db, f, e, rec), where = '', noRows = false, before = null, admitted = null;
+            if (vr) {
+              try { var bq = db.exec('SELECT COUNT(*) FROM ' + t); before = bq.length ? bq[0].values[0][0] : null; } catch (eb) {}
+              if (vr.verdict === 'applied') where = ' WHERE (' + vr.sql + ')';
+              // E3 — an unresolved @token@ CLEARS the lookup (MLookup.java:1128-1140, "Loader NOT Validated").
+              // iDempiere shows NO rows here; it does not silently show all of them. Matching that IS the item.
+              else if (vr.verdict === 'unresolved-tokens') noRows = true;
+              // any other verdict (empty/unsafe/sql-token/no-bound-table/engine-error) is OUR interpreter's
+              // limit, not iDempiere's verdict — degrade to the UNFILTERED picker and say so in the log, rather
+              // than hiding rows iDempiere does show. Named, never silent.
+            }
+            var res = [];
+            if (!noRows) {
+              try { res = db.exec('SELECT ' + pk + ',' + nameCol + ' FROM ' + t + where + ' ORDER BY ' + pk + ' LIMIT 200'); }
+              catch (ew) {                                    // a clause naming a column this narrower seed lacks
+                if (vr) vr.verdict = 'where-failed:' + String((ew && ew.message) || ew).slice(0, 60);
+                where = ''; res = db.exec('SELECT ' + pk + ',' + nameCol + ' FROM ' + t + ' ORDER BY ' + pk + ' LIMIT 200');
+              }
+            }
+            // f.admitted — the UNLIMITED admitted id-set, so validateField (P3.6) still rejects an excluded row
+            // when a legal one sorts past the picker's LIMIT 200. Same clause, so the OFFERED set and the
+            // ACCEPTED set are one set by construction and cannot drift apart.
+            if (vr && vr.verdict === 'applied') {
+              try {
+                var ar = db.exec('SELECT ' + pk + ' FROM ' + t + ' WHERE (' + vr.sql + ')'), am = {};
+                if (ar.length) ar[0].values.forEach(function (r) { am[String(r[0])] = 1; });
+                admitted = am;
+              } catch (ea) {}
+            } else if (noRows) admitted = {};                 // nothing is admitted while the lookup is not validated
+            f.admitted = admitted;
+            var rows = res.length ? res[0].values : [];
+            // §P2/§P1 (§IMPL F5), PRESERVED and strengthened: a lookup ALWAYS offers an empty choice when the
+            // field is not mandatory, has no value yet, OR its current value is not in the offered set — pre-fix
+            // an empty fk landed on row 1 and cleanVals persisted it on CREATE (harmless at 8 curated fields,
+            // catastrophic at 81: a payment against the first invoice/charge/project…). Filtering can now make a
+            // previously-shown value unmatched, so that third case must offer the blank too, never fall to row 1.
             var kEmpty = (keep === '' || keep == null);
-            var blankFk = (!f.required || kEmpty) ? '<option value=""' + (kEmpty ? ' selected' : '') + '></option>' : '';
-            el.innerHTML = blankFk + res[0].values.map(function (r) { return '<option value="' + esc(r[0]) + '"' + (String(r[0]) === String(keep) ? ' selected' : '') + '>' + esc(r[1] + ' (' + r[0] + ')') + '</option>'; }).join('');
+            var hasKeep = !kEmpty && rows.some(function (r) { return String(r[0]) === String(keep); });
+            var blankSel = (kEmpty || !hasKeep);
+            var blankFk = (!f.required || blankSel) ? '<option value=""' + (blankSel ? ' selected' : '') + '></option>' : '';
+            if (vr) console.log('§VALRULE col=' + f.col + ' vr=' + vr.id + ' rule="' + (vr.name || '') + '" table=' + t +
+              ' before=' + before + ' after=' + (admitted ? Object.keys(admitted).length : (noRows ? 0 : before)) +
+              ' offered=' + rows.length + ' verdict=' + vr.verdict +
+              (vr.unresolved && vr.unresolved.length ? ' unresolved=[' + vr.unresolved.join(',') + ']' : '') +
+              ' ctx=' + JSON.stringify(vr.ctx || {}) + ' kept=' + (hasKeep ? keep : '(blank)'));
+            if (!rows.length && !noRows) return;              // no data at all → leave the raw-value option as-is
+            el.innerHTML = blankFk + rows.map(function (r) { return '<option value="' + esc(r[0]) + '"' + (String(r[0]) === String(keep) ? ' selected' : '') + '>' + esc(r[1] + ' (' + r[0] + ')') + '</option>'; }).join('');
           } catch (er) {}
         });
       }
@@ -756,7 +847,7 @@
       h += '<label class=cfrow data-row="' + f.col + '" data-ad-table="' + esc(e.key) + '" data-ad-column="' + esc(f.col) + '"><span class=cfl>' + esc(f.label || f.col) + ' <i class=req data-req="' + f.col + '" style="display:none">*</i></span>' + fieldInput(f, vals[f.col]) + '<span class="cfe" data-col="' + f.col + '"></span></label>';
     });
     host.innerHTML = h; host.classList.add('idmp-inline-crud');
-    populateRefs(e);
+    populateRefs(e, orig);                                      // §P3 — see renderForm
     applyAdLogic(e);
     // baseline = the values AS RENDERED (populateRefs picks the selected option, fieldInput normalizes dates/numbers),
     //   so a freshly-mounted form reads CLEAN — dirty is a true user delta, not a render-normalization artifact.
@@ -764,6 +855,9 @@
     host.addEventListener('input', function () { applyAdLogic(e); _refreshInlineDirty(); });
     host.addEventListener('change', function (ev) {
       applyAdLogic(e);
+      // §P3 — a DEPENDENT lookup refresh: changing @C_BPartner_ID@ must re-narrow C_BPartner_Location_ID.
+      // valRuleOnly, because a full re-run would reset every list select to its render-time data-cur.
+      populateRefs(e, orig, { valRuleOnly: true });
       if (verb === 'create') { var el = ev.target && ev.target.closest ? ev.target.closest('[data-col]') : null; var col = el ? el.getAttribute('data-col') : null; if (col) fireCreateCallout(e, col); }
       _refreshInlineDirty();
     });
@@ -890,7 +984,7 @@
         var prevFhost = fhost; fhost = hostTd;
         hostTd.innerHTML = '<div class="ic-cell">' + fieldInput(f, orig[f.col]) + '<span class="cfe" data-col="' + esc(f.col) + '"></span></div>';
         hostTd.classList.add('idmp-cell-edit');
-        populateRefs(e);                                     // list/fk options (every col but ours → el null → skipped)
+        populateRefs(e, orig);                               // list/fk options (every col but ours → el null → skipped)
         var input = hostTd.querySelector('[data-col="' + f.col + '"]');
         var baseline = input ? _getVal(input) : (orig[f.col] == null ? '' : orig[f.col]);   // AS-RENDERED (selected option / normalized date / Y-N)
         fhost = prevFhost;                                   // references captured — restore the module host immediately

--- a/erp/idempiere.html
+++ b/erp/idempiere.html
@@ -512,6 +512,11 @@
 <!-- PLUGIN_SYSTEM_LANE.md §Phase A/D — the Fold-Engine plugin host (W-PLUGIN) + its pill overlay. ad_callout.js
      gives callout-contributing bundles a live target (it joins ad_modelval/ad_process/post_resolver already loaded). -->
 <script src="ad_callout.js?v=1"></script>
+<!-- ERP_IDEMPIERE_UX_PARITY.md §P3 (W-PARITY-VALRULE) — the AD_Val_Rule interpreter (W-VALRULE, already
+     witnessed headless) reaching the LIVE FK pickers: crud_overlay.populateRefs appends the rule's where-clause
+     to the lookup query, exactly as MLookupFactory:122-125 does. 61 displayed fields on the five document
+     header tabs carry an AD_Val_Rule_ID. -->
+<script src="ad_valrule.js?v=1"></script>
 <script src="plugin_registry.js?v=1"></script>
 <!-- NINJA_MODE_PILL.md — the Plugin Engine "Create" (PackOut) face: Excel model sheet → AD model → live install.
      Engine == bim-compiler build/erp source (headless-proven W-NINJA-PILL). Load order: model→stage→bundle→create

--- a/erp/sw.js
+++ b/erp/sw.js
@@ -10,7 +10,7 @@
 // init-bubble must be INSTANT, ERP_INIT_BUBBLE_INSTANT.md); network-first for non-precached .js (fresh on
 // deploy); cache-first for precached assets/.wasm/images. Freshness on deploy is carried by the SW version
 // bump (skipWaiting+clients.claim precache the new shell), so SWR strands a user at most one load post-deploy.
-const CACHE_VERSION = 'v774';   // bump on each deploy; per-change detail is the git commit message.
+const CACHE_VERSION = 'v775';   // bump on each deploy; per-change detail is the git commit message.
 // v772 (rebase of PR #203 onto origin/main) §INTEG-WIRE-B: disposable-host persistence in-app
 // (erp_replica_client.js + erp_persist_ui.js) — back the books up to a SIGNED snapshot the user
 // owns (signed by the edge key), restore on a FRESH device -> replay recomputes tip == signed
@@ -54,6 +54,7 @@ const PRECACHE_ASSETS = [
   'ad_parser.js',
   'ad_process.js',    // B-5/C-5 — process dispatch spine (window.AdProcess), W-PROC / W-AD-PROC-LIVE
   'ad_table_map.js',
+  'ad_valrule.js',   // §P3 — AD_Val_Rule interpreter feeding the live FK pickers (W-PARITY-VALRULE)
   'vfs_detect.js',    // CONSTRAINT_MITIGATION item 3 — OPFS/IDB detection at boot (§VFS monitor)
   'error_beacon.js',  // SYSTEM_MONITOR_WIDGETS §H — minimal field-error beacon (G2 seed)
   'field_health.js',  // SYSTEM_MONITOR_WIDGETS §H — 4 field-health widgets engine (ERP.FieldHealth)

--- a/erp/tests/poc_parity_valrule_live.js
+++ b/erp/tests/poc_parity_valrule_live.js
@@ -1,0 +1,259 @@
+// ⚠ DO NOT REMOVE — Scope guard
+// Scope: real-browser §-witness for §P3 of bim-compiler prompts/ERP_IDEMPIERE_UX_PARITY.md — W-PARITY-VALRULE.
+//   THE ISSUE this test proves/disproves: "AD_Val_Rule is not wired into the live app at all" (§MEASURED) —
+//     build/erp/ad_valrule.js was witnessed headless (W-VALRULE, 327/332 interpretable) but NO file in the
+//     shipped erp/ consumed it, so the FK pickers built a plain SELECT over the target table and offered the
+//     user rows iDempiere would never have shown. 61 displayed fields on the five document header tabs carry
+//     an AD_Val_Rule_ID.
+//   CLAIM: an FK picker on a column carrying an AD_Val_Rule_ID offers STRICTLY the rows the rule's
+//     where-clause admits (MLookupFactory.java:122-125 — the rule's Code IS the lookup's ValidationCode),
+//     asserted as before > after on NAMED real columns, plus a falsifier: a row the rule EXCLUDES is absent
+//     from the picker AND is REJECTED on save.
+//   ACT (GardenWorld). Every expected value is read from the seed through the app's own accessor
+//     (window.__idmpDb) AT RUN TIME — no count, id or clause is typed into this file:
+//     A · window 169 / tab 257 c_doctype_id — the ONE field-level rule on the five tabs, and it DISAGREES
+//         with its column's (AD_Field_v: COALESCE(f.ad_val_rule_id, c.ad_val_rule_id) — field wins). Proves
+//         the precedence, not just the filter.
+//     B · window 143 / tab 186 c_bpartner_id — the flagship Sales Order lookup.
+//     C · window 195 / tab 330 c_order_id    — the payment's order lookup.
+//     D · window 143 / tab 186 c_bpartner_location_id — the TOKEN arm, @C_BPartner_ID@. With no BPartner
+//         chosen the lookup offers NO ROWS (Env.java:1641-1645 empties the clause; MLookup.java:1128-1140
+//         then CLEARS the lookup — iDempiere does not silently show all of them); choosing a BPartner
+//         narrows it to exactly that partner's ship-to locations.
+//     FALSIFIER · an id the rule excludes is absent from the options AND validateField → valrule:not-admitted,
+//         with an admitted id passing as the control (so the check is not rejecting everything).
+//     VACUITY · a rule that filters nothing proves nothing: any arm whose before == after is reported
+//         INCONCLUSIVE, never PASS, and the known NO-BITE rules on these tabs are listed as such.
+//   §-log first — READ tests/poc_parity_valrule_live.log before any conclusion (exit code is NOT evidence).
+// Run:  node tests/poc_parity_valrule_live.js   (cwd = bim-ootb/erp)
+'use strict';
+const { chromium } = require(process.env.PW || (require('os').homedir() + '/bim-ootb/tests/node_modules/playwright'));
+const http = require('http'), fs = require('fs'), path = require('path');
+
+const ROOT = path.join(__dirname, '..');
+const MIME = { '.html':'text/html', '.js':'text/javascript', '.json':'application/json',
+  '.db':'application/octet-stream', '.png':'image/png', '.css':'text/css', '.wasm':'application/wasm' };
+const server = http.createServer((req, res) => {
+  let p = decodeURIComponent(req.url.split('?')[0]); if (p === '/') p = '/idempiere.html';
+  fs.readFile(path.join(ROOT, p), (e, buf) => {
+    if (e) { res.writeHead(404); res.end('404 ' + p); return; }
+    res.writeHead(200, { 'Content-Type': MIME[path.extname(p)] || 'application/octet-stream' }); res.end(buf);
+  });
+});
+let pass = 0, fail = 0, inconclusive = 0;
+const ok = (label, cond, extra) => { console.log('   ' + (cond ? '🟢' : '🔴') + ' ' + label + (extra ? ' — ' + extra : '')); cond ? pass++ : fail++; };
+// a vacuous population is NOT a pass (CLAUDE.md PRIMAL LAW §4) — it is its own verdict.
+const inconc = (label, why) => { console.log('   ⬜ INCONCLUSIVE ' + label + ' — ' + why); inconclusive++; };
+
+async function landed(page) {
+  await page.waitForSelector('[data-ad-table]', { timeout: 20000 }).catch(async () => {
+    const u = await page.$('#idmp-login-users .idmp-login-user:not(.disabled)');
+    if (u) { await u.click(); const okb = await page.$('#idmp-login-ok'); if (okb) await okb.click(); }
+    await page.waitForSelector('[data-ad-table]', { timeout: 15000 }).catch(() => {});
+  });
+  await page.waitForTimeout(600);
+}
+async function clickNew(page) {
+  await page.waitForSelector('#idmp-toolbar button[title^="New record"]', { timeout: 15000 });
+  await page.click('#idmp-toolbar button[title^="New record"]');
+  await page.waitForSelector('#idmp-inline-mount .cfrow', { timeout: 10000 });
+  await page.waitForTimeout(700);
+}
+
+// ── the ORACLE, read from the seed through the app's own accessor at run time ──────────────────────────────
+// Returns the rule bound to <tab>.<col> exactly as AD_Field_v resolves it, the unfiltered row count of the
+// lookup's target table, and — for a rule with no unresolved token left — the admitted id set. Token
+// substitution here is a plain String.replace, deliberately NOT ad_valrule.substitute(), so the expectation
+// is independent of the engine under test.
+const seedRule = (page, tab, col, ctx) => page.evaluate(({ tab, col, ctx }) => {
+  const q = (s) => { const r = window.__idmpDb.exec(s); return r.length ? r[0].values : []; };
+  const vr = q("SELECT COALESCE(NULLIF(f.AD_Val_Rule_ID,''), c.AD_Val_Rule_ID), f.AD_Val_Rule_ID, c.AD_Val_Rule_ID" +
+    " FROM AD_Field f JOIN AD_Column c ON f.AD_Column_ID=c.AD_Column_ID" +
+    " WHERE f.AD_Tab_ID=" + tab + " AND lower(c.ColumnName)='" + col + "' AND f.IsActive='Y'");
+  if (!vr.length || vr[0][0] == null) return { bound: false };
+  const id = vr[0][0], fieldLevel = vr[0][1], colLevel = vr[0][2];
+  const rr = q("SELECT name, code FROM ad_val_rule WHERE ad_val_rule_id=" + id);
+  if (!rr.length) return { bound: false, id };
+  const name = rr[0][0]; let code = String(rr[0][1] || '');
+  const t = col.replace(/_id$/, ''), pk = t + '_id';
+  let before = null; try { before = q('SELECT COUNT(*) FROM ' + t)[0][0]; } catch (e) {}
+  let sub = code, unresolved = [];
+  code.replace(/@([#$]?[A-Za-z0-9_]+)@/g, (whole, n) => {
+    const k = Object.keys(ctx || {}).find(x => x.toLowerCase() === n.toLowerCase().replace(/^[#$]/, ''));
+    if (k != null && ctx[k] != null && String(ctx[k]) !== '') sub = sub.split(whole).join(String(ctx[k]));
+    else unresolved.push(n);
+    return whole;
+  });
+  let admitted = null, err = null;
+  if (!unresolved.length) {
+    try { admitted = q('SELECT ' + pk + ' FROM ' + t + ' WHERE (' + sub + ')').map(r => String(r[0])); }
+    catch (e) { err = String(e && e.message); }
+  }
+  const all = (() => { try { return q('SELECT ' + pk + ' FROM ' + t).map(r => String(r[0])); } catch (e) { return []; } })();
+  return { bound: true, id, fieldLevel, colLevel, name, code, sub, unresolved, table: t, before, admitted, all, err };
+}, { tab, col, ctx: ctx || {} });
+
+// what the picker actually offers, and what the fold typed onto the field spec
+const pickerState = (page, col) => page.evaluate((col) => {
+  const el = document.querySelector('#idmp-inline-mount select[data-col="' + col + '"]');
+  const e = window.__crud.formEntry(); const f = e && (e.fields || []).find(x => x.col === col);
+  return {
+    dom: el ? { tag: el.tagName, values: Array.from(el.options).map(o => o.value).filter(v => v !== ''),
+                hasBlank: Array.from(el.options).some(o => o.value === ''), value: el.value, disabled: el.disabled } : null,
+    spec: f ? { type: f.type, ref: f.ref, valruleid: f.valruleid == null ? null : Number(f.valruleid),
+                required: !!f.required, admitted: f.admitted ? Object.keys(f.admitted).length : null } : null
+  };
+}, col);
+const validateVal = (page, col, val) => page.evaluate(({ col, val }) => {
+  const e = window.__crud.formEntry(); const f = e && (e.fields || []).find(x => x.col === col);
+  return f ? window.__crud.core.validateField(window.__crud.store(), f, val, undefined, {}, {}) : 'no-field';
+}, { col, val });
+
+// one before/after arm. Reports INCONCLUSIVE (never PASS) when the rule admits everything.
+async function arm(page, label, tab, col, ctx) {
+  const exp = await seedRule(page, tab, col, ctx);
+  const got = await pickerState(page, col);
+  console.log('§PARITY-VALRULE[' + col + '] seed=' + JSON.stringify({ id: exp.id, name: exp.name, table: exp.table,
+    before: exp.before, after: exp.admitted ? exp.admitted.length : null, unresolved: exp.unresolved, err: exp.err }) +
+    ' dom=' + JSON.stringify(got.dom && { n: got.dom.values.length, blank: got.dom.hasBlank, value: got.dom.value }) +
+    ' spec=' + JSON.stringify(got.spec));
+  if (!exp.bound) { inconc(label, 'no AD_Val_Rule bound to ' + tab + '.' + col + ' in this seed — nothing to judge'); return null; }
+  ok(label + ': the fold carried the rule onto the field spec (vr=' + exp.id + ')',
+     !!got.spec && Number(got.spec.valruleid) === Number(exp.id), JSON.stringify(got.spec));
+  if (exp.admitted == null) { inconc(label, 'expectation could not be computed (unresolved=' + JSON.stringify(exp.unresolved) + ' err=' + exp.err + ')'); return exp; }
+  if (exp.before === exp.admitted.length) {
+    inconc(label, 'rule ' + exp.id + ' admits every row (' + exp.before + '→' + exp.admitted.length + ') — a filter that filters nothing proves nothing');
+    return exp;
+  }
+  ok(label + ': the picker NARROWED, before > after (' + exp.before + ' → ' + exp.admitted.length + ')',
+     !!got.dom && got.dom.values.length === exp.admitted.length && got.dom.values.length < exp.before,
+     'offered=' + (got.dom ? got.dom.values.length : 'absent') + ' expected=' + exp.admitted.length + ' unfiltered=' + exp.before);
+  ok(label + ': the offered ids ARE the admitted set (exactly, not just the same count)',
+     !!got.dom && JSON.stringify(got.dom.values.slice().sort()) === JSON.stringify(exp.admitted.slice().sort()));
+  ok(label + ': a blank option is still offered (§IMPL F5 — an empty FK must never land on row 1)',
+     !!got.dom && got.dom.hasBlank && got.dom.value === '', got.dom ? ('blank=' + got.dom.hasBlank + ' value="' + got.dom.value + '"') : 'absent');
+  return exp;
+}
+
+(async () => {
+  await new Promise(r => server.listen(0, r));
+  const port = server.address().port;
+  const browser = await chromium.launch();
+  console.log('\n§PARITY-VALRULE ===== an FK picker offers strictly the rows its AD_Val_Rule admits (61 fields on the five document tabs) =====');
+  const logs = [], errs = [];
+  const page = await browser.newPage({ viewport: { width: 1280, height: 900 } });
+  page.on('console', m => logs.push(m.text()));
+  page.on('pageerror', e => errs.push(e.message));
+  const vrLogs = () => logs.filter(l => /^§VALRULE col=/.test(l));
+
+  // ══ B + D — window 143 / tab 186 (Sales Order) ═════════════════════════════════════════════════════════
+  await page.goto(`http://localhost:${port}/idempiere.html?seed=ad_seed.db&login=GardenAdmin&window=143`, { waitUntil: 'networkidle' });
+  await landed(page); await clickNew(page);
+
+  const expB = await arm(page, 'B c_order.c_bpartner_id', 186, 'c_bpartner_id', {});
+
+  // ── FALSIFIER — a row the rule EXCLUDES is absent from the picker AND rejected on save ────────────────
+  if (expB && expB.admitted && expB.admitted.length && expB.admitted.length < expB.all.length) {
+    const excluded = expB.all.find(id => expB.admitted.indexOf(id) < 0);
+    const included = expB.admitted[0];
+    const got = await pickerState(page, 'c_bpartner_id');
+    const vBad = await validateVal(page, 'c_bpartner_id', excluded);
+    const vGood = await validateVal(page, 'c_bpartner_id', included);
+    console.log('§PARITY-VALRULE-FALSIFIER col=c_bpartner_id excluded=' + excluded + ' included=' + included +
+      ' inOptions=' + (got.dom ? got.dom.values.indexOf(excluded) >= 0 : '?') + ' validate(excluded)=' + vBad + ' validate(included)=' + vGood);
+    ok('FALSIFIER (i): the excluded C_BPartner ' + excluded + ' is ABSENT from the picker',
+       !!got.dom && got.dom.values.indexOf(excluded) < 0);
+    ok('FALSIFIER (ii): saving it is REJECTED → valrule:not-admitted', vBad === 'valrule:not-admitted', String(vBad));
+    ok('FALSIFIER control: an ADMITTED id (' + included + ') still validates clean — the check is not rejecting everything',
+       vGood === null, String(vGood));
+  } else inconc('FALSIFIER', 'rule on c_bpartner_id excluded no row in this seed — nothing to be absent');
+
+  // ── D — the TOKEN arm. No BPartner chosen ⇒ NO rows (E3), then choose one and re-narrow ───────────────
+  const dCol = 'c_bpartner_location_id';
+  const d0 = await pickerState(page, dCol);
+  const dSeed0 = await seedRule(page, 186, dCol, {});
+  console.log('§PARITY-VALRULE[' + dCol + '/unresolved] seed=' + JSON.stringify({ id: dSeed0.id, unresolved: dSeed0.unresolved, before: dSeed0.before }) +
+    ' dom=' + JSON.stringify(d0.dom && { n: d0.dom.values.length, blank: d0.dom.hasBlank }) + ' spec=' + JSON.stringify(d0.spec));
+  if (!dSeed0.bound || !dSeed0.unresolved.length) inconc('D ' + dCol + ' (unresolved arm)', 'the rule has no unresolved token on a New form — the E3 path is not exercised');
+  else {
+    ok('D (E3): with no BPartner chosen the token is unresolved and the lookup offers NO ROWS (MLookup.java:1128-1140), not all ' + dSeed0.before,
+       !!d0.dom && d0.dom.values.length === 0, d0.dom ? ('offered=' + d0.dom.values.length + ' of ' + dSeed0.before) : 'absent');
+    const l0 = vrLogs().find(l => new RegExp('col=' + dCol + ' ').test(l) && /unresolved=\[/.test(l));
+    ok('D: the §VALRULE line NAMES the unresolved token rather than silently degrading', !!l0, l0 || 'no unresolved §VALRULE line for ' + dCol);
+  }
+  // pick a BPartner that actually HAS ship-to locations, then let the dependent lookup refresh
+  const bpPick = await page.evaluate(() => {
+    const q = (s) => { const r = window.__idmpDb.exec(s); return r.length ? r[0].values : []; };
+    const el = document.querySelector('#idmp-inline-mount select[data-col="c_bpartner_id"]');
+    if (!el) return null;
+    const offered = Array.from(el.options).map(o => o.value).filter(v => v !== '');
+    const withLoc = q("SELECT c_bpartner_id, COUNT(*) FROM c_bpartner_location WHERE isshipto='Y' AND isactive='Y' GROUP BY c_bpartner_id");
+    const hit = withLoc.map(r => String(r[0])).find(id => offered.indexOf(id) >= 0);
+    if (!hit) return null;
+    el.value = hit; el.dispatchEvent(new Event('change', { bubbles: true }));
+    return hit;
+  });
+  if (!bpPick) inconc('D ' + dCol + ' (resolved arm)', 'no offered C_BPartner in this seed has an active ship-to location');
+  else {
+    await page.waitForTimeout(500);
+    const expD = await seedRule(page, 186, dCol, { C_BPartner_ID: bpPick });
+    const gotD = await pickerState(page, dCol);
+    console.log('§PARITY-VALRULE[' + dCol + '/resolved] bp=' + bpPick + ' seed=' + JSON.stringify({ id: expD.id, sub: expD.sub, after: expD.admitted && expD.admitted.length, before: expD.before }) +
+      ' dom=' + JSON.stringify(gotD.dom && { n: gotD.dom.values.length, values: gotD.dom.values }));
+    if (!expD.admitted) inconc('D ' + dCol + ' (resolved arm)', 'expectation not computable: err=' + expD.err);
+    else if (expD.admitted.length === expD.before) inconc('D ' + dCol + ' (resolved arm)', 'this BPartner owns every location row (' + expD.before + ') — no narrowing to prove');
+    else {
+      ok('D: after choosing C_BPartner ' + bpPick + ' the dependent lookup re-narrows to exactly its ship-to locations (' + expD.before + ' → ' + expD.admitted.length + ')',
+         !!gotD.dom && JSON.stringify(gotD.dom.values.slice().sort()) === JSON.stringify(expD.admitted.slice().sort()),
+         'offered=' + (gotD.dom ? JSON.stringify(gotD.dom.values) : 'absent') + ' expected=' + JSON.stringify(expD.admitted));
+      ok('D: the @token@ feed resolved from the RECORD under edit (ctx carries C_BPartner_ID=' + bpPick + ')',
+         vrLogs().some(l => new RegExp('col=' + dCol + ' ').test(l) && l.indexOf('"C_BPartner_ID":"' + bpPick + '"') >= 0 || l.indexOf('"C_BPartner_ID":' + bpPick) >= 0),
+         (vrLogs().filter(l => new RegExp('col=' + dCol + ' ').test(l)).pop() || 'no §VALRULE line'));
+    }
+  }
+
+  // ══ A — window 169 / tab 257 (Shipment): the field-level rule must BEAT the column's ════════════════════
+  await page.goto(`http://localhost:${port}/idempiere.html?seed=ad_seed.db&login=GardenAdmin&window=169`, { waitUntil: 'networkidle' });
+  await landed(page); await clickNew(page);
+  const expA = await arm(page, 'A m_inout.c_doctype_id', 257, 'c_doctype_id', {});
+  if (expA && expA.bound) {
+    ok('A (AD_Field_v precedence): the FIELD rule (' + expA.fieldLevel + ') was used, not the COLUMN rule (' + expA.colLevel + ')',
+       expA.fieldLevel != null && String(expA.fieldLevel) !== '' && String(expA.id) === String(expA.fieldLevel) && String(expA.colLevel) !== String(expA.fieldLevel),
+       'field=' + expA.fieldLevel + ' column=' + expA.colLevel + ' used=' + expA.id);
+  }
+
+  // ══ C — window 195 / tab 330 (Payment) ═════════════════════════════════════════════════════════════════
+  await page.goto(`http://localhost:${port}/idempiere.html?seed=ad_seed.db&login=GardenAdmin&window=195`, { waitUntil: 'networkidle' });
+  await landed(page); await clickNew(page);
+  await arm(page, 'C c_payment.c_order_id', 330, 'c_order_id', {});
+
+  // ══ VACUITY ledger — the rules that do NOT bite are reported, never counted as passes ═══════════════════
+  const noBite = vrLogs().filter(l => {
+    const b = /before=(\d+)/.exec(l), a = /after=(\d+)/.exec(l);
+    return b && a && /verdict=applied/.test(l) && b[1] === a[1];
+  });
+  const bite = vrLogs().filter(l => {
+    const b = /before=(\d+)/.exec(l), a = /after=(\d+)/.exec(l);
+    return b && a && /verdict=applied/.test(l) && Number(a[1]) < Number(b[1]);
+  });
+  console.log('\n§PARITY-VALRULE-VACUITY applied=' + (noBite.length + bite.length) + ' BITE=' + bite.length + ' NO-BITE=' + noBite.length +
+    ' (a NO-BITE rule is reported, never counted as a pass)');
+  noBite.forEach(l => console.log('   ⬜ NO-BITE ' + /col=(\S+) vr=(\S+)/.exec(l).slice(1, 3).join(' vr=') + ' — ' + /before=\d+ after=\d+/.exec(l)[0]));
+  console.log('§PARITY-VALRULE-DEGRADED ' + vrLogs().filter(l => !/verdict=(applied|unresolved-tokens)/.test(l)).length +
+    ' field(s) fell back to the UNFILTERED picker and said so (our interpreter\'s limit, not iDempiere\'s verdict):');
+  vrLogs().filter(l => !/verdict=(applied|unresolved-tokens)/.test(l)).slice(0, 8)
+    .forEach(l => console.log('   ⬜ ' + /col=\S+/.exec(l)[0] + ' ' + /verdict=\S+/.exec(l)[0]));
+
+  ok('the wiring is LIVE on real document tabs (≥8 §VALRULE lines emitted)', vrLogs().length >= 8, String(vrLogs().length));
+  ok('at least one rule genuinely BITES (a filter that filters nothing would prove nothing)', bite.length >= 1, 'biting=' + bite.length);
+  ok('0 pageerrors across the run', errs.length === 0, errs.slice(0, 3).join(' | '));
+  await page.close();
+
+  const verdict = (fail === 0)
+    ? 'CRITIC ✔ AD_Val_Rule is wired: an FK picker on a val-rule column offers exactly the admitted rows (counts and id SETS asserted against the seed at run time), the AD_Field rule beats the AD_Column rule, an unresolved @token@ clears the lookup as MLookup does, and an excluded row is both absent from the picker and rejected on save.'
+    : 'CRITIC ✘ the picker still offers rows the rule excludes, or the falsifier did not fire — see the 🔴 above.';
+  console.log('\n§PARITY-VALRULE-VERDICT ' + verdict);
+  console.log((fail === 0 ? '✅' : '❌') + ' W-PARITY-VALRULE: ' + pass + '/' + (pass + fail) + ' PASS (' + fail + ' FAIL, ' + inconclusive + ' INCONCLUSIVE)');
+  await browser.close(); server.close();
+  process.exit(fail > 0 ? 1 : 0);
+})().catch(e => { console.error('FATAL', e); try { server.close(); } catch (x) {} process.exit(1); });


### PR DESCRIPTION
`ERP_IDEMPIERE_UX_PARITY.md` **§P3** / **§IMPL-P3** — Witness **W-PARITY-VALRULE, 23/23 PASS, 0 FAIL, 0 INCONCLUSIVE**. Base: `origin/main` 138af115 (PR #1613 already in).

## The gap this closes
`build/erp/ad_valrule.js` was witnessed headless (W-VALRULE, 327/332 interpretable) but **no file in the shipped `erp/` consumed it** — the FK pickers built a plain `SELECT` over the target table. **61 displayed fields on the five document header tabs carry an `AD_Val_Rule_ID`**, and every one of them offered rows iDempiere would never have shown. This item is the browser-side wiring plus the `@token@` context feed; the evaluator is unchanged and now **ships**, byte-identical to the copy.

## Wiring
- `ad_parser.getFields` carries `COALESCE(f.AD_Val_Rule_ID, c.AD_Val_Rule_ID)` — **AD_Field wins over AD_Column**, extracted from the `AD_Field_v` view itself (`202209141520_IDEMPIERE-5396.sql:7,14`), the same precedence `getFields` already applies to DefaultValue / AD_Reference_ID / AD_Reference_Value_ID.
- `foldCrudSpec` carries it as `spec.valruleid` (the fold stays **pure** — no db, no engine call); `mergeCuratedWithFold` layers it onto a **pinned curated** column like the three AD logic strings. Without that, `c_order.C_BPartner_ID` — curated *and* val-ruled — kept the unfiltered picker; the witness caught it red before the fix.
- `crud_overlay.populateRefs` runs the **shipped** interpreter through `_mvB3`, the same better-sqlite3 shim the beforeSave hooks already use, and appends the rule's clause to the lookup query (`MLookupFactory.java:122-125`). No second evaluator.
- `validateField` rejects a non-admitted FK from the **same id-set the picker was built from**, so the offered set and the accepted set cannot drift apart. The set is computed unlimited, so a legal row past the picker's `LIMIT 200` is never rejected.
- An **unresolved `@token@` clears the lookup** rather than silently showing everything — `Env.java:1641-1645` empties the clause and `MLookup.java:1128-1140` ("Loader NOT Validated") then clears it. Any *other* defer reason degrades to the unfiltered picker and **says so in the log** — that is our interpreter's limit, not iDempiere's verdict, and hiding rows on our own gap would be worse than showing them.
- The **§IMPL F5 blank option is preserved and strengthened**: a current value the filter now excludes also gets the blank, never a fall-through to row 1.

## Engine defect found and fixed en route (§P3-DEFECT)
`substitute()` wrapped every non-numeric value in quotes, against `Env.parseContext(forSQL=true)`, which appends the value **raw** with only `'` → `''` escaping. On the pre-quoted idiom `IsSOTrx='@IsSOTrx@'` it emitted `''Y''` — **a SQL syntax error, so the filter could not run at all**. **25 of 332** Type-S rules use that idiom; **6 of the 43** in-seed val-rule fields on these tabs hit it. Both W-VALRULE witnesses passed anyway because every fixture supplies **numeric** context — scope-blind, CLAUDE.md PRIMAL LAW §4. After the fix: **W-VALRULE PASS** and **W-VALRULE-HARDEN PASS** against the live Postgres oracle, **no fixture moved**.

## Measured (from `ad_seed.db`, this session)
264 displayed fields on the five tabs, **61 val-ruled**: 25 static / 36 token / 0 empty / 0 unsafe.

| tab | column | rule | before → after |
|---|---|---|---|
| 257 | `c_doctype_id` | **52053** (the ONE field-level rule, and it disagrees with its column's 125) | **52 → 3** |
| 186 | `c_bpartner_id` | 230 | **113 → 42** |
| 330 | `c_order_id` | 218 | **44 → 2** |
| 186 | `c_bpartner_location_id` | 167 `@C_BPartner_ID@` | **16 → 0** with no BPartner, **→ 1** after choosing one |

**Reported NO-BITE, never counted as a pass:** `ad_client_id` 6→6 · `c_invoice_id` 20→20 · `c_campaign_id` 2→2 · `c_paymentterm_id` 5→5.

## Witness — `erp/tests/poc_parity_valrule_live.js`
Real browser, real DOM. **Every expected count, id and clause is read from the seed through `window.__idmpDb` at run time** — none is typed into the file, and the token substitution in the oracle is a plain `String.replace`, deliberately *not* the engine under test. Falsifier fires both ways: an excluded `C_BPartner` is **absent from the picker** and `validateField` returns `valrule:not-admitted`, while an admitted id still validates clean. A vacuous arm reports **INCONCLUSIVE**, never PASS.

## Regression
- **W-PARITY-REFLIST 14/14 PASS** · **W-PARITY-FIELDSET 30/30 PASS** (the two PR #1613 witnesses)
- **W-ERP-TWIN PASS** — 0 undeclared/broken; `ad_valrule` declared `identical` in `scripts/erp_twins.json`
- **O2C: stages 1/2/3/5/6/7 PASS.** Stage 4 FAIL / stage 8 ABSENT are the known pre-existing structural gaps (no `m_storageonhand` fold, no vendor-invoice path). The runner prints `VERDICT=FAIL` because a DISCOVERY witness carries no pass marker by design.
- `erp/sw.js` CACHE_VERSION **v774 → v775**, same PR.

## Named limits (measured, not built)
- **18 of the 61** resolve to a target table absent under the picker's `<col minus _id>` convention (`c_doctypetarget_id`, `bill_*`, `dropship_*`, `salesrep_id`, `c_activity_id`, `c_cashplanline_id`…). These already degrade to the raw value today and are **unchanged**; AD_Ref_Table/Search target resolution is the same out-of-scope item §IMPL named.
- **1 of the 61 is a List, not an FK** — `trxtype` on tab 330. A val rule over an `AD_Ref_List` set is a different surface. Named, not wired.
- **The 5-of-332 uninterpretable rules:** id **118** (empty Code) and **52056 / 210 / 200162 / 200064** (`unsafe` — the clause carries `;`, `--`, `/*` or `union`). **None is bound to any field on the five tabs**, so none was skipped here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BTjD9Hx77LPZyFPiFNXygS
