### PR TITLE
feat(erp): iDempiere parity — whole-row mandatory check, AD_Ref_Table targets, GL_Category, DocNo both branches (§P7-§P10)

### DIFF
--- a/erp/ad_evaluator.js
+++ b/erp/ad_evaluator.js
@@ -152,11 +152,27 @@
   }
 
   // -- Evaluation (mirrors EvaluationVisitor) ------------------------------------------------------------
+  // §P8 (bim-compiler prompts/ERP_IDEMPIERE_UX_PARITY.md §P8-RESULT-DEFECT — Witness: W-PARITY-REFTABLE):
+  //   the lookup is CASE-INSENSITIVE on the second pass. AD logic tokens are CamelCase (`@TenderType@`,
+  //   `@IsSOTrx@`) but EVERY record this stack builds is lower-cased — crud_overlay's gatherVals() keys are
+  //   `f.col`, which foldCrudSpec lower-cases — so an exact-case lookup NEVER resolved a CamelCase token and
+  //   every such expression silently evaluated against "". Measured: C_Payment.TrxType's DisplayLogic
+  //   `@TenderType@=C` stayed false however the user set TenderType, so the field could never appear.
+  //   This is the same storage-detail mapping §P3-SPEC P3.5 already established for the val-rule @token@ feed
+  //   ("AD tokens are CamelCase and our records are lowercase, so that case mapping lives in the wiring") —
+  //   applied here too rather than left as a second, contradictory convention. Exact match still wins first,
+  //   so a record that DOES carry the AD casing is unaffected.
+  function _ciGet(bag, name) {
+    if (!bag) return undefined;
+    if (Object.prototype.hasOwnProperty.call(bag, name)) return bag[name];
+    var lower = String(name).toLowerCase();
+    if (Object.prototype.hasOwnProperty.call(bag, lower)) return bag[lower];
+    for (var k in bag) if (Object.prototype.hasOwnProperty.call(bag, k) && String(k).toLowerCase() === lower) return bag[k];
+    return undefined;
+  }
   function resolveVar(name, record, context) {
-    var raw;
-    if (record && Object.prototype.hasOwnProperty.call(record, name)) raw = record[name];
-    else if (context && Object.prototype.hasOwnProperty.call(context, name)) raw = context[name];
-    else raw = undefined;
+    var raw = _ciGet(record, name);
+    if (raw === undefined) raw = _ciGet(context, name);
     var val = (raw == null) ? '' : String(raw);
     if (val.trim() === '' && /_ID$/.test(name)) return '0';                // empty _ID -> "0" (267-268)
     return val;

--- a/erp/ad_parser.js
+++ b/erp/ad_parser.js
@@ -393,6 +393,52 @@
     return { type: valType || 'unknown', referenceId: referenceId };
   }
 
