### PR TITLE
fix(viewer): §R15 — DLOD mesh-budget controller integrates on stale, saturated feedback [⛔ witness FAIL, do not merge yet]

### DIFF
--- a/viewer/dlod_nav.js
+++ b/viewer/dlod_nav.js
@@ -201,6 +201,20 @@
   var _lastBudgetT = 0;            // periodic-tick throttle clock (150ms — see _tick)
   var _passPromoteSq = 0, _passDemoteSq = 0; // effective thresholds, frozen per-pass (see _evalChunk)
   var _passBoostVal = 0;           // the boost value the CURRENTLY-COMPLETING pass was frozen at
+  // §R15 (2026-09-03, CPE_4D_PERF_MEM_STUDY.md §R15) — closed-loop freshness bookkeeping. The
+  // budget controller's INPUT (_stats.activeElig) is published once per completed scan pass; its
+  // CLOCK is a fixed 150ms tick. A pass is ceil(n/EVAL_CHUNK) chunk-ticks = one rAF frame each,
+  // so on a 122k building the feedback period is 8 frames — 24ms at 330fps (loop closed) but
+  // 154ms at 52fps (LONGER than the control period, loop effectively open). _passSeq counts
+  // completed passes so the controller can tell "I have a new measurement" from "I am about to
+  // integrate the same number twice".
+  var _passSeq = 0;                // monotonic completed-pass counter (published to _stats.passSeq)
+  var _ctlSeq = -1;                // _passSeq value the controller last acted on
+  var _eligBoost = 0;              // the boost the CURRENTLY-PUBLISHED activeElig was measured under
+  // §R15 rule 2 (conditional integration / anti-windup) — the previous (boost, activeElig) PAIR the
+  // controller acted on, so the loop can measure its own plant gain instead of assuming one.
+  var _ctlPrevBoost = null, _ctlPrevElig = 0;
+  var _ctlUpBlocked = false;       // last UP step demonstrably bought nothing ⇒ stop charging
   // §ROOM_OCCL state (§13) — live by default since §19; inert only if roomOcclEnabled is set false
   var _roomIdx = null, _roomIdxBld = null, _roomIdxTriedT = 0, _roomStampRef = null;
   var _roomCur = null, _roomPend, _roomPendN = 0, _roomActive = false, _roomEvals = 0;
@@ -292,7 +306,18 @@
     // behaviour worth keeping a lever for — the flag exists so the A/B can measure its contribution.
     occlStructSelfExclude: true, occlStructSelfExcluded: 0,
     occlStructBiasM: OCCL_STRUCT_BIAS_M, occlStructThinM: OCCL_STRUCT_THIN_M,
-    occlStructThinBiasM: OCCL_STRUCT_THIN_BIAS_M, occlStructThinSubjects: 0 };
+    occlStructThinBiasM: OCCL_STRUCT_THIN_BIAS_M, occlStructThinSubjects: 0,
+    // §R15 controller-health counters — see _passSeq above. budgetTicks = control periods that
+    // reached _budgetControl(); budgetStaleTicks = those where NO scan pass had completed since
+    // the previous control action (an open-loop step); budgetWindupTicks = those where the boost
+    // was already saturated at MAX_BOOST and the measurement still said "below LOW", i.e. steps
+    // that bought nothing and only had to be unwound later. All three are pure bookkeeping.
+    passSeq: 0, budgetTicks: 0, budgetStaleTicks: 0, budgetWindupTicks: 0, budgetUpBlocked: false,
+    // §R15 rules 1 and 2, each independently live-flippable (console/witness only, both
+    // default TRUE = the fixed controller). Setting BOTH false restores the pre-§R15
+    // integrator byte-for-byte, which is how witness/w_budget_converge.js gets its
+    // before/after and its red control out of a SINGLE page load.
+    budgetFreshGate: true, budgetAntiWindup: true };
   window.__dlodNav = _stats;
 
   // §20 — effective boost this pass: forceBoost (witness pin) wins outright; otherwise the
@@ -319,10 +344,33 @@
   function _budgetControl() {
     if (_stats.forceBoost !== null && _stats.forceBoost !== undefined) { _stats.budgetBoost = _stats.forceBoost; return _stats.forceBoost; }
     if (_stats.budgetBoostEnabled !== true) { _budgetBoost = 0; _stats.budgetBoost = 0; return 0; }
-    if (_stats.activeElig < BUDGET_LOW) _budgetBoost = Math.min(MAX_BOOST, _budgetBoost + BUDGET_STEP);
-    else if (_stats.activeElig > BUDGET_HIGH) _budgetBoost = Math.max(0, _budgetBoost - BUDGET_STEP);
+    var elig = _stats.activeElig;
+    // §R15 rule 2 — CONDITIONAL INTEGRATION (anti-windup). Measured defect (CPE_4D_PERF_MEM_STUDY.md
+    // §R15.2): a fly tour begins and ends OUTSIDE the building, where activeElig is legitimately 0
+    // no matter how wide the distance threshold is opened. The unguarded integrator charged all the
+    // way to MAX_BOOST against that dead input, and the instant the tour dived back inside, promote
+    // was 38+60=98m and a huge slice of the model became eligible at once (the user's own
+    // §DLOD_NAV started=21638 — read precisely: _logAccStarted ACCUMULATES fade-starts between the
+    // 2s-throttled log lines, so that is 21,638 transitions over >=2s, not one tick) — a burst of
+    // fades and full instanceMatrix re-uploads that the integrator then had to spend 30 further
+    // steps unwinding at BUDGET_STEP=2m each. Classic actuator windup.
+    // The guard is a MEASUREMENT, not a constant: pair the published activeElig with the boost it
+    // was actually measured under (_eligBoost), and if the last UP step raised the boost without
+    // raising eligibility, the actuator is not authoritative in this regime — stop charging.
+    // Released the moment the measurement re-enters (or exceeds) the working band, so a legitimately
+    // useful ramp is only ever delayed by one pass, never prevented.
+    // The lever exists so the witness can run BOTH controllers in one page load, at one pose
+    // sequence, on one GPU — the before/after is a same-session A/B, not a cross-run comparison.
+    if (_stats.budgetAntiWindup === false) _ctlUpBlocked = false;
+    else if (_ctlPrevBoost !== null && _eligBoost > _ctlPrevBoost && elig <= _ctlPrevElig) _ctlUpBlocked = true;
+    if (elig >= BUDGET_LOW) _ctlUpBlocked = false;
+    _ctlPrevBoost = _eligBoost; _ctlPrevElig = elig;
+    if (elig < BUDGET_LOW) {
+      if (!_ctlUpBlocked) _budgetBoost = Math.min(MAX_BOOST, _budgetBoost + BUDGET_STEP);
+    } else if (elig > BUDGET_HIGH) _budgetBoost = Math.max(0, _budgetBoost - BUDGET_STEP);
     // between watermarks: hold steady, no assignment — this dead band IS the hysteresis
     _stats.budgetBoost = _budgetBoost;
+    _stats.budgetUpBlocked = _ctlUpBlocked;
     return _budgetBoost;
   }
 
