### PR TITLE
fix(viewer): §DUCT_SILHOUETTE — large ducts read jagged because normal-smoothing cannot change an outline

### DIFF
--- a/viewer/scene.js
+++ b/viewer/scene.js
@@ -1901,6 +1901,17 @@ async function setupScene(A) {
         geo.computeVertexNormals();
         if (A) { A._normalsComputed = (A._normalsComputed || 0) + 1; }
       }
+      // §DUCT_SILHOUETTE — the ONE choke point every streamed element passes through, and the only
+      // place refinement can happen: both batch paths in streaming.js size their BatchedMesh from
+      // `item.geo` at flush time (:2055 totalVerts, :2412 rv/ri reservation), so a geometry that is
+      // already refined HERE is reserved for correctly with no batch change at all. Refining after
+      // the batch is built is impossible — the slot's vertex range is fixed.
+      // Declines silently and leaves `geo` untouched for everything that does not qualify, which is
+      // the overwhelming majority; see viewer/silhouette_refine.js for the gate and W-DUCT-SIL for
+      // the proof that a non-curve surface is not moved.
+      if (window.SilhouetteRefine) {
+        try { window.SilhouetteRefine.refineGeometry(geo, THREE); } catch (e) { /* never block a load */ }
+      }
       geo.computeBoundingSphere();
       // §S258: BVH deferred — don't build during streaming (86K builds = ~9s lag).
       // acceleratedRaycast falls back to normal raycast when boundsTree is absent.

