### PR TITLE
fix(erp): two forward-ports the twin audit surfaced — ninja_model @callout grammar + crud_core audit-column casing

### DIFF
--- a/erp/crud_core.js
+++ b/erp/crud_core.js
@@ -457,7 +457,7 @@
             }
             // Task 1 — stamp Updated/UpdatedBy for CRUD_UPDATE (iDempiere PO.save parity)
             var ucols = _getTableCols(want);
-            if (opTs != null && ucols['updated'] && !Object.prototype.hasOwnProperty.call(ch, 'Updated') && !Object.prototype.hasOwnProperty.call(ch, 'updated')) ex['Updated'] = _fmtKernelTs(opTs);
+            if (opTs != null && ucols['updated'] && !Object.prototype.hasOwnProperty.call(ch, 'Updated') && !Object.prototype.hasOwnProperty.call(ch, 'updated')) ex['updated'] = _fmtKernelTs(opTs);   // lowercase — same #968 convention as its `updatedby` sibling below; CREATE stamps `updated` lowercase (:431), so the mixed-case form left a created-then-updated row carrying BOTH keys
             if (p.actor != null && ucols['updatedby'] && !Object.prototype.hasOwnProperty.call(ch, 'UpdatedBy') && !Object.prototype.hasOwnProperty.call(ch, 'updatedby')) ex['updatedby'] = p.actor;   // lowercase — the #968 convention (was 'UpdatedBy': a created-then-updated row carried BOTH keys; W-AUDIT-CHANGELOG/W-RECINFO caught it)
           }
         } else if (type === 'CRUD_DELETE') {

--- a/erp/crud_core.js
+++ b/erp/crud_core.js
@@ -458,7 +458,7 @@
             // Task 1 — stamp Updated/UpdatedBy for CRUD_UPDATE (iDempiere PO.save parity)
             var ucols = _getTableCols(want);
             if (opTs != null && ucols['updated'] && !Object.prototype.hasOwnProperty.call(ch, 'Updated') && !Object.prototype.hasOwnProperty.call(ch, 'updated')) ex['Updated'] = _fmtKernelTs(opTs);
-            if (p.actor != null && ucols['updatedby'] && !Object.prototype.hasOwnProperty.call(ch, 'UpdatedBy') && !Object.prototype.hasOwnProperty.call(ch, 'updatedby')) ex['UpdatedBy'] = p.actor;
+            if (p.actor != null && ucols['updatedby'] && !Object.prototype.hasOwnProperty.call(ch, 'UpdatedBy') && !Object.prototype.hasOwnProperty.call(ch, 'updatedby')) ex['updatedby'] = p.actor;   // lowercase — the #968 convention (was 'UpdatedBy': a created-then-updated row carried BOTH keys; W-AUDIT-CHANGELOG/W-RECINFO caught it)
           }
         } else if (type === 'CRUD_DELETE') {
           if (p.id != null && hidden.indexOf(p.id) < 0) hidden.push(p.id);

--- a/erp/idempiere.html
+++ b/erp/idempiere.html
@@ -521,7 +521,7 @@
 <!-- NINJA_MODE_PILL.md — the Plugin Engine "Create" (PackOut) face: Excel model sheet → AD model → live install.
      Engine == bim-compiler build/erp source (headless-proven W-NINJA-PILL). Load order: model→stage→bundle→create
      (bundle/create capture their deps at module-load) →starter, BEFORE plugin_overlay.js (the DOM host). -->
-<script src="ninja_model.js?v=1"></script>
+<script src="ninja_model.js?v=2"></script>
 <script src="ninja_stage.js?v=2"></script>
 <script src="ninja_bundle.js?v=1"></script>
 <script src="ninja_create.js?v=1"></script>

--- a/erp/ninja_model.js
+++ b/erp/ninja_model.js
@@ -74,6 +74,14 @@
     colDef = String(colDef || '').replace(/\s+/g, '');
     if (!colDef) return null;
 
+    // extract @callout suffix before type parsing (grammar token: ColName@class.method)
+    var callout = null;
+    var atIdx = colDef.indexOf('@');
+    if (atIdx >= 0) {
+      callout = colDef.slice(atIdx + 1) || null;
+      colDef  = colDef.slice(0, atIdx);
+    }
+
     var parts = colDef.split('#');
     var prefix = '';
     var colName = colDef;
@@ -128,7 +136,7 @@
 
     var fkTable = (colName.slice(-3) === '_ID') ? colName.slice(0, -3) : null;
 
-    return { name: colName, refId: refId, isStandard: false, fkTable: fkTable, listValues: listValues };
+    return { name: colName, refId: refId, isStandard: false, fkTable: fkTable, listValues: listValues, callout: callout };
   }
 
   // ── standardColumns(tableName) — mirror PackOut.xml standard set ────────────────────────────────