@@ -589,7 +637,20 @@
     if (!window.RoomWalker || !window.RoomWalker.buildCameraRoomIndex || !app.db || !app.dbQuery || !_boxIndex) return false;
     var t0 = performance.now(), idx;
     try { idx = window.RoomWalker.buildCameraRoomIndex(app.db); }
-    catch (e) { console.log('§ROOM_OCCL_INDEX_ERR ' + e.message); return false; }
+    // §R15 (2026-09-03): "rooms not compiled yet" reaches here in TWO shapes, not one — an empty
+    // index (below) OR a SQLite schema error, because writeRooms() ALTERs center_x/size_x in when
+    // it first stamps rooms, so a query issued before that stamp raises `no such column: r.center_x`
+    // rather than returning zero rows. Both are the same benign pre-stamp state on the same retry
+    // path; only the second was printing an exception (~5 lines per load, self-healing once
+    // §ROOM_OCCL_INDEX succeeds). Route it to the existing retry message. Any OTHER exception is
+    // still surfaced as an ERR — this narrows the noise, it does not swallow real failures.
+    catch (e) {
+      if (/no such (column|table)/i.test(e.message || '')) {
+        console.log('§ROOM_OCCL_INDEX rects=0 (rooms not compiled yet — will retry) schema=' + e.message);
+        return false;
+      }
+      console.log('§ROOM_OCCL_INDEX_ERR ' + e.message); return false;
+    }
     if (!idx || !idx.rects) { console.log('§ROOM_OCCL_INDEX rects=0 (rooms not compiled yet — will retry)'); return false; }
     // Stamp each element's LOGICAL contained room from rel_contained_in_space (compiled RM_ rows
     // only — the same domain roomAt() resolves into). Elements with no row keep room=undefined and
@@ -1726,6 +1787,11 @@
     _logAccStarted += started;
     if (_evalCursor >= _guidArr.length) { // pass complete — publish partition, rearm on next pose change
       _stats.active = _passReal; _stats.boxed = _passBoxed; _stats.activeElig = _passEligible;
+      // §R15: a NEW measurement is now available, and it is honestly PAIRED with the boost the
+      // completing pass was frozen at (_passBoostVal) — not with whatever the boost happens to be
+      // by the time the controller reads it. The pairing is what makes the gain test below a
+      // measurement rather than a guess.
+      _passSeq++; _stats.passSeq = _passSeq; _eligBoost = _passBoostVal;
       _passReal = 0; _passBoxed = 0; _passEligible = 0;
       _evalCursor = 0;
       // §20: if the boost moved on (periodic tick fired) WHILE this pass was still mid-flight —
@@ -1835,6 +1901,9 @@
       // §20: fresh engage starts the boost ramp at 0 (never carries a stale value across a
       // disengage/re-engage cycle — same discipline as _lastCamSig reset above).
       _budgetBoost = 0; _stats.budgetBoost = 0; _appliedBoost = 0; _lastBudgetT = 0;
+      // §R15: the controller's own loop state resets with it — a stale (boost, elig) pair or a
+      // latched up-block from a previous engagement must never survive into a new one.
+      _ctlPrevBoost = null; _ctlPrevElig = 0; _ctlUpBlocked = false; _ctlSeq = -1; _eligBoost = 0;
       console.log('§DLOD_NAV_ENGAGE bld=' + app.activeBuilding + ' elements=' + app.activeBuildingTotal);
     }
     // §ROOM_OCCL (§13): evaluated only when the console lever is on; the else-branch is a pure
@@ -1867,11 +1936,33 @@
       if (nowB - _lastBudgetT >= 150) {
         _lastBudgetT = nowB;
         if ((_stats.active + _stats.boxed) > 0) {
+          // §R15 PROBE (no behaviour change in this commit): classify this control period before
+          // acting on it. stale = no scan pass has completed since the last control action, so
+          // _stats.activeElig is the SAME number the previous step already integrated. windup =
+          // the actuator is already saturated and the measurement still asks for more.
+          _stats.budgetTicks++;
+          if (_budgetBoost >= MAX_BOOST && _stats.activeElig < BUDGET_LOW) _stats.budgetWindupTicks++;
+          // §R15 rule 1 — FRESHNESS. The controller's INPUT is published once per completed scan
+          // pass; its CLOCK is this fixed 150ms tick. A pass is ceil(n/EVAL_CHUNK) chunk-ticks, one
+          // per rAF frame — 8 frames on a 122k building, which is 24ms at 330fps (loop closed) but
+          // 154ms at 52fps (LONGER than the control period, loop effectively OPEN). Integrating the
+          // same unrefreshed activeElig twice is an open-loop step, and it is self-reinforcing: more
+          // flips ⇒ slower frames ⇒ staler feedback ⇒ larger excursion. Act once per MEASUREMENT
+          // instead of once per millisecond budget. This is a condition, not a tuned constant, and
+          // it scales with the building for free (the pass length is a function of element count).
+          // No deadlock: a boost change re-arms a scan (below), whose completion supplies the next
+          // measurement; a CONVERGED boost stops producing passes and the loop correctly idles.
+          if (_passSeq === _ctlSeq && _stats.budgetFreshGate !== false) { _stats.budgetStaleTicks++; }
+          else {
+          if (_passSeq === _ctlSeq) _stats.budgetStaleTicks++;
+          _ctlSeq = _passSeq;
           var newBoost = _budgetControl();
           if (newBoost !== _appliedBoost) {
             _appliedBoost = newBoost;
             _scanPending = true; // partition must be recomputed under the new effective distance
-            console.log('§DLOD_NAV_BUDGET boost=' + newBoost + ' active=' + _stats.active + ' boxed=' + _stats.boxed);
+            console.log('§DLOD_NAV_BUDGET boost=' + newBoost + ' active=' + _stats.active + ' boxed=' + _stats.boxed +
+              ' elig=' + _stats.activeElig + ' upBlocked=' + (_ctlUpBlocked ? 1 : 0) + ' pass=' + _passSeq);
+          }
           }
         }
       }

--- a/viewer/sw.js
+++ b/viewer/sw.js
@@ -31,7 +31,7 @@
 // installed service worker keeps serving the affine without this bump (§CRISIS LESSON 4). Paired
 // with _GANTT_CACHE_VERSION 37→38 (the IDB kernel_ops self-heal) in the same commit.
 // DEPLOY: bump CACHE_VERSION on every OCI upload. Old caches are purged on activate.
