### PR TITLE
fix(erp): rebase() dropped user_tag — every non-default actor's signature died on sync

### DIFF
--- a/erp/erp_sync_fsm.js
+++ b/erp/erp_sync_fsm.js
@@ -176,19 +176,31 @@
    * @returns {Promise<{applied:number, head:number}>}
    */
   async function rebase(db, kernel, sequencer) {
-    var r = db.exec('SELECT op_uuid,timestamp,op_type,parameters,input_guids,output_guid,gid,branch_id,sig FROM kernel_ops ORDER BY id');
+    // Implementing prompts/BACKEND_SUBSTRATE_LANE.md §RB.2 — Witness: W-REBASE-USERTAG.
+    // `user_tag` rides through the rewind+reapply for the SAME reason gid/branch_id/sig do (S7 above),
+    // and it is the one column that fix missed. kernel_ops.js:_canonicalV2 signs `actor: op.user_tag`,
+    // so a v2 content-signed row's signature ATTESTS its user_tag; the column DEFAULTs to 'local'
+    // (kernel_ops.js:42), so dropping it here silently rewrote every non-default actor's row to 'local'
+    // and sealChain — which does not re-sign a row that arrives with a sig — then verified a content
+    // hash the signature no longer covers. MEASURED before the fix: a row committed as `user:bob`
+    // came back `user_tag=local` and verifyChain went true -> false (why=signature, brokeAt=1).
+    var r = db.exec('SELECT op_uuid,timestamp,op_type,parameters,input_guids,output_guid,gid,branch_id,sig,user_tag FROM kernel_ops ORDER BY id');
     var local = (r.length ? r[0].values : []).map(function (row) {
       return { op_uuid: row[0], timestamp: row[1], op_type: row[2], parameters: row[3],
-               input_guids: row[4], output_guid: row[5], gid: row[6], branch_id: row[7], sig: row[8] };
+               input_guids: row[4], output_guid: row[5], gid: row[6], branch_id: row[7], sig: row[8],
+               user_tag: row[9] };
     });
     var pushRes = await sequencer.push(local); // idempotent ingest → canonical order (await: sync stub OR async HTTP relay)
     var canon = await sequencer.snapshot();    // the authoritative ordered log
     db.run('DELETE FROM kernel_ops');      // rewind: drop local order (ids restart at 1 — no AUTOINCREMENT)
     for (var i = 0; i < canon.length; i++) {
       var op = canon[i];
-      db.run('INSERT INTO kernel_ops (op_uuid,timestamp,op_type,parameters,input_guids,output_guid,gid,branch_id,sig) VALUES (?,?,?,?,?,?,?,?,?)',
+      db.run('INSERT INTO kernel_ops (op_uuid,timestamp,op_type,parameters,input_guids,output_guid,gid,branch_id,sig,user_tag) VALUES (?,?,?,?,?,?,?,?,?,?)',
         [op.op_uuid, op.timestamp, op.op_type, op.parameters, op.input_guids || null, op.output_guid || null,
-         op.gid || null, op.branch_id || null, op.sig || null]);
+         op.gid || null, op.branch_id || null, op.sig || null,
+         // fall back to the column DEFAULT only when the source row genuinely has none, so a
+         // pre-user_tag log still rebases to exactly the bytes it does today.
+         (op.user_tag != null ? op.user_tag : 'local')]);
     }
     await kernel.sealChain(db);             // re-seal over the canonical order (skips already-signed rows)
     console.log('§SYNC_FSM rebase applied=' + canon.length + ' head=' + (pushRes && pushRes.head != null ? pushRes.head : canon.length));

--- a/erp/sw.js
+++ b/erp/sw.js
@@ -10,7 +10,7 @@
 // init-bubble must be INSTANT, ERP_INIT_BUBBLE_INSTANT.md); network-first for non-precached .js (fresh on
 // deploy); cache-first for precached assets/.wasm/images. Freshness on deploy is carried by the SW version
 // bump (skipWaiting+clients.claim precache the new shell), so SWR strands a user at most one load post-deploy.
-const CACHE_VERSION = 'v778';   // bump on each deploy; per-change detail is the git commit message.
+const CACHE_VERSION = 'v779';   // bump on each deploy; per-change detail is the git commit message.
 // v772 (rebase of PR #203 onto origin/main) §INTEG-WIRE-B: disposable-host persistence in-app
 // (erp_replica_client.js + erp_persist_ui.js) — back the books up to a SIGNED snapshot the user
 // owns (signed by the edge key), restore on a FRESH device -> replay recomputes tip == signed


### PR DESCRIPTION
Implementing `prompts/BACKEND_SUBSTRATE_LANE.md` §RB — Witness: **W-REBASE-USERTAG**.
Closes `AGENT_QUEUE.md §ERP-SESSION-CLOSE` NEXT item 4.

## The defect
`erp/erp_sync_fsm.js:179`/`:189` rewound and reapplied the log through **nine** columns —
`op_uuid, timestamp, op_type, parameters, input_guids, output_guid, gid, branch_id, sig`. `user_tag` was
not one of them, and `kernel_ops.js:42` declares it `TEXT DEFAULT 'local'`, so every rebased row was
silently rewritten to `'local'`.

`kernel_ops.js:_canonicalV2` (`:240-249`) signs `actor: op.user_tag`, so a **v2 content-signed** row's
signature attests its `user_tag` — and `sealChain`'s `if (_signer && !sig)` guard deliberately does not
re-sign a row that arrives with a sig. After one sync a row committed by `user:bob` carried bob's
signature over `actor:"user:bob"` while the stored row said `actor:"local"`, so **verification failed for
every non-default actor**. Every witness to date commits as `'local'`, which is exactly why this never
surfaced.

Same class as the S7 fix this function's own docblock describes (`gid`/`branch_id`/`sig` were being
blanked by the rewind). `user_tag` was the column that fix missed.

## Measured — real ECDSA signer, real sequencer
```
before fix   pre  actor=user:bob verifyChain=true  nonDefaultRows=1
             post actor=local    verifyChain=false brokeAt=1 why=signature
after fix    post actor=user:bob localRow=local    verifyChain=true len=2
```

## The witness
`W-REBASE-USERTAG`, 4 arms added to `scripts/test_kernel_rebase.js`: **PRESERVE** · **SIG SURVIVES** ·
**DEFAULT UNCHANGED** (so the fix cannot be a no-op that merely stops asserting) · **NOT VACUOUS**
(an unusable fixture reports INCONCLUSIVE, never PASS).

**Falsifier proven:** on the pre-fix engine exactly 3 of the 4 go red — and DEFAULT UNCHANGED correctly
stays green, because a `'local'` row was never affected.

## Regression
All 6 `erp_sync_fsm`-judging witnesses PASS: `poc_blackout_resume`, `poc_schema_version`,
`test_kernel_sync`, `test_kernel_relay`, `test_kernel_rebase`, `test_kernel_relay_auth`.

`erp/sw.js` CACHE_VERSION v778 → **v779**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)