### PR TITLE
fix(viewer): §R15 — disarm the two controller rules by default; their own witness says FAIL

### DIFF
--- a/viewer/dlod_nav.js
+++ b/viewer/dlod_nav.js
@@ -313,11 +313,26 @@
     // was already saturated at MAX_BOOST and the measurement still said "below LOW", i.e. steps
     // that bought nothing and only had to be unwound later. All three are pure bookkeeping.
     passSeq: 0, budgetTicks: 0, budgetStaleTicks: 0, budgetWindupTicks: 0, budgetUpBlocked: false,
-    // §R15 rules 1 and 2, each independently live-flippable (console/witness only, both
-    // default TRUE = the fixed controller). Setting BOTH false restores the pre-§R15
-    // integrator byte-for-byte, which is how witness/w_budget_converge.js gets its
-    // before/after and its red control out of a SINGLE page load.
-    budgetFreshGate: true, budgetAntiWindup: true };
+    // §R15 rules 1 and 2, each independently live-flippable. Setting BOTH false is the pre-§R15
+    // integrator byte-for-byte, which is how witness/w_budget_converge.js gets its before/after
+    // and its red control out of a SINGLE page load.
+    // ⚠ DEFAULT FALSE (2026-09-03) — DELIBERATELY, and this is the honest reading of the evidence,
+    // not caution for its own sake. The two rules were landed default-TRUE in #1635 and #1635
+    // auto-merged before the second witness run came back. W-BUDGET-CONVERGE reports verdict=FAIL
+    // on BOTH runs and the gate was never relaxed (CPE_4D_PERF_MEM_STUDY.md §R15.5):
+    //   - the MECHANISM result reproduces exactly — boostSpan 60->4, boost changes 174->12,
+    //     windupTicks ->0, dive-back-in phase 56.9->24.4 ms (-57.1%) / -59.3% on the second run.
+    //   - the FRAME-TIME result does NOT — whole-cycle dt_mean was -0.5% on run 2 and +1.1% on
+    //     run 3. The sign flips, so run-to-run variance is the same size as the effect and there
+    //     is no measured mean win to claim in either direction. Run 3 regressed THREE phases by
+    //     15-45%, one of them 52.4->60.6 ms. Every regressed phase draws FEWER calls under the
+    //     fix, so the added ms is demote-side _startFade work, not rendering (queue item A-27).
+    // A behaviour change whose own witness says FAIL must not be the shipped default. Everything
+    // else from #1635 stays live and is pure gain: the §R15 counters (passSeq/budgetTicks/
+    // budgetStaleTicks/budgetWindupTicks), the richer §DLOD_NAV_BUDGET line, and the
+    // §ROOM_OCCL_INDEX_ERR noise fix. Flip these to true to re-arm the fix; land it as the default
+    // when A-27 removes the transition cost and the witness turns green on its OWN gate.
+    budgetFreshGate: false, budgetAntiWindup: false };
   window.__dlodNav = _stats;
 
   // §20 — effective boost this pass: forceBoost (witness pin) wins outright; otherwise the

--- a/viewer/sw.js
+++ b/viewer/sw.js
@@ -31,7 +31,7 @@
 // installed service worker keeps serving the affine without this bump (§CRISIS LESSON 4). Paired
 // with _GANTT_CACHE_VERSION 37→38 (the IDB kernel_ops self-heal) in the same commit.
 // DEPLOY: bump CACHE_VERSION on every OCI upload. Old caches are purged on activate.
-const CACHE_VERSION = 'v1130';   // bump on each deploy; per-change detail is the git commit message.
+const CACHE_VERSION = 'v1131';   // bump on each deploy; per-change detail is the git commit message.
 // v1128 (2026-09-02) §SUN_FILL_RATIO: viewer/effects.js — the Alt+S staging HDRI
 // (belfast_sunset_puresky_1k) was being pushed onto EVERY material by _reassertPhotoEnvMap, matte
 // concrete and plaster included. IBL is non-directional and is NOT shadow-map-occluded in three.js,
@@ -41,6 +41,11 @@ const CACHE_VERSION = 'v1130';   // bump on each deploy; per-change detail is th
 // (42/42 and 70/70 asserted still on it). effects.js is in PRECACHE_ASSETS and viewer.html's query
 // is bumped effects.js?v=30->31 in the SAME PR (§CRISIS LESSON 4).
 // Witness: witness_sun_fill_ratio.js (§SFR_REDGREEN, RED CONTROL 0.0005/0.0000).