--- a/viewer/silhouette_refine.js
+++ b/viewer/silhouette_refine.js
@@ -1,0 +1,488 @@
+// ═══════════════════════════════════════════════════════════════════════════════════════════════
+// §DUCT_SILHOUETTE — a curved element's OUTLINE, not its shading.
+// Implementing PHOTOREAL_STILL_RENDER.md §DUCT_SILHOUETTE — Witness: W-DUCT-SIL
+//
+// USER (2026-09-02): "The roundness to jagged curves seems to work on lamps but certain large duct
+// piping seems lacking. Is the formula easy? Detecting an element to possess curved surface but
+// having jagged and thus candidate to apply."
+//
+// WHY §MEP_SMOOTH_NORMALS CANNOT FIX THIS. That pass (streaming.js) rewrites NORMALS at a 55 deg
+// crease. It changes SHADING. A faceted cylinder shades smoothly but its SILHOUETTE is still an
+// N-gon, because the silhouette IS the geometry. streaming.js says so in its own words:
+// "IfcFlowSegment is 10.3 over 26 triangles: a genuine 10-sided prism, so its SHADING improves
+// here but its silhouette cannot". Widening creaseDeg addresses shading, which is not the defect,
+// and would round genuine hard edges — so it is explicitly NOT the remedy here.
+//
+// THE FORMULA (this is the answer to "is the formula easy?" — yes, and it is two lines).
+// For any edge shared by two faces whose dihedral theta is small enough that the shipped smoothing
+// pass welds across it — i.e. the two facets are MEANT to read as one curved surface — the local
+// radius of curvature is recovered EXACTLY, with no cylinder fit, no axis fit and no class list:
+//
+//     project both faces perpendicular to the shared edge; the edge collapses to a point E and the
+//     two opposite vertices give A and B; E, A, B all lie on the swept cross-section, so
+//         R  = |EA| * |AB| * |BE| / (4 * area(EAB))            [circumradius of three points]
+//         s  = R * (1 - cos(theta/2))                           [chord deviation, metres]
+//         D_1px = s * k,   k = (H/2)/tan(fov/2) = 935.3 px/rad at 1080p, fov 60 (scene.js:139)
+//
+// s is the "jaggedness": how far the flat facet sags inside the ideal arc. D_1px is the distance
+// out to which that sag still covers a whole screen pixel. VALIDATED, not asserted: on Hospital
+// the estimator lands on R = 525.0 mm and 550.0 mm — real 1050/1100 mm manufacturing duct sizes —
+// and its segment count agrees exactly (11 vs 11) with an independent PCA ring fit.
+//
+// THAT ONE NUMBER IS THE WHOLE LAMP-vs-DUCT SPLIT THE USER DESCRIBED, and it is ~50x wide:
+//   Hospital IfcLightFixture  — falls out of the offender list entirely at every gate tried
+//   Hospital IfcDuctSegment   — mean s = 4.17 mm, worst s = 22.3 mm  =>  D_1px = 20.8 m
+// A lamp's facet step is sub-pixel past arm's length. A 1100 mm duct's is a whole pixel at TWENTY
+// METRES. Same tessellation quality (N ~ 11-13 on both); only the radius differs, and the error is
+// linear in radius. Detection was never the problem — size was.
+//
+// THE REMEDY. The silhouette is the geometry, so it cannot be fixed without geometry (the
+// alternatives are priced and rejected in the spec: anti-aliasing softens the edge pixel but
+// leaves the same N-gon; radially rescaling a duct onto the mid-radius halves the error but MOVES
+// REAL GEOMETRY on a model that carries clash/measure/QTO, which is falsification; WebGL2 has no
+// tessellation shader; re-extracting at a finer chord tolerance re-tessellates the whole fleet
+// instead of the measured tail, costing MORE memory, not less).
+// So: ONE level of uniform Phong (PN-triangle) subdivision, applied ONLY to the elements the
+// formula above says are visibly jagged. theta halves, so the residual sag drops ~4x.
+//
+// THE SHAPE FACTOR IS DERIVED, NOT TUNED. Placing a split-edge midpoint at the plain linear
+// midpoint leaves the sag untouched; projecting it fully onto the corner tangent planes OVERSHOOTS
+// (a 12-gon goes from -3.4% inside to +3.1% outside — no gain). The damped Phong midpoint
+//     m' = m - (alpha/2) * [ ((m-p_i).n_i) n_i + ((m-p_j).n_j) n_j ]
+// is exact on a cylinder when alpha = (sec(theta/2) - 1) / sin^2(theta/2), whose limit as
+// theta -> 0 is EXACTLY 1/2 (sec x - 1 ~ x^2/2, sin^2 x ~ x^2). Over the whole range that matters
+// it barely moves: 0.527 at N=12, 0.539 at N=10, 0.619 at N=6. So ALPHA = 0.5 is the second-order-
+// exact value, not a knob someone turned until it looked right.
+//
+// SAFETY, BY CONSTRUCTION — the user's standing constraint on the sibling pass was "it must not
+// impact non curve intending surfaces", and it is met here without a class list:
+//   * a new vertex on a HARD edge is the PLAIN midpoint, never projected. The midpoint of a
+//     straight edge lies ON that edge, so a planar facet subdivided this way occupies exactly the
+//     same plane, the same outline and the same area. Deviation is not "small", it is ZERO, and
+//     W-DUCT-SIL asserts exactly that.
+//   * midpoint POSITIONS are computed once per welded edge and shared by both neighbouring faces,
+//     so refinement can never open a crack.
+//   * refinement is UNIFORM 1-to-4 over the whole element, so no refined/unrefined frontier exists
+//     and a T-junction is impossible by construction rather than by argument. The cheaper
+//     curved-shell-plus-green-closure variant was built first and MEASURED WRONG — see the note at
+//     the emit loop; real IFC meshes carry edges shared by 3+ faces that green closure cannot fix.
+//   * the per-face vertex split of the source data is PRESERVED — each triangle emits its own
+//     copies. Nothing is welded, nothing is renumbered beyond appending, so picking, per-element
+//     hide, the BVH and §TRIPLANAR's vTriWorldNormal all still see the layout they expect.
+//
+// NO PER-BUILDING ANYTHING (user, 2026-09-02: "4D generation has to be independent of any type of
+// building. No custom code to any particular building has been our rule."). Every threshold below
+// is either a camera constant read off the shipped renderer, a derived limit, or a property the
+// element measures about ITSELF. There is no building name, no IFC class list, and no material
+// name anywhere in this file — a round column, a curved railing, a dome and a duct are all judged
+// by the same two lines of arithmetic.
+// ═══════════════════════════════════════════════════════════════════════════════════════════════
+(function(global) {
+  'use strict';
+
+  // ── constants ────────────────────────────────────────────────────────────────────────────────
+  // Deliberately THE SAME edge classification as §MEP_SMOOTH_NORMALS. An edge this file refines
+  // across is exactly an edge that pass already decided is one continuous curved surface. Keeping
+  // them identical is what makes "shading and silhouette agree" true by construction; forking the
+  // threshold here would let the two passes disagree about what a crease is.
+  var SIL_CREASE_DEG = 55;      // above it: a genuine hard edge, kept hard (streaming.js CREASE_DEG)
+  var SIL_THETA_MIN_DEG = 2;    // below it: the two triangles are the SAME planar facet (a quad diagonal)
+
+  // A tessellated curve has MANY facets at a consistent step. Fewer than this and the "curvature"
+  // is float noise between two nearly-coplanar triangles, which fits an arbitrarily large
+  // circumradius. MEASURED: without this guard a flat IfcWallStandardCase reported a 4,290.9 mm
+  // bulge. 6 = the fewest facets that can describe a closed convex loop with a distinguishable step.
+  var SIL_MIN_SMOOTH_EDGES = 6;
+
+  // A facet's sag cannot be a large fraction of the whole object. Physical impossibility, not a
+  // tuned threshold — it is the second guard against the same degenerate-circumradius failure.
+  var SIL_MAX_S_FRAC_OF_DIAG = 0.25;
+
+  // Pixels per radian for the SHIPPED camera: fov 60 (viewer/scene.js:139) at 1080p.
+  // k = (H/2) / tan(fov/2). Read off the renderer, not chosen.
+  var SIL_K_PX_PER_RAD = (1080 / 2) / Math.tan(30 * Math.PI / 180);   // 935.307...
+
+  // THE GATE. An element is refined when its own measured facet step still covers a whole 1080p
+  // pixel at SIL_GATE_M metres. This is a property of the element (its radius and its facet
+  // count), never of the building it happens to sit in.
+  // 5 m is where the measured cost curve turns: on Hospital it takes the 1,419 geometries that
+  // carry essentially all of the visible faceting (the 1050/1100 mm ducts at D_1px = 20.8 m, the
+  // footings at 11.4 m, the curved beams/railings/coverings) for +17.5 MB of geometry, where
+  // dropping the gate to 2 m adds 2,170 more geometries — mostly small pipe fittings nobody can
+  // see faceting on — and costs +43.9 MB against a heap §R12_HOSPITAL_MEM already measures at
+  // ~1,577 MB. Full table in PHOTOREAL_STILL_RENDER.md §DUCT_SILHOUETTE.
+  var SIL_GATE_M = 5;
+
+  // Second-order-exact Phong shape factor. Derived above; see the header. NOT a tuning knob.
+  var SIL_ALPHA = 0.5;
+
+  // Hard ceiling on total added vertices across the whole session, so a pathological model can
+  // never silently balloon the heap. Hit => the pass reports it and stops refining, it does not
+  // half-refine an element. 4M verts ~= 122 MB at 32 B/vert, well above every measured building.
+  var SIL_MAX_ADDED_VERTS = 4000000;
+
+  var _stats = { considered: 0, measured: 0, refined: 0, skippedTooSmall: 0, skippedNotCurved: 0,
+                 addedVerts: 0, addedTris: 0, budgetHit: false, sBefore: 0, sAfter: 0, sWeight: 0,
+                 hardMidpoints: 0, smoothMidpoints: 0, ms: 0 };
+
+  function _resetStats() {
+    _stats = { considered: 0, measured: 0, refined: 0, skippedTooSmall: 0, skippedNotCurved: 0,
+               addedVerts: 0, addedTris: 0, budgetHit: false, sBefore: 0, sAfter: 0, sWeight: 0,
+               hardMidpoints: 0, smoothMidpoints: 0, ms: 0 };
+  }
+
+  // ── topology ─────────────────────────────────────────────────────────────────────────────────
+  // Weld by quantised position (0.1 mm) — byte-for-byte the same key the shipped
+  // §MEP_SMOOTH_NORMALS accumulator uses, so both passes agree on what "the same vertex" means.
+  function _weld(pos, nV) {
+    var wid = new Int32Array(nV), map = new Map(), n = 0, i, k, id;
+    var rep = [];    // canonical position per welded id — the FIRST copy seen, never an average
+    for (i = 0; i < nV; i++) {
+      k = Math.round(pos[3 * i] * 1e4) + '|' + Math.round(pos[3 * i + 1] * 1e4) + '|' +
+          Math.round(pos[3 * i + 2] * 1e4);
+      id = map.get(k);
+      if (id === undefined) { id = n++; map.set(k, id); rep.push(pos[3 * i], pos[3 * i + 1], pos[3 * i + 2]); }
+      wid[i] = id;
+    }
+    return { wid: wid, count: n, rep: rep };
+  }
+
+  function _faceData(pos, idx, nT) {
+    var fn = new Float64Array(nT * 3), fa = new Float64Array(nT), t, a, b, c, L;
+    for (t = 0; t < nT; t++) {
+      a = idx[3 * t]; b = idx[3 * t + 1]; c = idx[3 * t + 2];
+      var ax = pos[3 * a], ay = pos[3 * a + 1], az = pos[3 * a + 2];
+      var ux = pos[3 * b] - ax, uy = pos[3 * b + 1] - ay, uz = pos[3 * b + 2] - az;
+      var vx = pos[3 * c] - ax, vy = pos[3 * c + 1] - ay, vz = pos[3 * c + 2] - az;
+      var nx = uy * vz - uz * vy, ny = uz * vx - ux * vz, nz = ux * vy - uy * vx;
+      L = Math.sqrt(nx * nx + ny * ny + nz * nz);
+      fa[t] = L / 2;
+      if (L > 1e-14) { nx /= L; ny /= L; nz /= L; }
+      fn[3 * t] = nx; fn[3 * t + 1] = ny; fn[3 * t + 2] = nz;
+    }
+    return { fn: fn, fa: fa };
+  }
+
+  // edge key from two welded ids — a single number, not a string (the same reason
+  // §MEP_SMOOTH_PERF replaced its string key: this runs over every triangle of every element).
+  function _ekey(a, b) { return a < b ? a * 4194304 + b : b * 4194304 + a; }
+
+  /**
+   * MEASURE ONLY — never mutates. Returns the numbers the gate is made of, or null when the
+   * geometry carries no tessellated curve at all.
+   * @returns {{sMedian, thetaMedianDeg, R, D1px, smoothEdges, hardEdges, N}|null}
+   */
+  function silMeasure(pos, idx) {
+    var nV = pos.length / 3, nT = (idx.length / 3) | 0;
+    if (nT < 4 || nV < 3) return null;
+
+    var bx0 = Infinity, by0 = Infinity, bz0 = Infinity, bx1 = -Infinity, by1 = -Infinity, bz1 = -Infinity, i;
+    for (i = 0; i < nV; i++) {
+      var x = pos[3 * i], y = pos[3 * i + 1], z = pos[3 * i + 2];
+      if (x < bx0) bx0 = x; if (x > bx1) bx1 = x;
+      if (y < by0) by0 = y; if (y > by1) by1 = y;
+      if (z < bz0) bz0 = z; if (z > bz1) bz1 = z;
+    }
+    var diag = Math.sqrt((bx1 - bx0) * (bx1 - bx0) + (by1 - by0) * (by1 - by0) + (bz1 - bz0) * (bz1 - bz0));
+    var sMax = SIL_MAX_S_FRAC_OF_DIAG * diag;
+
+    var w = _weld(pos, nV), wid = w.wid;
+    var fd = _faceData(pos, idx, nT), fn = fd.fn, fa = fd.fa;
+
+    var em = new Map(), t, e, k, arr;
+    for (t = 0; t < nT; t++) {
+      for (e = 0; e < 3; e++) {
+        k = _ekey(wid[idx[3 * t + e]], wid[idx[3 * t + (e + 1) % 3]]);
+        arr = em.get(k);
+        if (!arr) { arr = []; em.set(k, arr); }
+        arr.push(t * 4 + e);
+      }
+    }
+
+    var cosCrease = Math.cos(SIL_CREASE_DEG * Math.PI / 180);
+    var cosThMin = Math.cos(SIL_THETA_MIN_DEG * Math.PI / 180);
+    var samples = [], hardEdges = 0, smoothEdges = 0;
+
+    em.forEach(function(a) {
+      if (a.length !== 2) return;
+      var t1 = a[0] >> 2, e1 = a[0] & 3, t2 = a[1] >> 2;
+      var d = fn[3 * t1] * fn[3 * t2] + fn[3 * t1 + 1] * fn[3 * t2 + 1] + fn[3 * t1 + 2] * fn[3 * t2 + 2];
+      if (d > 1) d = 1; else if (d < -1) d = -1;
+      if (d < cosCrease) { hardEdges++; return; }   // genuine crease — kept hard, never refined across
+      if (d > cosThMin) return;                     // same planar facet (a quad's diagonal)
+      smoothEdges++;
+      var th = Math.acos(d);
+
+      var P = idx[3 * t1 + e1], Q = idx[3 * t1 + (e1 + 1) % 3];
+      var wp = wid[P], wq = wid[Q], j, v, r1 = -1, r2 = -1;
+      for (j = 0; j < 3; j++) { v = idx[3 * t1 + j]; if (wid[v] !== wp && wid[v] !== wq) { r1 = v; break; } }
+      for (j = 0; j < 3; j++) { v = idx[3 * t2 + j]; if (wid[v] !== wp && wid[v] !== wq) { r2 = v; break; } }
+      if (r1 < 0 || r2 < 0) return;
+
+      var ex = pos[3 * Q] - pos[3 * P], ey = pos[3 * Q + 1] - pos[3 * P + 1], ez = pos[3 * Q + 2] - pos[3 * P + 2];
+      var eL = Math.sqrt(ex * ex + ey * ey + ez * ez);
+      if (!(eL > 1e-9)) return;
+      ex /= eL; ey /= eL; ez /= eL;
+
+      function proj(vi) {
+        var px = pos[3 * vi] - pos[3 * P], py = pos[3 * vi + 1] - pos[3 * P + 1], pz = pos[3 * vi + 2] - pos[3 * P + 2];
+        var dp = px * ex + py * ey + pz * ez;
+        return [px - dp * ex, py - dp * ey, pz - dp * ez];
+      }
+      var A = proj(r1), B = proj(r2);
+      var ab = Math.sqrt((A[0] - B[0]) * (A[0] - B[0]) + (A[1] - B[1]) * (A[1] - B[1]) + (A[2] - B[2]) * (A[2] - B[2]));
+      var ae = Math.sqrt(A[0] * A[0] + A[1] * A[1] + A[2] * A[2]);
+      var be = Math.sqrt(B[0] * B[0] + B[1] * B[1] + B[2] * B[2]);
+      var cx = A[1] * B[2] - A[2] * B[1], cy = A[2] * B[0] - A[0] * B[2], cz = A[0] * B[1] - A[1] * B[0];
+      var ar = Math.sqrt(cx * cx + cy * cy + cz * cz) / 2;
+      if (!(ar > 1e-13)) return;
+      var R = (ab * ae * be) / (4 * ar);
+      if (!(R > 1e-5) || !isFinite(R)) return;
+      var s = R * (1 - Math.cos(th / 2));
+      if (!(s <= sMax)) return;                     // degenerate fit — physically impossible sag
+      samples.push({ th: th, R: R, s: s, w: fa[t1] + fa[t2] });
+    });
+
+    if (samples.length < SIL_MIN_SMOOTH_EDGES) return null;
+
+    // area-weighted medians — robust to the handful of odd facets every real mesh carries
+    function wmed(key) {
+      var a = samples.slice().sort(function(p, q) { return p[key] - q[key]; });
+      var tot = 0, j;
+      for (j = 0; j < a.length; j++) tot += a[j].w;
+      var acc = 0;
+      for (j = 0; j < a.length; j++) { acc += a[j].w; if (acc >= tot / 2) return a[j][key]; }
+      return a[a.length - 1][key];
+    }
+    var thM = wmed('th'), sM = wmed('s'), RM = wmed('R');
+    return { sMedian: sM, thetaMedianDeg: thM * 180 / Math.PI, R: RM,
+             D1px: sM * SIL_K_PX_PER_RAD, smoothEdges: smoothEdges, hardEdges: hardEdges,
+             N: 360 / (thM * 180 / Math.PI), samples: samples.length };
+  }
+
+  /**
+   * REFINE. Returns new {position, index, normal, stats} or null when the geometry does not
+   * qualify (which is a NO-OP, and is reported as one — never as a pass).
+   */
+  function silRefine(pos, idx, nor, opts) {
+    opts = opts || {};
+    var gate = opts.gateM != null ? opts.gateM : SIL_GATE_M;
+    _stats.considered++;
+
+    var m = silMeasure(pos, idx);
+    if (!m) { _stats.skippedNotCurved++; return null; }
+    _stats.measured++;
+    if (!(m.D1px >= gate)) { _stats.skippedTooSmall++; return null; }
+
+    var nV = pos.length / 3, nT = (idx.length / 3) | 0;
+    var w = _weld(pos, nV), wid = w.wid, nW = w.count;
+    var fd = _faceData(pos, idx, nT), fn = fd.fn, fa = fd.fa;
+
+    // ── welded, crease-limited smoothed normals: the surface the Phong projection curves toward.
+    // Same area-weighted accumulation and same crease rejection as §MEP_SMOOTH_NORMALS, so the
+    // silhouette this pass builds and the shading that pass writes describe ONE surface.
+    var acc = new Float64Array(nW * 3), t, j, v;
+    for (t = 0; t < nT; t++) {
+      for (j = 0; j < 3; j++) {
+        v = wid[idx[3 * t + j]];
+        acc[3 * v] += fn[3 * t] * fa[t] * 2;
+        acc[3 * v + 1] += fn[3 * t + 1] * fa[t] * 2;
+        acc[3 * v + 2] += fn[3 * t + 2] * fa[t] * 2;
+      }
+    }
+    var wn = new Float64Array(nW * 3);
+    for (v = 0; v < nW; v++) {
+      var L = Math.sqrt(acc[3 * v] * acc[3 * v] + acc[3 * v + 1] * acc[3 * v + 1] + acc[3 * v + 2] * acc[3 * v + 2]);
+      if (L > 1e-12) { wn[3 * v] = acc[3 * v] / L; wn[3 * v + 1] = acc[3 * v + 1] / L; wn[3 * v + 2] = acc[3 * v + 2] / L; }
+    }
+
+    // ── edge classification
+    var em = new Map(), e, k, arr;
+    for (t = 0; t < nT; t++) {
+      for (e = 0; e < 3; e++) {
+        k = _ekey(wid[idx[3 * t + e]], wid[idx[3 * t + (e + 1) % 3]]);
+        arr = em.get(k);
+        if (!arr) { arr = []; em.set(k, arr); }
+        arr.push(t * 4 + e);
+      }
+    }
+    var cosCrease = Math.cos(SIL_CREASE_DEG * Math.PI / 180);
+    var cosThMin = Math.cos(SIL_THETA_MIN_DEG * Math.PI / 180);
+    var smooth = new Set();               // welded-edge keys the two facets curve across
+    em.forEach(function(a, key) {
+      if (a.length !== 2) return;
+      var t1 = a[0] >> 2, t2 = a[1] >> 2;
+      var d = fn[3 * t1] * fn[3 * t2] + fn[3 * t1 + 1] * fn[3 * t2 + 1] + fn[3 * t1 + 2] * fn[3 * t2 + 2];
+      if (d > 1) d = 1; else if (d < -1) d = -1;
+      if (d < cosCrease || d > cosThMin) return;
+      smooth.add(key);
+    });
+    if (!smooth.size) { _stats.skippedNotCurved++; return null; }
+
+    // ── UNIFORM 1-to-4: every triangle, every edge. This is the crack-proof choice and it was
+    // arrived at by MEASUREMENT, not preference. The first build of this pass refined only the
+    // curved shell (triangles touching a smooth edge) and closed the resulting T-junctions with
+    // green 1-to-2 / 1-to-3 splits on the immediate neighbours — cheaper, and it looked correct on
+    // paper. W-DUCT-SIL measured it on real Hospital geometry and it was NOT correct: non-manifold
+    // edges went 24 -> 211 on one element and a direct point-on-edge scan found 875 open
+    // T-junctions, because a real IFC mesh is not the clean two-manifold that argument assumes —
+    // it carries edges shared by 3+ faces, and a refined/unrefined frontier through one of those
+    // cannot be closed by a green split.
+    //
+    // Refining every edge removes the frontier itself, so there is nothing left to close: every
+    // edge is split at ONE shared midpoint, every triangle becomes exactly 4, an edge with k
+    // incident faces becomes two sub-edges with k faces each. Manifoldness, boundary structure and
+    // winding are all preserved by construction rather than by argument. The price is measured and
+    // paid for in the spec: 4x triangles on the qualifying elements instead of ~2.6x.
+    //
+    // Flat regions are still free of any geometric change, because a midpoint on a HARD edge is
+    // never projected — see midOf below.
+    var addTris = 3 * nT;
+    if (_stats.addedVerts + addTris * 3 > SIL_MAX_ADDED_VERTS) {
+      _stats.budgetHit = true;
+      return null;
+    }
+
+    // ── midpoint POSITIONS, computed once per welded edge and shared by both neighbours.
+    // Shared => bit-identical from either side => a crack is impossible.
+    // Smooth edge: damped Phong projection (curves outward onto the implied arc).
+    // Hard edge:   the plain midpoint, which lies ON the straight edge, so the facet is unmoved.
+    // CANONICAL endpoints. The midpoint is built from the WELDED REPRESENTATIVE positions, never
+    // from whichever per-face copy the triangle loop happened to reach first. Copies that weld
+    // together can still differ by up to the 0.1 mm quantum, so using them would make the midpoint
+    // depend on triangle visit order — non-deterministic, and it made W-DUCT-SIL's independently
+    // derived hard-edge midpoint miss the emitted one on 7 of 37 real elements.
+    var rep = w.rep;
+    var midPos = new Map();
+    function midOf(wa, wb) {
+      var key = _ekey(wa, wb);
+      var got = midPos.get(key);
+      if (got) return got;
+      var ax = rep[3 * wa], ay = rep[3 * wa + 1], az = rep[3 * wa + 2];
+      var bx = rep[3 * wb], by = rep[3 * wb + 1], bz = rep[3 * wb + 2];
+      var mx = (ax + bx) / 2, my = (ay + by) / 2, mz = (az + bz) / 2;
+      if (smooth.has(key)) {
+        // m' = m - (alpha/2) * [ ((m-p_i).n_i) n_i + ((m-p_j).n_j) n_j ]
+        var na = wa * 3, nb = wb * 3;
+        var da = (mx - ax) * wn[na] + (my - ay) * wn[na + 1] + (mz - az) * wn[na + 2];
+        var db = (mx - bx) * wn[nb] + (my - by) * wn[nb + 1] + (mz - bz) * wn[nb + 2];
+        var h = SIL_ALPHA / 2;
+        mx -= h * (da * wn[na] + db * wn[nb]);
+        my -= h * (da * wn[na + 1] + db * wn[nb + 1]);
+        mz -= h * (da * wn[na + 2] + db * wn[nb + 2]);
+        _stats.smoothMidpoints++;
+      } else {
+        _stats.hardMidpoints++;
+      }
+      got = [mx, my, mz];
+      midPos.set(key, got);
+      return got;
+    }
+
+    // ── emit. Each triangle appends its OWN copies of the vertices it uses, so the per-face vertex
+    // split of the source data is preserved exactly and nothing upstream is renumbered.
+    var outT = nT + addTris;
+    var oPos = new Float32Array(outT * 9);
+    var oNor = new Float32Array(outT * 9);
+    var oIdx = outT * 3 < 65536 ? new Uint16Array(outT * 3) : new Uint32Array(outT * 3);
+    var vp = 0, ip = 0;
+
+    function push(p, n) {
+      oPos[3 * vp] = p[0]; oPos[3 * vp + 1] = p[1]; oPos[3 * vp + 2] = p[2];
+      var L2 = Math.sqrt(n[0] * n[0] + n[1] * n[1] + n[2] * n[2]) || 1;
+      oNor[3 * vp] = n[0] / L2; oNor[3 * vp + 1] = n[1] / L2; oNor[3 * vp + 2] = n[2] / L2;
+      oIdx[ip++] = vp; vp++;
+    }
+    function P(i) { return [pos[3 * i], pos[3 * i + 1], pos[3 * i + 2]]; }
+    function N(i) { return nor ? [nor[3 * i], nor[3 * i + 1], nor[3 * i + 2]] : [0, 1, 0]; }
+    function avgN(i, j) { var a = N(i), b = N(j); return [a[0] + b[0], a[1] + b[1], a[2] + b[2]]; }
+    function tri(pa, na, pb, nb, pc, nc) { push(pa, na); push(pb, nb); push(pc, nc); }
+
+    for (t = 0; t < nT; t++) {
+      var i0 = idx[3 * t], i1 = idx[3 * t + 1], i2 = idx[3 * t + 2];
+      var w0 = wid[i0], w1 = wid[i1], w2 = wid[i2];
+      var p0 = P(i0), p1 = P(i1), p2 = P(i2), n0 = N(i0), n1 = N(i1), n2 = N(i2);
+
+      var m01 = midOf(w0, w1);
+      var m12 = midOf(w1, w2);
+      var m20 = midOf(w2, w0);
+      var q01 = avgN(i0, i1), q12 = avgN(i1, i2), q20 = avgN(i2, i0);
+
+      // standard 1-to-4, winding preserved on all four children
+      tri(p0, n0, m01, q01, m20, q20);
+      tri(m01, q01, p1, n1, m12, q12);
+      tri(m20, q20, m12, q12, p2, n2);
+      tri(m01, q01, m12, q12, m20, q20);
+    }
+
+    _stats.refined++;
+    _stats.addedVerts += (outT - nT) * 3;
+    _stats.addedTris += addTris;
+    // silhouette quality, area-weighted so a big element counts for more than a small one:
+    // one level halves theta, so the residual sag is R*(1-cos(theta/4)).
+    var thR = m.thetaMedianDeg * Math.PI / 180;
+    _stats.sBefore += m.sMedian;
+    _stats.sAfter += m.R * (1 - Math.cos(thR / 4));
+    _stats.sWeight++;
+
+    return { position: oPos, index: oIdx, normal: oNor, measure: m,
+             triBefore: nT, triAfter: outT };
+  }
+
+  // ── three.js wrapper (browser only) ──────────────────────────────────────────────────────────
+  function refineGeometry(geo, THREE, opts) {
+    if (!geo || !geo.index || !geo.attributes || !geo.attributes.position) return false;
+    var pos = geo.attributes.position.array;
+    var nor = geo.attributes.normal ? geo.attributes.normal.array : null;
+    var idx = geo.index.array;
+    var r;
+    try { r = silRefine(pos, idx, nor, opts); } catch (e) { return false; }
+    if (!r) return false;
+    geo.setAttribute('position', new THREE.BufferAttribute(r.position, 3));
+    geo.setAttribute('normal', new THREE.BufferAttribute(r.normal, 3));
+    geo.setIndex(new THREE.BufferAttribute(r.index, 1));
+    geo.computeBoundingSphere();
+    geo.computeBoundingBox();
+    return true;
+  }
+
+  function report(log) {
+    var s = _stats;
+    // §CLAUDE.md PRIMAL LAW clause 4 — a pass that cannot report its own failure is not a witness.
+    // NO-OP and VACUOUS are printed as themselves; neither is ever dressed up as a pass.
+    var verdict = s.considered === 0 ? '  VACUOUS — no geometry was judged'
+                : s.measured === 0 ? '  VACUOUS — nothing carried a tessellated curve to judge'
+                : s.refined === 0 ? '  NO-OP — every curved element was already sub-pixel at the gate'
+                : '';
+    var line = '§DUCT_SILHOUETTE considered=' + s.considered + ' measured=' + s.measured +
+      ' refined=' + s.refined + ' skippedTooSmall=' + s.skippedTooSmall +
+      ' skippedNotCurved=' + s.skippedNotCurved +
+      ' addedVerts=' + s.addedVerts + ' addedTris=' + s.addedTris +
+      ' smoothMid=' + s.smoothMidpoints + ' hardMid=' + s.hardMidpoints +
+      ' gateM=' + SIL_GATE_M + ' alpha=' + SIL_ALPHA + ' kPxPerRad=' + SIL_K_PX_PER_RAD.toFixed(1) +
+      (s.sWeight ? ' meanSagittaMm=' + (s.sBefore / s.sWeight * 1000).toFixed(3) +
+                   '->' + (s.sAfter / s.sWeight * 1000).toFixed(3) +
+                   ' (' + (s.sBefore / Math.max(1e-12, s.sAfter)).toFixed(2) + 'x)' : '') +
+      (s.budgetHit ? ' BUDGET_HIT maxAddedVerts=' + SIL_MAX_ADDED_VERTS : '') +
+      verdict;
+    if (log !== false) console.log(line);
+    return line;
+  }
+
+  var API = {
+    silMeasure: silMeasure,
+    silRefine: silRefine,
+    refineGeometry: refineGeometry,
+    report: report,
+    resetStats: _resetStats,
+    stats: function() { return _stats; },
+    K: SIL_K_PX_PER_RAD,
+    GATE_M: SIL_GATE_M,
+    ALPHA: SIL_ALPHA,
+    CREASE_DEG: SIL_CREASE_DEG,
+    MIN_SMOOTH_EDGES: SIL_MIN_SMOOTH_EDGES
+  };
+
+  if (typeof module !== 'undefined' && module.exports) module.exports = API;
+  if (global) { global.SilhouetteRefine = API; if (global.APP) global.APP.silhouette = API; }
+})(typeof window !== 'undefined' ? window : (typeof globalThis !== 'undefined' ? globalThis : this));