@@ -156,7 +164,15 @@
     colDefs.forEach(function (def) {
       var parsed = parseColDef(def, warnings);
       if (!parsed) return;
-      if (seen[parsed.name]) return;  // idempotent (NinjaProcessor skips existing)
+      if (seen[parsed.name]) {
+        // callout annotation on an already-seen (standard) col: graft the callout onto it
+        if (parsed.callout) {
+          for (var k = 0; k < columns.length; k++) {
+            if (columns[k].name === parsed.name) { columns[k].callout = parsed.callout; break; }
+          }
+        }
+        return;
+      }
       seen[parsed.name] = true;
       columns.push(parsed);
     });

--- a/erp/sw.js
+++ b/erp/sw.js
@@ -10,7 +10,7 @@
 // init-bubble must be INSTANT, ERP_INIT_BUBBLE_INSTANT.md); network-first for non-precached .js (fresh on
 // deploy); cache-first for precached assets/.wasm/images. Freshness on deploy is carried by the SW version
 // bump (skipWaiting+clients.claim precache the new shell), so SWR strands a user at most one load post-deploy.
-const CACHE_VERSION = 'v775';   // bump on each deploy; per-change detail is the git commit message.
+const CACHE_VERSION = 'v776';   // bump on each deploy; per-change detail is the git commit message.
 // v772 (rebase of PR #203 onto origin/main) §INTEG-WIRE-B: disposable-host persistence in-app
 // (erp_replica_client.js + erp_persist_ui.js) — back the books up to a SIGNED snapshot the user
 // owns (signed by the edge key), restore on a FRESH device -> replay recomputes tip == signed


### PR DESCRIPTION
Fallout from `W-ERP-TWIN` (`scripts/check_erp_twins.js`), the gate added today after a witness was found reporting 4 FAILs that were artefacts of a stale `build/erp` copy rather than the product. Classifying the 11 unreviewed pairs found **two places where the bim-compiler copy was AHEAD of what ships** — the reverse of the expected direction, and one of them is a real shipped defect.

Full write-up: bim-compiler `prompts/ERP_IDEMPIERE_UX_PARITY.md` §TWIN-CLASSIFIED.

## 1 — `ninja_model.js`: the `@callout` grammar was half-shipped

`#309` shipped the `ninja_stage.js` half of the sheet-driven callout wiring but not the `ninja_model.js` half, so `ninja_stage` consumed a grammar the shipped parser never produced. Ported forward verbatim from the copy the witnesses already judged. `ninja_model.js?v=2` in `idempiere.html`.

Witnesses: `poc_ninja_callout` / `bundle` / `export` / `extract` PASS; `poc_ninja_model` `vsOracle=MATCH`, `poc_ninja_stage` `render=PASS rollback=PASS`.

## 2 — `crud_core.js`: the CRUD_UPDATE audit stamp broke #968's own casing rule

`#968` (§ADORGID-CASING) established that every key written onto a row is **lowercase**, because readers expect `r.ad_org_id` — the mixed-case form silently read as nothing, which is how `AD_Org_ID=NaN` reached Generate-Invoices. The CREATE path was fixed then and writes all four audit columns lowercase (`:426-431`): `createdby`, `updatedby`, `created`, `updated`.

The CRUD_UPDATE path was missed, on **two adjacent lines**:

- `:461 ex['UpdatedBy']` → `ex['updatedby']`
- `:460 ex['Updated']` → `ex['updated']` — the same defect one line above, caught while reviewing the first fix

So a created-then-updated row carried **both** spellings of both columns. Nothing reads the mixed-case form as a JS property; SQLite's own column case is irrelevant here, since SQL matches case-insensitively but JS object keys do not.

`poc_recinfo` was RED on the shipped bytes and GREEN on the fix — the falsifier held. Re-run after the second line: **W-RECINFO PASS**, **W-AUDIT-CHANGELOG 25/25 PASS**.

## Regression

The twin audit ran **all 80 judging scripts** before and after: baseline 73/80 → **76/80**, with **zero PASS→FAIL**. The three FAIL→PASS flips were `poc_morder_save` (the stale-copy artefact that started this), `poc_rate_input` (a stale require), and `test_crud_writeloop_overlay` (was pairing against the viewer kernel). The 4 remaining non-PASS are pre-existing `run_witness.sh` marker-regex misses whose logs carry substantive pass lines — named, not touched.

`erp/sw.js` v775→**v776**.

On merge, `crud_core` and `ninja_model` flip to `identical` in `scripts/erp_twins.json`, taking the gate to 0 unreviewed pairs among the original 11.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BTjD9Hx77LPZyFPiFNXygS