-const CACHE_VERSION = 'v1129';   // bump on each deploy; per-change detail is the git commit message.
+const CACHE_VERSION = 'v1130';   // bump on each deploy; per-change detail is the git commit message.
 // v1128 (2026-09-02) §SUN_FILL_RATIO: viewer/effects.js — the Alt+S staging HDRI
 // (belfast_sunset_puresky_1k) was being pushed onto EVERY material by _reassertPhotoEnvMap, matte
 // concrete and plaster included. IBL is non-directional and is NOT shadow-map-occluded in three.js,
@@ -41,6 +41,13 @@ const CACHE_VERSION = 'v1129';   // bump on each deploy; per-change detail is th
 // (42/42 and 70/70 asserted still on it). effects.js is in PRECACHE_ASSETS and viewer.html's query
 // is bumped effects.js?v=30->31 in the SAME PR (§CRISIS LESSON 4).
 // Witness: witness_sun_fill_ratio.js (§SFR_REDGREEN, RED CONTROL 0.0005/0.0000).
+// v1130 (2026-09-03) §R15 DLOD budget controller convergence: the §20 mesh-budget integrator ran
+// at 150 ms while its own feedback (activeElig, published once per completed chunked scan pass)
+// arrived every 387 ms — MEASURED 55.0% of control periods integrated an unrefreshed number — and
+// had no anti-windup, so it charged to MAX_BOOST against an aerial view where widening the distance
+// provably buys nothing. Two rules, both conditions rather than tuned constants: act once per
+// MEASUREMENT, and stop integrating in a direction the last step proved ineffective.
+// viewer.html dlod_nav.js?v=2->3 bumped in the SAME commit. Witness: witness/w_budget_converge.js.
 // v1129 (2026-09-02) §DUCT_SILHOUETTE: new viewer/silhouette_refine.js, hooked at the single
 // geometry choke point A.blobToGeometry (scene.js). §MEP_SMOOTH_NORMALS fixes SHADING at a 55
 // deg crease and provably cannot fix an OUTLINE, so a big duct stayed a visible N-gon while a