+  // ── §P8 (bim-compiler prompts/ERP_IDEMPIERE_UX_PARITY.md §P8-SPEC P8.1 — Witness: W-PARITY-REFTABLE) ──
+  /**
+   * resolveRefTable — an FK's REAL target, for DisplayType 18 (Table) and 30 (Search).
+   *
+   * A port of MLookupFactory.getLookup_Table(ctx, WindowNo, AD_Reference_Value_ID): the target table, its key
+   * column and its display column are DECLARED in AD_Ref_Table, not inferred from the column name. The
+   * `<column minus _id>` convention the pickers use is iDempiere's TableDIR rule (DisplayType 19,
+   * getLookup_TableDir) and it is simply WRONG for 18/30 — measured on this seed, 34 of the 115 FK
+   * field-instances across the five document tabs (18 distinct columns: SalesRep_ID -> ad_user,
+   * Bill_BPartner_ID -> c_bpartner, C_DocTypeTarget_ID -> c_doctype, User1_ID/User2_ID -> c_elementvalue and
+   * the DropShip, Return and Bill address family) resolve to a table that does not exist under that
+   * convention, so their pickers degraded to the raw value and their AD_Val_Rules had never bitten at all.
+   *
+   * AD_Ref_Table also carries a WhereClause and an OrderByClause which iDempiere appends to the lookup query —
+   * a SECOND narrowing, independent of AD_Val_Rule (ref 190 restricts AD_User to IsSalesRep='Y' partners;
+   * ref 138 to non-summary active partners; ref 130 excludes AD_Org 0).
+   *
+   * @param {Object} db               sql.js database
+   * @param {number} referenceValueId AD_Reference_Value_ID
+   * @returns {Object|null} { tableName, keyCol, displayCol, isValueDisplayed, whereClause, orderByClause }
+   *                        or null when this reference has no AD_Ref_Table row (caller keeps the convention)
+   */
+  function resolveRefTable(db, referenceValueId) {
+    if (referenceValueId == null || referenceValueId === '') return null;
+    try {
+      var r = db.exec(
+        'SELECT t.TableName, ck.ColumnName AS KeyCol, cd.ColumnName AS DisplayCol, ' +
+        '       rt.isvaluedisplayed, rt.whereclause, rt.orderbyclause ' +
+        'FROM ad_ref_table rt ' +
+        'JOIN AD_Table t ON t.AD_Table_ID = rt.ad_table_id ' +
+        'LEFT JOIN AD_Column ck ON ck.AD_Column_ID = rt.ad_key ' +
+        'LEFT JOIN AD_Column cd ON cd.AD_Column_ID = rt.ad_display ' +
+        'WHERE rt.ad_reference_id = ?', [referenceValueId]);
+      if (!r.length || !r[0].values.length) return null;
+      var v = r[0].values[0];
+      var out = { tableName: v[0], keyCol: v[1], displayCol: v[2],
+                  isValueDisplayed: String(v[3]) === 'Y', whereClause: v[4] || null, orderByClause: v[5] || null };
+      console.log('§AD_PARSER resolveRefTable id=' + referenceValueId + ' table=' + out.tableName +
+                  ' key=' + out.keyCol + ' where=' + (out.whereClause ? 'yes' : 'none'));
+      return out;
+    } catch (e) {
+      console.log('§AD_PARSER resolveRefTable id=' + referenceValueId + ' UNAVAILABLE (' + (e && e.message) + ')');
+      return null;
+    }
+  }
+
   // ── Table name lookup ──────────────────────────────────────────────
 
   /**
@@ -476,6 +522,7 @@
     getFields:            getFields,
     setTipSource:         setTipSource,
     resolveReference:     resolveReference,
+    resolveRefTable:      resolveRefTable,   // §P8 (W-PARITY-REFTABLE): MLookupFactory.getLookup_Table
     getTableName:         getTableName,
     getWindowFromMenu:    getWindowFromMenu,
     evaluateDisplayLogic: evaluateDisplayLogic,

--- a/erp/crud_core.js
+++ b/erp/crud_core.js
@@ -764,7 +764,7 @@
     opts = opts || {};
     var roTable = !!opts.isView || !!opts.isReadOnly;     // AD_Table.IsView or AD_Tab.IsReadOnly → the whole row is read-only
     var forVerb = opts.forVerb || 'update';
-    var exemptLog = [], dtLog = [], exprLog = [], unresolvedLog = [];   // §P7 — witness seams, emitted once per fold
+    var exemptLog = [], dtLog = [], exprLog = [], unresolvedLog = [], refTblLog = [];   // §P7/§P8 — witness seams, emitted once per fold
     var fields = (adFields || []).map(function (f) {
       // type from the AUTHORITATIVE AD_Reference_ID; fall back to the coarse referenceType string.
       var type = (f && f.referenceId != null ? mapRefDisplayType(f.referenceId) : null) || mapRefType(f && f.referenceType);
@@ -829,7 +829,24 @@
         var dtd = gridFieldDatatypeDefault(f.columnName, f.referenceId, type);
         if (dtd != null) { spec.default = dtd; spec.defaultsource = 'datatype'; dtLog.push(spec.col + '=' + dtd); }
       }
-      if (type === 'fk') spec.ref = String(f.columnName).toLowerCase().replace(/_id$/, '');
+      if (type === 'fk') {
+        // §P8 P8.2 (ERP_IDEMPIERE_UX_PARITY.md §P8-SPEC — Witness: W-PARITY-REFTABLE): `<col minus _id>` is
+        // iDempiere's TableDIR rule (DisplayType 19, MLookupFactory.getLookup_TableDir) and it is WRONG for
+        // DisplayType 18 (Table) / 30 (Search), whose target is DECLARED in AD_Ref_Table
+        // (getLookup_Table: TableName + AD_Key + AD_Display + WhereClause + OrderByClause). The fold stays
+        // PURE — the host injects opts.refTable(refValueId), exactly as §P2.7 injects opts.refList.
+        // No AD_Ref_Table row (or no resolver) → keep the convention verbatim, unchanged behaviour.
+        spec.ref = String(f.columnName).toLowerCase().replace(/_id$/, '');
+        var rt = (typeof opts.refTable === 'function' && f.referenceValueId != null) ? opts.refTable(f.referenceValueId) : null;
+        if (rt && rt.tableName) {
+          spec.ref = String(rt.tableName).toLowerCase();
+          if (rt.keyCol) spec.refkey = String(rt.keyCol).toLowerCase();
+          if (rt.whereClause) spec.refwhere = rt.whereClause;
+          if (rt.orderByClause) spec.reforder = rt.orderByClause;
+          spec.refsource = 'AD_Ref_Table:' + f.referenceValueId;
+          refTblLog.push(spec.col + '→' + spec.ref + (rt.whereClause ? '+where' : ''));
+        }
+      }
       // §P3 (ERP_IDEMPIERE_UX_PARITY.md §P3-SPEC P3.3 — Witness: W-PARITY-VALRULE): carry the lookup's
       // AD_Val_Rule id so the picker can filter to the rows the rule admits (MLookupFactory.java:122-125 —
       // the rule's Code IS the lookup's ValidationCode). The fold stays PURE: no db, no engine call here;
@@ -863,6 +880,8 @@
                   '] (GridField.defaultFromDatatype:1022-1051)');
       console.log('§GRIDFIELD-EXPR-DEFAULT key=' + (opts.key || '?') + ' resolved=' + exprLog.length + ' [' + exprLog.join(' · ') +
                   '] unresolved=' + unresolvedLog.length + ' [' + unresolvedLog.join(' · ') + '] (GridField.defaultFromExpression:875-913)');
+      console.log('§REFTABLE-FOLD key=' + (opts.key || '?') + ' resolved=' + refTblLog.length + ' [' + refTblLog.join(',') +
+                  '] (MLookupFactory.getLookup_Table — DisplayType 18/30 targets that <col minus _id> gets wrong)');
     }
     return { key: opts.key, title: opts.title || opts.key, folded: true, isView: !!opts.isView,
              verbs: roTable ? [] : ['create', 'update', 'delete'], fields: fields };
@@ -895,9 +914,17 @@
         // this, a lookup that is BOTH curated and val-ruled kept the unfiltered picker: measured 2026-09-02,
         // c_order.C_BPartner_ID (curated, rule 230) offered all 113 partners instead of the 42 iDempiere
         // admits, while the same rule bit correctly on every non-curated column.
-        ['displaylogic', 'readonlylogic', 'mandatorylogic', 'valruleid'].forEach(function (lk) {
+        // §P8 P8.3: `refkey`/`refwhere`/`reforder`/`refsource` join the layered list — purely ADDITIVE (no
+        // curated field has ever carried one), so §IMPL F3's deliberately-pinned attributes are untouched.
+        // `ref` itself is layered ONLY when the AD resolved a target from AD_Ref_Table AND the curated ref
+        // does not name a real table under the convention — bill_bpartner_id IS a curated pin on c_order AND
+        // one of the 18, so without this the fix would miss the very column §MEASURED lists. This is the
+        // §P3-RESULT-DEFECT-2 lesson (a curated pin swallowed the rule) applied in advance rather than after.
+        ['displaylogic', 'readonlylogic', 'mandatorylogic', 'valruleid',
+         'refkey', 'refwhere', 'reforder', 'refsource'].forEach(function (lk) {
           if ((o[lk] == null || String(o[lk]).trim() === '') && ad[lk] != null && String(ad[lk]).trim() !== '') o[lk] = ad[lk];
         });
+        if (ad.refsource && ad.ref && o.type === 'fk' && String(o.ref || '') !== String(ad.ref)) o.ref = ad.ref;
         if (o.seq == null && ad.seq != null) o.seq = ad.seq;
       }
       return o;

--- a/erp/crud_core.js
+++ b/erp/crud_core.js
@@ -696,7 +696,12 @@
   //   control). else (10 String · 14 Text · …) → string.
   function mapRefDisplayType(rid) {
     switch (Number(rid)) {
-      case 11: case 12: case 22: case 29: return 'number';
+      // §P7 P7.3 (ERP_IDEMPIERE_UX_PARITY.md §P7-EXTRACT E4 — W-PARITY-MANDATORY-CREATE): 37 CostPrice is
+      // NUMERIC in iDempiere (DisplayType.java:329-333 isNumeric = {Amount 12, Number 22, CostPrice 37,
+      // Integer 11, Quantity 29}; SystemIDs.java:132 REFERENCE_DATATYPE_COSTPRICE = 37). It fell through to
+      // `string` here, which is why C_OrderLine's mandatory PriceEntered/PriceActual/PriceList rendered as
+      // un-defaulted text boxes instead of the `0` GridField.defaultFromDatatype:1044-1047 gives them.
+      case 11: case 12: case 22: case 29: case 37: return 'number';
       case 15: case 16: case 24: return 'date';
       case 18: case 19: case 30: return 'fk';
       case 13: return 'id'; case 28: return 'button';
@@ -719,10 +724,47 @@
       default: return 'string';   // string · text · char · unknown
     }
   }
+  // ── §P7 (ERP_IDEMPIERE_UX_PARITY.md §P7-EXTRACT E5 — Witness: W-PARITY-MANDATORY-CREATE) ────────────────
+  // gridFieldMandatoryExempt — a FAITHFUL port of GridField.isMandatory(boolean):377-385. In a WINDOW,
+  // iDempiere never treats these five column shapes as mandatory, whatever AD_Column.IsMandatory says,
+  // "(persistence layer manages them)":
+  //     if (m_gridTab != null && ( (m_vo.IsKey && ColumnName.endsWith("_ID"))
+  //        || ColumnName.startsWith("Created") || ColumnName.startsWith("Updated")
+  //        || ColumnName.equals("Value") || ColumnName.equals("DocumentNo")
+  //        || ColumnName.equals("M_AttributeSetInstance_ID")   //  0 is valid
+  //        )) return false;
+  // This is why turning the create-time mandatory check on does NOT need "New-time defaults for DocumentNo
+  // and M_AttributeSetInstance_ID" — iDempiere does not require them either. Case-sensitive on purpose: the
+  // Java compares the raw AD ColumnName, so the AD casing is what is tested (not our lower-cased spec.col).
+  function gridFieldMandatoryExempt(columnName, isKey) {
+    var c = String(columnName == null ? '' : columnName);
+    if (isKey && /_ID$/.test(c)) return 'key_id';
+    if (c.indexOf('Created') === 0) return 'Created*';
+    if (c.indexOf('Updated') === 0) return 'Updated*';
+    if (c === 'Value') return 'Value';
+    if (c === 'DocumentNo') return 'DocumentNo';
+    if (c === 'M_AttributeSetInstance_ID') return 'M_AttributeSetInstance_ID';
+    return null;
+  }
+  // §P7 P7.2 — a FAITHFUL port of GridField.defaultFromDatatype():1022-1051, the LAST stage of
+  // getDefault()'s "123457" priority chain (GridField.java:98). SOURCE ORDER IS LOAD-BEARING: the `_ID` →
+  // null test (:1038-1041) precedes the numeric → "0" test (:1044-1047), so NO *_ID column ever gets 0 here
+  // — M_AttributeSetInstance_ID included (its 0 comes from MOrderLine, not the grid). Returns null when the
+  // stage yields nothing, so the caller leaves the field empty rather than inventing a value.
+  //     Button non-_ID → "N" (:1027-1030) · YesNo → "N" (:1033-1036) · _ID → null · numeric → "0"
+  function gridFieldDatatypeDefault(columnName, refId, type) {
+    var c = String(columnName == null ? '' : columnName), r = Number(refId);
+    if (r === 28 && !/_ID$/.test(c)) return 'N';
+    if (r === 20 || type === 'yesno') return 'N';
+    if (/_ID$/.test(c)) return null;
+    if (type === 'number') return '0';               // type already folds DisplayType.isNumeric (incl. 37, P7.3)
+    return null;
+  }
   function foldCrudSpec(adFields, opts) {
     opts = opts || {};
     var roTable = !!opts.isView || !!opts.isReadOnly;     // AD_Table.IsView or AD_Tab.IsReadOnly → the whole row is read-only
     var forVerb = opts.forVerb || 'update';
+    var exemptLog = [], dtLog = [], exprLog = [], unresolvedLog = [];   // §P7 — witness seams, emitted once per fold
     var fields = (adFields || []).map(function (f) {
       // type from the AUTHORITATIVE AD_Reference_ID; fall back to the coarse referenceType string.
       var type = (f && f.referenceId != null ? mapRefDisplayType(f.referenceId) : null) || mapRefType(f && f.referenceType);
@@ -732,8 +774,12 @@
       // IsUpdateable='N' is SETTABLE on New (iDempiere fills it once) but display-only on Edit; isReadOnly + a
       // read-only table/tab are always read-only.
       var readonly = !!f.isReadOnly || roTable || (forVerb === 'update' && f.isUpdateable === false);
+      // §P7 P7.1 — GridField.isMandatory():377-385's window exemptions, before anything else reads `required`.
+      var exempt = gridFieldMandatoryExempt(f.columnName, !!f.isKey);
+      if (exempt) exemptLog.push(String(f.columnName) + ':' + exempt);
       var spec = { col: String(f.columnName).toLowerCase(), label: f.name || f.columnName, type: type,
-                   required: !!f.isMandatory, readonly: readonly };
+                   required: !!f.isMandatory && !exempt, readonly: readonly };
+      if (exempt) spec.mandatoryexempt = exempt;
       // DEFAULTS: resolve the well-known AD context variables iDempiere's Env fills on New (@#AD_Client_ID@,
       // @#AD_Org_ID@, @#Date@) from opts.ctx — so a mandatory system column (AD_Client_ID/AD_Org_ID) doesn't block a
       // folded create; keep PLAIN literals (0/N/Y/DR…); drop any OTHER unevaluated expression (@SQL=…, functions) —
@@ -746,6 +792,42 @@
         else if (ds === '@#AD_Org_ID@' && ctx.orgId != null) spec.default = ctx.orgId;
         else if (ds === '@#Date@' && ctx.today) spec.default = ctx.today;
         else if (!/[@()]/.test(ds)) spec.default = d;
+        else {
+          // §P7 P7.7 — GridField.defaultFromExpression():875-913, the DefaultValue-expression stage (3) of
+          // getDefault()'s "123457" chain, now resolved against the WINDOW context instead of dropped.
+          // Faithful to the Java: tokenize on `,;` (:884); `@SysDate@` → now (:888-889); `@…@` → Env.parseContext
+          // with ignoreUnparsable=false, so an unresolved token yields "" and the NEXT token is tried (:890-891,
+          // :904); a quoted 'String' has its quotes stripped (:892-893); the first non-empty wins (:907).
+          // `@SQL=` is stage 2 and is NOT run here (no db in a pure fold) — named in §P7-NOT-BUILT.
+          // ctx.win is the window context the host supplies: on a DETAIL tab it is the PARENT row (plus Env
+          // globals), which is what fills C_OrderLine's @C_BPartner_Location_ID@ / @DateOrdered@ /
+          // @M_Warehouse_ID@ / @AD_Client_ID@ / @AD_Org_ID@ — five AD-mandatory line columns.
+          var win = ctx.win || {}, resolved = null;
+          if (ds.indexOf('@SQL=') !== 0) {
+            ds.split(/[,;]/).some(function (tokRaw) {
+              var tok = String(tokRaw).trim(); if (!tok) return false;
+              var v = null;
+              if (tok === '@SysDate@') v = ctx.today || null;
+              else if (tok.indexOf('@') >= 0) {
+                var m = /^@([#$]?[A-Za-z0-9_]+)@$/.exec(tok);
+                if (m) { var w = win[String(m[1]).toLowerCase()]; if (w == null) w = win[String(m[1]).toLowerCase().replace(/^[#$]/, '')]; v = (w == null || String(w) === '') ? null : w; }
+              } else if (tok.indexOf("'") >= 0) v = tok.replace(/'/g, ' ').trim();
+              else v = tok;
+              if (v != null && String(v) !== '') { resolved = v; return true; }
+              return false;
+            });
+          }
+          if (resolved != null) { spec.default = resolved; spec.defaultsource = 'expression'; exprLog.push(spec.col + '="' + ds + '"→' + resolved); }
+          else if (ds.indexOf('@') >= 0) unresolvedLog.push(spec.col + '="' + ds + '"');
+        }
+      }
+      // §P7 P7.2 — the DATA-TYPE stage of GridField.getDefault(), reached ONLY when no earlier stage
+      // resolved (Java: priority "123457", :98). Faithful to :1022-1051 including its order. iDempiere's
+      // mandatory check then reads this filled row (GridTable.dataNew:2129-2143 → getMandatory:1985, where
+      // "0" and "N" are NOT empty), which is exactly why an untouched New can be required-checked at all.
+      if (!Object.prototype.hasOwnProperty.call(spec, 'default')) {
+        var dtd = gridFieldDatatypeDefault(f.columnName, f.referenceId, type);
+        if (dtd != null) { spec.default = dtd; spec.defaultsource = 'datatype'; dtLog.push(spec.col + '=' + dtd); }
       }
       if (type === 'fk') spec.ref = String(f.columnName).toLowerCase().replace(/_id$/, '');
       // §P3 (ERP_IDEMPIERE_UX_PARITY.md §P3-SPEC P3.3 — Witness: W-PARITY-VALRULE): carry the lookup's
@@ -773,6 +855,15 @@
       if (f.seqNo != null) spec.seq = f.seqNo;
       return spec;
     });
+    // §P7 — the two ports made witnessable per fold (a 0 on either is a real, reportable value, not silence).
+    if (typeof console !== 'undefined') {
+      console.log('§GRIDFIELD-EXEMPT key=' + (opts.key || '?') + ' n=' + exemptLog.length + ' cols=[' + exemptLog.join(',') +
+                  '] (GridField.isMandatory:377-385)');
+      console.log('§GRIDFIELD-DATATYPE-DEFAULT key=' + (opts.key || '?') + ' n=' + dtLog.length + ' [' + dtLog.join(',') +
+                  '] (GridField.defaultFromDatatype:1022-1051)');
+      console.log('§GRIDFIELD-EXPR-DEFAULT key=' + (opts.key || '?') + ' resolved=' + exprLog.length + ' [' + exprLog.join(' · ') +
+                  '] unresolved=' + unresolvedLog.length + ' [' + unresolvedLog.join(' · ') + '] (GridField.defaultFromExpression:875-913)');
+    }
     return { key: opts.key, title: opts.title || opts.key, folded: true, isView: !!opts.isView,
              verbs: roTable ? [] : ['create', 'update', 'delete'], fields: fields };
   }
@@ -1095,6 +1186,8 @@
     entriesOf: entriesOf, verbEnabled: verbEnabled, defaultsFor: defaultsFor,
     foldCrudSpec: foldCrudSpec, mapRefType: mapRefType, mapRefDisplayType: mapRefDisplayType,   // S2B: AD-folded CRUD spec (general, not curated)
     mergeCuratedWithFold: mergeCuratedWithFold,                                  // §P1 (W-PARITY-FIELDSET): AD field set + curated pins/verbs
+    gridFieldMandatoryExempt: gridFieldMandatoryExempt,                          // §P7 (W-PARITY-MANDATORY-CREATE): GridField.isMandatory:377-385
+    gridFieldDatatypeDefault: gridFieldDatatypeDefault,                          // §P7: GridField.defaultFromDatatype:1022-1051
     validateField: validateField, validate: validate, effectiveFlags: effectiveFlags, cleanVals: cleanVals, buildOp: buildOp,
     docActionOutcome: docActionOutcome, legalDocActions: legalDocActions, kernelParamsFor: kernelParamsFor, readTip: readTip, tipValues: tipValues,
     normDateValue: normDateValue, buildDocActionGroup: buildDocActionGroup, docLabel: docLabel,

--- a/erp/crud_overlay.js
+++ b/erp/crud_overlay.js
@@ -571,6 +571,15 @@
     for (k in vals) if (vals[k] != null && String(vals[k]) !== '') low[String(k).toLowerCase()] = vals[k];
     var app = global.APP || {};
     var fill = function (n, v) { if (v != null && String(v) !== '' && (low[n] == null || String(low[n]) === '')) low[n] = v; };
+    // §P7 P7.8 — the PARENT tab's row is part of the same WINDOW context. iDempiere resolves a val rule with
+    // Env.parseContext(ctx, WindowNo, TabNo, …), and Env.getContext falls back from "WindowNo|TabNo|Column" to
+    // "WindowNo|Column" (the window-wide value the parent tab pushed via GridTab.setCurrentRow → updateContext),
+    // so a DETAIL tab's rule sees its header's columns. Measured: without this, C_OrderLine's
+    // C_BPartner_Location_ID (AD_Val_Rule 167 `…C_BPartner_ID=@C_BPartner_ID@…`) can never resolve — the line's
+    // own C_BPartner_ID is IsReadOnly='Y' with an `@SQL=` default we do not run — so the picker offered 0 rows
+    // and the AD-mandatory column was unfillable. Row first, window second: the record under edit always wins.
+    var win = app._winCtx;
+    if (win) for (k in win) fill(String(k).toLowerCase(), win[k]);
     fill('ad_client_id', app.clientId); fill('ad_org_id', app.orgId);
     fill('ad_user_id', app.actor); fill('salesrep_id', app.actor); fill('date', today());
     // the per-window Sales/Purchase signal idempiere.html already extracts from the active AD_Tab's own
@@ -752,6 +761,20 @@
       // read as a forbidden edit and REJECTED every Sales Order create (found by the O2C regression run).
       var origV = orig;
       if (orig && appliedCols.length) { origV = {}; var ok0; for (ok0 in orig) origV[ok0] = orig[ok0]; appliedCols.forEach(function (c) { origV[c] = vals[c]; }); }
+      // §P7 P7.4 — the SAME rule on a CREATE, where `orig` is now null (the whole new row is checked). A
+      // hook-derived value is written by the MODEL layer (MOrder.setBPartner → set_Value), never through the
+      // grid — iDempiere's lookup validation (GridField.validateValueNoDirect:1141-1229) runs at dataNew /
+      // setValue time on GRID values and never re-inspects what beforeSave wrote afterwards. So a derived
+      // column is folded into the baseline here too: `orig === val` → unchanged → skipped, exactly as on an
+      // update, while EVERY other column still sees `orig === undefined` → fully checked (crud_core.js:126).
+      // Without this the create check rejected MOrder.billDefaults' own Bill_Location_ID as
+      // `valrule:not-admitted` — the derived id is legal for the model and simply is not in the picker's set.
+      // Only a NON-EMPTY derivation is folded in: a hook that derived nothing must still let `required` fire.
+      else if (!orig && appliedCols.length) {
+        origV = {};
+        appliedCols.forEach(function (c) { if (vals[c] != null && String(vals[c]).trim() !== '') origV[c] = vals[c]; });
+        if (!Object.keys(origV).length) origV = null;
+      }
       var res = CORE.validate(STORE, e, vals, origV);
       // §PARITY-MANDATORY — the §P5 consequence made witnessable: which required fields the user typed, which the
       // engine derived (iDempiere's defaults/callouts equivalent), and which are still missing (→ REJECT required).
@@ -864,20 +887,25 @@
     // Save validates + diffs against the POST-RENDER baseline (the true user delta) — so untouched fields that the
     //   spec/render handles imperfectly (a readonly fk select that fell to another option, a string-coded fk) never
     //   trip validation and are never written; only what the user actually changed is checked + committed.
-    // ⚠ KNOWN GAP, measured 2026-09-02 (bim-compiler prompts/ERP_IDEMPIERE_UX_PARITY.md §STATUS, W-PARITY-FIELDSET
-    //   falsifier — OPEN): on a CREATE this hands validate() the post-render baseline, so an untouched EMPTY mandatory
-    //   field reads "unchanged" (crud_core.js validateField's update rule) and its `required` check never fires — an
-    //   inline New saves a Sales Order with no Business Partner. Passing `null` for a create (validateField's own
-    //   documented create contract) is a one-line fix and was tried this session: it is CORRECT (iDempiere
-    //   GridTable.getMandatory runs over the whole new row) but rejects every C_OrderLine create on
-    //   m_attributesetinstance_id + pricelist (AD-mandatory, no seed default, CalloutOrder.product absent from the
-    //   callout engine) and every manual M_InOut on c_doctype_id + c_bpartner_location_id — the O2C cycle's stages
-    //   1/6/7 fall. It needs the New-time default/callout coverage iDempiere has BEFORE it can be turned on. Left as
-    //   shipped, deliberately; not a §P1/§P2 change.
-    var save = function () { if (!_inlineDirty()) return; saveForm(verb, e, _inlineBaseline || orig, id); };
+    // §P7 P7.4 (ERP_IDEMPIERE_UX_PARITY.md §P7-SPEC — Witness: W-PARITY-MANDATORY-CREATE) — GAP CLOSED
+    //   2026-09-03. A CREATE now hands validate() `null`, validateField's own documented create contract
+    //   (crud_core.js:126, `orig===undefined` → EVERY field checked), so an untouched EMPTY mandatory field is
+    //   finally required-checked — iDempiere's GridTable.dataSave:1647-1653 → getMandatory:1973-2001 runs over
+    //   the WHOLE new row, not over a user delta. An UPDATE keeps the post-render baseline (only what the user
+    //   actually changed is checked + committed), which is GridField's unchanged-field rule and is unaffected.
+    //   The earlier attempt at this one-liner failed on C_OrderLine/M_InOut only because three faithful New-time
+    //   behaviours were missing; they are now ported, so the reject set is iDempiere's, not ours:
+    //     P7.1 GridField.isMandatory:377-385  — DocumentNo and M_AttributeSetInstance_ID are NEVER window-mandatory
+    //     P7.2 GridField.defaultFromDatatype:1022-1051 — YesNo→'N', numeric→'0' (and '0'/'N' are not empty at :1985)
+    //     P7.3 DisplayType 37 CostPrice is numeric — PriceEntered/PriceActual/PriceList get their 0
+    //   What remains rejectable is what a real iDempiere user must type (C_BPartner_ID, Warehouse, …); the
+    //   validator is NOT weakened anywhere (§P5). §P7-NOT-BUILT names the three stages still absent
+    //   (@token@ DefaultValue, preference defaults, GridTab.dataNew:1179-1181's New-time callout fan).
+    var baselineFor = function (v) { return v === 'create' ? null : (_inlineBaseline || orig); };
+    var save = function () { if (!_inlineDirty()) return; saveForm(verb, e, baselineFor(verb), id); };
     var wire = function (v, fn) { var b = host.querySelector('.ic-vb[data-v="' + v + '"]'); if (b) b.addEventListener('click', fn); };
     wire('save', save);
-    wire('savenew', function () { if (!_inlineDirty()) return; _inlinePendingNew = true; saveForm(verb, e, _inlineBaseline || orig, id); });
+    wire('savenew', function () { if (!_inlineDirty()) return; _inlinePendingNew = true; saveForm(verb, e, baselineFor(verb), id); });
     wire('ignore', function () { ignoreInline(verb); });
     wire('refresh', function () { if (_inlineOpts && typeof _inlineOpts.refresh === 'function') _inlineOpts.refresh(); });
     wire('new', function () { if (_inlineOpts && typeof _inlineOpts.onNew === 'function') _inlineOpts.onNew(); });

--- a/erp/crud_overlay.js
+++ b/erp/crud_overlay.js
@@ -592,6 +592,27 @@
     });
     return ctx;
   }
+  // §P8 P8.5 — _valRuleListFilter: apply a column's AD_Val_Rule to its AD_Ref_List option set. iDempiere runs
+  //   the SAME ValidationCode against the AD_Ref_List query (MLookupFactory.getLookup_List), so the clause is
+  //   evaluated by the SAME shipped engine over ad_ref_list scoped to this reference — not a second evaluator,
+  //   and not a hand-rolled string match. Returns { verdict, admitted:{value:1} } or a named degrade.
+  function _valRuleListFilter(db, f) {
+    var VR = global.AdValRule;
+    if (!VR || f.valruleid == null || f.refListId == null) return { verdict: 'no-engine', admitted: null };
+    var b3 = _mvB3(db), row = null;
+    try { row = b3.prepare('SELECT ad_val_rule_id,name,type,code FROM ad_val_rule WHERE ad_val_rule_id=?').get(Number(f.valruleid)); } catch (e0) {}
+    if (!row || row.code == null) return { verdict: 'no-rule-row', admitted: null };
+    var res;
+    try { res = VR.evalValRule(b3, Number(f.valruleid), { ctx: _valRuleCtx(row.code, f._entry || { fields: [] }, null), table: 'ad_ref_list' }); }
+    catch (e1) { return { verdict: 'engine-error:' + String((e1 && e1.message) || e1).slice(0, 50), admitted: null }; }
+    if (!res || !res.ok) return { verdict: (res && res.deferred) || 'deferred', admitted: null };
+    try {
+      var q = b3.prepare('SELECT value FROM ad_ref_list WHERE ad_reference_id=? AND UPPER(isactive)=\'Y\' AND (' + res.sql + ')')
+                .all(Number(f.refListId));
+      var am = {}; (q || []).forEach(function (r) { am[String(r.value)] = 1; });
+      return { verdict: 'applied', admitted: am, sql: res.sql };
+    } catch (e2) { return { verdict: 'where-failed:' + String((e2 && e2.message) || e2).slice(0, 50), admitted: null }; }
+  }
   // _valRuleFilter — run the SHIPPED interpreter through the SAME better-sqlite3 shim the beforeSave hooks
   // use (_mvB3), so the witnessed engine executes verbatim in the browser and there is no second evaluator.
   function _valRuleFilter(db, f, e, rec) {
@@ -624,6 +645,33 @@
         // mandatory OR has no value yet (MLookup adds "" for non-mandatory; an empty mandatory field must read
         // '' so the validator reports `required` instead of silently persisting the first option).
         var opts = f.optionList || (STORE && STORE.__meta && STORE.__meta[f.ref]) || {}; var cur = el.getAttribute('data-cur') || '';
+        // §P8 P8.5 (ERP_IDEMPIERE_UX_PARITY.md §P8-SPEC — W-PARITY-REFTABLE): a LIST can carry an AD_Val_Rule
+        // too, and iDempiere appends it to the AD_Ref_List query exactly as it does for a table lookup
+        // (MLookupFactory.getLookup_List: the rule's Code IS the lookup's ValidationCode). Measured: `trxtype`
+        // on tab 330 (ref 17, AD_Val_Rule 200012 `AD_Ref_List.Value NOT IN ('A','F')`) is the one val-ruled
+        // list on the five document tabs, and it BITES 6 options → 4. Filtered through the SAME shipped engine
+        // (ad_valrule.js over the AD_Ref_List rows) — no second evaluator. A clause the engine cannot apply
+        // DEGRADES to the unfiltered set and says so, never silently narrows.
+        var listVr = null;
+        if (f.valruleid != null && Array.isArray(f.optionList) && f.optionList.length && typeof withBundle === 'function') {
+          withBundle(function (ldb) {
+            if (!ldb) return;
+            listVr = _valRuleListFilter(ldb, f);
+            if (listVr && listVr.verdict === 'applied') {
+              var keepSet = listVr.admitted;
+              var kept = f.optionList.filter(function (o) { return Object.prototype.hasOwnProperty.call(keepSet, String(o.value)); });
+              if (kept.length) {
+                opts = {}; kept.forEach(function (o) { opts[o.value] = o.name; });
+                // P8.6 — validateField reads the SAME map the picker was built from, so the OFFERED set and
+                // the ACCEPTED set are one set by construction (the §P3.6 invariant, extended to lists).
+                f.options = opts;
+              }
+            }
+          });
+          console.log('§REFLIST-VALRULE col=' + f.col + ' vr=' + f.valruleid +
+                      ' before=' + f.optionList.length + ' after=' + Object.keys(opts).length +
+                      ' verdict=' + (listVr ? listVr.verdict : 'no-engine'));
+        }
         var lo = CORE.listOptions(opts, cur);
         var blank = (!f.required || cur === '') ? '<option value=""' + (cur === '' ? ' selected' : '') + '></option>' : '';
         el.innerHTML = blank + lo.map(function (o) { return '<option value="' + esc(o.value) + '"' + (o.selected ? ' selected' : '') + '>' + esc(o.label) + '</option>'; }).join('');
@@ -644,7 +692,7 @@
           if (keep === '' || keep == null) return;
           withBundle(function (db) {
             try {
-              var t = f.ref, pk = t + '_id', nameCol = recHasCol(db, t, 'name') ? 'name' : (recHasCol(db, t, 'documentno') ? 'documentno' : pk);
+              var t = f.ref, pk = f.refkey || (t + '_id'), nameCol = recHasCol(db, t, 'name') ? 'name' : (recHasCol(db, t, 'documentno') ? 'documentno' : pk);
               var res = db.exec('SELECT ' + pk + ',' + nameCol + ' FROM ' + t + ' WHERE ' + pk + '=' + Number(keep));
               var label = (res.length && res[0].values.length) ? (res[0].values[0][1] + ' (' + res[0].values[0][0] + ')') : keep;
               el.innerHTML = '<option value="' + esc(keep) + '" selected>' + esc(label) + '</option>';
@@ -654,14 +702,40 @@
         }
         withBundle(function (db) {
           try {
-            var t = f.ref, pk = t + '_id', nameCol = recHasCol(db, t, 'name') ? 'name' : (recHasCol(db, t, 'documentno') ? 'documentno' : pk);
+            // §P8 P8.4 (W-PARITY-REFTABLE): the pk is the AD_Ref_Table AD_Key when there is one
+            // (MLookupFactory.getLookup_Table), else the TableDIR convention.
+            var t = f.ref, pk = f.refkey || (t + '_id'), nameCol = recHasCol(db, t, 'name') ? 'name' : (recHasCol(db, t, 'documentno') ? 'documentno' : pk);
             // ── §P3 (§P3-SPEC P3.4 — W-PARITY-VALRULE): narrow the candidate set to exactly the rows this
             // column's AD_Val_Rule admits. MLookupFactory.java:122-125 — the rule's Code IS the lookup's
             // ValidationCode, appended to the lookup query; that is all this does.
             var vr = _valRuleFilter(db, f, e, rec), where = '', noRows = false, before = null, admitted = null;
+            // §P8 P8.4 — AD_Ref_Table.WhereClause is a SECOND narrowing iDempiere appends to the lookup query,
+            // independent of AD_Val_Rule (ref 190 → AD_User restricted to IsSalesRep='Y' partners; ref 138 →
+            // non-summary active partners; ref 130 → AD_Org <> 0). Substituted through the SAME engine as the
+            // val rule (AdValRule.substitute — ONE owner, no second substituter); an unresolved @token@ empties
+            // the clause exactly as Env.java:1641-1645 + MLookup.java:1128-1140 say, and we then decline to
+            // apply it rather than invent a narrowing.
+            var refWhere = null, refWhereState = 'none';
+            if (f.refwhere) {
+              refWhereState = 'unresolved';
+              try {
+                var VRe = global.AdValRule;
+                if (VRe && typeof VRe.substitute === 'function') {
+                  var sub = VRe.substitute(String(f.refwhere), _valRuleCtx(String(f.refwhere), e, rec));
+                  var subSql = (sub && sub.sql != null) ? sub.sql : (typeof sub === 'string' ? sub : null);
+                  var unresolved = sub && sub.unresolved && sub.unresolved.length;
+                  if (subSql && String(subSql).trim() !== '' && !unresolved) { refWhere = subSql; refWhereState = 'applied'; }
+                } else if (String(f.refwhere).indexOf('@') < 0) { refWhere = String(f.refwhere); refWhereState = 'applied'; }
+              } catch (eRw) { refWhereState = 'error'; }
+              if (!refWhere && String(f.refwhere).indexOf('@') < 0) { refWhere = String(f.refwhere); refWhereState = 'applied'; }
+            }
+            var andRef = function (clause) {
+              if (!refWhere) return clause;
+              return clause ? '(' + clause + ') AND (' + refWhere + ')' : refWhere;
+            };
             if (vr) {
               try { var bq = db.exec('SELECT COUNT(*) FROM ' + t); before = bq.length ? bq[0].values[0][0] : null; } catch (eb) {}
-              if (vr.verdict === 'applied') where = ' WHERE (' + vr.sql + ')';
+              if (vr.verdict === 'applied') where = ' WHERE (' + andRef(vr.sql) + ')';
               // E3 — an unresolved @token@ CLEARS the lookup (MLookup.java:1128-1140, "Loader NOT Validated").
               // iDempiere shows NO rows here; it does not silently show all of them. Matching that IS the item.
               else if (vr.verdict === 'unresolved-tokens') noRows = true;
@@ -669,6 +743,7 @@
               // limit, not iDempiere's verdict — degrade to the UNFILTERED picker and say so in the log, rather
               // than hiding rows iDempiere does show. Named, never silent.
             }
+            if (!vr && refWhere) where = ' WHERE (' + refWhere + ')';
             var res = [];
             if (!noRows) {
               try { res = db.exec('SELECT ' + pk + ',' + nameCol + ' FROM ' + t + where + ' ORDER BY ' + pk + ' LIMIT 200'); }
@@ -682,7 +757,7 @@
             // ACCEPTED set are one set by construction and cannot drift apart.
             if (vr && vr.verdict === 'applied') {
               try {
-                var ar = db.exec('SELECT ' + pk + ' FROM ' + t + ' WHERE (' + vr.sql + ')'), am = {};
+                var ar = db.exec('SELECT ' + pk + ' FROM ' + t + ' WHERE (' + andRef(vr.sql) + ')'), am = {};
                 if (ar.length) ar[0].values.forEach(function (r) { am[String(r[0])] = 1; });
                 admitted = am;
               } catch (ea) {}
@@ -698,6 +773,8 @@
             var hasKeep = !kEmpty && rows.some(function (r) { return String(r[0]) === String(keep); });
             var blankSel = (kEmpty || !hasKeep);
             var blankFk = (!f.required || blankSel) ? '<option value=""' + (blankSel ? ' selected' : '') + '></option>' : '';
+            if (f.refsource) console.log('§REFTABLE col=' + f.col + ' src=' + f.refsource + ' table=' + t + ' key=' + pk +
+              ' refWhere=' + refWhereState + ' rows=' + (res.length ? res[0].values.length : 0));
             if (vr) console.log('§VALRULE col=' + f.col + ' vr=' + vr.id + ' rule="' + (vr.name || '') + '" table=' + t +
               ' before=' + before + ' after=' + (admitted ? Object.keys(admitted).length : (noRows ? 0 : before)) +
               ' offered=' + rows.length + ' verdict=' + vr.verdict +

--- a/erp/crud_overlay.js
+++ b/erp/crud_overlay.js
@@ -2155,6 +2155,18 @@
                     formEntry: function () { return _formCtx ? _formCtx.e : null; },              // §P1 (W-PARITY-FIELDSET): the open form's (merged) entry — field set + pins, read-only
                     registerFolded: registerFolded, ensureStore: _ensureStore, hasEntry: hasEntry,   // S2B: AD-folded CRUD — host registers a dictionary-derived spec so ANY table is editable (entryFor fallback)
                     fireCreateCallout: fireCreateCallout,   // S2/J4: host glue — AD callout dispatch on a create-form field change (price/defaults)
+                    // §P10 (bim-compiler prompts/ERP_IDEMPIERE_UX_PARITY.md §P4-OPEN item 5 — W-DOCNO-BRANCH):
+                    //   READ-ONLY witness seam over the two IsDocNoControlled branches. The only DocNo witness
+                    //   asserted the TABLE-level path against a MOCKED __idmpDb whose oracle was written beside
+                    //   the assertion, so the doctype-controlled branch (34 seeded doctypes ='Y', all 34 with a
+                    //   resolving ACTIVE ad_sequence) was never judged at all. These expose the SHIPPED functions
+                    //   — no reimplementation — so a witness can drive BOTH branches against the real seed.
+                    //   Neither consumes a sequence: _previewDocNo is the non-consuming preview iDempiere shows
+                    //   on a New form; _allocDocNo (the consuming one) is deliberately NOT exposed.
+                    docNoSeam: { docTypeSeqId: function (fields) {
+                                   var m = (typeof globalThis !== 'undefined' && globalThis.__idmpDb) || null;
+                                   return m ? _docTypeSeqId(m, fields) : null; },
+                                 previewDocNo: _previewDocNo },
                     foldBack: foldBackDocOp, foldForward: foldForwardDocOp,  // §A-GRAIL: fold via scrub
                     setStatus: setDocStatus, statusBar: function () { return statusBar; }, pulseProc: pulseProc,
                     kernelDb: function () { return SIDE; }, withSidecar: withSidecar,

--- a/erp/idempiere.html
+++ b/erp/idempiere.html
@@ -660,6 +660,7 @@ if (typeof qrcode !== "undefined") window.qrcode = qrcode;
   var _viewMode = 'grid';    // 'grid' | 'form'
   var _gridSel = Object.create(null);  // GRID_BATCH_FORM_PILL_SPEC item 4 — multi-select: set of record PK strings (reset on _records reload)
   var _selByLevel = {};      // tabLevel -> selected record's key value (drives master-detail filtering)
+  var _recByLevel = {};      // §P7 — tabLevel -> the selected RECORD (the window context a detail tab reads)
   var _lastFoldCreated = []; // Fix: ERP_BUSINESS_CYCLE_E2E.md Stage-1 SO parent-binding — Witness: W-SO-CHILD-BIND
                               // most recent _overlayListTip() fold's `created` synthetic-pk list (ascending
                               // opId order — see CORE.listTip in crud_overlay.js). CRUD_CREATE ops never carry
@@ -935,7 +936,20 @@ if (typeof qrcode !== "undefined") window.qrcode = qrcode;
                             : users.filter(function (u) { return (u.name || '').toLowerCase().indexOf(ql) >= 0; })[0];
     if (!m) { console.log('§IDEMPIERE-AUTOLOGIN miss q=' + q); return false; }
     var roles = SES.rolesForUser(db, m.id); if (!roles.length) return false;
-    var rid = roles[0].id, orgs = SES.orgsForRole(db, rid), oid = orgs.length ? orgs[0].id : 0;
+    // §P7 (ERP_IDEMPIERE_UX_PARITY.md §P7-RESULT — Witness: W-PARITY-MANDATORY-CREATE): an UNATTENDED
+    //   deep-link login must land on an org that can actually author a document. `orgsForRole` sorts
+    //   `ORDER BY oa.AD_Org_ID`, so `*` (AD_Org_ID 0) always came first — but the dictionary itself says `*`
+    //   is never a document Organization: AD_Val_Rule 130, bound to AD_Org_ID on all five document tabs,
+    //   reads `AD_Org.AD_Org_ID <> 0 AND AD_Org.IsSummary='N'`, and GridField.validateValueNoDirect:1219-1229
+    //   NULLS a default the lookup rejects → GridTable.getMandatory:1985 then reports FillMandatory. So a
+    //   `*` context cannot save a Sales Order in iDempiere either; picking it for an unattended login was an
+    //   artifact of our id-ordering (iDempiere's own Login.getOrgs:234 orders `BY o.Name`). The INTERACTIVE
+    //   picker still offers `*` — a user who chooses it gets iDempiere's behaviour, unchanged.
+    var rid = roles[0].id, orgs = SES.orgsForRole(db, rid);
+    var realOrgs = orgs.filter(function (o) { return Number(o.id) !== 0; });
+    var oid = realOrgs.length ? realOrgs[0].id : (orgs.length ? orgs[0].id : 0);
+    console.log('§AUTOLOGIN-ORG picked=' + oid + ' of [' + orgs.map(function (o) { return o.id; }).join(',') +
+                '] realOrgs=' + realOrgs.length + ' (AD_Val_Rule 130: a document org is never 0)');
     _loginUser = m;
     _session = SES.buildContext(db, m.id, { roleId: rid, orgId: oid });
     if (!_session) return false;
@@ -1237,7 +1251,7 @@ if (typeof qrcode !== "undefined") window.qrcode = qrcode;
       _openWins[windowId] = { win: win, name: name || win.name };
       console.log('§IDEMPIERE window=' + win.name + '(' + windowId + ') tabs=' + (win.tabs ? win.tabs.length : 0) + ' source=sqlite');
     }
-    _activeWin = windowId; _activeTabIdx = 0; _viewMode = 'grid'; _selByLevel = {};
+    _activeWin = windowId; _activeTabIdx = 0; _viewMode = 'grid'; _selByLevel = {}; _recByLevel = {};
     renderWinTabs(); renderToolbar(); renderTabStrip(); renderActiveTab();
     _histPush('window');   // §B — window opened / window-tab switched (this is the single activation choke point)
   }
@@ -1733,7 +1747,27 @@ if (typeof qrcode !== "undefined") window.qrcode = qrcode;
     var lvl = tab.tabLevel || 0;
     var rec = _records[_recIdx];
     _selByLevel[lvl] = rec ? recVal(rec, _keyCol(tab)) : null;
+    // §P7 P7.6 (ERP_IDEMPIERE_UX_PARITY.md §P7-SPEC — W-PARITY-MANDATORY-CREATE): keep the selected ROW, not
+    //   just its key. iDempiere's GridTab.setCurrentRow pushes EVERY column of the selected row into the window
+    //   Env (GridField.setValue → updateContext), which is what a detail tab's @token@ DefaultValue and its
+    //   val rules read. _selByLevel alone carried only the parent key, so a child New could resolve nothing.
+    _recByLevel[lvl] = rec || null;
     Object.keys(_selByLevel).forEach(function (L) { if (Number(L) > lvl) delete _selByLevel[L]; });
+    Object.keys(_recByLevel).forEach(function (L) { if (Number(L) > lvl) delete _recByLevel[L]; });
+  }
+  // _winCtx — the WINDOW context for the tab about to be folded: the PARENT row's columns (lower-cased) for a
+  //   detail tab, then the Env globals filling what it lacks. Mirrors Env.getContext's "WindowNo|TabNo|Column"
+  //   → "WindowNo|Column" fallback (org.compiere.util.Env), which is why a line sees its header's values.
+  function _winCtxFor(tab) {
+    var ctx = {}, lvl = (tab && tab.tabLevel) || 0, k;
+    var prec = lvl > 0 ? _recByLevel[lvl - 1] : null;
+    if (prec) for (k in prec) if (Object.prototype.hasOwnProperty.call(prec, k) && prec[k] != null && String(prec[k]) !== '') ctx[String(k).toLowerCase()] = prec[k];
+    var put = function (n, v) { if (v != null && String(v) !== '' && (ctx[n] == null || String(ctx[n]) === '')) ctx[n] = v; };
+    put('ad_client_id', (_session && _session.client) ? _session.client.id : null);
+    put('ad_org_id', (_session && _session.org) ? _session.org.id : null);
+    put('ad_user_id', (_session && _session.user) ? _session.user.id : null);
+    put('date', (new Date()).toISOString().slice(0, 10));
+    return ctx;
   }
   function renderActiveTab() {
     _newMode = null;   // P3 — any tab switch / grid reload exits new-record mode (untouched New auto-discards, nothing committed)
@@ -3069,6 +3103,10 @@ if (typeof qrcode !== "undefined") window.qrcode = qrcode;
       try { var rr = (window.ADParser && db) ? window.ADParser.resolveReference(db, id) : null; return (rr && rr.type === 'list') ? rr.options : null; }
       catch (eRef) { return null; }
     };
+    // §P7 P7.6 — the window context (parent row + Env globals) the AD DefaultValue expressions resolve from,
+    //   and the same map crud_overlay's _valRuleCtx reads for a detail tab's @token@ val rules (APP._winCtx).
+    ctx.win = _winCtxFor(tab);
+    try { window.APP = window.APP || {}; window.APP._winCtx = ctx.win; } catch (eW) {}
     var spec = window.__crud.core.foldCrudSpec(tab.fields, {
       key: tn, title: tab.name || tn, isView: _tableIsView(tn), isReadOnly: !!tab.isReadOnly, forVerb: forVerb || 'update', ctx: ctx, refList: refList });
     window.__crud.registerFolded(tn, spec);

--- a/erp/idempiere.html
+++ b/erp/idempiere.html
@@ -3107,8 +3107,15 @@ if (typeof qrcode !== "undefined") window.qrcode = qrcode;
     //   and the same map crud_overlay's _valRuleCtx reads for a detail tab's @token@ val rules (APP._winCtx).
     ctx.win = _winCtxFor(tab);
     try { window.APP = window.APP || {}; window.APP._winCtx = ctx.win; } catch (eW) {}
+    // §P8 P8.2 (ERP_IDEMPIERE_UX_PARITY.md §P8-SPEC — W-PARITY-REFTABLE): an FK of DisplayType 18/30 takes its
+    //   target table + key column + WhereClause from AD_Ref_Table (MLookupFactory.getLookup_Table), not from the
+    //   `<col minus _id>` TableDIR convention. Same injection shape as refList; the fold stays pure.
+    var refTable = function (id) {
+      try { return (window.ADParser && window.ADParser.resolveRefTable && db) ? window.ADParser.resolveRefTable(db, id) : null; }
+      catch (eRT) { return null; }
+    };
     var spec = window.__crud.core.foldCrudSpec(tab.fields, {
-      key: tn, title: tab.name || tn, isView: _tableIsView(tn), isReadOnly: !!tab.isReadOnly, forVerb: forVerb || 'update', ctx: ctx, refList: refList });
+      key: tn, title: tab.name || tn, isView: _tableIsView(tn), isReadOnly: !!tab.isReadOnly, forVerb: forVerb || 'update', ctx: ctx, refList: refList, refTable: refTable });
     window.__crud.registerFolded(tn, spec);
     console.log('§S2B-FOLD table=' + tn + ' verb=' + (forVerb || 'update') + ' verbs=[' + (spec.verbs || []).join(',') + '] fields=' + (spec.fields || []).length + ' isView=' + spec.isView + ' tabRO=' + !!tab.isReadOnly);
     return spec;

--- a/erp/sw.js
+++ b/erp/sw.js
@@ -10,7 +10,7 @@
 // init-bubble must be INSTANT, ERP_INIT_BUBBLE_INSTANT.md); network-first for non-precached .js (fresh on
 // deploy); cache-first for precached assets/.wasm/images. Freshness on deploy is carried by the SW version
 // bump (skipWaiting+clients.claim precache the new shell), so SWR strands a user at most one load post-deploy.
-const CACHE_VERSION = 'v776';   // bump on each deploy; per-change detail is the git commit message.
+const CACHE_VERSION = 'v777';   // bump on each deploy; per-change detail is the git commit message.
 // v772 (rebase of PR #203 onto origin/main) §INTEG-WIRE-B: disposable-host persistence in-app
 // (erp_replica_client.js + erp_persist_ui.js) — back the books up to a SIGNED snapshot the user
 // owns (signed by the edge key), restore on a FRESH device -> replay recomputes tip == signed

--- a/erp/tests/poc_ad_folded_crud.js
+++ b/erp/tests/poc_ad_folded_crud.js
@@ -45,7 +45,16 @@ const credit = upd.fields.find(f => f.col === 'so_creditlimit');
 const grp = upd.fields.find(f => f.col === 'c_bp_group_id');
 ok('amount → number', credit && credit.type === 'number', credit && credit.type);
 ok('tableDirect → fk with ref = column minus _id', grp && grp.type === 'fk' && grp.ref === 'c_bp_group', grp && (grp.type + '/' + grp.ref));
-ok('string → string + required carried from IsMandatory', upd.fields.find(f => f.col === 'value').type === 'string' && upd.fields.find(f => f.col === 'value').required === true);
+// §P7 P7.1 (ERP_IDEMPIERE_UX_PARITY.md §P7-EXTRACT E5 — W-PARITY-MANDATORY-CREATE): this assertion USED to read
+//   "value … required === true". It froze the pre-port contract: GridField.isMandatory(boolean):377-385 exempts
+//   ColumnName.equals("Value") in a WINDOW, whatever AD_Column.IsMandatory says ("persistence layer manages
+//   them"), so the faithful fold is required===false WITH the exemption recorded. `name` is the CONTROL — also
+//   IsMandatory='Y', not on the exempt list — so this now judges BOTH arms and cannot pass by the port firing
+//   too widely. The claim is unchanged (IsMandatory reaches the spec); the oracle moved to the Java's.
+const vF = upd.fields.find(f => f.col === 'value'), nF = upd.fields.find(f => f.col === 'name');
+ok('string → string; IsMandatory reaches the spec (name required) …', vF.type === 'string' && nF.required === true, 'name.required=' + nF.required);
+ok('… but ColumnName "Value" is window-EXEMPT per GridField.isMandatory:380 → required=false + tag',
+   vF.required === false && vF.mandatoryexempt === 'Value', 'value.required=' + vF.required + ' tag=' + vF.mandatoryexempt);
 // §P2 (bim-compiler prompts/ERP_IDEMPIERE_UX_PARITY.md §IMPL P2.3, W-PARITY-REFLIST) — LEG-1 RETIRED 2026-09-02: a Yes-No
 //   is a Y/N control ('yesno'), a List is an AD_Ref_List select ('list'). This assertion used to PIN the leg ("folds to STRING").
 ok('Yes-No (AD_Reference_ID=20) folds to YESNO (a Y/N control) — not fk, and no longer string (LEG-1 retired)', upd.fields.find(f => f.col === 'iscustomer').type === 'yesno', upd.fields.find(f => f.col === 'iscustomer').type);

--- a/erp/tests/poc_parity_docno_live.js
+++ b/erp/tests/poc_parity_docno_live.js
@@ -1,0 +1,158 @@
+// ⚠ DO NOT REMOVE — Scope guard
+// Scope: real-browser §-witness for §P10 of bim-compiler prompts/ERP_IDEMPIERE_UX_PARITY.md — W-DOCNO-BRANCH.
+//   THE ISSUE this test proves/disproves: §P4-CANDIDATES scored the IsDocNoControlled IMPLEMENTATION faithful
+//     (crud_overlay.js _docTypeSeqId ≡ MSequence.getDocumentNo:683-686 — 'N' means "use the TABLE sequence
+//     DocumentNo_<TableName>", not "no number"), but the only DocNo witness (bim-compiler
+//     scripts/poc_audit_changelog.js W-DOCNO) was SCOPE-BLIND in the strongest sense: it asserted only the
+//     table-level path AND it did so against a MOCKED __idmpDb whose expected 'SO-1000' was written three
+//     lines above the assertion — a tautology, not an oracle. The doctype-controlled branch was never judged,
+//     though the seed carries 34 doctypes IsDocNoControlled='Y', ALL 34 with a DocNoSequence_ID resolving to
+//     an ACTIVE AD_Sequence, and 18 ='N', NONE carrying one.
+//   CLAIM: run against the REAL seed through the SHIPPED functions (window.__crud.docNoSeam — no
+//     reimplementation), BOTH branches are correct and load-bearing: every ='Y' doctype resolves to its OWN
+//     DocNoSequence_ID; every ='N' doctype resolves to null so the caller falls back to DocumentNo_<table>;
+//     and the two branches produce DIFFERENT DocumentNo previews wherever the two sequences differ.
+//   Expected ids and counts are READ FROM THE SEED (window.__idmpDb) AT RUN TIME. Nothing is typed here.
+// §-log first — READ tests/poc_parity_docno_live.log before any conclusion (exit code is NOT evidence).
+// Run:  node tests/poc_parity_docno_live.js   (cwd = bim-ootb/erp)
+'use strict';
+const { chromium } = require(process.env.PW || (require('os').homedir() + '/bim-ootb/tests/node_modules/playwright'));
+const http = require('http'), fs = require('fs'), path = require('path');
+
+const ROOT = path.join(__dirname, '..');
+const MIME = { '.html': 'text/html', '.js': 'text/javascript', '.json': 'application/json',
+  '.db': 'application/octet-stream', '.png': 'image/png', '.css': 'text/css', '.wasm': 'application/wasm' };
+const server = http.createServer((req, res) => {
+  let p = decodeURIComponent(req.url.split('?')[0]); if (p === '/') p = '/idempiere.html';
+  fs.readFile(path.join(ROOT, p), (e, buf) => {
+    if (e) { res.writeHead(404); res.end('404 ' + p); return; }
+    res.writeHead(200, { 'Content-Type': MIME[path.extname(p)] || 'application/octet-stream' }); res.end(buf);
+  });
+});
+let pass = 0, fail = 0, inconclusive = 0;
+const ok = (label, cond, extra) => { console.log('   ' + (cond ? '🟢' : '🔴') + ' ' + label + (extra ? ' — ' + extra : '')); cond ? pass++ : fail++; };
+const judged = (label, n, cond, extra) => {
+  if (!n) { console.log('   ⬜ INCONCLUSIVE ' + label + ' — judged population is 0 (' + (extra || '') + ')'); inconclusive++; return; }
+  ok(label + ' (n=' + n + ')', cond, extra);
+};
+
+(async () => {
+  await new Promise(r => server.listen(0, r));
+  const port = server.address().port;
+  const browser = await chromium.launch();
+  const page = await browser.newPage();
+  const errs = []; page.on('pageerror', e => errs.push(String(e)));
+
+  console.log('§W-DOCNO-BRANCH start (real seed, SHIPPED functions via window.__crud.docNoSeam)');
+  await page.goto('http://localhost:' + port + '/idempiere.html?login=GardenAdmin&window=143', { waitUntil: 'load' });
+  await page.waitForSelector('[data-ad-table]', { timeout: 20000 });
+  await page.waitForTimeout(800);
+
+  const seamOk = await page.evaluate(() => !!(window.__crud && window.__crud.docNoSeam && typeof window.__crud.docNoSeam.docTypeSeqId === 'function'));
+  ok('the shipped DocNo seam is reachable (the witness judges the product, not a mock)', seamOk);
+  if (!seamOk) { console.log('❌ W-DOCNO-BRANCH: harness cannot reach the seam'); await browser.close(); server.close(); process.exit(1); }
+
+  const R = await page.evaluate(() => {
+    const q = s => { const r = window.__idmpDb.exec(s); return r.length ? r[0].values : []; };
+    const SEAM = window.__crud.docNoSeam;
+    // ── the POPULATION, straight from the seed ────────────────────────────────────────────────
+    const yes = q("SELECT c_doctype_id, docnosequence_id FROM c_doctype WHERE UPPER(isdocnocontrolled)='Y'")
+      .map(r => ({ id: Number(r[0]), seq: r[1] == null ? null : Number(r[1]) }));
+    const no = q("SELECT c_doctype_id, docnosequence_id FROM c_doctype WHERE UPPER(isdocnocontrolled)='N'")
+      .map(r => ({ id: Number(r[0]), seq: r[1] == null ? null : Number(r[1]) }));
+    const yesWithActiveSeq = q("SELECT COUNT(*) FROM c_doctype d JOIN ad_sequence s ON s.ad_sequence_id=d.docnosequence_id " +
+      "WHERE UPPER(d.isdocnocontrolled)='Y' AND UPPER(s.isactive)='Y'");
+    // ── branch 1: every ='Y' doctype resolves to its OWN DocNoSequence_ID ────────────────────
+    const yMiss = yes.filter(d => SEAM.docTypeSeqId({ c_doctype_id: d.id }) !== d.seq);
+    // ── branch 2: every ='N' doctype resolves to null (→ table sequence) ─────────────────────
+    const nMiss = no.filter(d => SEAM.docTypeSeqId({ c_doctype_id: d.id }) !== null);
+    // C_DocTypeTarget_ID is the same branch by a second column name (MOrder/MInvoice carry the target)
+    const tgtMiss = yes.filter(d => SEAM.docTypeSeqId({ c_doctypetarget_id: d.id }) !== d.seq);
+    // ── the branches must produce DIFFERENT numbers where the sequences differ ───────────────
+    const tableSeq = q("SELECT AD_Sequence_ID, CurrentNext, Prefix, Suffix FROM AD_Sequence " +
+      "WHERE UPPER(Name)=UPPER('DocumentNo_c_order') AND UPPER(IsActive)='Y'");
+    const tableSeqId = tableSeq.length ? Number(tableSeq[0][0]) : null;
+    const tablePreview = tableSeq.length ? ((tableSeq[0][2] || '') + tableSeq[0][1] + (tableSeq[0][3] || '')) : null;
+    // pick a ='Y' doctype on c_order whose sequence is NOT the table sequence — read, not chosen by hand
+    const cand = yes.filter(d => d.seq != null && d.seq !== tableSeqId)
+      .filter(d => q("SELECT 1 FROM ad_sequence WHERE ad_sequence_id=" + d.seq + " AND UPPER(isactive)='Y'").length > 0);
+    let dtCase = null;
+    if (cand.length) {
+      const d = cand[0];
+      const s = q("SELECT CurrentNext, Prefix, Suffix FROM AD_Sequence WHERE AD_Sequence_ID=" + d.seq);
+      dtCase = { doctype: d.id, seq: d.seq,
+                 expected: s.length ? ((s[0][1] || '') + s[0][0] + (s[0][2] || '')) : null,
+                 got: SEAM.previewDocNo('c_order', { c_doctype_id: d.id }) };
+    }
+    const noDoctypePreview = SEAM.previewDocNo('c_order', {});
+    // ── FALSIFIER: invert the branch. A ='Y' doctype whose flag is flipped in the probe row must
+    //    fall back to null; and an id that is not a doctype at all must too.
+    const falsifier = {
+      unknownDoctype: SEAM.docTypeSeqId({ c_doctype_id: -424242 }),
+      noDoctype: SEAM.docTypeSeqId({}),
+      // a ='N' doctype is the real in-seed inversion of a ='Y' one — same call shape, opposite flag
+      nSample: no.length ? { id: no[0].id, got: SEAM.docTypeSeqId({ c_doctype_id: no[0].id }) } : null,
+      ySample: yes.length ? { id: yes[0].id, seq: yes[0].seq, got: SEAM.docTypeSeqId({ c_doctype_id: yes[0].id }) } : null
+    };
+    return { yes: yes.length, no: no.length,
+             yesWithActiveSeq: yesWithActiveSeq.length ? Number(yesWithActiveSeq[0][0]) : 0,
+             yMiss: yMiss.slice(0, 5), nMiss: nMiss.slice(0, 5), tgtMiss: tgtMiss.slice(0, 5),
+             tableSeqId: tableSeqId, tablePreview: tablePreview, noDoctypePreview: noDoctypePreview,
+             dtCase: dtCase, falsifier: falsifier };
+  });
+
+  console.log('\n── the population, read from the seed ──');
+  console.log('   §DOCNO-POPULATION controlled_Y=' + R.yes + ' (of which a resolving ACTIVE sequence: ' + R.yesWithActiveSeq +
+              ') controlled_N=' + R.no + ' tableSeq(DocumentNo_c_order)=' + R.tableSeqId);
+
+  console.log('\n── branch 1 · IsDocNoControlled = Y → the DOCTYPE\'s own DocNoSequence_ID ──');
+  judged("every ='Y' doctype resolves to its own DocNoSequence_ID", R.yes, R.yMiss.length === 0,
+    R.yMiss.length ? JSON.stringify(R.yMiss) : 'all ' + R.yes + ' match the seed');
+  judged("…and the same holds through C_DocTypeTarget_ID (the column MOrder/MInvoice actually carry)", R.yes,
+    R.tgtMiss.length === 0, R.tgtMiss.length ? JSON.stringify(R.tgtMiss) : 'all ' + R.yes + ' match');
+  judged("the branch is not vacuous — every ='Y' doctype's sequence is a REAL active AD_Sequence", R.yes,
+    R.yesWithActiveSeq === R.yes, R.yesWithActiveSeq + '/' + R.yes + ' resolve to an active sequence');
+
+  console.log('\n── branch 2 · IsDocNoControlled = N → null, so the caller uses DocumentNo_<TableName> ──');
+  judged("every ='N' doctype resolves to null (MSequence.getDocumentNo:683-686)", R.no, R.nMiss.length === 0,
+    R.nMiss.length ? JSON.stringify(R.nMiss) : 'all ' + R.no + ' → null');
+  judged('the table-level fallback is a REAL sequence and previews from it', R.tableSeqId ? 1 : 0,
+    R.noDoctypePreview != null && R.noDoctypePreview === R.tablePreview,
+    'seed DocumentNo_c_order → ' + R.tablePreview + ' · seam(no doctype) → ' + R.noDoctypePreview);
+
+  console.log('\n── the two branches are DISTINGUISHABLE (otherwise neither arm proves anything) ──');
+  if (!R.dtCase) {
+    console.log('   ⬜ INCONCLUSIVE no ="Y" doctype in this seed carries a sequence different from DocumentNo_c_order'); inconclusive++;
+  } else {
+    ok('a doctype-controlled preview uses THAT doctype\'s sequence, not the table one',
+      R.dtCase.got === R.dtCase.expected && R.dtCase.got !== R.noDoctypePreview,
+      'doctype=' + R.dtCase.doctype + ' seq=' + R.dtCase.seq + ' expected=' + R.dtCase.expected +
+      ' got=' + R.dtCase.got + ' · table-branch=' + R.noDoctypePreview);
+    console.log('   §DOCNO-BRANCH doctype=' + R.dtCase.doctype + ' seq=doctype#' + R.dtCase.seq +
+                ' docno=' + R.dtCase.got + ' docNoControlled=true  |  table seq=DocumentNo_c_order docno=' +
+                R.noDoctypePreview + ' docNoControlled=false');
+  }
+
+  console.log('\n── FALSIFIER · the flag is what decides, not the presence of a doctype ──');
+  judged("an in-seed ='N' doctype takes the SAME call shape and returns null — the flag is load-bearing",
+    R.falsifier.nSample ? 1 : 0,
+    R.falsifier.nSample && R.falsifier.nSample.got === null &&
+    R.falsifier.ySample && R.falsifier.ySample.got === R.falsifier.ySample.seq,
+    JSON.stringify({ N: R.falsifier.nSample, Y: R.falsifier.ySample }));
+  ok('an unknown doctype id and an absent doctype both fall back to the table sequence (null), never fabricate',
+    R.falsifier.unknownDoctype === null && R.falsifier.noDoctype === null,
+    JSON.stringify(R.falsifier.unknownDoctype) + ' / ' + JSON.stringify(R.falsifier.noDoctype));
+
+  ok(errs.length + ' pageerrors across the run', errs.length === 0, errs.slice(0, 2).join(' | '));
+
+  console.log('\n§DOCNO-BRANCH-VERDICT CRITIC ' + (fail === 0 ? '✔' : '✘') + ' ' + (fail === 0
+    ? 'Both IsDocNoControlled branches are now judged against the real seed through the shipped functions: all ' +
+      R.yes + " doctypes ='Y' resolve to their own active DocNoSequence_ID (also via C_DocTypeTarget_ID), all " +
+      R.no + " ='N' resolve to null so the caller falls back to DocumentNo_<TableName>, and the two branches " +
+      'produce different numbers — the scope-blind, mock-oracled W-DOCNO arm is superseded.'
+    : 'an IsDocNoControlled branch diverges from MSequence.getDocumentNo — see the 🔴 above.'));
+  console.log((fail === 0 ? '✅' : '❌') + ' W-DOCNO-BRANCH: ' + pass + '/' + (pass + fail) +
+              ' PASS (' + fail + ' FAIL, ' + inconclusive + ' INCONCLUSIVE)');
+  await browser.close(); server.close();
+  process.exit(fail === 0 ? 0 : 1);
+})().catch(e => { console.error('🔴 W-DOCNO-BRANCH harness threw: ' + e.message); process.exit(1); });

--- a/erp/tests/poc_parity_mandatory_live.js
+++ b/erp/tests/poc_parity_mandatory_live.js
@@ -1,0 +1,263 @@
+// ⚠ DO NOT REMOVE — Scope guard
+// Scope: real-browser §-witness for §P7 of bim-compiler prompts/ERP_IDEMPIERE_UX_PARITY.md —
+//   W-PARITY-MANDATORY-CREATE.
+//   THE ISSUE this test proves/disproves: the inline CREATE path validated against its POST-RENDER BASELINE, so an
+//     UNTOUCHED empty mandatory field read "unchanged" (crud_core.js validateField's update rule) and its `required`
+//     check NEVER FIRED — an inline New saved a Sales Order with no Business Partner. §IMPL-RESULT named it OPEN and
+//     "not a pass". CLAIM: a CREATE now validates the WHOLE new row (validateField's own create contract,
+//     orig===undefined), exactly as iDempiere's GridTable.dataSave:1647-1653 → getMandatory:1973-2001 runs over a row
+//     that dataNew's defaults and the callouts already filled — and it does so WITHOUT weakening the validator,
+//     because three New-time behaviours were ported faithfully first:
+//       P7.1  GridField.isMandatory(boolean):377-385 — in a WINDOW, DocumentNo / Value / M_AttributeSetInstance_ID /
+//             Created* / Updated* / a key *_ID are NEVER mandatory whatever AD_Column.IsMandatory says.
+//       P7.2  GridField.defaultFromDatatype():1022-1051 — Button non-_ID→'N', YesNo→'N', *_ID→null, numeric→'0',
+//             IN THAT ORDER (so no *_ID ever gets 0), and '0'/'N' are NOT empty at GridTable.java:1985.
+//       P7.3  DisplayType 37 CostPrice is numeric (DisplayType.java:329-333) — it fell through to `string` here.
+//       P7.7  GridField.defaultFromExpression():875-913 — a @token@ DefaultValue resolved from the WINDOW context,
+//             which on a DETAIL tab is the PARENT row (Env's "WindowNo|TabNo|Column"→"WindowNo|Column" fallback).
+//   Every expected value — IsMandatory, DisplayType, the parent row's own column — is READ FROM THE SEED through the
+//   app's own accessor (window.__idmpDb) AT RUN TIME. Nothing is typed into this file.
+// §-log first — READ tests/poc_parity_mandatory_live.log before any conclusion (exit code is NOT evidence).
+// Run:  node tests/poc_parity_mandatory_live.js   (cwd = bim-ootb/erp)
+'use strict';
+const { chromium } = require(process.env.PW || (require('os').homedir() + '/bim-ootb/tests/node_modules/playwright'));
+const http = require('http'), fs = require('fs'), path = require('path');
+
+const ROOT = path.join(__dirname, '..');
+const MIME = { '.html': 'text/html', '.js': 'text/javascript', '.json': 'application/json',
+  '.db': 'application/octet-stream', '.png': 'image/png', '.css': 'text/css', '.wasm': 'application/wasm' };
+const server = http.createServer((req, res) => {
+  let p = decodeURIComponent(req.url.split('?')[0]); if (p === '/') p = '/idempiere.html';
+  fs.readFile(path.join(ROOT, p), (e, buf) => {
+    if (e) { res.writeHead(404); res.end('404 ' + p); return; }
+    res.writeHead(200, { 'Content-Type': MIME[path.extname(p)] || 'application/octet-stream' }); res.end(buf);
+  });
+});
+let pass = 0, fail = 0, inconclusive = 0;
+const ok = (label, cond, extra) => { console.log('   ' + (cond ? '🟢' : '🔴') + ' ' + label + (extra ? ' — ' + extra : '')); cond ? pass++ : fail++; };
+// PRIMAL LAW §4 — a check whose judged population is EMPTY prints INCONCLUSIVE, never PASS.
+const judged = (label, n, cond, extra) => {
+  if (!n) { console.log('   ⬜ INCONCLUSIVE ' + label + ' — judged population is 0 (' + (extra || '') + ')'); inconclusive++; return; }
+  ok(label + ' (n=' + n + ')', cond, extra);
+};
+
+async function landed(page) {
+  await page.waitForSelector('[data-ad-table]', { timeout: 20000 }).catch(async () => {
+    const u = await page.$('#idmp-login-users .idmp-login-user:not(.disabled)');
+    if (u) { await u.click(); const okb = await page.$('#idmp-login-ok'); if (okb) await okb.click(); }
+    await page.waitForSelector('[data-ad-table]', { timeout: 15000 }).catch(() => {});
+  });
+  await page.waitForTimeout(500);
+}
+async function clickNew(page) {
+  await page.waitForSelector('#idmp-toolbar button[title^="New record"]', { timeout: 15000 });
+  await page.click('#idmp-toolbar button[title^="New record"]');
+  await page.waitForSelector('#idmp-inline-mount .cfrow', { timeout: 10000 });
+  await page.waitForTimeout(700);
+}
+
+(async () => {
+  await new Promise(r => server.listen(0, r));
+  const port = server.address().port;
+  const base = 'http://localhost:' + port + '/idempiere.html';
+  const browser = await chromium.launch();
+  const page = await browser.newPage();
+  const LOG = []; const errs = [];
+  page.on('console', m => LOG.push(m.text()));
+  page.on('pageerror', e => errs.push(String(e)));
+
+  console.log('§W-PARITY-MANDATORY-CREATE start (real DOM; every expectation read from ad_seed.db at run time)');
+
+  // ══ ARM A — the defect is GONE: an untouched empty mandatory field is required-checked on a CREATE ══
+  console.log('\n── A · §PARITY-MANDATORY-CREATE: a New typed with ONLY DocumentNo is REJECTED ──');
+  await page.goto(base + '?login=GardenAdmin&window=143', { waitUntil: 'load' });
+  await landed(page); await clickNew(page);
+
+  // the oracle: which columns tab 186 itself declares mandatory, displayed and not exempt — read from the seed.
+  const seedMand = await page.evaluate(() => {
+    const q = s => { const r = window.__idmpDb.exec(s); return r.length ? r[0].values : []; };
+    const rows = q("SELECT c.ColumnName, COALESCE(NULLIF(f.IsMandatory,''), c.IsMandatory) " +
+      "FROM AD_Field f JOIN AD_Column c ON c.AD_Column_ID=f.AD_Column_ID " +
+      "WHERE f.AD_Tab_ID=186 AND f.IsActive='Y' AND f.IsDisplayed='Y' AND c.IsKey='N'");
+    return rows.filter(r => r[1] === 'Y').map(r => String(r[0]));
+  });
+  const bpMandatory = seedMand.some(c => c.toLowerCase() === 'c_bpartner_id');
+  judged('the seed itself declares C_BPartner_ID mandatory+displayed on tab 186 (so arm A is not vacuous)',
+    seedMand.length, bpMandatory, seedMand.length + ' mandatory displayed columns on 186');
+
+  const beforeN = LOG.length;
+  await page.fill('#idmp-inline-mount [data-col="documentno"]', String(Date.now()));
+  await page.locator('#idmp-inline-mount [data-col="documentno"]').first().blur().catch(() => {});
+  await page.waitForTimeout(200);
+  // Save the way a user does on this surface: the toolbar Save (the sibling witnesses' proven gesture) — the
+  // inline bar's Save is the same handler but sits below the fold of a 56-row form, tripping actionability.
+  const tb = await page.$('#idmp-toolbar button[title^="Save"]');
+  if (tb) await tb.click();
+  else await page.evaluate(() => { const b = document.querySelector('#idmp-inline-mount .ic-vb[data-v="save"]'); if (b) b.click(); });
+  await page.waitForTimeout(1100);
+  const after = LOG.slice(beforeN);
+  const rej = after.filter(l => /§CRUD validate key=c_order verb=create REJECT/.test(l)).pop() || '';
+  const persisted = after.some(l => /§CRUD-PERSIST/.test(l));
+  const mandLine = after.filter(l => /§PARITY-MANDATORY key=c_order verb=create/.test(l)).pop() || '';
+  ok('a c_order New carrying ONLY DocumentNo is REJECTED, not saved', !!rej && !persisted,
+    rej ? rej.slice(0, 170) : ('no REJECT line; persisted=' + persisted));
+  ok('the reject names C_BPartner_ID as `required` (the column the seed declares mandatory)',
+    /"col":"c_bpartner_id","why":"required"/.test(rej), rej.slice(0, 170));
+  console.log('   §PARITY-MANDATORY ' + (mandLine ? mandLine.slice(mandLine.indexOf('required=')) : '(absent)').slice(0, 260));
+
+  // ══ ARM C — the P7.1 exemption, asserted as a CONTRAST against the seed's own IsMandatory ══
+  console.log('\n── C · GridField.isMandatory:377-385 — DocumentNo / M_AttributeSetInstance_ID are exempt IN A WINDOW ──');
+  const exempt = await page.evaluate(() => {
+    const q = s => { const r = window.__idmpDb.exec(s); return r.length ? r[0].values : []; };
+    const CORE = window.__crud.core;
+    const seedSays = c => {
+      const r = q("SELECT c.IsMandatory FROM AD_Column c JOIN AD_Table t ON t.AD_Table_ID=c.AD_Table_ID " +
+        "WHERE lower(t.TableName)='" + c.t + "' AND lower(c.ColumnName)='" + c.c + "'");
+      return r.length ? String(r[0][0]) : null;
+    };
+    const e = window.__crud.formEntry();     // the OPEN c_order New form's merged entry (read-only seam)
+    const dn = ((e && e.fields) || []).filter(f => f.col === 'documentno')[0] || null;
+    return {
+      docnoSeed: seedSays({ t: 'c_order', c: 'documentno' }),
+      asiSeed: seedSays({ t: 'c_orderline', c: 'm_attributesetinstance_id' }),
+      // the PURE engine is the oracle for the port itself — it is exported for exactly this
+      docnoExempt: CORE.gridFieldMandatoryExempt('DocumentNo', false),
+      asiExempt: CORE.gridFieldMandatoryExempt('M_AttributeSetInstance_ID', false),
+      keyExempt: CORE.gridFieldMandatoryExempt('C_Order_ID', true),
+      createdExempt: CORE.gridFieldMandatoryExempt('CreatedBy', false),
+      // a column iDempiere does NOT exempt must come back null — the port must not be wider than the Java
+      bpNotExempt: CORE.gridFieldMandatoryExempt('C_BPartner_ID', false),
+      whNotExempt: CORE.gridFieldMandatoryExempt('M_Warehouse_ID', false),
+      curatedDocnoStillPinned: dn ? !!dn.required : null
+    };
+  });
+  judged('the seed says DocumentNo IS AD-mandatory, yet the window exempts it (the whole point of the port)',
+    exempt.docnoSeed ? 1 : 0, exempt.docnoSeed === 'Y' && exempt.docnoExempt === 'DocumentNo',
+    'seed IsMandatory=' + exempt.docnoSeed + ' exempt=' + exempt.docnoExempt);
+  judged('the seed says C_OrderLine.M_AttributeSetInstance_ID IS AD-mandatory, yet the window exempts it ("0 is valid")',
+    exempt.asiSeed ? 1 : 0, exempt.asiSeed === 'Y' && exempt.asiExempt === 'M_AttributeSetInstance_ID',
+    'seed IsMandatory=' + exempt.asiSeed + ' exempt=' + exempt.asiExempt);
+  ok('the other three shapes the Java lists are exempt too (key *_ID, Created*)',
+    exempt.keyExempt === 'key_id' && exempt.createdExempt === 'Created*',
+    JSON.stringify({ key: exempt.keyExempt, created: exempt.createdExempt }));
+  ok('FALSIFIER-2a — the port is NOT wider than the Java: C_BPartner_ID / M_Warehouse_ID are NOT exempt',
+    exempt.bpNotExempt === null && exempt.whNotExempt === null,
+    JSON.stringify({ bp: exempt.bpNotExempt, wh: exempt.whNotExempt }));
+  ok('§IMPL F3 respected — the CURATED documentno pin keeps its own `required` (the fold exemption is AD-side only)',
+    exempt.curatedDocnoStillPinned === true, 'curated documentno.required=' + exempt.curatedDocnoStillPinned);
+
+  // ══ ARM D — the P7.2/P7.3 data-type defaults, asserted against each column's DisplayType in the seed ══
+  console.log('\n── D · GridField.defaultFromDatatype:1022-1051 — YesNo→N, numeric→0, *_ID→null (in that order) ──');
+  const dt = await page.evaluate(() => {
+    const q = s => { const r = window.__idmpDb.exec(s); return r.length ? r[0].values : []; };
+    const ref = (t, c) => {
+      const r = q("SELECT COALESCE(NULLIF(f.AD_Reference_ID,''), c.AD_Reference_ID) FROM AD_Field f " +
+        "JOIN AD_Column c ON c.AD_Column_ID=f.AD_Column_ID JOIN AD_Table tt ON tt.AD_Table_ID=c.AD_Table_ID " +
+        "WHERE lower(tt.TableName)='" + t + "' AND lower(c.ColumnName)='" + c + "' AND f.IsDisplayed='Y' LIMIT 1");
+      return r.length ? Number(r[0][0]) : null;
+    };
+    const dom = c => { const el = document.querySelector('#idmp-inline-mount [data-col="' + c + '"]'); return el ? (el.type === 'checkbox' ? (el.checked ? 'Y' : 'N') : el.value) : null; };
+    const CORE = window.__crud.core;
+    return {
+      freightRef: ref('c_order', 'freightamt'), freightVal: dom('freightamt'),
+      discRef: ref('c_order', 'isdiscountprinted'), discVal: dom('isdiscountprinted'),
+      priceListRef: ref('c_orderline', 'pricelist'),
+      // the pure port, so the *_ID-before-numeric ORDER is judged, not just the outcome
+      idBeatsNumeric: CORE.gridFieldDatatypeDefault('M_AttributeSetInstance_ID', 11, 'number'),
+      yesno: CORE.gridFieldDatatypeDefault('IsDiscountPrinted', 20, 'yesno'),
+      numeric: CORE.gridFieldDatatypeDefault('FreightAmt', 12, 'number'),
+      costPriceIsNumber: CORE.mapRefDisplayType(37)
+    };
+  });
+  judged('a DisplayType-' + dt.freightRef + ' (numeric) mandatory column renders 0, not empty', dt.freightRef ? 1 : 0,
+    String(dt.freightVal) === '0', 'freightamt="' + dt.freightVal + '"');
+  judged('a DisplayType-' + dt.discRef + ' (Yes-No) mandatory column reads N, not empty', dt.discRef ? 1 : 0,
+    String(dt.discVal) === 'N', 'isdiscountprinted="' + dt.discVal + '"');
+  judged('DisplayType ' + dt.priceListRef + ' (C_OrderLine.PriceList) maps to `number` — DisplayType.isNumeric includes CostPrice 37',
+    dt.priceListRef ? 1 : 0, Number(dt.priceListRef) === 37 && dt.costPriceIsNumber === 'number',
+    'seed ref=' + dt.priceListRef + ' → ' + dt.costPriceIsNumber);
+  ok('ORDER is faithful — the *_ID test precedes the numeric test, so an *_ID never gets 0',
+    dt.idBeatsNumeric === null && dt.yesno === 'N' && dt.numeric === '0',
+    JSON.stringify({ id: dt.idBeatsNumeric, yesno: dt.yesno, numeric: dt.numeric }));
+
+  // ══ ARM E — P7.7: a DETAIL tab's @token@ DefaultValue resolves from the PARENT row ══
+  console.log('\n── E · GridField.defaultFromExpression:875-913 — a line defaults from its header (window context) ──');
+  await page.goto(base + '?login=GardenAdmin&window=181', { waitUntil: 'load' });
+  await landed(page);
+  await page.waitForSelector('.idmp-grid tbody tr[data-ad-record]', { timeout: 15000 });
+  await page.evaluate(() => { const tr = document.querySelector('.idmp-grid tbody tr[data-ad-record]'); if (tr) tr.click(); });
+  await page.waitForTimeout(700);
+  await page.click('#idmp-tabstrip >> text=PO Line', { timeout: 8000 });
+  await page.waitForTimeout(800);
+  const mdLine = LOG.filter(l => /§IDEMPIERE-MD tab=PO Line/.test(l)).pop() || '';
+  const parentId = (/C_Order_ID=(\d+)/.exec(mdLine) || [])[1] || null;
+  await clickNew(page);
+  const expr = await page.evaluate((pid) => {
+    const q = s => { const r = window.__idmpDb.exec(s); return r.length ? r[0].values : []; };
+    const adDefault = q("SELECT c.DefaultValue FROM AD_Column c JOIN AD_Table t ON t.AD_Table_ID=c.AD_Table_ID " +
+      "WHERE lower(t.TableName)='c_orderline' AND lower(c.ColumnName)='c_bpartner_location_id'");
+    const parent = pid ? q("SELECT C_BPartner_Location_ID FROM c_order WHERE C_Order_ID=" + Number(pid)) : [];
+    const el = document.querySelector('#idmp-inline-mount [data-col="c_bpartner_location_id"]');
+    return { adDefault: adDefault.length ? String(adDefault[0][0]) : null,
+             parentVal: parent.length ? String(parent[0][0]) : null,
+             rendered: el ? String(el.value) : null };
+  }, parentId);
+  judged('the AD default for C_OrderLine.C_BPartner_Location_ID IS a @token@ expression (arm E is not vacuous)',
+    expr.adDefault ? 1 : 0, /^@[A-Za-z_]+@$/.test(String(expr.adDefault)), 'DefaultValue=' + expr.adDefault);
+  judged('a PO Line New pre-fills it from its PARENT order\'s own column, read from the seed',
+    expr.parentVal ? 1 : 0, expr.rendered === expr.parentVal,
+    'parent C_Order_ID=' + parentId + ' → ' + expr.parentVal + ' · rendered=' + expr.rendered);
+  const exprLog = LOG.filter(l => /§GRIDFIELD-EXPR-DEFAULT key=c_orderline/.test(l)).pop() || '';
+  console.log('   ' + (exprLog || '§GRIDFIELD-EXPR-DEFAULT (absent)').slice(0, 260));
+
+  // ══ FALSIFIERS — through the PURE engine, so they judge the rule, not the render ══
+  console.log('\n── FALSIFIER · the validator is intact, and the exemption is load-bearing in BOTH directions ──');
+  const fal = await page.evaluate(() => {
+    const CORE = window.__crud.core;
+    const e = window.__crud.formEntry();      // the OPEN PO-Line New form's entry (ARM E left it mounted)
+    const key = e ? String(e.key || '') : '';
+    const asi = ((e && e.fields) || []).filter(f => f.col === 'm_attributesetinstance_id')[0] || null;
+    const mk = (f, over) => { const o = {}; for (const k in f) o[k] = f[k]; for (const k in (over || {})) o[k] = over[k]; return o; };
+    const bp = { col: 'c_bpartner_id', type: 'fk', required: true };
+    return {
+      // FALSIFIER-1 — an AD-mandatory column with no default and no derivation still REJECTS on a NEW row
+      reqEmpty: CORE.validateField({}, bp, '', undefined, {}, {}),
+      reqFilled: CORE.validateField({}, bp, '112', undefined, {}, {}),
+      formKey: key,
+      asiFoldedRequired: asi ? !!asi.required : null,
+      asiExemptTag: asi ? (asi.mandatoryexempt || null) : null,
+      // FALSIFIER-2b — re-mark the SAME field mandatory and the SAME empty value is rejected: the ONLY thing
+      // keeping it out of the reject set is the port, so a port that ever stops firing shows up here.
+      asiIfNotExempt: asi ? CORE.validateField({}, mk(asi, { required: true }), '', undefined, {}, {}) : null,
+      asiAsShipped: asi ? CORE.validateField({}, asi, '', undefined, {}, {}) : null
+    };
+  });
+  ok('FALSIFIER-1 — an empty AD-mandatory fk on a NEW row → `required`; a filled one → ok (validator not weakened)',
+    fal.reqEmpty === 'required' && fal.reqFilled === null, JSON.stringify({ empty: fal.reqEmpty, filled: fal.reqFilled }));
+  judged('C_OrderLine.M_AttributeSetInstance_ID folds required=false with its exemption tag recorded',
+    fal.asiFoldedRequired === null ? 0 : 1,
+    fal.asiFoldedRequired === false && fal.asiExemptTag === 'M_AttributeSetInstance_ID',
+    'openForm=' + fal.formKey + ' required=' + fal.asiFoldedRequired + ' tag=' + fal.asiExemptTag);
+  judged('FALSIFIER-2b — the SAME field marked mandatory rejects the SAME empty value; as shipped it does not',
+    fal.asiFoldedRequired === null ? 0 : 1,
+    fal.asiIfNotExempt === 'required' && fal.asiAsShipped === null,
+    JSON.stringify({ ifMandatory: fal.asiIfNotExempt, asShipped: fal.asiAsShipped }));
+
+  ok(errs.length + ' pageerrors across the run', errs.length === 0, errs.slice(0, 2).join(' | '));
+
+  const exemptLogs = LOG.filter(l => /§GRIDFIELD-EXEMPT/.test(l));
+  const dtLogs = LOG.filter(l => /§GRIDFIELD-DATATYPE-DEFAULT/.test(l));
+  console.log('\n§PARITY-MANDATORY-CREATE-LOGS §GRIDFIELD-EXEMPT=' + exemptLogs.length +
+              ' §GRIDFIELD-DATATYPE-DEFAULT=' + dtLogs.length +
+              ' §GRIDFIELD-EXPR-DEFAULT=' + LOG.filter(l => /§GRIDFIELD-EXPR-DEFAULT/.test(l)).length);
+  if (exemptLogs.length) console.log('   ' + exemptLogs[exemptLogs.length - 1].slice(0, 200));
+  if (dtLogs.length) console.log('   ' + dtLogs[dtLogs.length - 1].slice(0, 200));
+
+  console.log('\n§PARITY-MANDATORY-VERDICT CRITIC ' + (fail === 0 ? '✔' : '✘') + ' ' + (fail === 0
+    ? 'The create path validates the WHOLE new row, as iDempiere does: an untouched empty mandatory field is finally rejected, while DocumentNo and M_AttributeSetInstance_ID are exempt and YesNo/numeric columns carry their data-type defaults — all four ports faithful to GridField, and the validator itself unchanged.'
+    : 'a create-time mandatory behaviour diverges from GridField/GridTable — see the 🔴 above.'));
+  console.log((fail === 0 ? '✅' : '❌') + ' W-PARITY-MANDATORY-CREATE: ' + pass + '/' + (pass + fail) +
+              ' PASS (' + fail + ' FAIL, ' + inconclusive + ' INCONCLUSIVE)');
+  await browser.close(); server.close();
+  process.exit(fail === 0 ? 0 : 1);
+})().catch(e => { console.error('🔴 W-PARITY-MANDATORY-CREATE harness threw: ' + e.message); process.exit(1); });

--- a/erp/tests/poc_parity_reftable_live.js
+++ b/erp/tests/poc_parity_reftable_live.js
@@ -1,0 +1,224 @@
+// ⚠ DO NOT REMOVE — Scope guard
+// Scope: real-browser §-witness for §P8 of bim-compiler prompts/ERP_IDEMPIERE_UX_PARITY.md — W-PARITY-REFTABLE.
+//   THE ISSUE this test proves/disproves: the FK pickers resolved every target table as `<column minus _id>`.
+//     That is iDempiere's TableDIR rule (DisplayType 19, MLookupFactory.getLookup_TableDir) and it is WRONG for
+//     DisplayType 18 (Table) and 30 (Search), whose target table / key column / WhereClause / OrderByClause are
+//     DECLARED in AD_Ref_Table (getLookup_Table). §P3-RESULT named the consequence and left it open: those
+//     columns "already degrade to the raw value", so their AD_Val_Rules had never bitten either.
+//   CLAIM: (a) an FK of DisplayType 18/30 resolves its target from AD_Ref_Table, so a picker that offered
+//     NOTHING now offers exactly the target table's rows; (b) AD_Ref_Table.WhereClause is applied as a SECOND
+//     narrowing on top of the val rule; (c) a val-ruled LIST filters its AD_Ref_List options by the rule, as
+//     MLookupFactory.getLookup_List does; (d) the offered set and the accepted set remain ONE set.
+//   Every expected table name, key column, clause and row count is READ FROM THE SEED (window.__idmpDb) AT RUN
+//   TIME. Nothing is typed into this file.
+// §-log first — READ tests/poc_parity_reftable_live.log before any conclusion (exit code is NOT evidence).
+// Run:  node tests/poc_parity_reftable_live.js   (cwd = bim-ootb/erp)
+'use strict';
+const { chromium } = require(process.env.PW || (require('os').homedir() + '/bim-ootb/tests/node_modules/playwright'));
+const http = require('http'), fs = require('fs'), path = require('path');
+
+const ROOT = path.join(__dirname, '..');
+const MIME = { '.html': 'text/html', '.js': 'text/javascript', '.json': 'application/json',
+  '.db': 'application/octet-stream', '.png': 'image/png', '.css': 'text/css', '.wasm': 'application/wasm' };
+const server = http.createServer((req, res) => {
+  let p = decodeURIComponent(req.url.split('?')[0]); if (p === '/') p = '/idempiere.html';
+  fs.readFile(path.join(ROOT, p), (e, buf) => {
+    if (e) { res.writeHead(404); res.end('404 ' + p); return; }
+    res.writeHead(200, { 'Content-Type': MIME[path.extname(p)] || 'application/octet-stream' }); res.end(buf);
+  });
+});
+let pass = 0, fail = 0, inconclusive = 0;
+const ok = (label, cond, extra) => { console.log('   ' + (cond ? '🟢' : '🔴') + ' ' + label + (extra ? ' — ' + extra : '')); cond ? pass++ : fail++; };
+const judged = (label, n, cond, extra) => {
+  if (!n) { console.log('   ⬜ INCONCLUSIVE ' + label + ' — judged population is 0 (' + (extra || '') + ')'); inconclusive++; return; }
+  ok(label + ' (n=' + n + ')', cond, extra);
+};
+async function landed(page) { await page.waitForSelector('[data-ad-table]', { timeout: 20000 }); await page.waitForTimeout(500); }
+async function clickNew(page) {
+  await page.waitForSelector('#idmp-toolbar button[title^="New record"]', { timeout: 15000 });
+  await page.click('#idmp-toolbar button[title^="New record"]');
+  await page.waitForSelector('#idmp-inline-mount .cfrow', { timeout: 10000 });
+  await page.waitForTimeout(900);
+}
+
+(async () => {
+  await new Promise(r => server.listen(0, r));
+  const port = server.address().port;
+  const base = 'http://localhost:' + port + '/idempiere.html';
+  const browser = await chromium.launch();
+  const page = await browser.newPage();
+  const LOG = [], errs = [];
+  page.on('console', m => LOG.push(m.text()));
+  page.on('pageerror', e => errs.push(String(e)));
+
+  console.log('§W-PARITY-REFTABLE start (real DOM; every expectation read from ad_seed.db at run time)');
+
+  // ══ the POPULATION — how many FK fields the convention gets wrong, and how many AD_Ref_Table fixes ══
+  await page.goto(base + '?login=GardenAdmin&window=143', { waitUntil: 'load' });
+  await landed(page); await clickNew(page);
+
+  const POP = await page.evaluate(() => {
+    const q = s => { const r = window.__idmpDb.exec(s); return r.length ? r[0].values : []; };
+    const seedTables = {}; q("SELECT name FROM sqlite_master WHERE type='table'").forEach(r => { seedTables[String(r[0]).toLowerCase()] = 1; });
+    const fk = q("SELECT f.AD_Tab_ID, c.ColumnName, COALESCE(NULLIF(f.AD_Reference_ID,''), c.AD_Reference_ID), " +
+      "COALESCE(f.AD_Reference_Value_ID, c.AD_Reference_Value_ID) " +
+      "FROM AD_Field f JOIN AD_Column c ON c.AD_Column_ID=f.AD_Column_ID " +
+      "WHERE f.AD_Tab_ID IN (186,257,263,330,349) AND f.IsActive='Y' AND f.IsDisplayed='Y'")
+      .filter(r => [18, 19, 30].indexOf(Number(r[2])) >= 0);
+    let convOK = 0, fixable = 0, unfixable = 0; const fixCols = {}, unfixCols = {};
+    fk.forEach(r => {
+      const cn = String(r[1]).toLowerCase(), conv = cn.replace(/_id$/, '');
+      if (seedTables[conv]) { convOK++; return; }
+      const rt = window.ADParser.resolveRefTable(window.__idmpDb, r[3]);
+      const tgt = rt && rt.tableName ? String(rt.tableName).toLowerCase() : null;
+      if (tgt && seedTables[tgt]) { fixable++; fixCols[r[1]] = tgt; } else { unfixable++; unfixCols[r[1]] = tgt || '(no AD_Ref_Table row)'; }
+    });
+    return { fkInstances: fk.length, convOK, fixable, unfixable,
+             fixCols, unfixCols, distinctFix: Object.keys(fixCols).length, distinctUnfix: Object.keys(unfixCols).length };
+  });
+  console.log('\n── the population, read from the seed ──');
+  console.log('   §REFTABLE-POPULATION fkInstances=' + POP.fkInstances + ' resolvedByConvention=' + POP.convOK +
+              ' fixableFromAD_Ref_Table=' + POP.fixable + ' (' + POP.distinctFix + ' distinct columns)' +
+              ' noTarget=' + POP.unfixable + ' (' + POP.distinctUnfix + ' distinct)');
+  console.log('   FIXED : ' + JSON.stringify(POP.fixCols));
+  console.log('   ⬜ NOT RESOLVED (no AD_Ref_Table row and no table under the convention — reported, never a pass): ' +
+              JSON.stringify(POP.unfixCols));
+  judged('the convention genuinely fails for a real, non-trivial set of FK fields (else this item is vacuous)',
+    POP.fkInstances, POP.fixable > 0, POP.fixable + ' of ' + POP.fkInstances + ' FK field-instances');
+
+  // ══ A · a picker that offered NOTHING now offers the AD_Ref_Table target's rows ══
+  console.log('\n── A · MLookupFactory.getLookup_Table — the target comes from AD_Ref_Table, not the column name ──');
+  const A = await page.evaluate(() => {
+    const q = s => { const r = window.__idmpDb.exec(s); return r.length ? r[0].values : []; };
+    const E = window.__crud.formEntry();
+    const f = c => ((E && E.fields) || []).filter(x => x.col === c)[0] || null;
+    const dom = c => { const el = document.querySelector('#idmp-inline-mount [data-col="' + c + '"]'); return el && el.tagName === 'SELECT' ? el.options.length : null; };
+    const sr = f('salesrep_id');
+    // the ORACLE: what the seed says salesrep_id's reference resolves to, and how many rows that table has
+    const rt = sr ? window.ADParser.resolveRefTable(window.__idmpDb, null) : null;   // placeholder, real read below
+    const refVal = q("SELECT COALESCE(f.AD_Reference_Value_ID, c.AD_Reference_Value_ID) FROM AD_Field f " +
+      "JOIN AD_Column c ON c.AD_Column_ID=f.AD_Column_ID WHERE f.AD_Tab_ID=186 AND lower(c.ColumnName)='salesrep_id'");
+    const seedRt = refVal.length ? window.ADParser.resolveRefTable(window.__idmpDb, refVal[0][0]) : null;
+    const convTableExists = q("SELECT name FROM sqlite_master WHERE type='table' AND lower(name)='salesrep'").length > 0;
+    return { specRef: sr ? sr.ref : null, specKey: sr ? sr.refkey : null, specSrc: sr ? sr.refsource : null,
+             seedTable: seedRt ? String(seedRt.tableName).toLowerCase() : null,
+             seedKey: seedRt ? String(seedRt.keyCol).toLowerCase() : null,
+             convTableExists, options: dom('salesrep_id') };
+  });
+  judged('salesrep_id resolves to the table AD_Ref_Table names, with that reference\'s AD_Key as the pk',
+    A.seedTable ? 1 : 0,
+    A.specRef === A.seedTable && A.specKey === A.seedKey && !A.convTableExists,
+    'seed says ' + A.seedTable + '/' + A.seedKey + ' · spec has ' + A.specRef + '/' + A.specKey +
+    ' · the convention table "salesrep" exists=' + A.convTableExists + ' (that is why it degraded)');
+  judged('and its picker now offers real rows instead of degrading to the raw value', A.options ? 1 : 0,
+    A.options > 1, 'option count (incl. the blank) = ' + A.options);
+
+  // ══ B · AD_Ref_Table.WhereClause is a SECOND narrowing, independent of AD_Val_Rule ══
+  console.log('\n── B · AD_Ref_Table.WhereClause applied on top of the val rule ──');
+  const refLines = LOG.filter(l => /§REFTABLE col=/.test(l));
+  const applied = refLines.filter(l => /refWhere=applied/.test(l));
+  const B = await page.evaluate(() => {
+    const q = s => { const r = window.__idmpDb.exec(s); return r.length ? r[0].values : []; };
+    // c_employee_id → C_BPartner narrowed by AD_Ref_Table 252 (`C_BPartner.IsEmployee='Y'`), no val rule at all,
+    // so it isolates the AD_Ref_Table clause from the AD_Val_Rule path. Both counts read from the seed.
+    const all = q("SELECT COUNT(*) FROM c_bpartner");
+    const emp = q("SELECT COUNT(*) FROM c_bpartner WHERE IsEmployee='Y'");
+    const rt = window.ADParser.resolveRefTable(window.__idmpDb, 252);
+    return { all: all.length ? Number(all[0][0]) : null, emp: emp.length ? Number(emp[0][0]) : null,
+             clause: rt ? String(rt.whereClause || '') : null };
+  });
+  judged('the AD_Ref_Table clause is real and NARROWS (before > after), read from the seed both ways',
+    B.all ? 1 : 0, B.all != null && B.emp != null && B.emp < B.all && /IsEmployee/i.test(B.clause || ''),
+    'c_bpartner ' + B.all + ' → ' + B.emp + ' under AD_Ref_Table 252 "' + B.clause + '"');
+  judged('the live pickers logged the clause as APPLIED on real columns', refLines.length,
+    applied.length > 0, applied.length + ' of ' + refLines.length + ' §REFTABLE lines report refWhere=applied');
+  applied.slice(0, 4).forEach(l => console.log('   ' + l.slice(0, 150)));
+
+  // ══ C · the val-ruled LIST (getLookup_List) ══
+  console.log('\n── C · a val-ruled List filters its AD_Ref_List options (MLookupFactory.getLookup_List) ──');
+  await page.goto(base + '?login=GardenAdmin&window=195', { waitUntil: 'load' });
+  await landed(page); await clickNew(page);
+  const C = await page.evaluate(() => {
+    const q = s => { const r = window.__idmpDb.exec(s); return r.length ? r[0].values : []; };
+    const E = window.__crud.formEntry();
+    const f = ((E && E.fields) || []).filter(x => x.col === 'trxtype')[0] || null;
+    const vrId = f ? f.valruleid : null;
+    const code = vrId != null ? q("SELECT code FROM ad_val_rule WHERE ad_val_rule_id=" + Number(vrId)) : [];
+    const refId = f ? f.refListId : null;
+    const before = refId != null ? q("SELECT COUNT(*) FROM AD_Ref_List WHERE AD_Reference_ID=" + Number(refId) + " AND IsActive='Y'") : [];
+    // the ORACLE: apply the rule's clause to AD_Ref_List directly — NOT through the engine under test
+    const after = (refId != null && code.length)
+      ? q("SELECT Value FROM AD_Ref_List WHERE AD_Reference_ID=" + Number(refId) + " AND IsActive='Y' AND (" + code[0][0] + ")")
+      : [];
+    // build the record that makes trxtype VISIBLE, straight from its own DisplayLogic (e.g. "@TenderType@=C")
+    const dlRow = q("SELECT f.DisplayLogic FROM AD_Field f JOIN AD_Column c ON c.AD_Column_ID=f.AD_Column_ID " +
+      "WHERE f.AD_Tab_ID=330 AND lower(c.ColumnName)='trxtype'");
+    const dl = dlRow.length ? String(dlRow[0][0] || '') : '';
+    const rec = {};
+    const m = /@([A-Za-z0-9_]+)@\s*=\s*'?([A-Za-z0-9_]+)'?/.exec(dl);
+    if (m) rec[m[1].toLowerCase()] = m[2];
+    const el = document.querySelector('#idmp-inline-mount [data-col="trxtype"]');
+    const domOpts = el && el.tagName === 'SELECT' ? Array.from(el.options).map(o => o.value).filter(v => v !== '') : null;
+    return { vrId, code: code.length ? String(code[0][0]) : null, refId,
+             before: before.length ? Number(before[0][0]) : null,
+             oracle: after.map(r => String(r[0])).sort(),
+             dom: domOpts ? domOpts.slice().sort() : null,
+             engineOptions: f && f.options ? Object.keys(f.options).sort() : null,
+             // trxtype carries DisplayLogic (read from the seed here, not assumed) — a HIDDEN field is not
+             // validated at all (GridField parity, validateField:122), so the membership arm must judge it in
+             // the state where iDempiere would show it. The trigger value is EXTRACTED from the logic string.
+             displayLogic: dl,
+             visibleRecord: rec,
+             validateExcluded: f ? window.__crud.core.validateField({}, f, 'A', undefined, rec, {}) : null,
+             validateAdmitted: f && after.length ? window.__crud.core.validateField({}, f, String(after[0][0]), undefined, rec, {}) : null,
+             hiddenIsSkipped: f ? window.__crud.core.validateField({}, f, 'A', undefined, {}, {}) : null };
+  });
+  judged('trxtype carries a val rule and the seed\'s own AD_Ref_List is narrowed by it (before > after)',
+    C.before || 0, C.before != null && C.oracle.length > 0 && C.oracle.length < C.before,
+    'ref ' + C.refId + ': ' + C.before + ' active options → ' + C.oracle.length + ' admitted by rule ' + C.vrId + ' "' + C.code + '"');
+  judged('the rendered <select> offers EXACTLY the admitted values, computed independently of the engine',
+    C.dom ? C.dom.length : 0, JSON.stringify(C.dom) === JSON.stringify(C.oracle),
+    'oracle=' + JSON.stringify(C.oracle) + ' dom=' + JSON.stringify(C.dom));
+  judged('P8.6 — validateField reads the SAME filtered map, so offered == accepted',
+    C.engineOptions ? C.engineOptions.length : 0,
+    JSON.stringify(C.engineOptions) === JSON.stringify(C.oracle) &&
+    C.validateExcluded === 'list:not-an-option' && C.validateAdmitted === null,
+    'options=' + JSON.stringify(C.engineOptions) + ' · shown when ' + JSON.stringify(C.visibleRecord) +
+    ' (its own DisplayLogic "' + C.displayLogic + '") · validate(excluded "A")=' + C.validateExcluded +
+    ' validate(admitted)=' + C.validateAdmitted);
+  ok('…and while its DisplayLogic HIDES it, the validator skips it entirely (GridField parity, validateField:122)',
+    C.hiddenIsSkipped === null, 'validate(excluded "A", empty record) = ' + C.hiddenIsSkipped);
+
+  // ══ FALSIFIER ══
+  console.log('\n── FALSIFIER · the resolution is read from the dictionary, not hard-coded ──');
+  const F = await page.evaluate(() => {
+    const P = window.ADParser, db = window.__idmpDb;
+    return { unknown: P.resolveRefTable(db, -424242), nullId: P.resolveRefTable(db, null),
+             // a TableDIR column (19) has no AD_Reference_Value_ID, so it MUST keep the convention
+             tableDirKeepsConvention: (function () {
+               const E = window.__crud.formEntry();
+               const f = ((E && E.fields) || []).filter(x => x.type === 'fk' && !x.refsource)[0];
+               return f ? { col: f.col, ref: f.ref, refsource: f.refsource || null } : null;
+             })() };
+  });
+  ok('an unknown / null AD_Reference_Value_ID returns null — the caller keeps the convention, nothing invented',
+    F.unknown === null && F.nullId === null, JSON.stringify({ unknown: F.unknown, nullId: F.nullId }));
+  judged('a DisplayType-19 (TableDIR) column still uses `<col minus _id>` — the port is not applied too widely',
+    F.tableDirKeepsConvention ? 1 : 0,
+    !!(F.tableDirKeepsConvention && F.tableDirKeepsConvention.ref &&
+       F.tableDirKeepsConvention.ref === F.tableDirKeepsConvention.col.replace(/_id$/, '')),
+    JSON.stringify(F.tableDirKeepsConvention));
+
+  ok(errs.length + ' pageerrors across the run', errs.length === 0, errs.slice(0, 2).join(' | '));
+
+  console.log('\n§PARITY-REFTABLE-VERDICT CRITIC ' + (fail === 0 ? '✔' : '✘') + ' ' + (fail === 0
+    ? 'An FK of DisplayType 18/30 now takes its target table, key column and where-clause from AD_Ref_Table as ' +
+      'MLookupFactory.getLookup_Table does, so ' + POP.distinctFix + ' columns that had been querying a table that ' +
+      'does not exist offer real rows; the AD_Ref_Table clause narrows on top of the val rule; and a val-ruled ' +
+      'List filters its AD_Ref_List options, with the validator reading the same set the picker was built from.'
+    : 'a lookup target or a list filter diverges from MLookupFactory — see the 🔴 above.'));
+  console.log((fail === 0 ? '✅' : '❌') + ' W-PARITY-REFTABLE: ' + pass + '/' + (pass + fail) +
+              ' PASS (' + fail + ' FAIL, ' + inconclusive + ' INCONCLUSIVE)');
+  await browser.close(); server.close();
+  process.exit(fail === 0 ? 0 : 1);
+})().catch(e => { console.error('🔴 W-PARITY-REFTABLE harness threw: ' + e.message); process.exit(1); });


### PR DESCRIPTION
Closes the four AD-UI items the earlier parity PRs (#1613, #1626, #1632) left open. Specs and per-item results: bim-compiler `prompts/ERP_IDEMPIERE_UX_PARITY.md` §P7–§P10.

## The one that matters most — a shipped defect that had silently disabled AD logic

`ad_evaluator` matched record keys **case-sensitively**, while every record we build is lowercase. So **any `DisplayLogic` / `ReadOnlyLogic` / `MandatoryLogic` expression naming a CamelCase column silently evaluated against `""`** — `C_Payment.TrxType`'s `@TenderType@=C` could never become true. It looked exactly like a test bug. Fixed to this lane's own already-written convention (§P3-SPEC P3.5).

## §P7 · `§PARITY-MANDATORY-CREATE` — closed (18/18)

The create path now validates the **whole new row**, as `GridTable.dataSave` → `getMandatory` does, so an *untouched* empty mandatory field is finally rejected — the item `poc_parity_fieldset_live.js` had been carrying as OPEN. It now reads **0 OPEN**.

The prior session's verdict was half wrong: `GridField.isMandatory:377-385` **hard-exempts** `DocumentNo` and `M_AttributeSetInstance_ID` in a window, so two of its four named blockers were never blockers. Four faithful ports (that exemption, `defaultFromDatatype`, DisplayType 37 CostPrice as numeric, and `defaultFromExpression` resolving a detail tab's `@token@` defaults from the parent row) took `c_orderline`'s un-defaultable mandatory blockers **6→3**, all three typed by the O2C witness.

The validator was **not** weakened — falsifiers fire in both directions, including one asserting the port is not *wider* than the Java. Three witnesses carrying frozen incorrect contracts were moved to the real one (O2C stage 7 asserted vendor+warehouse were mandatory and then saved without them).

## §P8 · `AD_Ref_Table` / Search targets — closed (12/12)

Of 115 FK field-instances: **61 resolve by convention, 34 are fixable from `AD_Ref_Table` (18 distinct columns), 20 have no target at all** (8 columns) — those are reported NOT RESOLVED and never counted as passes.

Found a second narrowing nobody had noticed: **`AD_Ref_Table.WhereClause` applies independently of the val rule** (`c_bpartner` 113→20 under `IsEmployee='Y'`). `trxtype` filters 6→4.

## §P9 · GL_Category — 7/7, 50/50 documents match the seed's own `fact_acct`

All three `Doc.setDocumentType` stages exercised. Already verified and committed on the bim-compiler side.

## §P10 · DocNo — both branches judged (10/10)

The old arm was worse than scope-blind, it was **tautological**: a mocked `__idmpDb` whose expected value was written beside the assertion. Both `IsDocNoControlled` branches are now judged against the real seed through the shipped functions (34 doctypes `='Y'` with resolving active sequences, 18 `='N'`).

## Regression

Six live parity witnesses, **107 assertions, 0 FAIL, 0 INCONCLUSIVE**. Twin gate **64 pairs / 0 unreviewed**. O2C **stages 1/2/3/5/6/7 PASS** (stage 4 FAIL / stage 8 ABSENT are the known structural gaps). `erp/sw.js` v776→**v777**.

## ⚠ MANDATORY POST-MERGE STEP — the twin gate will go red

`check_erp_twins.js` compares each `build/erp/<mod>.js` against **`origin/main` bytes**, by design. This branch changes three shipped files that are locked `identical`: **`crud_core.js` (21 witnesses), `crud_overlay.js` (21), `ad_evaluator.js` (3)** — 45 witness references in total.

It reads PASS today *only because this branch is unmerged*. **On merge the gate WILL fail** (`declared identical but DRIFTED`) until those three copies are re-derived from the merged shipped files. Mirroring them pre-merge would have failed the gate immediately, and `scripts/erp_twins.json` was owned by another agent this session. Recorded as §P8-TWIN-HANDOVER; the merging session must do the re-derive and re-run the gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BTjD9Hx77LPZyFPiFNXygS