### PR TITLE
fix(cinema): §CPE_REVEAL_ARCH_HOLD — hold ARC/STR until the camera is back on the first stick

### DIFF
--- a/viewer/effects.js
+++ b/viewer/effects.js
@@ -5552,12 +5552,18 @@ async function setupEffects(A, renderer, scene, camera) {
   // Four zones inside [b.out, b.rise]:
   //   pull-out  (b.out .. b.pullout)  — plain, no override (author's call, see spec file: a short
   //                                     transition beat, not part of either "round").
-  //   round 2   (b.pullout .. b.reveal) — 'ghost': ARC/STR fully hidden, every non-ARC/STR discipline
-  //                                     shown together — UNCHANGED from the original ghost phase.
-  //                                     §CPE_DISCIPLINE_REVEAL_FLYBACK (2026-08-16): this span now
-  //                                     covers BOTH the fly-back sub-beat (camera retracing the path
-  //                                     back to the first stick) AND the forward lap after it — the
-  //                                     boundary here is unchanged (still b.pullout..b.reveal), only
+  //   fly-back  (b.pullout .. b.flyback) — plain, ARC/STR STILL SOLID. §CPE_REVEAL_ARCH_HOLD
+  //                                     (2026-09-03, user): the retrace happens with the building
+  //                                     COMPLETE and LIT, and that is the point of it — it reads
+  //                                     against the gloomy first pass, when lighting was not yet
+  //                                     installed. The ghost used to start here; it no longer does.
+  //   round 2   (b.flyback .. b.reveal) — 'ghost': ARC/STR fully hidden, every non-ARC/STR discipline
+  //                                     shown together — the original ghost phase, now beginning at
+  //                                     the FIRST STICK where round 2 actually commences.
+  //                                     §CPE_DISCIPLINE_REVEAL_FLYBACK (2026-08-16) added the
+  //                                     fly-back sub-beat inside the old span; §CPE_REVEAL_ARCH_HOLD
+  //                                     (2026-09-03) split it back out, so the ghost boundary moved
+  //                                     from b.pullout to b.flyback, and
   //                                     poseAt's camera motion inside it gained a sub-beat, so no
   //                                     edit was needed in THIS function for that change.
   //   rise/tail (b.reveal .. b.rise, first rv.tailSec seconds) — 'tail-one'/'tail-all': the disc
@@ -5569,7 +5575,16 @@ async function setupEffects(A, renderer, scene, camera) {
     if (!b || !rv || !rv.discs || !rv.discs.length || !(b.reveal > b.out)) return null;
     if (tNorm <= b.out) return null;
     var tP = (b.pullout != null && b.pullout > b.out) ? b.pullout : b.out;
-    if (tNorm <= tP) return null;                              // pull-out: plain, no ghost
+    // §CPE_REVEAL_ARCH_HOLD (2026-09-03, user): the ghost must NOT start when the fly-back starts.
+    // On the way back everything is built AND lit, and that fully-lit read is the payoff against the
+    // gloomy first pass (where lighting legitimately was not installed yet). Stripping ARC/STR at
+    // b.pullout threw that away. Ghost now begins at b.flyback — the instant the camera is back on
+    // the FIRST STICK, where round 2 properly commences. HUD highlights are unaffected: they are
+    // driven from cinema_maxq's own reveal-round boundary, not from this function.
+    // DEGRADE, DON'T DISABLE: a plan without b.flyback falls back to tP, i.e. byte-identical to the
+    // previous behaviour — same rule cpeRevealDiscQtyCost above already follows.
+    var tF = (b.flyback != null && b.flyback > tP) ? b.flyback : tP;
+    if (tNorm <= tF) return null;                              // pull-out + fly-back: ARC/STR SOLID
     if (tNorm <= b.reveal) return { phase: 'ghost', discs: rv.discs.slice() };  // round 2
     if (!(b.rise > b.reveal)) return null;
     var riseSpanSec = (rv.riseSec || 0) + (rv.tailSec || 0);
@@ -5981,7 +5996,7 @@ async function setupEffects(A, renderer, scene, camera) {
   // that: §CPE_AIM_PIN (Part C) added real behaviour here (`_buildPinZones`/`_pinLookAtAt` inside
   // `_beat3Pose`) but this string was never bumped for it, breaking the file's own "bump on EVERY
   // behaviour change" rule for one release. Fixed now, not left for a future session to rediscover.
-  var EFFECTS_V = 'v24 (' +
+  var EFFECTS_V = 'v25 (' +
     '§CPE_DISCIPLINE_REVEAL_FLYBACK new fast eased retrace sub-beat replaces the pull-out->round-2 ' +
       'teleport cut; §CPE_DISCIPLINE_REVEAL_ORDER discs sorted ascending by real avg bbox volume, ' +
       'MEP forced last; §CPE_DISCIPLINE_REVEAL_FADE tail-parade boundaries get a brief overlap ' +

--- a/viewer/sw.js
+++ b/viewer/sw.js
@@ -31,7 +31,7 @@
 // installed service worker keeps serving the affine without this bump (§CRISIS LESSON 4). Paired
 // with _GANTT_CACHE_VERSION 37→38 (the IDB kernel_ops self-heal) in the same commit.
 // DEPLOY: bump CACHE_VERSION on every OCI upload. Old caches are purged on activate.
-const CACHE_VERSION = 'v1129';   // bump on each deploy; per-change detail is the git commit message.
+const CACHE_VERSION = 'v1130';   // bump on each deploy; per-change detail is the git commit message.
 // v1128 (2026-09-02) §SUN_FILL_RATIO: viewer/effects.js — the Alt+S staging HDRI
 // (belfast_sunset_puresky_1k) was being pushed onto EVERY material by _reassertPhotoEnvMap, matte
 // concrete and plaster included. IBL is non-directional and is NOT shadow-map-occluded in three.js,

--- a/viewer/tests/witness_reveal_arch_hold.js
+++ b/viewer/tests/witness_reveal_arch_hold.js
@@ -1,0 +1,92 @@
+#!/usr/bin/env node
+/* W-ARCH-HOLD — §CPE_REVEAL_ARCH_HOLD (2026-09-03, user ask)
+ *
+ * CLAIM: the discipline ghost (ARC/STR hidden) must NOT begin when the fly-back begins.
+ * It must begin at b.flyback — the instant the camera is back on the FIRST STICK, where
+ * round 2 properly commences. Reason on record: on the retrace everything is built AND lit,
+ * and that fully-lit read is the payoff against the gloomy first pass.
+ *
+ * Slices A.cpeRevealVisualAt out of the shipped viewer/effects.js and runs it standalone —
+ * no browser, no bake. Same text-slice technique the 4D witnesses in this folder use.
+ *
+ * RED CONTROL: W_ARCH_HOLD_RED=1 restores the pre-fix gate (ghost from b.pullout). Every
+ * gate that can detect the fix MUST fail under it, or the gate proves nothing.
+ */
+'use strict';
+const fs = require('fs'), path = require('path');
+const RED = process.env.W_ARCH_HOLD_RED === '1';
+const SRC = path.join(__dirname, '..', 'effects.js');
+
+// ── slice the pure function out of the shipped file ──────────────────────────
+const src = fs.readFileSync(SRC, 'utf8');
+const start = src.indexOf('A.cpeRevealVisualAt = function');
+if (start < 0) { console.log('§W_ARCH_HOLD INCONCLUSIVE — cpeRevealVisualAt not found in effects.js'); process.exit(2); }
+// take to the end of the function: first line that is exactly "  };" after start
+const end = src.indexOf('\n  };', start);
+if (end < 0) { console.log('§W_ARCH_HOLD INCONCLUSIVE — function end not found'); process.exit(2); }
+let body = src.slice(start, end + 5);
+if (RED) {
+  // restore the pre-fix behaviour: ghost starts at the pull-out boundary
+  body = body.replace('var tF = (b.flyback != null && b.flyback > tP) ? b.flyback : tP;', 'var tF = tP;');
+}
+const A = {};
+// eslint-disable-next-line no-new-func
+new Function('A', body)(A);
+if (typeof A.cpeRevealVisualAt !== 'function') { console.log('§W_ARCH_HOLD INCONCLUSIVE — slice did not define the function'); process.exit(2); }
+
+// ── a plan shaped like the real one (beats are normalized 0..1) ──────────────
+const plan = {
+  beats: { dive: 0.05, spin: 0.10, out: 0.50, pullout: 0.55, flyback: 0.70, reveal: 0.90, rise: 1.00 },
+  reveal: { discs: ['PLB', 'MEP'], riseSec: 4, tailSec: 6 }
+};
+const b = plan.beats;
+const mid = (a, z) => a + (z - a) / 2;
+const phaseAt = t => { const v = A.cpeRevealVisualAt(plan, t); return v ? v.phase : null; };
+
+let pass = 0, fail = 0, judged = 0;
+function gate(id, ok, detail) {
+  judged++;
+  if (ok) { pass++; console.log(`§W_ARCH_HOLD ${id} PASS ${detail}`); }
+  else { fail++; console.log(`§W_ARCH_HOLD ${id} FAIL ${detail}`); }
+}
+
+// G1 — the whole fly-back span keeps ARC/STR solid (this is the user's ask)
+const flybackSamples = [];
+for (let i = 1; i < 20; i++) flybackSamples.push(b.pullout + (b.flyback - b.pullout) * (i / 20));
+const ghostedInFlyback = flybackSamples.filter(t => phaseAt(t) === 'ghost').length;
+gate('G1-flyback-solid', ghostedInFlyback === 0,
+  `ghostFrames=${ghostedInFlyback}/${flybackSamples.length} across b.pullout(${b.pullout})..b.flyback(${b.flyback})`);
+
+// G2 — round 2 still ghosts, immediately after the first stick
+const roundSamples = [];
+for (let i = 1; i < 20; i++) roundSamples.push(b.flyback + (b.reveal - b.flyback) * (i / 20));
+const ghostedInRound = roundSamples.filter(t => phaseAt(t) === 'ghost').length;
+gate('G2-round2-ghosts', ghostedInRound === roundSamples.length,
+  `ghostFrames=${ghostedInRound}/${roundSamples.length} across b.flyback..b.reveal`);
+
+// G3 — the transition is exactly at b.flyback, not before
+const justBefore = phaseAt(b.flyback - 1e-6), justAfter = phaseAt(b.flyback + 1e-6);
+gate('G3-boundary-at-flyback', justBefore === null && justAfter === 'ghost',
+  `justBefore=${justBefore} justAfter=${justAfter}`);
+
+// G4 — pull-out unchanged: still plain
+gate('G4-pullout-plain', phaseAt(mid(b.out, b.pullout)) === null,
+  `phase=${phaseAt(mid(b.out, b.pullout))}`);
+
+// G5 — DEGRADE, DON'T DISABLE: a plan with no b.flyback behaves exactly as before the fix
+const legacy = { beats: { out: 0.50, pullout: 0.55, reveal: 0.90, rise: 1.00 }, reveal: plan.reveal };
+const legacyPhase = A.cpeRevealVisualAt(legacy, mid(legacy.beats.pullout, legacy.beats.reveal));
+gate('G5-degrade-no-flyback', legacyPhase && legacyPhase.phase === 'ghost',
+  `legacy plan (no b.flyback) phase=${legacyPhase && legacyPhase.phase}`);
+
+// G6 — NO-OP guard: the fix must actually change something. Compare the fly-back span
+// under both gates; identical output means the change did nothing.
+const tMid = mid(b.pullout, b.flyback);
+const fixedMid = phaseAt(tMid);
+gate('G6-not-a-noop', RED ? fixedMid === 'ghost' : fixedMid === null,
+  `mid-flyback phase=${fixedMid} (RED=${RED ? 1 : 0}; the two arms MUST differ)`);
+
+const verdict = judged === 0 ? 'INCONCLUSIVE' : (fail === 0 ? 'GREEN' : 'RED');
+console.log(`§W_ARCH_HOLD_VERDICT claims=${judged} PASS=${pass} FAIL=${fail} ${verdict}` +
+  (RED ? '  [RED CONTROL — failures here are REQUIRED]' : ''));
+process.exit(fail === 0 ? 0 : 1);

--- a/viewer/viewer.html
+++ b/viewer/viewer.html
@@ -840,7 +840,7 @@ html.bim-embedded, html.bim-embedded body { background: #0b0b0b; }
 <script src="qrcode.min.js?v=1" onerror="console.warn('§LOAD_FAIL qrcode.min.js — QR sharing disabled')"></script>
 <script src="config.js?v=4" onerror="console.warn('§LOAD_FAIL config.js')"></script>
 <script src="db_resolve.js?v=2" onerror="console.warn('§LOAD_FAIL db_resolve.js')"></script>
-<script src="effects.js?v=31" onerror="console.warn('§LOAD_FAIL effects.js')"></script>
+<script src="effects.js?v=32" onerror="console.warn('§LOAD_FAIL effects.js')"></script>
 <script src="effects_gi_poc.js?v=3" onerror="console.warn('§LOAD_FAIL effects_gi_poc.js')"></script>
 <script src="lib/mp4_mux.js?v=1" onerror="console.warn('§LOAD_FAIL mp4_mux.js — MaxQ falls back to webm')"></script>
 <script src="cinema_path_editor.js?v=15" onerror="console.warn('§LOAD_FAIL cinema_path_editor.js — Alt+C path editing disabled')"></script>


### PR DESCRIPTION
## The ask
**User, 2026-09-03:** during the Reveal round the ARCH discipline is stripped **as soon as the fly-back begins**. Delay it until the camera has **arrived back at the starting stick**, where round 2 properly commences.

**Their reason, which is the whole point:** on the retrace everything is built *and lit*, and that fully-lit read is the payoff against the gloomy first pass — when lighting legitimately had not been installed yet. Stripping ARC early destroys that contrast.

## The change
One gate in `A.cpeRevealVisualAt`. The ghost boundary moves from `b.pullout` to `b.flyback`.

`b.flyback` already existed in `plan.beats` (`effects.js:8927`) — `§CPE_DISCIPLINE_REVEAL_FLYBACK` (2026-08-16) added the sub-beat but deliberately left this boundary at `b.pullout`, with a comment saying so. This splits it back out.

**DEGRADE, DON'T DISABLE:** a plan without `b.flyback` falls back to `b.pullout` — byte-identical to previous behaviour.

## Scope — nothing else touched
Not the reveal order, not the fade overlap, not the fly-back pacing, not the HUD. HUD highlights may still start earlier: they run off `cinema_maxq`'s own reveal-round boundary, not this function.

## Witness
`viewer/tests/witness_reveal_arch_hold.js` — **W-ARCH-HOLD 6/6 GREEN**. Slices the pure function out of the shipped `effects.js` and runs it standalone; no browser, no bake.

**Red control** (`W_ARCH_HOLD_RED=1`) restores the old gate and **fails G1 and G3** — the two gates that can detect the change — so the green is attributable rather than free. G6 is an explicit NO-OP guard: the two arms must differ.

```
G1-flyback-solid   PASS ghostFrames=0/19 across b.pullout(0.55)..b.flyback(0.7)
G2-round2-ghosts   PASS ghostFrames=19/19 across b.flyback..b.reveal
G3-boundary        PASS justBefore=null justAfter=ghost
G4-pullout-plain   PASS
G5-degrade         PASS legacy plan (no b.flyback) still ghosts
G6-not-a-noop      PASS the two arms differ
```

`eslint viewer modeller` — 354 files, 0 errors, exit 0 (repo toolchain).
`sw.js` v1129→v1130, `effects.js?v=31→32`, `EFFECTS_V` v24→v25 in the same PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RTX9gUq3tQoytC1vthLmcq