--- a/viewer/streaming.js
+++ b/viewer/streaming.js
@@ -229,6 +229,11 @@ function setupStreaming(A) {
       ' creaseDeg=' + CREASE_DEG + ' minDistinctN=' + CURVE_MIN_DISTINCT + ' ms=' + out.ms +
       (geomsTouched === 0 ? '  INCONCLUSIVE — no curve-class range was found; nothing was judged' : '') +
       '');
+    // §DUCT_SILHOUETTE reports alongside, because the two passes are the two halves of one answer
+    // and reading them apart is what made "roundness works on lamps but not on ducts" hard to
+    // diagnose: this line says how many vertices got a smoother NORMAL, the next says how many
+    // elements got a rounder OUTLINE. A pass that changed nothing prints NO-OP, not silence.
+    if (window.SilhouetteRefine) { try { window.SilhouetteRefine.report(); } catch (e) {} }
     // §IDX16 reports SEPARATELY (2026-08-30): it used to ride the line above, so on Hospital —
     // where this pass did not fire at all — its saving was invisible rather than absent.
     console.log('§IDX16 geoms=' + _idx16Geoms + ' saved=' + (_idx16Saved / 1048576).toFixed(1) + 'MB' +

--- a/viewer/sw.js
+++ b/viewer/sw.js
@@ -31,7 +31,7 @@
 // installed service worker keeps serving the affine without this bump (§CRISIS LESSON 4). Paired
 // with _GANTT_CACHE_VERSION 37→38 (the IDB kernel_ops self-heal) in the same commit.
 // DEPLOY: bump CACHE_VERSION on every OCI upload. Old caches are purged on activate.
-const CACHE_VERSION = 'v1128';   // bump on each deploy; per-change detail is the git commit message.
+const CACHE_VERSION = 'v1129';   // bump on each deploy; per-change detail is the git commit message.
 // v1128 (2026-09-02) §SUN_FILL_RATIO: viewer/effects.js — the Alt+S staging HDRI
 // (belfast_sunset_puresky_1k) was being pushed onto EVERY material by _reassertPhotoEnvMap, matte
 // concrete and plaster included. IBL is non-directional and is NOT shadow-map-occluded in three.js,
@@ -41,6 +41,16 @@ const CACHE_VERSION = 'v1128';   // bump on each deploy; per-change detail is th
 // (42/42 and 70/70 asserted still on it). effects.js is in PRECACHE_ASSETS and viewer.html's query
 // is bumped effects.js?v=30->31 in the SAME PR (§CRISIS LESSON 4).
 // Witness: witness_sun_fill_ratio.js (§SFR_REDGREEN, RED CONTROL 0.0005/0.0000).
+// v1129 (2026-09-02) §DUCT_SILHOUETTE: new viewer/silhouette_refine.js, hooked at the single
+// geometry choke point A.blobToGeometry (scene.js). §MEP_SMOOTH_NORMALS fixes SHADING at a 55
+// deg crease and provably cannot fix an OUTLINE, so a big duct stayed a visible N-gon while a
+// lamp did not — MEASURED, the two differ 50x in projected chord deviation, not in detection.
+// One level of uniform Phong subdivision on the elements whose own facet step still covers a
+// 1080p pixel at 5 m. Hard edges keep the plain midpoint, so flat surfaces are untouched.
+// viewer.html scene.js?v=58->59 and streaming.js?v=68->69 bumped in the SAME commit.
+// PRECACHE entry added in this same commit — a new module that is not precached is invisible
+// offline, and a precached scene.js served past a version bump would call a function that is
+// not there (the §CRISIS LESSON 4 failure mode noted under v1127).
 // v1127 (2026-09-02) §MEP_COLOR_SURVIVES_PHOTOREAL: streaming.js gives an MEP element its trade
 // HUE when its own colour carries none, keeping the element's own V (and every roughness/metalness/
 // envMap/triplanar term) untouched — so MEP reads by system in an Alt+S still and the Alt+C movie
@@ -443,6 +453,7 @@ const PRECACHE_ASSETS = [
   'config.js',
   'db_resolve.js',
   'helpers.js',
+  'silhouette_refine.js',
   'loader.js',
   'effects.js',
   'cinema_maxq.js',

--- a/viewer/tests/witness_duct_silhouette.js
+++ b/viewer/tests/witness_duct_silhouette.js
@@ -1,0 +1,483 @@
+// WITNESS — W-DUCT-SIL · §DUCT_SILHOUETTE
+// Spec: bim-compiler prompts/PHOTOREAL_STILL_RENDER.md §DUCT_SILHOUETTE.
+// Built on witness_kit/contract.js (CLAUDE.md Session Startup 7).
+//
+// ISSUE IT PROVES / DISPROVES ────────────────────────────────────────────────────────────────────
+// §MEP_SMOOTH_NORMALS rewrites NORMALS at a 55 deg crease: it changes SHADING, not geometry. A
+// faceted cylinder therefore shades smoothly while its OUTLINE stays an N-gon. The user reports
+// exactly that asymmetry — "the roundness to jagged curves seems to work on lamps but certain
+// large duct piping seems lacking" — and asks whether the detector is easy.
+//
+// This witness answers both halves numerically, on REAL shipped geometry read out of the building
+// DBs, with no browser, no bake and no screenshot anywhere in the chain (CLAUDE.md PRIMAL LAW +
+// FUNDAMENTAL LAW: the proof is a number computed from real object state, never a picture):
+//
+//   C1  the split is SIZE, not detection — the lamp class and the duct class are both detected as
+//       curved, and separate only on projected chord deviation.
+//   C2  LOAD-BEARING. Refinement must not move a non-curve surface. Every original vertex is
+//       preserved to the bit, and every new vertex born on a HARD edge sits EXACTLY on the segment
+//       between its endpoints (deviation identically 0, not "small"). This is the user's own
+//       standing constraint on the sibling pass — "it must not impact non curve intending surfaces".
+//   C3  the silhouette actually improves, RE-MEASURED on the output rather than predicted from the
+//       formula that motivated the change.
+//   C4  no T-junction / crack is introduced: a closed input stays closed.
+//   C5  the pass can report NO-OP. Raise the gate out of reach and it must say NO-OP, refine
+//       nothing, and leave geometry byte-identical.
+//
+// A verdict of PASS here means those five held on the population named in the summary line. If the
+// population is empty the contract fails loudly (§W-EMPTY-POP) rather than reporting a green zero.
+'use strict';
+const path = require('path');
+const fs = require('fs');
+const { Witness } = require(path.join(__dirname, '..', '..', 'witness_kit', 'contract.js'));
+const SIL = require(path.join(__dirname, '..', 'silhouette_refine.js'));
+
+// ── real geometry, from the shipped building DBs ────────────────────────────────────────────────
+const BUILDINGS_DIR = process.env.BUILDINGS_DIR || path.join(__dirname, '..', '..', 'buildings');
+let Database = null;
+for (const p of ['better-sqlite3', '/home/red1/bim-compiler/node_modules/better-sqlite3']) {
+  try { Database = require(p); break; } catch (e) { /* try next */ }
+}
+
+// Every building present is judged. The list is a FILE-SYSTEM scan, not a hand-written fleet: a
+// building that ships tomorrow is judged tomorrow without editing this witness, and none of the
+// thresholds below can key on which building it is (user, 2026-09-02: "No custom code to any
+// particular building has been our rule").
+function discoverBuildings() {
+  if (!Database || !fs.existsSync(BUILDINGS_DIR)) return [];
+  return fs.readdirSync(BUILDINGS_DIR)
+    .filter(f => /_extracted\.db$/.test(f))
+    .map(f => ({ name: f.replace(/_extracted\.db$/, ''), main: path.join(BUILDINGS_DIR, f),
+                 geo: path.join(BUILDINGS_DIR, f.replace('_extracted.db', '_geo.db')) }))
+    .filter(b => { try { return fs.statSync(b.main).size > 1024 * 1024; } catch (e) { return false; } });
+}
+
+const MAX_GEOMS_PER_BUILDING = +(process.env.SIL_MAX_GEOMS || 4000);
+
+function loadGeoms(b) {
+  const out = [];
+  let db;
+  try { db = new Database(b.main, { readonly: true, fileMustExist: true }); } catch (e) { return out; }
+  try {
+    let table = 'component_geometries';
+    const hasLocal = db.prepare("SELECT 1 FROM sqlite_master WHERE type='table' AND name='component_geometries'").get();
+    if (!hasLocal) {
+      if (!fs.existsSync(b.geo)) { db.close(); return out; }
+      db.exec(`ATTACH DATABASE '${b.geo.replace(/'/g, "''")}' AS geo`);
+      table = 'geo.component_geometries';
+    }
+    // class is carried for REPORTING only — nothing in the gate reads it.
+    let cls = new Map();
+    try {
+      for (const r of db.prepare('SELECT ei.geometry_hash h, em.ifc_class c FROM element_instances ei ' +
+                                 'LEFT JOIN elements_meta em ON em.guid = ei.guid').all()) {
+        if (r.h && !cls.has(r.h)) cls.set(r.h, r.c || '');
+      }
+    } catch (e) { /* split DB without instances — class stays blank, gate unaffected */ }
+    const rows = db.prepare(`SELECT geometry_hash h, vertices v, faces f FROM ${table} ` +
+                            'WHERE vertices IS NOT NULL AND faces IS NOT NULL ' +
+                            `LIMIT ${MAX_GEOMS_PER_BUILDING}`).all();
+    for (const r of rows) {
+      if (!r.v || !r.f || r.v.byteLength < 36 || r.f.byteLength < 12) continue;
+      out.push({ building: b.name, hash: r.h, cls: cls.get(r.h) || '',
+                 pos: new Float32Array(r.v.buffer, r.v.byteOffset, r.v.byteLength / 4),
+                 idx: new Uint32Array(r.f.buffer, r.f.byteOffset, r.f.byteLength / 4) });
+    }
+  } catch (e) { /* fall through with whatever loaded */ }
+  try { db.close(); } catch (e) {}
+  return out;
+}
+
+// ── geometry helpers used by the CHECKS (deliberately independent of the code under test) ───────
+const Q = v => Math.round(v * 1e4);
+const wkey = (p, i) => Q(p[3 * i]) + '|' + Q(p[3 * i + 1]) + '|' + Q(p[3 * i + 2]);
+
+// Edge census: how many welded edges carry 1 face (boundary) and how many carry 3+ (non-manifold).
+// Uniform refinement must preserve BOTH structures exactly — every edge becomes two sub-edges with
+// the same face count — so boundary doubles and non-manifold doubles, and neither may grow beyond
+// that. Computed here in the witness, never read from the pass.
+function edgeCensus(pos, idx) {
+  const id = new Map(); const w = new Int32Array(pos.length / 3);
+  for (let i = 0; i < pos.length / 3; i++) {
+    const k = wkey(pos, i); let v = id.get(k); if (v === undefined) { v = id.size; id.set(k, v); } w[i] = v;
+  }
+  const cnt = new Map();
+  for (let t = 0; t < idx.length / 3; t++) {
+    for (let e = 0; e < 3; e++) {
+      const a = w[idx[3 * t + e]], b = w[idx[3 * t + (e + 1) % 3]];
+      const k = a < b ? a + '_' + b : b + '_' + a;
+      cnt.set(k, (cnt.get(k) || 0) + 1);
+    }
+  }
+  let boundary = 0, nonManifold = 0;
+  cnt.forEach(c => { if (c === 1) boundary++; else if (c > 2) nonManifold++; });
+  return { boundary, nonManifold, edges: cnt.size, verts: id.size, tris: idx.length / 3 };
+}
+
+// DIRECT crack test — the one that actually caught the first implementation. A T-junction is a
+// vertex sitting strictly inside another triangle's edge; the edge-count census above missed 875
+// of them on one Hospital element because that mesh was already non-manifold. Measured BEFORE and
+// AFTER, so an input that already had them is not blamed on the pass.
+function tJunctions(pos, idx, cap) {
+  const uniq = new Map();
+  for (let i = 0; i < pos.length / 3; i++) {
+    const k = wkey(pos, i);
+    if (!uniq.has(k)) uniq.set(k, [pos[3 * i], pos[3 * i + 1], pos[3 * i + 2]]);
+  }
+  const verts = [...uniq.values()];
+  if (verts.length > (cap || 4000)) return -1;          // -1 = not judged, never silently 0
+  const seen = new Set(); let hits = 0;
+  for (let t = 0; t < idx.length / 3; t++) {
+    for (let e = 0; e < 3; e++) {
+      const ia = idx[3 * t + e], ib = idx[3 * t + (e + 1) % 3];
+      const ka = wkey(pos, ia), kb = wkey(pos, ib);
+      const key = ka < kb ? ka + '#' + kb : kb + '#' + ka;
+      if (seen.has(key)) continue;
+      seen.add(key);
+      const A = [pos[3 * ia], pos[3 * ia + 1], pos[3 * ia + 2]];
+      const B = [pos[3 * ib], pos[3 * ib + 1], pos[3 * ib + 2]];
+      const vx = B[0] - A[0], vy = B[1] - A[1], vz = B[2] - A[2];
+      const L2 = vx * vx + vy * vy + vz * vz;
+      if (L2 < 1e-18) continue;
+      for (const V of verts) {
+        let tt = ((V[0] - A[0]) * vx + (V[1] - A[1]) * vy + (V[2] - A[2]) * vz) / L2;
+        if (tt <= 0.001 || tt >= 0.999) continue;
+        const d = Math.hypot(V[0] - (A[0] + tt * vx), V[1] - (A[1] + tt * vy), V[2] - (A[2] + tt * vz));
+        if (d < 1e-5) hits++;
+      }
+    }
+  }
+  return hits;
+}
+
+// distance of point m from the SEGMENT ab. Used for C2: a midpoint on a hard edge must be exactly
+// on the edge, so this must be identically 0 (to float precision), never merely small.
+function distFromSegment(m, a, b) {
+  const vx = b[0] - a[0], vy = b[1] - a[1], vz = b[2] - a[2];
+  const L2 = vx * vx + vy * vy + vz * vz;
+  if (L2 < 1e-20) return Math.hypot(m[0] - a[0], m[1] - a[1], m[2] - a[2]);
+  let t = ((m[0] - a[0]) * vx + (m[1] - a[1]) * vy + (m[2] - a[2]) * vz) / L2;
+  t = Math.max(0, Math.min(1, t));
+  return Math.hypot(m[0] - (a[0] + t * vx), m[1] - (a[1] + t * vy), m[2] - (a[2] + t * vz));
+}
+
+// Independent re-derivation of the hard/smooth edge split, so C2 does not simply trust the pass's
+// own classification of which midpoints it was allowed to move.
+function hardEdgeMidpoints(pos, idx) {
+  const nT = idx.length / 3, id = new Map(), w = new Int32Array(pos.length / 3);
+  const rep = new Map();
+  for (let i = 0; i < pos.length / 3; i++) {
+    const k = wkey(pos, i);
+    let v = id.get(k);
+    if (v === undefined) { v = id.size; id.set(k, v); rep.set(v, [pos[3 * i], pos[3 * i + 1], pos[3 * i + 2]]); }
+    w[i] = v;
+  }
+  const fn = [];
+  for (let t = 0; t < nT; t++) {
+    const a = idx[3 * t], b = idx[3 * t + 1], c = idx[3 * t + 2];
+    const ax = pos[3 * a], ay = pos[3 * a + 1], az = pos[3 * a + 2];
+    const ux = pos[3 * b] - ax, uy = pos[3 * b + 1] - ay, uz = pos[3 * b + 2] - az;
+    const vx = pos[3 * c] - ax, vy = pos[3 * c + 1] - ay, vz = pos[3 * c + 2] - az;
+    let nx = uy * vz - uz * vy, ny = uz * vx - ux * vz, nz = ux * vy - uy * vx;
+    const L = Math.hypot(nx, ny, nz) || 1; fn.push([nx / L, ny / L, nz / L]);
+  }
+  const em = new Map();
+  for (let t = 0; t < nT; t++) for (let e = 0; e < 3; e++) {
+    const ia = idx[3 * t + e], ib = idx[3 * t + (e + 1) % 3];
+    const a = w[ia], b = w[ib], k = a < b ? a + '_' + b : b + '_' + a;
+    let arr = em.get(k); if (!arr) { arr = []; em.set(k, arr); }
+    arr.push({ t, ia, ib, wa: a, wb: b });
+  }
+  const cosCrease = Math.cos(SIL.CREASE_DEG * Math.PI / 180);
+  const cosThMin = Math.cos(2 * Math.PI / 180);
+  const hard = [];
+  em.forEach(arr => {
+    if (arr.length !== 2) return;
+    const n1 = fn[arr[0].t], n2 = fn[arr[1].t];
+    let d = n1[0] * n2[0] + n1[1] * n2[1] + n1[2] * n2[2];
+    d = Math.max(-1, Math.min(1, d));
+    const isSmooth = (d >= cosCrease && d <= cosThMin);
+    if (isSmooth) return;                      // smooth: the pass IS allowed to curve this one
+    // Endpoints are the WELDED REPRESENTATIVES (first copy of each welded position), not this
+    // triangle's own copies: copies that weld together can differ by up to the 0.1 mm quantum, so
+    // taking one triangle's pair would place the expected midpoint in a different quantisation
+    // cell from the emitted one and report a phantom miss. This fixes WHICH POINT is named; the
+    // load-bearing claim — that the point lies ON the segment — is still computed independently.
+    hard.push({ a: rep.get(arr[0].wa), b: rep.get(arr[0].wb) });
+  });
+  return hard;
+}
+
+// ── build the population: one row per geometry that the pass actually refined ───────────────────
+const buildings = discoverBuildings();
+const rows = [];
+const perBuilding = new Map();
+let consideredAll = 0, measuredAll = 0;
+
+for (const b of buildings) {
+  const geoms = loadGeoms(b);
+  if (!geoms.length) continue;
+  SIL.resetStats();
+  const bStat = { name: b.name, considered: 0, measured: 0, refined: 0,
+                  sBefore: 0, sAfter: 0, addedVerts: 0, vertsBefore: 0, byClass: new Map() };
+  for (const g of geoms) {
+    bStat.considered++; consideredAll++;
+    const m = SIL.silMeasure(g.pos, g.idx);
+    if (m) {
+      bStat.measured++; measuredAll++;
+      if (g.cls) {
+        let c = bStat.byClass.get(g.cls);
+        if (!c) { c = { n: 0, maxD1px: 0, sumS: 0 }; bStat.byClass.set(g.cls, c); }
+        c.n++; c.sumS += m.sMedian; if (m.D1px > c.maxD1px) c.maxD1px = m.D1px;
+      }
+    }
+    const r = SIL.silRefine(g.pos, g.idx, null, {});
+    if (!r) continue;
+
+    // ---- everything below is MEASURED ON THE OUTPUT, not predicted ----
+    // C3: re-run the same estimator on the refined mesh and read its real residual sag.
+    const after = SIL.silMeasure(r.position, r.index);
+
+    // C2a: every original vertex position still present, bit-exact.
+    const outSet = new Set();
+    for (let i = 0; i < r.position.length / 3; i++) outSet.add(wkey(r.position, i));
+    let missing = 0;
+    const inSet = new Set();
+    for (let i = 0; i < g.pos.length / 3; i++) inSet.add(wkey(g.pos, i));
+    inSet.forEach(k => { if (!outSet.has(k)) missing++; });
+
+    // C2b — LOAD-BEARING. Every HARD original edge must have been split at its EXACT linear
+    // midpoint, which lies ON the edge, so the facet is geometrically untouched. The hard/smooth
+    // split is re-derived here from the raw mesh; the pass's own classification is not consulted.
+    // Vertices are matched by exact welded key, NOT by proximity: an earlier revision of this
+    // witness scanned every output vertex within 0.5 mm of the midpoint and so charged a
+    // neighbouring SMOOTH vertex's legitimate displacement against the hard edge, failing C2 on
+    // all 37 rows for a reason that was in the witness, not the code.
+    const hard = hardEdgeMidpoints(g.pos, g.idx);
+    // ALL occupants of each 0.1 mm weld cell, not just the first. A cell can legitimately hold
+    // several distinct vertices (MEASURED: 7 in one Hospital cell), and an earlier revision of this
+    // witness took whichever landed there first — so it charged a NEIGHBOURING edge's vertex
+    // against the hard edge under test and reported a 0.042 mm displacement that never happened.
+    const outByKey = new Map();
+    for (let i = 0; i < r.position.length / 3; i++) {
+      const k = wkey(r.position, i);
+      let a = outByKey.get(k); if (!a) { a = []; outByKey.set(k, a); }
+      a.push([r.position[3 * i], r.position[3 * i + 1], r.position[3 * i + 2]]);
+    }
+    let worstHardDev = 0, worstHardUlp = 0, hardChecked = 0, hardMissing = 0;
+    for (const h of hard) {
+      // fround because the pass STORES into a Float32Array: the float64 midpoint and its float32
+      // image can land either side of a 0.1 mm quantisation boundary, which reported 7 phantom
+      // "missing" midpoints out of 37 rows. This aligns the precision, not the arithmetic.
+      const mid = [Math.fround((h.a[0] + h.b[0]) / 2),
+                   Math.fround((h.a[1] + h.b[1]) / 2),
+                   Math.fround((h.a[2] + h.b[2]) / 2)];
+      const mk = Q(mid[0]) + '|' + Q(mid[1]) + '|' + Q(mid[2]);
+      const cell = outByKey.get(mk);
+      if (!cell || !cell.length) { hardMissing++; continue; }  // uniform refinement always emits it
+      // identify WHICH occupant is this edge's midpoint: the nearest one to the expected position.
+      let got = cell[0], best = Infinity;
+      for (const c of cell) {
+        const dd = Math.hypot(c[0] - mid[0], c[1] - mid[1], c[2] - mid[2]);
+        if (dd < best) { best = dd; got = c; }
+      }
+      hardChecked++;
+      const dv = distFromSegment(got, h.a, h.b);
+      // Expressed in float32 ULPs at this edge's own coordinate magnitude, because that is the
+      // FLOOR of what can be measured at all: positions are stored in a Float32Array, whose ULP at
+      // a 35 m coordinate is 35 * 2^-23 = 4.2 microns. A real displacement by this pass would be
+      // the sagitta — MILLIMETRES, ~1000x above that floor — so "within a few ULP" and "displaced"
+      // are never confusable. Reporting an absolute micron figure instead would be measuring
+      // float32, not the code.
+      const mag = Math.max(Math.abs(h.a[0]), Math.abs(h.a[1]), Math.abs(h.a[2]),
+                           Math.abs(h.b[0]), Math.abs(h.b[1]), Math.abs(h.b[2]), 1);
+      const ulp = mag * Math.pow(2, -23);
+      const dvUlp = dv / ulp;
+      if (dvUlp > worstHardUlp) worstHardUlp = dvUlp;
+      if (dv > worstHardDev) worstHardDev = dv;
+    }
+
+    // C4: structure preserved + no NEW crack.
+    const cBefore = edgeCensus(g.pos, g.idx);
+    const cAfter = edgeCensus(r.position, r.index);
+    const tjBefore = tJunctions(g.pos, g.idx);
+    const tjAfter = tJunctions(r.position, r.index);
+
+    bStat.refined++;
+    bStat.sBefore += r.measure.sMedian;
+    bStat.sAfter += after ? after.sMedian : r.measure.sMedian;
+    bStat.addedVerts += (r.triAfter - r.triBefore) * 3;
+    bStat.vertsBefore += g.pos.length / 3;
+
+    rows.push({
+      building: b.name,
+      ifcClass: g.cls || '(none)',
+      segCountBefore: +r.measure.N.toFixed(2),
+      radiusMm: +(r.measure.R * 1000).toFixed(2),
+      sagittaBeforeMm: +(r.measure.sMedian * 1000).toFixed(4),
+      sagittaAfterMm: +((after ? after.sMedian : r.measure.sMedian) * 1000).toFixed(4),
+      d1pxBeforeM: +r.measure.D1px.toFixed(3),
+      d1pxAfterM: +((after ? after.D1px : r.measure.D1px)).toFixed(3),
+      triBefore: r.triBefore,
+      triAfter: r.triAfter,
+      originalVertsMissing: missing,
+      hardEdgesChecked: hardChecked,
+      hardEdgeMidpointsMissing: hardMissing,
+      worstHardEdgeDeviationMm: +(worstHardDev * 1000).toFixed(9),
+      worstHardEdgeDeviationUlp: +worstHardUlp.toFixed(3),
+      boundaryEdgesBefore: cBefore.boundary,
+      boundaryEdgesAfter: cAfter.boundary,
+      edgesBefore: cBefore.edges,
+      edgesAfter: cAfter.edges,
+      nonManifoldBefore: cBefore.nonManifold,
+      nonManifoldAfter: cAfter.nonManifold,
+      // Uniform 1-to-4 identity: V' = V + E, E' = 2E + 3T, T' = 4T. It holds EXACTLY unless the
+      // source mesh carries two vertices closer together than the 0.1 mm weld quantum, in which
+      // case two midpoints share a cell and the identity legitimately runs short. That deficit is
+      // MEASURED per element and named, so C4a can say which rows it did not judge instead of
+      // passing over them silently (CLAUDE.md PRIMAL LAW clause 4: scope-blind is a defect).
+      weldCollisions: (cBefore.verts + cBefore.edges) - cAfter.verts,
+      identityJudged: ((cBefore.verts + cBefore.edges) - cAfter.verts) === 0,
+      tJunctionsBefore: tjBefore,
+      tJunctionsAfter: tjAfter
+    });
+  }
+  perBuilding.set(b.name, bStat);
+}
+
+// ── §-log: the primary evidence, printed before any verdict (CLAUDE.md PRIMAL LAW clause 3) ─────
+console.log(`§SIL_FLEET buildings=${buildings.length} geometriesConsidered=${consideredAll} ` +
+            `curveMeasured=${measuredAll} refined=${rows.length} gateM=${SIL.GATE_M} ` +
+            `alpha=${SIL.ALPHA} kPxPerRad=${SIL.K.toFixed(1)} creaseDeg=${SIL.CREASE_DEG}`);
+for (const [, s] of perBuilding) {
+  const ratio = s.sAfter > 0 ? (s.sBefore / s.sAfter) : 0;
+  console.log(`§SIL_BUILDING ${s.name} considered=${s.considered} curveMeasured=${s.measured} ` +
+              `refined=${s.refined} meanSagittaMm=${s.refined ? (s.sBefore / s.refined * 1000).toFixed(3) : 'n/a'}` +
+              `->${s.refined ? (s.sAfter / s.refined * 1000).toFixed(3) : 'n/a'} ` +
+              `(${s.refined ? ratio.toFixed(2) + 'x' : 'NO-OP'}) addedVerts=${s.addedVerts} ` +
+              `vertsOfRefined=${s.vertsBefore}` +
+              (s.refined === 0 ? '  NO-OP — nothing qualified in this building' : ''));
+  // C1 evidence: the lamp-vs-duct separation, by measurement, for whatever classes this DB carries.
+  const interesting = [...s.byClass.entries()]
+    .filter(([c]) => /LightFixture|DuctSegment|DuctFitting|FlowSegment|FlowTerminal|PipeSegment/.test(c))
+    .sort((a, b2) => b2[1].maxD1px - a[1].maxD1px);
+  for (const [c, v] of interesting) {
+    console.log(`  §SIL_CLASS ${s.name} ${c} curveGeoms=${v.n} meanSagittaMm=${(v.sumS / v.n * 1000).toFixed(3)} maxD_1px=${v.maxD1px.toFixed(2)}m`);
+  }
+}
+
+// C5 — NO-OP reporting, exercised for real: same population, gate raised out of reach.
+let noopRefined = 0, noopChanged = 0;
+if (buildings.length) {
+  const g0 = loadGeoms(buildings[0]).slice(0, 400);
+  for (const g of g0) {
+    const r = SIL.silRefine(g.pos, g.idx, null, { gateM: 1e9 });
+    if (r) { noopRefined++; if (r.position.length !== g.pos.length) noopChanged++; }
+  }
+}
+console.log(`§SIL_NOOP gateM=1e9 judged=${buildings.length ? 400 : 0} refined=${noopRefined} ` +
+            `geometryChanged=${noopChanged}` +
+            (noopRefined === 0 ? '  NO-OP — correctly refused every element at an unreachable gate' : '  WRONG'));
+
+// ── the contract ────────────────────────────────────────────────────────────────────────────────
+Witness('DUCT_SIL')
+  .population(() => rows)
+  .schema({
+    type: 'object',
+    required: ['building', 'segCountBefore', 'radiusMm', 'sagittaBeforeMm', 'sagittaAfterMm',
+               'd1pxBeforeM', 'triBefore', 'triAfter', 'originalVertsMissing',
+               'worstHardEdgeDeviationMm', 'boundaryEdgesBefore', 'boundaryEdgesAfter',
+               'nonManifoldBefore', 'nonManifoldAfter', 'tJunctionsBefore', 'tJunctionsAfter'],
+    properties: {
+      building: { type: 'string', minLength: 1 },
+      ifcClass: { type: 'string' },
+      segCountBefore: { type: 'number', minimum: 2 },
+      radiusMm: { type: 'number', exclusiveMinimum: 0 },
+      sagittaBeforeMm: { type: 'number', exclusiveMinimum: 0 },
+      sagittaAfterMm: { type: 'number', minimum: 0 },
+      // the gate is the definition of the population: nothing below it may be in here
+      d1pxBeforeM: { type: 'number', minimum: 5 },
+      d1pxAfterM: { type: 'number', minimum: 0 },
+      triBefore: { type: 'integer', minimum: 4 },
+      triAfter: { type: 'integer', minimum: 4 },
+      originalVertsMissing: { type: 'integer', maximum: 0 },
+      hardEdgeMidpointsMissing: { type: 'integer', maximum: 0 },
+      // 4 float32 ULP at the edge's own coordinate magnitude — i.e. indistinguishable from zero
+      // in the format the positions are stored in. The red control below sets 120 ULP and is
+      // caught, so this bound still separates "unmoved" from "moved" by a wide margin.
+      worstHardEdgeDeviationUlp: { type: 'number', maximum: 4 },
+      worstHardEdgeDeviationMm: { type: 'number', maximum: 0.01 },
+      boundaryEdgesBefore: { type: 'integer', minimum: 0 },
+      boundaryEdgesAfter: { type: 'integer', minimum: 0 },
+      nonManifoldBefore: { type: 'integer', minimum: 0 },
+      nonManifoldAfter: { type: 'integer', minimum: 0 },
+      tJunctionsBefore: { type: 'integer', minimum: -1 },
+      tJunctionsAfter: { type: 'integer', minimum: -1 }
+    }
+  })
+  // C2 — LOAD-BEARING. No original vertex lost; every hard edge split at its exact linear
+  // midpoint, so every flat facet occupies the same plane, outline and area it did before.
+  .invariant('C2 non-curve surfaces unmoved (0 original verts lost, every hard-edge midpoint ' +
+             'within 4 float32 ULP of its own edge)',
+    rs => rs.every(r => r.originalVertsMissing === 0 && r.hardEdgeMidpointsMissing === 0 &&
+                        r.worstHardEdgeDeviationUlp <= 4))
+  // C3 — the silhouette measurably improves, re-measured on the OUTPUT. Theory says 4x; the gate
+  // is 3.5x so a real regression is caught while normal per-element scatter is not flagged.
+  .invariant('C3 silhouette sagitta improves >=3.5x fleet-wide (re-measured on the refined mesh)',
+    rs => {
+      const b = rs.reduce((a, r) => a + r.sagittaBeforeMm, 0);
+      const a2 = rs.reduce((a, r) => a + r.sagittaAfterMm, 0);
+      return a2 > 0 && (b / a2) >= 3.5;
+    })
+  .invariant('C3b every refined element got strictly rounder (no element regressed)',
+    rs => rs.every(r => r.sagittaAfterMm < r.sagittaBeforeMm))
+  // C4 — refinement introduces no crack. Uniform 1-to-4 turns every edge into two sub-edges with
+  // the same face count, so boundary and non-manifold structure must EXACTLY double and never more
+  // (0 stays 0). Plus a direct point-on-edge scan: no T-junction the input did not already have.
+  // This is the claim that caught the first implementation (24 -> 211 non-manifold, 875 new
+  // T-junctions); it is not decoration.
+  .invariant('C4a uniform-refinement identity holds exactly on every weld-injective element ' +
+             '(V\'=V+E, E\'=2E+3T, T\'=4T, boundary and non-manifold structure exactly doubled)',
+    rs => {
+      const judged = rs.filter(r => r.identityJudged);
+      if (judged.length === 0) { console.log('    INCONCLUSIVE — 0 weld-injective elements to judge'); return false; }
+      return judged.every(r => r.triAfter === 4 * r.triBefore &&
+                               r.edgesAfter === 2 * r.edgesBefore + 3 * r.triBefore &&
+                               r.boundaryEdgesAfter === 2 * r.boundaryEdgesBefore &&
+                               r.nonManifoldAfter === 2 * r.nonManifoldBefore);
+    })
+  // C4b — the DIRECT geometric crack test, deliberately scoped to the only population where it can
+  // decide. The scan calls any vertex within 0.01 mm of another edge's interior a T-junction, so on
+  // a mesh that ALREADY has such coincidences the count grows with tessellation density whether or
+  // not the pass opened anything (MEASURED: Terminal 003ad5a1 goes 8 -> 114, and its combinatorial
+  // structure is nonetheless exactly preserved — C4a passes on it). Judging those rows would be
+  // measuring the source mesh, not this change. So the claim is made ONLY on elements that enter
+  // clean, where 0 -> 0 is unambiguous, and the judged count is printed rather than assumed
+  // non-empty (CLAUDE.md PRIMAL LAW clause 4: vacuous must read INCONCLUSIVE, never PASS).
+  .invariant('C4b clean-in stays clean-out (direct point-on-edge scan on tJunctionsBefore==0 rows)',
+    rs => {
+      const judged = rs.filter(r => r.tJunctionsBefore === 0 && r.tJunctionsAfter >= 0);
+      console.log(`    C4b population: ${judged.length} clean-input elements judged of ${rs.length} ` +
+                  `(${rs.filter(r => r.tJunctionsBefore > 0).length} entered with coincidences, ` +
+                  `${rs.filter(r => r.tJunctionsAfter < 0).length} exceeded the scan cap)`);
+      if (judged.length === 0) { console.log('    INCONCLUSIVE — no clean-input element to judge'); return false; }
+      return judged.every(r => r.tJunctionsAfter === 0);
+    })
+  // C5 — the pass can decline. Proven above against the real population at an unreachable gate.
+  .invariant('C5 reports NO-OP at an unreachable gate (refined 0, geometry untouched)',
+    () => noopRefined === 0 && noopChanged === 0)
+  // Triangle growth must stay bounded — a runaway refinement is a memory regression, not a fix.
+  .invariant('C6 triangle growth is exactly 4x per element, never more',
+    rs => rs.every(r => r.triAfter === r.triBefore * 4))
+  // RED CONTROL — moves a hard-edge midpoint off its edge and flattens the improvement. If the
+  // witness still passes with this, it is not measuring what it claims to measure.
+  .redControl(rs => rs.map(r => Object.assign({}, r, {
+    worstHardEdgeDeviationMm: 0.5,
+    worstHardEdgeDeviationUlp: 120,
+    tJunctionsAfter: (r.tJunctionsBefore > 0 ? r.tJunctionsBefore : 1) * 9,
+    nonManifoldAfter: r.nonManifoldBefore * 7 + 5,
+    edgesAfter: r.edgesAfter * 3 + 11,
+    identityJudged: true,
+    sagittaAfterMm: r.sagittaBeforeMm
+  })))
+  .run();

--- a/viewer/viewer.html
+++ b/viewer/viewer.html
@@ -852,10 +852,11 @@ html.bim-embedded, html.bim-embedded body { background: #0b0b0b; }
 <script src="list_builder.js?v=1" onerror="console.warn('§LOAD_FAIL list_builder.js')"></script>
 <script src="settings_editor.js?v=1" onerror="console.warn('§LOAD_FAIL settings_editor.js')"></script>
 <script src="../common/history_tap.js?v=7" onerror="console.warn('§LOAD_FAIL history_tap.js')"></script>
-<script src="scene.js?v=58" onerror="console.warn('§LOAD_FAIL scene.js')"></script>
+<script src="scene.js?v=59" onerror="console.warn('§LOAD_FAIL scene.js')"></script>
 <script src="panel_nav.js?v=1" onerror="console.warn('§LOAD_FAIL panel_nav.js')"></script>
 <script src="helpers.js?v=6" onerror="console.warn('§LOAD_FAIL helpers.js')"></script>
-<script src="streaming.js?v=68" onerror="console.warn('§LOAD_FAIL streaming.js')"></script>
+<script src="silhouette_refine.js?v=1" onerror="console.warn('§LOAD_FAIL silhouette_refine.js')"></script>
+<script src="streaming.js?v=69" onerror="console.warn('§LOAD_FAIL streaming.js')"></script>
 <script src="dlod.js?v=8" onerror="console.warn('§LOAD_FAIL dlod.js')"></script>
 <script src="panels.js?v=44" onerror="console.warn('§LOAD_FAIL panels.js')"></script>
 <script src="tools.js?v=45" onerror="console.warn('§LOAD_FAIL tools.js')"></script>


### PR DESCRIPTION
**User:** *"The roundness to jagged curves seems to work on lamps but certain large duct piping seems lacking. Is the formula easy? Detecting an element to possess curved surface but having jagged and thus candidate to apply."*

Spec + every measurement: `bim-compiler/prompts/PHOTOREAL_STILL_RENDER.md` §DUCT_SILHOUETTE.

## The answer to the question actually asked
**Yes, the formula is easy — two lines — and the detector the user is imagining already exists. The split they are seeing is not a detection failure at all. It is SIZE, and it is ~50x wide.**

`§MEP_SMOOTH_NORMALS` rewrites **normals** at a 55° crease, so it changes **shading** and provably cannot change an **outline**. `streaming.js` says so in its own header: *"IfcFlowSegment is 10.3 over 26 triangles: a genuine 10-sided prism, so its SHADING improves here but its silhouette cannot."* ⛔ Widening `creaseDeg` is therefore **not** the knob — it addresses shading, which is not the defect, and would round genuine hard edges. `CREASE_DEG` stays 55, and this pass deliberately reuses the same 55°/2° edge classification so the two always describe one surface.

## The formula
For an edge the smoothing pass already welds across, project both faces perpendicular to it: the edge collapses to a point `E`, the two opposite vertices give `A` and `B`, all three on the swept cross-section.

```
R     = |EA|·|AB|·|BE| / (4·area(EAB))    circumradius — EXACT, no cylinder fit, no axis fit
s     = R · (1 − cos(θ/2))                chord deviation — "the jaggedness"
D_1px = s · k,  k = (H/2)/tan(fov/2)      = 935.3 px/rad at 1080p, fov 60 (scene.js:139)
```

**Validated, not asserted:** on Hospital it lands on **R = 525.0 and 550.0 mm** — real 1050/1100 mm manufacturing duct sizes — and its segment count agrees exactly (**11 vs 11**) with an independent PCA ring fit. A cheaper centroid estimator was biased a constant 0.653 by triangulated quads and was discarded, not patched with a fudge factor.

## The lamp-vs-duct split, in numbers
| Hospital class | detected curved? | mean N | mean s | worst D_1px |
|---|---|---|---|---|
| `IfcLightFixture` | yes | 13.3 | — | **drops out of the offender list at every gate tried** |
| `IfcDuctSegment` | yes | 12.8 | 4.17 mm | **20.8 m** |
| `IfcPipeSegment` | yes | 11.0 | 0.75 mm | 5.2 m |
| `IfcBeam` (curved sweeps) | yes | 11.8 | 21.50 mm | 685.5 m |

Both are detected; both carry N ≈ 11–13. The error is **linear in radius**, so a lamp is sub-pixel past arm's length while an 1100 mm duct is a whole pixel at **twenty metres**. ⚠ Hospital's worst offenders are not ducts at all but large-radius **curved sweeps** (railings, curved beams) — the user named ducts because that is what they were looking at.

## Both remedies costed; one chosen
**No-new-geometry treatment: no credible option exists, and that is a finding.** Anti-aliasing (already shipped) softens the edge pixel and leaves the same N-gon. Radial rescale halves the error but **moves real geometry** on a model carrying clash/measure/QTO — rejected on PRIME RULE grounds. WebGL2 has no tessellation shader. Re-extracting at a finer chord tolerance is the correct fix at the source but re-tessellates the whole fleet instead of the measured tail and costs **more** memory.

**Chosen: one level of uniform Phong subdivision on the qualifying tail.** Hospital cost curve, measured through the shipped module:

| gate | refined geoms | instances | +MB per-geom | +MB per-inst | mean sagitta |
|---|---|---|---|---|---|
| ≥ 2 m | 3,589 | 8,372 | +107.0 | **+307.0** | 12.324 → 2.457 mm |
| ≥ 3 m | 2,607 | 6,649 | +85.4 | +241.8 | 14.773 → 2.783 mm |
| **≥ 5 m** | **1,419** | **4,019** | **+59.3** | **+159.3** | **21.331 → 3.383 mm (6.31x)** |
| ≥ 10 m | 860 | 2,898 | +43.5 | +126.1 | 26.991 → 3.646 mm |

**Gate = 5 m, chosen on the curve.** 5→3 m costs +82 MB for 1,188 mostly-invisible small fittings; 5→10 m saves only 33 MB while dropping 559. `§R12_HOSPITAL_MEM` puts Hospital's heap at ~1,577 MB, so the 2 m gate's +307 MB is exactly the "hundreds of MB is not a win" case and is **rejected**. 5 m is +3.8% to +10.1%. Both bounds are quoted because the truth is between them: JS heap is per-geometry (`meshCache` is hash-keyed), GPU buffers are per-instance on the `BatchedMesh` path.

## Fleet result at the shipped gate
| building | curve-detected | refined | +MB perGeom/perInst | mean sagitta mm |
|---|---|---|---|---|
| Hospital | 15,428 | 1,419 | +59.3 / +159.3 | 21.331 → 3.383 (**6.31x**) |
| Terminal | 7,424 | 28 | +30.6 / +30.6 | 42.924 → 5.238 (**8.20x**) |
| JKR | 5,342 | 74 | +10.7 / +10.7 | 47.440 → 4.495 (**10.55x**) |
| Clinic | 4,366 | 59 | +6.1 / +94.2 | 30.012 → 5.508 (**5.45x**) |
| HHS_Office_Federated | 2,314 | 117 | +3.9 / +6.9 | 14.591 → 2.848 (**5.12x**) |
| Duplex | 503 | 6 | +1.4 / +1.4 | 42.804 → 10.968 (**3.90x**) |

## Safety, by construction — no class list, no building name
The user's standing constraint (*"it must not impact non curve intending surfaces"*) is met without naming anything: a midpoint on a **HARD** edge is **never projected**, and the midpoint of a straight edge lies **on** that edge, so a flat facet keeps the same plane, outline and area. Midpoints come from **welded representatives** and are shared by both neighbours, so the result cannot depend on triangle visit order and a crack cannot open. The per-face vertex split is preserved — nothing welded, nothing renumbered — so picking, per-element hide, the BVH and `§TRIPLANAR` see their layout unchanged. **There is no building name, IFC class or material name in the file** (user: *"No custom code to any particular building has been our rule."*).

`ALPHA = 0.5` is **derived, not tuned**: the damped Phong midpoint is exact on a cylinder at `α = (sec(θ/2)−1)/sin²(θ/2)`, whose θ→0 limit is exactly 1/2 (0.527 at N=12, 0.539 at N=10).

## Two things the witness caught and the code changed for
1. **Curved-shell-only refinement + green T-junction closure — measured wrong, abandoned.** The obvious ~2.6x optimisation drove **non-manifold edges 24 → 211** and opened **875 T-junctions** on real Hospital geometry: a real IFC mesh carries edges shared by 3+ faces, and a refined/unrefined frontier through one cannot be closed by a green split. Uniform 1→4 removes the frontier itself. The extra cost is the 4x column above, paid deliberately.
2. **Midpoints built from whichever per-face copy the loop reached first** — order-dependent; now built from the welded representative.

## Witness — `viewer/tests/witness_duct_silhouette.js`
**`§WITNESS_DUCT_SIL pass=10 fail=0 ran=37`**, 8 building DBs, red control caught, exit 0. No browser, no bake, no screenshot anywhere in the chain — it reads real geometry blobs from the shipped DBs and calls the shipped module.

- **C2 (load-bearing)** — 0 original vertices lost; every hard-edge midpoint within **4 float32 ULP** of its own edge. In ULPs because that is the measurement floor (a `Float32Array` ULP at 35 m is 4.2 µm) while a real displacement would be the sagitta — millimetres, ~1000x above. Red control sets 120 ULP and is caught.
- **C3 / C3b** — ≥3.5x fleet-wide and **no element regressed**, re-measured on the **output** mesh rather than predicted from the formula that motivated the change.
- **C4a** — refinement identity `V'=V+E`, `E'=2E+3T`, `T'=4T` holds **exactly** on every weld-injective element; boundary and non-manifold structure exactly doubled.
- **C4b** — direct point-on-edge crack scan, **scoped and declared**: 8 clean-input elements judged of 37, with the 29 that entered with coincidences and the 2 over the scan cap named rather than passed over. Prints `INCONCLUSIVE`, never PASS, on an empty population.
- **C5** — `§SIL_NOOP gateM=1e9 judged=400 refined=0 geometryChanged=0`: the pass declines and says **NO-OP**. Per-building lines print NO-OP where nothing qualified, never a green zero.

## Three traps recorded so nobody pays twice
1. A 12-gon round duct has **~14** distinct face normals and so **fails** the shipped `CURVE_MIN_DISTINCT = 16` shape gate — it is smoothed only via the class list.
2. The class gate lets **boxes** through (`IfcFlowTerminal` includes 12-triangle `distinct=6` rectangular diffusers). Harmless for shading, a disaster for re-tessellation — which is why this pass gates on **shape only** and never reads a class.
3. A nearly-coplanar triangle pair fits an arbitrarily large circumradius and reported a **4,290.9 mm** bulge on a flat wall. Two physical guards (`s ≤ 0.25 × bbox diagonal`, ≥ 6 smooth edges) fix it — and with them on, `IfcLightFixture` drops out of the offender list, independently reproducing the user's own "it works on lamps".

## Wiring
`A.blobToGeometry` (scene.js) is the single choke point every streamed element passes through, and the only place this can happen: both batch paths size their `BatchedMesh` from `item.geo` at flush time, so an already-refined geometry is reserved for correctly with **no batch change**; refining after the batch is built is impossible — the slot's vertex range is fixed.

`sw.js CACHE_VERSION v1128→v1129` + precache entry, `viewer.html scene.js?v=58→59` and `streaming.js?v=68→69`, all in the same commit. ESLint via the repo's own toolchain, exit 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RTX9gUq3tQoytC1vthLmcq