### PR TITLE
fix(erp): commitGroup hashed every op TWICE — the batch write path did 2× the SHA-256 work

### DIFF
--- a/erp/kernel_ops.js
+++ b/erp/kernel_ops.js
@@ -596,9 +596,27 @@
     }
 
     // ── 4. SEAL ONCE from the tip forward (the I-D win — not N whole-log re-seals). ──
-    // Rows were inserted ALREADY-sealed (prev_hash/op_hash/sig staged); sealFrom is idempotent over them
-    // and confirms the tip. This keeps per-group seal cost O(N-in-group).
-    var sealRes = await sealFrom(db, tipRow);
+    // Implementing prompts/PROD_SCALE_FORECAST.md §10.3 F1 — Witness: W-SCALE-THRU.
+    // Rows were inserted ALREADY-sealed (prev_hash/op_hash/sig staged off tipRow), so in the CLEAN case
+    // — the tip IS the last row, i.e. nothing below it is unsealed — the staged hashes already ARE the
+    // chain and re-deriving them is pure waste: sealFrom(db, tipRow) selects `id > tipRow.id`, which is
+    // this group's OWN rows, and re-hashes + UPDATEs every one. MEASURED: 2,000 ops cost 4,040 digests
+    // instead of 2,040, and each digest is an await, so the extra 2,000 promise round-trips are what made
+    // batch LOSE to naive per-op commit under CPU contention (§10.1: speedup flipped to 0.82×).
+    // `sealed` still reports ids.length — the rows WERE sealed, at stage time — so the return contract
+    // poc_crud_group.js:91 / test_crud_process_writeloop.js:39 assert on is unchanged.
+    // DIRTY case (unsealed rows sit BELOW the tip, e.g. a prior commitOp that was never sealed) keeps the
+    // full re-seal: those rows must be re-chained, and the staged hashes are superseded by it. It is now
+    // announced (§KRN_GROUP RESEAL) instead of being a silent slow path.
+    var cleanTip = (tipRow.id === nextId - 1);
+    var sealRes;
+    if (cleanTip) {
+      sealRes = { sealed: ids.length, tip: opHashes[opHashes.length - 1], fromId: tipRow.id, skipped: true };
+    } else {
+      console.log('§KRN_GROUP RESEAL gid=' + gid + ' unsealedBelowTip=' + (nextId - 1 - tipRow.id) +
+                  ' rows → full sealFrom(id>' + tipRow.id + ') (staged hashes superseded)');
+      sealRes = await sealFrom(db, tipRow);
+    }
     console.log('§KRN_GROUP committed gid=' + gid + ' ops=' + ids.length + ' groupHash=' + groupHash.slice(0, 12) +
                 '… tip=' + sealRes.tip.slice(0, 12) + '… sealed=' + sealRes.sealed + ' (WHOLE — all-or-none)');
     _persistToIdb(db);

--- a/erp/sw.js
+++ b/erp/sw.js
@@ -10,7 +10,7 @@
 // init-bubble must be INSTANT, ERP_INIT_BUBBLE_INSTANT.md); network-first for non-precached .js (fresh on
 // deploy); cache-first for precached assets/.wasm/images. Freshness on deploy is carried by the SW version
 // bump (skipWaiting+clients.claim precache the new shell), so SWR strands a user at most one load post-deploy.
-const CACHE_VERSION = 'v777';   // bump on each deploy; per-change detail is the git commit message.
+const CACHE_VERSION = 'v778';   // bump on each deploy; per-change detail is the git commit message.
 // v772 (rebase of PR #203 onto origin/main) §INTEG-WIRE-B: disposable-host persistence in-app
 // (erp_replica_client.js + erp_persist_ui.js) — back the books up to a SIGNED snapshot the user
 // owns (signed by the edge key), restore on a FRESH device -> replay recomputes tip == signed


### PR DESCRIPTION
Implementing `prompts/PROD_SCALE_FORECAST.md` §10.3 F1 — Witness: **W-SCALE-THRU**.
Paired bim-compiler commit: `06002a60b` (the instrument half + the spec).

## The defect
`commitGroup` step 4 called `sealFrom(db, tipRow)` with `tipRow` captured **before** the INSERTs, so
`WHERE id > tip.id` selected the group's **own** just-inserted rows and re-derived every hash it had
already staged, plus N `UPDATE`s. Its own comment stated the intent it did not implement — *"Rows were
inserted ALREADY-sealed … sealFrom is idempotent over them and confirms the tip."*

Each digest is an `await`, so the extra 2,000 promise round-trips are what made the batch path **lose**
to naive per-op commit under CPU contention: `W-SCALE-FORECAST` logged `speedup=0.82×` on a loaded box
while the engine had not changed.

## Measured — 2,000 ops through the real engine
| | before | after |
|---|---|---|
| digests | 4,040 | **2,040** |
| batch/naive hashing | 2.02× | **1.02×** |
| speedup, isolated | 2.25× | **3.69×** |
| speedup, in-witness | **0.82× (FAIL)** | **3.53× median**, worst rep 3.44× |

```
§SCALE-THRU naive=7785op/s batch=27449op/s speedup=3.53× (median of 3 interleaved reps; per-rep 4.55× 3.53× 3.44×)
§SCALE-THRU-WORK naive digests=2000 rows=2000 · batch digests=2040 rows=2000
                 · batch/naive hashing=1.02× (contention-immune) · batch chain ok=true len=2000
🟢 W-SCALE-FORECAST PASS — 5 measured claims hold
```

## Contract preserved
`sealed` still reports `ids.length` — the rows **were** sealed, at stage time. That is what
`poc_crud_group.js:91` and `test_crud_process_writeloop.js:39` assert on, and what
`poc_pos_deliverlater/register/replenish_staged` + `poc_kitchen_queue` truth-test.

The **DIRTY** case (unsealed rows below the tip, e.g. a prior `commitOp` never sealed) keeps the full
re-seal — those rows must be re-chained — and now announces itself as `§KRN_GROUP RESEAL` instead of
being a silent slow path.

## Falsified, not assumed
```
clean case  returnedHashes==stored=true  tip==lastStored=true  verifyChain=true
dirty case  sealed=3  unsealedRowsLeft=0  verifyChain=true len=3
batch arm   verifyChain ok=true len=2000   ← now a witness claim, not an assumption
```

## Regression
73 kernel_ops-judging witnesses run **before and after** the engine change: **66 PASS / 7 FAIL,
identical set both times → 0 regressions.** The 7 are pre-existing and unrelated — `poc_kernel`,
`test_kernel_owner`, `test_kernel_sign` are `MODULE_NOT_FOUND` (the engine is never reached);
`poc_kds_live`, `poc_pos_live`, `poc_replenish_live`, `poc_wh_cache` need a served app.

`W-ERP-TWIN` is RED until this merges (copy=`28599b4b` vs shipped=`3f5f6215`) — that is the gate working
as designed (§P8-TWIN-HANDOVER); it goes GREEN on merge.

`erp/sw.js` CACHE_VERSION v777 → **v778** (mandatory, same PR as a shipped `erp/` change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)