+// v1131 (2026-09-03) §R15 levers DEFAULT FALSE. #1635 auto-merged before the second
+// W-BUDGET-CONVERGE run returned; that run reports verdict=FAIL (as did the first) with THREE
+// phases 15-45% slower and whole-cycle dt_mean flipping sign between runs. The counters, the
+// richer §DLOD_NAV_BUDGET line and the §ROOM_OCCL_INDEX_ERR fix all stay; only the behaviour
+// change is disarmed until A-27 removes the demote-side fade cost. dlod_nav.js?v=3->4.
 // v1130 (2026-09-03) §R15 DLOD budget controller convergence: the §20 mesh-budget integrator ran
 // at 150 ms while its own feedback (activeElig, published once per completed chunked scan pass)
 // arrived every 387 ms — MEASURED 55.0% of control periods integrated an unrefreshed number — and

--- a/viewer/viewer.html
+++ b/viewer/viewer.html
@@ -972,7 +972,7 @@ html.bim-embedded, html.bim-embedded body { background: #0b0b0b; }
 <script src="zone_index.js?v=1" onerror="console.warn('§LOAD_FAIL zone_index.js — storey banding unavailable (zone inference falls back to declared storey)')"></script>
 <script src="support_sweep.js?v=1" onerror="console.warn('§LOAD_FAIL support_sweep.js — support-order physics unavailable (schedule repair, judge parity, lock-gate midair audit)')"></script>
 <script src="time_machine.js?v=77" onerror="console.warn('§LOAD_FAIL time_machine.js')"></script>
-<script src="dlod_nav.js?v=3" onerror="console.warn('§LOAD_FAIL dlod_nav.js')"></script>
+<script src="dlod_nav.js?v=4" onerror="console.warn('§LOAD_FAIL dlod_nav.js')"></script>
 <script src="schedule_author.js?v=14" onerror="console.warn('§LOAD_FAIL schedule_author.js')"></script>
 <script src="schedule_sync.js?v=3" onerror="console.warn('§LOAD_FAIL schedule_sync.js')"></script>
 <script src="schedule_author_ui.js?v=9" onerror="console.warn('§LOAD_FAIL schedule_author_ui.js')"></script>


### PR DESCRIPTION
## Why this exists

#1635 **auto-merged before the second W-BUDGET-CONVERGE run returned.** That run — and the first — report:

```
§R15_CONVERGE g1_actuator_stops_swinging=true g2_windup_gone=true
              g3_loaded_phases_faster=false noop=false redControlReproduced=true verdict=FAIL
```

The gate was never relaxed to match the data. Splitting what reproduces from what does not (`prompts/CPE_4D_PERF_MEM_STUDY.md` §R15.5):

| | run 2 | run 3 | reproduces? |
|---|---|---|---|
| `boostSpan` | 60 → 4 | 60 → 4 | ✅ exact |
| boost changes | 174 → 12 | 174 → 12 | ✅ exact |
| `windupTicks` | 314 → 0 | 328 → 0 | ✅ |
| best phase gain (dive back in) | −57.1% | −59.3% | ✅ |
| `dt_p95` | −8.5% | −4.7% | ✅ direction |
| **`dt_mean` whole cycle** | **−0.5%** | **+1.1%** | ❌ **sign flips** |
| **phases worse >10%** | **1** | **3** (one at 52.4 → 60.6 ms) | ❌ worse |
| `flips_mean` | +66.6% | +83.6% | ❌ magnitude grows |

The **mechanism** result reproduces exactly. The **frame-time** result does not: run-to-run variance is the same size as the effect, so there is no measured mean win to claim in either direction.

Every regressed phase has the fixed build drawing **fewer** draw calls, so the added milliseconds are not rendering — they are demote-side `_startFade` work plus the full `instanceMatrix` re-upload each flip forces. That is queue item **A-27**.

## What this changes

`budgetFreshGate` and `budgetAntiWindup` default **false** = the pre-§R15 integrator byte-for-byte (the witness's own LEGACY arm proves that equivalence). Flip either to `true` to re-arm; land them as the default when A-27 removes the transition cost and the witness turns green **on its own gate**.

**Everything else from #1635 stays live and is pure gain:** the §R15 controller counters (`passSeq` / `budgetTicks` / `budgetStaleTicks` / `budgetWindupTicks`), the richer `§DLOD_NAV_BUDGET` line carrying `elig=` / `upBlocked=` / `pass=`, and the `§ROOM_OCCL_INDEX_ERR no such column: r.center_x` noise fix.

The §R15.2 **diagnosis is unaffected and still stands**: `stalePct=55.0` (the controller ran at 2.6× the rate of its own feedback), `windupTicks` confirmed, the cost attributed to draw calls rather than flips, and `§DUCT_SILHOUETTE` bounded at 3.3% of per-frame triangles and ruled not material.

`sw.js CACHE_VERSION v1130 → v1131`; `viewer.html dlod_nav.js?v=3 → v=4`. `eslint viewer modeller` exit 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RTX9gUq3tQoytC1vthLmcq