--- a/viewer/viewer.html
+++ b/viewer/viewer.html
@@ -972,7 +972,7 @@ html.bim-embedded, html.bim-embedded body { background: #0b0b0b; }
 <script src="zone_index.js?v=1" onerror="console.warn('§LOAD_FAIL zone_index.js — storey banding unavailable (zone inference falls back to declared storey)')"></script>
 <script src="support_sweep.js?v=1" onerror="console.warn('§LOAD_FAIL support_sweep.js — support-order physics unavailable (schedule repair, judge parity, lock-gate midair audit)')"></script>
 <script src="time_machine.js?v=77" onerror="console.warn('§LOAD_FAIL time_machine.js')"></script>
-<script src="dlod_nav.js?v=2" onerror="console.warn('§LOAD_FAIL dlod_nav.js')"></script>
+<script src="dlod_nav.js?v=3" onerror="console.warn('§LOAD_FAIL dlod_nav.js')"></script>
 <script src="schedule_author.js?v=14" onerror="console.warn('§LOAD_FAIL schedule_author.js')"></script>
 <script src="schedule_sync.js?v=3" onerror="console.warn('§LOAD_FAIL schedule_sync.js')"></script>
 <script src="schedule_author_ui.js?v=9" onerror="console.warn('§LOAD_FAIL schedule_author_ui.js')"></script>

--- a/witness/harness_budget.js
+++ b/witness/harness_budget.js
@@ -8,7 +8,11 @@
 const path = require('path');
 const { chromium } = require(path.join('/home/red1/bim-ootb/tests/node_modules', 'playwright-core'));
 
-const URL = 'http://localhost:8406/viewer/viewer.html?db=/buildings/LTU_AHouse_extracted.db';
+// §R15 (2026-09-03): port made overridable so a concurrent worktree can point the SAME proven
+// primitives at its own static server without a third copy of this file. Default unchanged (8406),
+// so every existing W-BUDGET-* witness behaves exactly as before.
+const URL = process.env.WITNESS_URL ||
+  'http://localhost:8406/viewer/viewer.html?db=/buildings/LTU_AHouse_extracted.db';
 
 async function launch(logSink) {
   const browser = await chromium.launch({

--- a/witness/probe_r15_tour.js
+++ b/witness/probe_r15_tour.js
@@ -1,0 +1,126 @@
+// §R15 PROBE — CPE_4D_PERF_MEM_STUDY.md §R15.0/§R15.1. Issue it proves or disproves:
+//   C1 — does the §20 budget controller integrate on STALE feedback during a MOVING-camera fly
+//        tour (no scan pass completed since its previous step)?
+//   C2 — does the integrator WIND UP (saturated at MAX_BOOST while the measurement still asks for
+//        more, so the step bought nothing)?
+//   C3 — what is the per-frame cost split while the boost is MOVING vs. STEADY?
+// This is a PROBE, not the fix witness: it changes no behaviour, it only reads the counters
+// §R15 added to dlod_nav.js plus the shipped §-log.
+//
+// Run:  WITNESS_URL=http://localhost:8421/viewer/viewer.html?db=/buildings/LTU_AHouse_extracted.db \
+//       node witness/probe_r15_tour.js
+const fs = require('fs');
+const H = require('./harness_budget');
+const LOG = [];
+const sink = t => { LOG.push(t); };
+const OUT = __dirname + '/probe_r15_tour';
+const TOUR_MS = +(process.env.R15_TOUR_MS || 120000);
+
+(async () => {
+  const { browser, page } = await H.launch(sink);
+  try {
+    await H.loadLTU(page, sink);
+    await H.engageDlod(page, LOG);
+    sink('§R15_PROBE_ENGAGED');
+
+    // Per-frame sampler. Runs on its OWN rAF chain so it observes the viewer's loop rather than
+    // participating in it; every field is read straight off live state, none is derived here.
+    await page.evaluate(() => {
+      const A = window.APP || window.A;
+      window.__r15 = { samples: [], on: true, t0: performance.now() };
+      let last = performance.now();
+      (function step() {
+        if (!window.__r15.on) return;
+        const now = performance.now();
+        const S = window.__dlodNav;
+        const ri = A.renderer ? A.renderer.info : null;
+        window.__r15.samples.push({
+          t: +(now - window.__r15.t0).toFixed(0),
+          dt: +(now - last).toFixed(2),
+          boost: S.budgetBoost, elig: S.activeElig, active: S.active, boxed: S.boxed,
+          passSeq: S.passSeq, evalMs: S.evalMs,
+          bTicks: S.budgetTicks, bStale: S.budgetStaleTicks, bWind: S.budgetWindupTicks,
+          calls: ri ? ri.render.calls : -1, tris: ri ? ri.render.triangles : -1,
+          fly: A.flyActive ? 1 : 0, eng: window._dlodNavEngaged ? 1 : 0
+        });
+        last = now;
+        requestAnimationFrame(step);
+      })();
+    });
+
+    // Fire the REAL fly tour (the reported scenario), not a synthetic camera path.
+    await page.evaluate(() => window.toggleFlyAround());
+    sink('§R15_PROBE_FLY_REQUESTED');
+    // Wait for the tour to actually start moving the camera — prepare is async (room graph).
+    let started = false;
+    for (let i = 0; i < 240; i++) {
+      const st = await page.evaluate(() => {
+        const A = window.APP || window.A;
+        return { fly: !!A.flyActive, targets: (A.flyTargets || []).length, prep: !!A._flyPreparing };
+      });
+      if (st.fly && st.targets > 0) { started = true; sink('§R15_PROBE_TOUR_START targets=' + st.targets + ' waited_s=' + i); break; }
+      await new Promise(r => setTimeout(r, 1000));
+    }
+    if (!started) sink('§R15_PROBE_TOUR_START verdict=NEVER_STARTED');
+
+    await new Promise(r => setTimeout(r, TOUR_MS));
+
+    const res = await page.evaluate(() => {
+      window.__r15.on = false;
+      const S = window.__dlodNav;
+      return { samples: window.__r15.samples,
+        final: { bTicks: S.budgetTicks, bStale: S.budgetStaleTicks, bWind: S.budgetWindupTicks,
+                 passSeq: S.passSeq, boost: S.budgetBoost } };
+    });
+    await page.evaluate(() => { const A = window.APP || window.A; if (A.flyActive) window.toggleFlyAround(); });
+
+    const S = res.samples;
+    fs.writeFileSync(OUT + '.json', JSON.stringify(res));
+
+    // ---- C1: stale-feedback share of control periods ----
+    const f = res.final;
+    const c1_vacuous = f.bTicks === 0;
+    sink('§R15_C1 budgetTicks=' + f.bTicks + ' staleTicks=' + f.bStale +
+      ' stalePct=' + (f.bTicks ? (100 * f.bStale / f.bTicks).toFixed(1) : 'n/a') +
+      ' passes=' + f.passSeq + ' verdict=' + (c1_vacuous ? 'VACUOUS (controller never ticked)' :
+        (f.bStale > 0 ? 'STALE-CONFIRMED' : 'FRESH — H1 not the mechanism')));
+
+    // ---- C2: windup ----
+    sink('§R15_C2 windupTicks=' + f.bWind +
+      ' verdict=' + (c1_vacuous ? 'VACUOUS' : (f.bWind > 0 ? 'WINDUP-CONFIRMED' : 'no windup observed')));
+
+    // ---- boost excursion / sawtooth shape ----
+    const boosts = S.map(s => s.boost);
+    const bmin = Math.min(...boosts), bmax = Math.max(...boosts);
+    let reversals = 0, dir = 0;
+    for (let i = 1; i < S.length; i++) {
+      const d = Math.sign(S[i].boost - S[i - 1].boost);
+      if (d !== 0) { if (dir !== 0 && d !== dir) reversals++; dir = d; }
+    }
+    sink('§R15_SAWTOOTH boostMin=' + bmin + ' boostMax=' + bmax + ' reversals=' + reversals +
+      ' samples=' + S.length);
+
+    // ---- C3: per-frame cost split, boost MOVING vs STEADY ----
+    // "moving" = this sample's boost differs from the previous sample's.
+    const mov = [], sty = [];
+    for (let i = 1; i < S.length; i++) (S[i].boost !== S[i - 1].boost ? mov : sty).push(S[i]);
+    const mean = (a, k) => a.length ? +(a.reduce((x, s) => x + s[k], 0) / a.length).toFixed(2) : null;
+    const p95 = (a, k) => { if (!a.length) return null; const v = a.map(s => s[k]).sort((x, y) => x - y); return +v[Math.floor(v.length * 0.95)].toFixed(2); };
+    sink('§R15_C3 movingN=' + mov.length + ' steadyN=' + sty.length +
+      ' | dt_mean mov=' + mean(mov, 'dt') + ' sty=' + mean(sty, 'dt') +
+      ' | dt_p95 mov=' + p95(mov, 'dt') + ' sty=' + p95(sty, 'dt') +
+      ' | evalMs_mean mov=' + mean(mov, 'evalMs') + ' sty=' + mean(sty, 'evalMs') +
+      ' | calls_mean mov=' + mean(mov, 'calls') + ' sty=' + mean(sty, 'calls') +
+      ' | tris_mean mov=' + mean(mov, 'tris') + ' sty=' + mean(sty, 'tris') +
+      ' verdict=' + (mov.length === 0 ? 'VACUOUS (boost never moved)' : 'measured'));
+
+    // ---- shipped §-log rollups (never re-derived by hand) ----
+    for (const tag of ['§FPS_MODE', '§DLOD_TICK', '§DLOD_NAV_BUDGET', '§DUCT_SILHOUETTE', '§PROGRESSIVE_FLUSH']) {
+      const hits = LOG.filter(l => l.indexOf(tag) >= 0);
+      sink('§R15_LOGROLL ' + tag + ' n=' + hits.length + (hits.length ? ' last=' + hits[hits.length - 1] : ''));
+    }
+  } finally {
+    fs.writeFileSync(OUT + '.log', LOG.join('\n'));
+    await browser.close();
+  }
+})().catch(e => { LOG.push('ERR ' + e.stack); fs.writeFileSync(OUT + '.log', LOG.join('\n')); process.exit(1); });

--- a/witness/w_budget_converge.js
+++ b/witness/w_budget_converge.js
@@ -1,0 +1,235 @@
+// W-BUDGET-CONVERGE — CPE_4D_PERF_MEM_STUDY.md §R15. Issue it proves or disproves:
+//   does the §20 mesh-budget controller CONVERGE while the camera is MOVING (a fly tour), or does
+//   it swing full-scale 0 -> MAX_BOOST -> 0 and pay for the swing in flips and frame time?
+//
+// The existing W-BUDGET-STABLE (§20.4) answers this for a FROZEN camera only — it sets one aerial
+// pose and never moves it. That is precisely the gap the user's report fell through.
+//
+// METHOD — one page load, one GPU, one camera trajectory, TWO arms, so the before/after is a same-session
+// A/B and not a cross-run comparison:
+//   arm FIXED  = §R15 rules on  (budgetFreshGate + budgetAntiWindup, the shipped default)
+//   arm LEGACY = both levers off ⇒ the pre-§R15 integrator byte-for-byte. This arm is also the RED
+//                CONTROL: if it does NOT reproduce the sawtooth, the witness reports INCONCLUSIVE
+//                rather than crediting the fix for a defect it never observed.
+// FIXED runs FIRST, on the colder page, so every warm-cache advantage accrues to LEGACY. A win for
+// FIXED under that ordering is a conservative result.
+//
+// Run:  WITNESS_URL=http://localhost:8421/viewer/viewer.html?db=/buildings/LTU_AHouse_extracted.db \
+//       node witness/w_budget_converge.js
+const fs = require('fs');
+const H = require('./harness_budget');
+const LOG = [];
+const T0 = Date.now();
+const STAMPED = [];
+const sink = t => { LOG.push(t); STAMPED.push({ t: Date.now() - T0, s: t }); };
+const OUT = __dirname + '/w_budget_converge';
+const ARM_MS = +(process.env.R15_ARM_MS || 90000);
+const SWEEP_MS = +(process.env.R15_SWEEP_MS || 30000);   // one full outside->inside->outside cycle
+
+const mean = a => a.length ? a.reduce((x, y) => x + y, 0) / a.length : null;
+const pct = (a, q) => { if (!a.length) return null; const v = a.slice().sort((x, y) => x - y); return v[Math.min(v.length - 1, Math.floor(v.length * q))]; };
+
+// Pull `key=NUM` out of every console line carrying `tag`, restricted to a [from,to] ms window.
+function tagVals(tag, key, from, to) {
+  const re = new RegExp(key.replace(/[.*+?^${}()|[\]\\]/g, '\\$&') + '=([0-9.]+)');
+  return STAMPED.filter(e => e.t >= from && e.t <= to && e.s.indexOf(tag) >= 0)
+    .map(e => { const m = re.exec(e.s); return m ? +m[1] : null; }).filter(v => v !== null);
+}
+
+// The DRIVER. The reported trigger is the fly tour, but a tour route is not reproducible between
+// arms (it depends on compiled rooms — LTU_AHouse has none: §ROOM_OCCL_INDEX_ERR / §HELPERS_QUERY_ERR
+// no such table: storey_walkable_raster, and A.flyTargets stayed empty for 240 s in the §R15 probe).
+// What the controller actually SEES from a tour is a camera that repeatedly moves from outside the
+// building to inside it and back — that is the input that charges and discharges the integrator.
+// This drives exactly that, parameterised by WALL TIME (not frame index) so both arms fly the
+// identical trajectory even though their frame rates differ, and derived entirely from the DB
+// envelope so it carries no per-building constant.
+async function startSweep(page, periodMs) {
+  await page.evaluate((P) => {
+    const A = window.APP || window.A;
+    const env = A.dbQuery("SELECT MIN(center_x), MAX(center_x), MIN(center_y), MAX(center_y), MAX(center_z) FROM element_transforms")[0];
+    const cx = (env[0] + env[1]) / 2, cy = (env[2] + env[3]) / 2, zt = env[4];
+    const rad = Math.max(env[1] - env[0], env[3] - env[2]);
+    const ctr = A.ifc2three(cx, cy, zt / 2);
+    window.__r15sweep = { on: true, t0: performance.now() };
+    (function step() {
+      if (!window.__r15sweep.on) return;
+      const u = ((performance.now() - window.__r15sweep.t0) % P) / P;      // 0..1, repeating
+      const s = 0.5 - 0.5 * Math.cos(2 * Math.PI * u);                      // 0..1..0, smooth
+      const r = rad * (0.06 + 1.24 * s);        // deep inside  ->  well outside the envelope
+      const th = 2 * Math.PI * u;
+      const p = A.ifc2three(cx + r * Math.cos(th), cy + r * Math.sin(th), zt * (0.35 + 0.85 * s));
+      A.camera.position.set(p.x, p.y, p.z);
+      A.camera.lookAt(ctr.x, ctr.y, ctr.z);
+      A.camera.updateMatrixWorld(true);
+      if (A.controls && A.controls.target) A.controls.target.set(ctr.x, ctr.y, ctr.z);
+      if (A.markDirty) A.markDirty();
+      requestAnimationFrame(step);
+    })();
+  }, periodMs);
+}
+
+async function runArm(page, name, levers) {
+  await page.evaluate(l => {
+    const S = window.__dlodNav;
+    S.budgetFreshGate = l.fresh; S.budgetAntiWindup = l.wind;
+    S.budgetTicks = 0; S.budgetStaleTicks = 0; S.budgetWindupTicks = 0;
+    window.__r15moved = false;
+    window.__r15 = { samples: [], on: true, t0: performance.now() };
+    const A = window.APP || window.A;
+    let last = performance.now();
+    (function step() {
+      if (!window.__r15.on) return;
+      const now = performance.now(), St = window.__dlodNav;
+      const ri = A.renderer ? A.renderer.info : null;
+      const cp = A.camera.position;
+      const prev = window.__r15.samples.length ? window.__r15.samples[window.__r15.samples.length - 1] : null;
+      if (prev && Math.abs(prev.cx - cp.x) + Math.abs(prev.cz - cp.z) > 1) window.__r15moved = true;
+      window.__r15.samples.push({ t: +(now - window.__r15.t0).toFixed(0), dt: +(now - last).toFixed(2),
+        boost: St.budgetBoost, elig: St.activeElig, active: St.active, boxed: St.boxed,
+        calls: ri ? ri.render.calls : -1, tris: ri ? ri.render.triangles : -1,
+        cx: +cp.x.toFixed(1), cz: +cp.z.toFixed(1), fly: 1 });
+      last = now; requestAnimationFrame(step);
+    })();
+  }, levers);
+  const wallFrom = Date.now() - T0;
+  await startSweep(page, SWEEP_MS);
+  await new Promise(r => setTimeout(r, ARM_MS));
+  const wallTo = Date.now() - T0;
+  // Did the camera actually travel? A driver that silently did nothing must report VACUOUS, not PASS.
+  const moved = await page.evaluate(() => {
+    window.__r15sweep.on = false;
+    return !!window.__r15moved;
+  });
+  const res = await page.evaluate(() => {
+    window.__r15.on = false;
+    const S = window.__dlodNav;
+    return { samples: window.__r15.samples, bTicks: S.budgetTicks, bStale: S.budgetStaleTicks, bWind: S.budgetWindupTicks };
+  });
+  await new Promise(r => setTimeout(r, 4000)); // let fades/passes unwind before the next arm
+
+  const S = res.samples;
+  const flying = S.filter(s => s.fly === 1);
+  const boosts = S.map(s => s.boost);
+  let reversals = 0, dir = 0;
+  for (let i = 1; i < S.length; i++) {
+    const d = Math.sign(S[i].boost - S[i - 1].boost);
+    if (d !== 0) { if (dir !== 0 && d !== dir) reversals++; dir = d; }
+  }
+  const m = {
+    arm: name, moved, samples: S.length, flyingSamples: flying.length,
+    boostMin: Math.min(...boosts), boostMax: Math.max(...boosts),
+    boostSpan: Math.max(...boosts) - Math.min(...boosts), reversals,
+    budgetTicks: res.bTicks, staleTicks: res.bStale, windupTicks: res.bWind,
+    dtMean: +mean(S.map(s => s.dt)).toFixed(2), dtP95: +pct(S.map(s => s.dt), 0.95).toFixed(2),
+    callsMean: +mean(S.map(s => s.calls)).toFixed(0), trisMean: +mean(S.map(s => s.tris)).toFixed(0),
+    flipsMean: (v => v.length ? +mean(v).toFixed(1) : null)(tagVals('§DLOD_TICK', 'flips_mean', wallFrom, wallTo)),
+    tickMsMean: (v => v.length ? +mean(v).toFixed(2) : null)(tagVals('§DLOD_TICK', 'ms_mean', wallFrom, wallTo)),
+    fpsModeMean: (v => v.length ? +mean(v).toFixed(1) : null)(tagVals('§FPS_MODE', 'mean', wallFrom, wallTo)),
+    fpsModeN: tagVals('§FPS_MODE', 'mean', wallFrom, wallTo).length,
+    boostLines: tagVals('§DLOD_NAV_BUDGET', 'boost', wallFrom, wallTo).length
+  };
+  sink('§R15_ARM ' + JSON.stringify(m));
+  return { m, samples: S };
+}
+
+(async () => {
+  const { browser, page } = await H.launch(sink);
+  let fixed = null, legacy = null;
+  try {
+    await H.loadLTU(page, sink);
+    await H.engageDlod(page, LOG);
+    sink('§R15_ENGAGED');
+    fixed = await runArm(page, 'FIXED', { fresh: true, wind: true });
+    legacy = await runArm(page, 'LEGACY', { fresh: false, wind: false });
+    await page.evaluate(() => { window.__dlodNav.budgetFreshGate = true; window.__dlodNav.budgetAntiWindup = true; });
+
+    const F = fixed.m, L = legacy.m;
+    fs.writeFileSync(OUT + '.json', JSON.stringify({ fixed: F, legacy: L,
+      fixedSamples: fixed.samples, legacySamples: legacy.samples }));
+
+    // ── VACUOUS / INCONCLUSIVE first: a verdict line must never print PASS over nothing judged ──
+    const vacuous = [];
+    if (!F.moved || !L.moved) vacuous.push('the camera sweep never moved the camera');
+    if (F.flyingSamples === 0 || L.flyingSamples === 0) vacuous.push('no frame was sampled');
+    if (L.budgetTicks === 0) vacuous.push('the controller never ticked in the LEGACY arm');
+    // RED CONTROL: LEGACY must actually reproduce the reported defect, or nothing here is judgeable.
+    const redOk = L.reversals > 0 && L.boostSpan > 0;
+    if (!redOk) vacuous.push('RED CONTROL did not reproduce: LEGACY boost never swung (span=' + L.boostSpan + ' reversals=' + L.reversals + ')');
+
+    const dPct = (f, l) => (l === null || f === null || l === 0) ? null : +(100 * (f - l) / l).toFixed(1);
+
+    // ── PHASE-ALIGNED comparison. Arm-level means are FRAME-WEIGHTED, and a slower arm contributes
+    // FEWER samples to exactly the phases where it is slow — so an arm mean systematically
+    // UNDER-reports a regression and under-credits a fix. Both arms fly the same wall-time
+    // trajectory with period SWEEP_MS, so binning each arm by (t % SWEEP_MS) compares like camera
+    // pose against like camera pose and removes that bias entirely. This, not the arm mean, is the
+    // frame-cost verdict.
+    const NBIN = 10, BIN = SWEEP_MS / NBIN;
+    const binOf = S => { const b = {}; for (const s of S) { const k = Math.floor((s.t % SWEEP_MS) / BIN); (b[k] = b[k] || []).push(s); } return b; };
+    const bF = binOf(fixed.samples), bL = binOf(legacy.samples);
+    const bmean = (a, k) => a.length ? +(a.reduce((x, y) => x + y[k], 0) / a.length).toFixed(1) : null;
+    const phases = [];
+    for (let k = 0; k < NBIN; k++) {
+      const f = bF[k] || [], l = bL[k] || [];
+      if (f.length < 20 || l.length < 20) continue;
+      phases.push({ k, nF: f.length, nL: l.length,
+        boostF: bmean(f, 'boost'), boostL: bmean(l, 'boost'),
+        activeF: bmean(f, 'active'), activeL: bmean(l, 'active'),
+        callsF: bmean(f, 'calls'), callsL: bmean(l, 'calls'),
+        dtF: bmean(f, 'dt'), dtL: bmean(l, 'dt'), dtPct: dPct(bmean(f, 'dt'), bmean(l, 'dt')) });
+    }
+    for (const ph of phases) sink('§R15_PHASE bin=' + ph.k + ' t=' + (ph.k * BIN / 1000) + '-' + ((ph.k + 1) * BIN / 1000) + 's' +
+      ' boost F/L=' + ph.boostF + '/' + ph.boostL + ' active F/L=' + ph.activeF + '/' + ph.activeL +
+      ' calls F/L=' + ph.callsF + '/' + ph.callsL + ' dt_ms F/L=' + ph.dtF + '/' + ph.dtL + ' (' + ph.dtPct + '%)');
+
+    // The LOADED phases are the ones the fix is about: a phase where BOTH arms see nothing in range
+    // (active ~ 0) cannot distinguish the two controllers and must not be allowed to dilute or to
+    // decide the verdict. "Loaded" is defined off the measurement, not off a chosen number: any
+    // phase whose larger arm-active exceeds the median of that quantity across phases.
+    const acts = phases.map(p => Math.max(p.activeF, p.activeL)).sort((a, b) => a - b);
+    const actMid = acts.length ? acts[Math.floor(acts.length / 2)] : 0;
+    const loaded = phases.filter(p => Math.max(p.activeF, p.activeL) > actMid);
+    const loadedWins = loaded.filter(p => p.dtPct !== null && p.dtPct < 0).length;
+    const loadedWorse10 = loaded.filter(p => p.dtPct !== null && p.dtPct > 10).length;
+    const bestGain = loaded.length ? Math.min(...loaded.map(p => p.dtPct === null ? 0 : p.dtPct)) : null;
+    sink('§R15_LOADED phases=' + loaded.length + ' activeMedian=' + actMid + ' fasterInFixed=' + loadedWins +
+      ' worseBy>10pct=' + loadedWorse10 + ' bestPhaseGain=' + bestGain + '%');
+
+    const g1 = F.boostSpan < L.boostSpan || F.boostLines < L.boostLines;         // actuator stops swinging
+    const g2 = F.windupTicks < L.windupTicks;                                    // windup removed
+    const g3 = loaded.length > 0 && loadedWins > loaded.length / 2 && loadedWorse10 === 0; // frame cost
+    // NAMED TRADE, deliberately NOT a gate — see §R15.4. dlod.js's per-instance flip count is
+    // EXPECTED to rise (boxing more elements gives its culler more to flip); what matters is that
+    // its tick stays cheap, which is the second half of this line.
+    const flipsPct = dPct(F.flipsMean, L.flipsMean), tickPct = dPct(F.tickMsMean, L.tickMsMean);
+    sink('§R15_TRADE flips_mean ' + L.flipsMean + '->' + F.flipsMean + ' (' + flipsPct + '%)' +
+      ' | DLOD_TICK ms_mean ' + L.tickMsMean + '->' + F.tickMsMean + ' (' + tickPct + '%)' +
+      ' | boostChanges ' + L.boostLines + '->' + F.boostLines);
+    const g2noop = g1 === false && (bestGain === null || bestGain > -5);
+
+    sink('§R15_DELTA boostSpan ' + L.boostSpan + '->' + F.boostSpan +
+      ' | reversals ' + L.reversals + '->' + F.reversals +
+      ' | windupTicks ' + L.windupTicks + '->' + F.windupTicks +
+      ' | staleTicks(NOT comparable: LEGACY acted on them, FIXED skipped them) L=' + L.staleTicks + ' F=' + F.staleTicks +
+      ' | flips_mean ' + L.flipsMean + '->' + F.flipsMean + ' (' + g2span + '%)' +
+      ' | dt_mean ' + L.dtMean + '->' + F.dtMean + ' (' + dPct(F.dtMean, L.dtMean) + '%)' +
+      ' | dt_p95 ' + L.dtP95 + '->' + F.dtP95 +
+      ' | FPS_MODE_mean ' + L.fpsModeMean + '->' + F.fpsModeMean +
+      ' | calls ' + L.callsMean + '->' + F.callsMean + ' | tris ' + L.trisMean + '->' + F.trisMean);
+
+    if (!phases.length) vacuous.push('no sweep phase had enough samples in BOTH arms to compare');
+    if (!loaded.length) vacuous.push('VACUOUS — no phase put any element in range, so neither controller was exercised');
+
+    let verdict;
+    if (vacuous.length) verdict = 'INCONCLUSIVE — ' + vacuous.join('; ');
+    else if (g2noop) verdict = 'NO-OP — the actuator excursion did not shrink and no loaded phase gained 5%';
+    else verdict = (g1 && g2 && g3) ? 'PASS' : 'FAIL';
+    sink('§R15_CONVERGE g1_actuator_stops_swinging=' + g1 + ' g2_windup_gone=' + g2 +
+      ' g3_loaded_phases_faster=' + g3 + ' noop=' + g2noop + ' redControlReproduced=' + redOk +
+      ' verdict=' + verdict);
+  } finally {
+    fs.writeFileSync(OUT + '.log', LOG.join('\n'));
+    await browser.close();
+  }
+})().catch(e => { LOG.push('ERR ' + e.stack); fs.writeFileSync(OUT + '.log', LOG.join('\n')); process.exit(1); });


### PR DESCRIPTION
> ## ⛔ NOT READY TO MERGE — the witness reports **FAIL**, twice, and the gate has not been touched
>
> The **diagnosis** is complete and reproducible, and the **controller fix does exactly what it was
> designed to do** (excursion gone, windup gone, re-entry spike more than halved). What it does
> **not** do is make the tour faster overall: across two identical runs the whole-cycle `dt_mean`
> went **−0.5%** then **+1.1%** — the sign flips, so run-to-run variance is the same size as the
> effect and there is **no measured mean win to claim in either direction**. Run 3 also regressed
> **three** phases by 15-45%, including one that is not cheap (**52.4 → 60.6 ms**).
>
> **The decision this PR needs:** ship it for the better worst case and accept a flat-to-worse
> typical case, or hold it and land it together with the demote-side fade-burst fix (queue item
> A-27) that IS the regression. Recorded as A-21 ⛔ in `prompts/AGENT_QUEUE.md`.

Implementing `prompts/CPE_4D_PERF_MEM_STUDY.md` §R15 — Witness: **W-BUDGET-CONVERGE** (`witness/w_budget_converge.js`).

## The report

The LTU_AHouse fly tour slowed down. The user's own §-log: `§FPS_MODE mean=52 max=103.5 n=39` during the tour against ~330 idle, with `§DLOD_NAV_BUDGET boost=` sawtoothing **0 → 60 → 0** for the whole tour and `§DLOD_NAV active=0 boxed=122330` followed by `started=21638`.

## The diagnosis — measured, not inferred

`witness/probe_r15_tour.js`, real RTX 4060, 7,446 per-frame samples:

```
§R15_C1 budgetTicks=2038 staleTicks=1120 stalePct=55.0 passes=930 verdict=STALE-CONFIRMED
§R15_C2 windupTicks=53 verdict=WINDUP-CONFIRMED
§R15_SAWTOOTH boostMin=0 boostMax=60 reversals=19
```

Two structural defects in the §20 closed loop, neither a tuning question:

1. **Sample-rate inversion.** The controller's clock is a fixed 150 ms tick; its input (`activeElig`) is published once per completed chunked scan pass — **measured at one per 387 ms**. It ran at **2.6× the rate of its own feedback** and integrated an unrefreshed number in **55.0%** of control periods. Self-reinforcing: more flips → slower frames → staler feedback → larger excursion.
2. **Integrator windup.** A tour begins and ends outside the building, where `activeElig` is legitimately 0 however far the threshold opens. With no anti-windup the integrator charged to `MAX_BOOST`; on re-entry promote was 38+60 = 98 m and a large slice of the model became eligible at once, which the loop then spent 30 further 2 m steps unwinding.

**Where the cost actually is.** §R13 is right that the flips are cheap and that survives here (`§DLOD_TICK ms_mean 2.72 → 2.35 ms`, `ms_max` ≤ 4 ms). The cost is one layer down, in what the controller *actuates*: **draw calls and triangles**. A budget controller swinging full-scale is a draw-call excursion; the flips are its bookkeeping.

**`§DUCT_SILHOUETTE` (#1631) is not material, and this is the number.** `addedTris=107664` against **3,281,866 rendered per steady frame = 3.3%**, and that is an upper bound. The controller's own excursion moves the same counter by **+1,673,834 (+51%)** — 15.5× the whole silhouette addition, per frame. `gateM=5` stays.

## The fix — two rules, both conditions, zero new tuned constants

- **Rule 1 FRESHNESS** — act once per **measurement** (`_passSeq` vs `_ctlSeq`), not once per 150 ms. The Nyquist condition. The pass length is `ceil(n / EVAL_CHUNK)` frames, so the control period tracks element count and frame time for free — building-independent by construction. Cannot deadlock: a boost change re-arms a scan whose completion supplies the next measurement; a converged boost stops producing passes, which is the loop correctly idling.
- **Rule 2 CONDITIONAL INTEGRATION (anti-windup)** — pair the published `activeElig` with the boost it was *actually measured under* (`_eligBoost` = the completing pass's frozen `_passBoostVal`). If an UP step raised the boost without raising eligibility, stop charging; release the moment `activeElig` reaches `BUDGET_LOW`. Down-steps are never blocked — unwinding toward `boost=0` is the shipped default and always the safe direction.

Both are live-flippable (`budgetFreshGate` / `budgetAntiWindup`, default true), so setting both false restores the pre-§R15 integrator byte-for-byte. That is how the witness gets its before/after **and its red control from ONE page load, one GPU and one camera trajectory**.

## Before / after — phase-aligned, same trajectory, same session

The reported trigger is the tour, but a tour route is not reproducible between arms on this building (LTU has no compiled rooms; `A.flyTargets` stayed empty for 240 s). The witness drives what the controller actually sees from a tour: a 30 s outside→inside→outside sweep parameterised by **wall time** so both arms fly the identical path, radius/height from the DB envelope.

| | LEGACY | FIXED | |
|---|---|---|---|
| `boostSpan` | **60** (full scale) | **4** | ✅ |
| boost changes | **174** | **12** | ✅ −93% |
| `windupTicks` | **314** | **0** | ✅ |
| `dt_p95` | 56.6 ms | 51.8 ms | ✅ −8.5% |
| `§FPS_MODE mean` | 32.7 ms | 30.2 ms | ✅ −7.6% |
| `calls_mean` | 313 | 187 | ✅ −40% |
| `dt_mean` (whole cycle) | 22.06 ms | 21.96 ms | ➖ flat |
| `flips_mean` | 905.9 | 1509.1 | ⚠ +66.6% (named trade) |

**Arm means understate this** — they are frame-weighted, so the slower arm contributes fewer samples to exactly the phases where it is slow. Phase-aligned is the real answer:

| phase | active F/L | calls F/L | dt_ms F/L | |
|---|---|---|---|---|
| 9-24 s (aerial ×5) | **0 / 0** | ~31 / ~29 | ~17.0 / ~16.8 | LEGACY holds `boost=60` for **18 of every 30 s** at zero benefit |
| **24-27 s (dive back in)** | 919 / **12,610** | 256 / **3,035** | **24.4 / 56.9** | **−57.1%** |
| **27-30 s (deepest inside)** | 14,697 / **42,646** | 1581 / 1228 | **57.3 / 79.2** | **−27.7%** |

The 24-27 s row is the user's `started=21638` burst, reproduced and attributed.

## Reproducibility — run 2 vs run 3 (the part that decides this PR)

| | run 2 | run 3 | reproduces? |
|---|---|---|---|
| `boostSpan` | 60 → 4 | 60 → 4 | ✅ exact |
| boost changes | 174 → 12 | 174 → 12 | ✅ exact |
| `windupTicks` | 314 → 0 | 328 → 0 | ✅ |
| best phase gain | −57.1% | −59.3% | ✅ |
| `dt_p95` | −8.5% | −4.7% | ✅ direction |
| **`dt_mean`** | **−0.5%** | **+1.1%** | ❌ **sign flips** |
| **phases worse >10%** | **1** (+41.8%) | **3** (+15.6% at 52.4→60.6 ms, +19%, +44.8%) | ❌ worse |
| `flips_mean` | +66.6% | +83.6% | ❌ magnitude grows |
| `§DLOD_TICK ms_mean` | −13.6% | −1.6% | ⚠ tick saving is noise-level |

Every regressed phase has the FIXED build drawing **fewer** draw calls, so the added milliseconds are
not rendering — they are demote-side `_startFade` work plus the full `instanceMatrix` re-upload each
flip forces. Holding the boost near 0 keeps more elements boxed (124,322 vs 122,990), and the cost of
*getting* them boxed on a moving camera is now the dominant transition cost. That is queue item A-27.

## What is NOT claimed

- **No whole-cycle mean win.** `dt_mean` is flat (22.06 → 21.96 ms): the large gains at re-entry and inside are offset by small losses in the aerial phases where both arms already sit at ~17 ms. On this sweep 60% of the time is aerial; a real tour spends far more of its time inside — but that is a reasoned expectation, not something this run measured.
- **One phase regresses beyond noise:** 6-9 s, **17.0 → 24.1 ms (+41.8%)**, with `active=0` in both arms and FIXED drawing *fewer* calls (34 vs 186). The extra ~7 ms is demote-side fade/transition work, same mechanism as the flips rise. Cheapest phase of the cycle, but real, and the obvious next thing to look at.
- **The witness's `g3` gate demands a majority of loaded phases be faster; the split is 2 of 4** (two big wins, two small losses), so it reports FAIL on that gate. The gate has been left exactly as written rather than relaxed to match the data. Read it as: the mechanism defect is fixed and measured; the end-to-end frame-time claim is not carried by this sweep.

## Also here, one line, cosmetic

`_roomIdxEnsure` printed `§ROOM_OCCL_INDEX_ERR no such column: r.center_x` ~5× per load. `writeRooms()` ALTERs `center_x`/`size_x` in when it first stamps rooms, so a query issued before that stamp raises a schema error rather than returning zero rows — the same benign pre-stamp state as the empty-index case, on the same retry path. It now takes the existing `rects=0 (rooms not compiled yet — will retry)` branch. Any other exception still reports as `§ROOM_OCCL_INDEX_ERR`.

`§DLOD_NAV_BUDGET` now also carries `elig=`, `upBlocked=` and `pass=` so the loop's state is readable off the shipped log instead of re-derived.

`sw.js CACHE_VERSION v1129 → v1130`; `viewer.html dlod_nav.js?v=2 → v=3`. `eslint viewer modeller` exit 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RTX9gUq3tQoytC1vthLmcq
