### PR TITLE
fix(4d): §STOREY_DATUM_FRAME — the declared storey ladder must be in the geometry's vertical frame

### DIFF
--- a/viewer/schedule_author.js
+++ b/viewer/schedule_author.js
@@ -324,6 +324,118 @@
   // assignStoreyByZ) — ported verbatim, same reasoning: an element with no real storey containment
   // (a literal "Unknown" IFC storey label — 69.9% of Terminal) is reassigned to the nearest REAL
   // storey by median center-Z, deterministic, nothing invented.
+
+  // ══ §STOREY_DATUM_FRAME (2026-09-03, bim-compiler prompts/4D_MODEL_INTEGRITY.md §I.6) ═════════
+  // A DECLARED STOREY DATUM SHIPS IN TWO COLUMN SHAPES, AND THEY CAN BE IN TWO VERTICAL FRAMES.
+  //   `elevation` — IfcBuildingStorey.Elevation (extract.py §STOREY_DATUM, buildings/patches/*.sql)
+  //   `center_z`  — the COMPILED placement point (STC_* rows, size_z NULL/0 ⇒ center_z IS the datum)
+  // #1551 chose between them by EMPTINESS ("elevation rows if any, else center_z"). That is a
+  // statement about the schema, not about the frame. MEASURED 2026-09-03 on the DB the viewer
+  // actually loads (Hospital_meta.db — the split pair streaming.js §DB_SPLIT_DETECT serves; NOT
+  // Hospital_extracted.db, which has no spatial_structure at all and is why #1551's own check read
+  // "no declared storeys ⇒ byte-identical"): 63 IfcBuildingStorey rows in TWO frames —
+  //   56 federated source rows    elevation 0.0 … 34.0 m     (a LOCAL per-file frame)
+  //    7 COMPILED STC_Level_*     center_z  168.7 … 201.4 m  (the model's WORLD frame)
+  // and every element base-Z is 156.6 … 202.8 m. The elevation rows won by emptiness, every element
+  // sat above the top datum, all 63,182 landed in the last band: bandsUsed=1, 7 tasks, 509 days
+  // (was 8 bands / 42 tasks / 318 days). The film did not change length, so calendar-per-second
+  // went +60% — the user's "the bake is too fast paced". The user's own Hospital_silent.db: same.
+  //
+  // THE RULE: a datum set must be in the same vertical frame as the geometry it bands, and that is
+  // CHECKABLE. Both candidates are read, each is tested against the element base-Z distribution,
+  // and the first IN-FRAME one wins — elevation before center_z, so the IFC's own declaration keeps
+  // priority and every building where both are in frame is BYTE-IDENTICAL to #1551 (Terminal,
+  // Clinic, Duplex, HHS: proven per building by witness_storey_datum_frame.js). THE TEST: the
+  // ladder's span [d_0, d_last] must contain the element base-Z MEDIAN. The median is used because
+  // it is the one location statistic that needs no tolerance constant and that a stray element
+  // cannot fake (an interval-overlap test on min/max is defeated by ONE outlier). A ladder that
+  // fails is not this geometry's frame: it is REJECTED and the §-line says so. If no candidate is
+  // in frame the declared path is REFUSED and the old label inference runs — DEGRADE, DON'T
+  // DISABLE — with the reason named. These verbs are exported so the witness judges the SAME
+  // choice on the SAME inputs, never a re-derivation.
+  function _storeyDatumCandidates(db) {
+    function q(sql) {
+      var out = [];
+      try {
+        var res = db.exec(sql);
+        if (res && res.length) res[0].values.forEach(function (v) {
+          var z = Number(v[1]);
+          if (v[0] != null && isFinite(z)) out.push({ name: String(v[0]), z: z });
+        });
+      } catch (e) { /* column or table absent → an EMPTY candidate, never a throw */ }
+      return out;
+    }
+    return [
+      { source: 'elevation', rows: q("SELECT name, elevation FROM spatial_structure WHERE type='IfcBuildingStorey' AND elevation IS NOT NULL") },
+      { source: 'center_z',  rows: q("SELECT name, center_z FROM spatial_structure WHERE type='IfcBuildingStorey' AND center_z IS NOT NULL") }
+    ];
+  }
+  // Sort by datum; two storeys at the same datum are one floor under two names — keep the first,
+  // deterministically. Unchanged from #1551.
+  function _storeyLadder(rows) {
+    var s = rows.slice().sort(function (a, b) { return a.z - b.z || (a.name < b.name ? -1 : 1); });
+    var out = [];
+    for (var i = 0; i < s.length; i++) {
+      if (out.length && Math.abs(s[i].z - out[out.length - 1].z) < 1e-6) continue;
+      out.push(s[i]);
+    }
+    return out;
+  }
+  // Band index of base-Z `bz` on `ladder`. Everything below the lowest datum is band 0
+  // (foundations are the ground floor's groundworks, not a level of their own).
+  function _ladderBandIndex(ladder, bz) {
+    var k = 0;
+    for (var i = 0; i < ladder.length; i++) if (bz >= ladder[i].z - 1e-9) k = i;
+    return k;
+  }
+  // THE FRAME TEST. `cands` in preference order (from _storeyDatumCandidates), `ezs` = element
+  // base-Z with the §4D_NOGEO population already excluded. Pure; no DB, no console.
+  // Returns { mode:'DECLARED'|'INFERRED', source, ladder, lo, hi, rungsUsed, reason, legacySource,
+  //           ez:{n,min,median,max}, candidates:[{source,rows,datums,lo,hi,verdict,rungsUsed,below,above}] }
+  // `rungsUsed` counts populated ladder RUNGS (distinct datums); the §STOREY_DATUM `bandsUsed` counts
+  // distinct NAMES (a name can sit on two rungs 1e-6 apart, e.g. Terminal's 44 rungs → 22 names).
+  // `legacySource` is what #1551's emptiness rule would have picked, so the §-line can say whether
+  // this choice CHANGED anything (PRIMAL LAW clause 4: a pass must be able to report its own no-op).
+  function _chooseStoreyDatum(cands, ezs) {
+    var sorted = ezs.slice().sort(function (a, b) { return a - b; });
+    var n = sorted.length;
+    var ez = n ? { n: n, min: sorted[0], median: sorted[Math.floor(n / 2)], max: sorted[n - 1] }
+               : { n: 0, min: NaN, median: NaN, max: NaN };
+    var legacy = null;
+    for (var li = 0; li < cands.length; li++) if (cands[li].rows.length) { legacy = cands[li].source; break; }
+    var report = [], chosen = null;
+    for (var ci = 0; ci < cands.length; ci++) {
+      var c = cands[ci], ladder = _storeyLadder(c.rows);
+      var rep = { source: c.source, rows: c.rows.length, datums: ladder.length, lo: NaN, hi: NaN,
+        verdict: 'EMPTY', rungsUsed: 0, below: 0, above: 0, ladder: ladder };
+      if (!c.rows.length) { report.push(rep); continue; }
+      rep.lo = ladder[0].z; rep.hi = ladder[ladder.length - 1].z;
+      if (ladder.length < 2) { rep.verdict = 'TOO_FEW'; report.push(rep); continue; }
+      if (!n) { rep.verdict = 'NO_ELEMENTS'; report.push(rep); continue; }
+      var used = {};
+      for (var ei = 0; ei < n; ei++) {
+        var bz = sorted[ei];
+        if (bz < rep.lo) rep.below++; else if (bz >= rep.hi) rep.above++;
+        used[_ladderBandIndex(ladder, bz)] = 1;
+      }
+      rep.rungsUsed = Object.keys(used).length;   // ladder RUNGS populated (distinct datums; names can repeat across rungs)
+      var inFrame = rep.lo <= ez.median && ez.median <= rep.hi;
+      rep.verdict = inFrame ? 'IN_FRAME' : 'OUT_OF_FRAME';
+      report.push(rep);
+      if (inFrame && !chosen) chosen = rep;
+    }
+    if (chosen) {
+      return { mode: 'DECLARED', source: chosen.source, ladder: chosen.ladder, lo: chosen.lo, hi: chosen.hi,
+        rungsUsed: chosen.rungsUsed, reason: 'IN_FRAME', legacySource: legacy, ez: ez, candidates: report };
+    }
+    var reason = !n ? 'NO_ELEMENTS'
+      : !legacy ? 'NO_DECLARED_STOREYS'
+      : report.some(function (x) { return x.verdict === 'OUT_OF_FRAME'; }) ? 'NO_CANDIDATE_IN_FRAME'
+      : 'TOO_FEW_DATUMS';
+    return { mode: 'INFERRED', source: null, ladder: [], lo: NaN, hi: NaN, rungsUsed: 0,
+      reason: reason, legacySource: legacy, ez: ez, candidates: report };
+  }
+
   function _buildScheduleElements(db, rules, opts) {
     opts = opts || {};
     var dflt = opts.defaultRule || (global.SEQUENCE_DEFAULT) || { phase: 'Architecture', sequence: 6, resource: null };
@@ -385,33 +497,22 @@
     // MEASURED on every shipped DB carrying the table, storey rows have size_z NULL/0 — the row IS
     // a placement point, so center_z IS the elevation. Not a proxy, the same number by another name.
     //
-    // ⛔ NO DECLARED STOREYS ⇒ NOTHING CHANGES. Duplex and Hospital ship with no spatial_structure
-    // table at all; they keep the old inference byte-identically, and the §-line says so out loud
-    // rather than implying a datum that does not exist.
-    var _declared = [];
-    try {
-      var _dq = null;
-      try { _dq = db.exec("SELECT name, elevation FROM spatial_structure WHERE type='IfcBuildingStorey' AND elevation IS NOT NULL"); }
-      catch (e0) { _dq = null; }
-      if (!_dq || !_dq.length) {
-        try { _dq = db.exec("SELECT name, center_z FROM spatial_structure WHERE type='IfcBuildingStorey' AND center_z IS NOT NULL"); }
-        catch (e1) { _dq = null; }
-      }
-      if (_dq && _dq.length) {
-        _dq[0].values.forEach(function (v) {
-          var nm = v[0], z = Number(v[1]);
-          if (nm != null && isFinite(z)) _declared.push({ name: String(nm), z: z });
-        });
-      }
-    } catch (e) { _declared = []; }
-    // Two storeys at the same datum are one floor under two names — keep the first, deterministically.
-    _declared.sort(function (a, b) { return a.z - b.z || (a.name < b.name ? -1 : 1); });
-    var _bands = [];
-    for (var _di = 0; _di < _declared.length; _di++) {
-      if (_bands.length && Math.abs(_declared[_di].z - _bands[_bands.length - 1].z) < 1e-6) continue;
-      _bands.push(_declared[_di]);
-    }
-    var _datumMode = _bands.length >= 2;
+    // ⛔ NO DECLARED STOREYS ⇒ NOTHING CHANGES. A DB with no spatial_structure table (Duplex,
+    // LTU_AHouse, every *_extracted.db) keeps the old inference byte-identically, and the §-line
+    // says so out loud rather than implying a datum that does not exist.
+    //
+    // §STOREY_DATUM_FRAME (2026-09-03): the two column shapes are two CANDIDATE sets, and the one
+    // that bands this geometry is the one in its vertical frame — see _chooseStoreyDatum above.
+    // (#1551 picked by emptiness; on Hospital_meta.db that put 63,182 elements in one band.)
+    var _ezs = [];
+    r[0].values.forEach(function (row) {
+      var cx = row[4], cy = row[5], cz = row[6], bx = row[7], by = row[8], bz = row[9];
+      if (bx === 0 && by === 0 && bz === 0 && cx === 0 && cy === 0 && cz === 0) return;   // §4D_NOGEO, same filter as the recipe below
+      _ezs.push(cz - bz / 2);
+    });
+    var _frame = _chooseStoreyDatum(_storeyDatumCandidates(db), _ezs);
+    var _bands = _frame.ladder;
+    var _datumMode = _frame.mode === 'DECLARED';
 
     var storeyZs = {};
     r[0].values.forEach(function (row) {
@@ -489,12 +590,39 @@
       if (_raw != null && _raw !== '_UNKNOWN' && !/^unknown$/i.test(_raw) && _raw !== _e.storey) _rl++;
       delete _e._rawStorey;
     }
+    // §STOREY_DATUM_FRAME — the line must name WHICH candidate set won, its range, the element
+    // base-Z range it was checked against, and the rejected set; and it must say whether the
+    // choice differs from #1551's (vs#1551=same is the per-building NO-OP proof).
+    var _fz = function (x) { return isFinite(x) ? Number(x).toFixed(3) : 'n/a'; };
+    var _candDesc = _frame.candidates.map(function (c) {
+      return c.source + ':' + c.datums + (isFinite(c.lo) ? '[' + _fz(c.lo) + '..' + _fz(c.hi) + ']' : '') + '=' + c.verdict +
+        ((c.verdict === 'IN_FRAME' || c.verdict === 'OUT_OF_FRAME')
+          ? '(rungsUsed=' + c.rungsUsed + ' below=' + c.below + ' above=' + c.above + ')' : '');
+    }).join(' ');
+    var _rejected = _frame.candidates.filter(function (c) { return c.verdict === 'OUT_OF_FRAME'; });
+    var _bandsUsedNow = Object.keys(_lv).length;
     console.log('§STOREY_DATUM mode=' + (_datumMode ? 'DECLARED' : 'INFERRED') +
+      ' source=' + (_frame.source || 'none') +
       ' declaredStoreys=' + _bands.length + ' labelsInDB=' + storeyNames.length +
-      ' bandsUsed=' + Object.keys(_lv).length + ' relabelled=' + _rl + '/' + _bseList.length +
+      ' bandsUsed=' + _bandsUsedNow + ' relabelled=' + _rl + '/' + _bseList.length +
+      ' ladder=' + (_datumMode ? _bands.length + '[' + _fz(_frame.lo) + '..' + _fz(_frame.hi) + ']' : 'none') +
+      ' elementBaseZ=' + _frame.ez.n + '[' + _fz(_frame.ez.min) + '..' + _fz(_frame.ez.max) + ' median=' + _fz(_frame.ez.median) + ']' +
+      ' rejected=' + (_rejected.length ? _rejected.map(function (c) { return c.source + ':' + c.datums + '[' + _fz(c.lo) + '..' + _fz(c.hi) + ']'; }).join(',') : 'none') +
+      ' vs#1551=' + (_frame.source === _frame.legacySource ? 'same' : 'CHANGED(' + _frame.legacySource + '→' + (_frame.source || 'INFERRED') + ')') +
       (_datumMode
-        ? ' — a level is [datum_i, datum_i+1) and the element sits in the band containing its BASE'
-        : ' — NO declared storey datum in this DB (no spatial_structure): nearest-median-Z INFERENCE, unchanged. Bands here are not a datum.'));
+        ? (_bandsUsedNow < 2 ? ' verdict=NO-OP (the ladder put every element in ONE band — it partitioned nothing)' : '') +
+          ' — a level is [datum_i, datum_i+1) and the element sits in the band containing its BASE'
+        : ' — NO declared storey datum IN FRAME (reason=' + _frame.reason + '): nearest-median-Z INFERENCE, unchanged. Bands here are not a datum.'));
+    console.log('§STOREY_DATUM_FRAME candidates: ' + _candDesc +
+      ' — test: the ladder span must contain the element base-Z median (no tolerance constant; a stray element cannot fake a frame); first IN_FRAME wins, elevation before center_z');
+    _rejected.forEach(function (c) {
+      console.log('§STOREY_DATUM_FRAME_REJECT source=' + c.source + ' ladder=' + c.datums + '[' + _fz(c.lo) + '..' + _fz(c.hi) + ']' +
+        ' vs elementBaseZ median=' + _fz(_frame.ez.median) + ' [' + _fz(_frame.ez.min) + '..' + _fz(_frame.ez.max) + ']' +
+        ' below=' + c.below + ' above=' + c.above + ' rungsUsed=' + c.rungsUsed +
+        ' — not this geometry\'s vertical frame; ' +
+        (_datumMode ? 'banding on ' + _frame.source + ' instead'
+          : 'NO candidate in frame → declared path REFUSED, label inference runs (DEGRADE, not disable)'));
+    });
     return _bseList;
   }
 
@@ -3029,6 +3157,10 @@
     materializeDefault: materializeDefault,
     materializeZones: materializeZones,
     _buildScheduleElements: _buildScheduleElements,
+    // §STOREY_DATUM_FRAME — exported so witness_storey_datum_frame.js judges the same verb
+    _storeyDatumCandidates: _storeyDatumCandidates,
+    _chooseStoreyDatum: _chooseStoreyDatum,
+    _storeyLadder: _storeyLadder,
     instantiateTemplate: instantiateTemplate,
     // §TPL_LEVEL_AXIS — exported so the axis and its disagreement measurement are testable on their
     // own, without having to drive a whole materializeZones write to see them.

--- a/viewer/sw.js
+++ b/viewer/sw.js
@@ -31,7 +31,13 @@
 // installed service worker keeps serving the affine without this bump (§CRISIS LESSON 4). Paired
 // with _GANTT_CACHE_VERSION 37→38 (the IDB kernel_ops self-heal) in the same commit.
 // DEPLOY: bump CACHE_VERSION on every OCI upload. Old caches are purged on activate.
-const CACHE_VERSION = 'v1132';   // bump on each deploy; per-change detail is the git commit message.
+// v1133 (2026-09-03) §STOREY_DATUM_FRAME: schedule_author.js + time_machine.js changed — the declared
+// storey ladder is now chosen by VERTICAL FRAME (its span must contain the element base-Z median),
+// not by which column is non-empty; on Hospital_meta.db the 56 local-frame elevation rows had won
+// over the 7 world-frame center_z rows and collapsed the building to ONE band (7 tasks, 509 d vs
+// 8 bands / 42 tasks / 318 d). Both files are in PRECACHE_ASSETS, so an installed service worker
+// keeps serving the collapse without this bump. Paired with _GANTT_CACHE_VERSION 38→39.
+const CACHE_VERSION = 'v1133';   // bump on each deploy; per-change detail is the git commit message.
 // v1128 (2026-09-02) §SUN_FILL_RATIO: viewer/effects.js — the Alt+S staging HDRI
 // (belfast_sunset_puresky_1k) was being pushed onto EVERY material by _reassertPhotoEnvMap, matte
 // concrete and plaster included. IBL is non-directional and is NOT shadow-map-occluded in three.js,

--- a/viewer/tests/witness_storey_datum_frame.js
+++ b/viewer/tests/witness_storey_datum_frame.js
@@ -1,0 +1,223 @@
+#!/usr/bin/env node
+// witness_storey_datum_frame.js — §STOREY_DATUM_FRAME: the declared storey ladder must be in the
+// same VERTICAL FRAME as the geometry it bands, on the DBs the viewer ACTUALLY LOADS.
+//
+// ⚠ DO NOT REMOVE — SCOPE (bim-compiler prompts/4D_MODEL_INTEGRITY.md §I.6, 2026-09-03).
+// Read the §-log after every run. Judges the meta / patched-meta / silent DBs, NOT only *_extracted.db
+// — a witness that passes only on extracted is the exact defect that shipped PR #1551.
+//
+// THE ISSUE IT PROVES OR DISPROVES (user, 2026-09-03: "the bake is too fast paced"; and: "The local
+// saved DB is supposedly similar to the OCI one. Thus its 4D schedule should be the same."):
+//   PR #1551 (§STOREY_DATUM) chose the datum column by EMPTINESS — `elevation` rows if any, else
+//   `center_z`. Hospital_meta.db (the split pair streaming.js §DB_SPLIT_DETECT serves, and the user's
+//   Hospital_silent.db) carry 63 IfcBuildingStorey rows in TWO frames: 56 federated `elevation` rows
+//   at 0.0…34.0 m (a local per-file frame) and 7/8 COMPILED `center_z` rows at 166…201 m (the world
+//   frame the geometry is in). Elevation won, every element base-Z (156.6…202.8 m) sat above the top
+//   datum, and all 63,182 landed in ONE band: 7 tasks / 509 days instead of 8 bands / 42 tasks / 318.
+//   #1551's own check ran on Hospital_extracted.db, which has NO spatial_structure table, and read
+//   "no declared storeys ⇒ byte-identical" — true there, false on what the viewer loads.
+//
+// WHAT IT ASSERTS (each named; the contract prints PASS/FAIL per invariant and proves the red control):
+//   frame-consistent        every DECLARED row's ladder span [d_0, d_last] contains the element base-Z median
+//   declared-partitions     every DECLARED row uses >= 2 bands (a ladder that puts everything in one band is a NO-OP)
+//   hospital-not-collapsed  Hospital meta / patched-meta / silent: DECLARED on center_z, the elevation set
+//                           REJECTED as OUT_OF_FRAME, >= 7 bands; and #1551's rule on the SAME data → 1 rung
+//                           (the defect existed; this fix is not a no-op there)
+//   fleet-noop-vs-1551      every non-Hospital row: the chosen source equals what #1551's rule picks (NO-OP)
+//   log-matches-verb        the shipped §STOREY_DATUM line names the same source and bandsUsed the verb returned
+//   silent-matches-meta     (only when ~/Downloads/Hospital_silent.db is present, else INCONCLUSIVE) the
+//                           user's DB and the OCI meta DB choose the same mode+source, and the meta ladder's
+//                           level names are a subset of the silent ladder's — the residual is NAMED, not hidden
+//   extracted-is-vacuous    Hospital_extracted.db → INFERRED, reason NO_DECLARED_STOREYS: the row #1551 judged
+//                           could never have seen the defect
+//
+// NO-OP / VACUOUS / INCONCLUSIVE: no Hospital_meta.db on this machine ⇒ the verdict line prints
+// INCONCLUSIVE (never PASS); no silent DB ⇒ that one claim prints INCONCLUSIVE and the verdict says so.
+//
+// Command: node viewer/tests/witness_storey_datum_frame.js
+//   env BLD_DIR (default ~/bim-ootb/buildings), SILENT_DB (default ~/Downloads/Hospital_silent.db)
+'use strict';
+const fs = require('fs'), path = require('path'), vm = require('vm'), os = require('os');
+const { Witness } = require('../../witness_kit/contract');
+const HOME = os.homedir();
+const V = path.join(__dirname, '..');
+const BLD_DIR = process.env.BLD_DIR || path.join(HOME, 'bim-ootb', 'buildings');
+const SILENT_DB = process.env.SILENT_DB || path.join(HOME, 'Downloads', 'Hospital_silent.db');
+const PATCH_DIR = path.join(BLD_DIR, 'patches');
+
+const SG = require(path.join(V, 'schedule_gate.js')); global.ScheduleGate = SG;
+const SA = require(path.join(V, 'schedule_author.js'));
+const SS = require(path.join(V, 'support_sweep.js')); global.SupportSweep = SS;
+const CP = require(path.join(V, 'cpm_schedule.js')); global.CpmSchedule = CP;
+const GM = require(path.join(V, 'gantt_model.js')); global.GanttModel = GM;
+globalThis.RoomWalker = require(path.join(V, 'lib', 'room_walker.js'));
+globalThis.LevelDeriver = require(path.join(V, 'lib', 'level_deriver.js'));
+globalThis.LocationAxis = require(path.join(V, 'location_axis.js'));
+const T = JSON.parse(fs.readFileSync(path.join(V, 'rates', '4D_template.json'), 'utf8'));
+const TMP = require(path.join(V, '..', 'scripts', 'lib', 'tm_played_layer.js'));
+const tmSrc = fs.readFileSync(path.join(V, 'time_machine.js'), 'utf8');
+
+function executedRules() {
+  const sb = { console: { log() {}, warn() {}, error() {} } };
+  vm.createContext(sb);
+  vm.runInContext(fs.readFileSync(path.join(V, 'rates.js'), 'utf8'), sb);
+  return sb;
+}
+// Mirror of viewer/scene.js A._runSqlChunked — statement split on a line ending in `;`, 500 per run.
+function runSqlChunked(db, sql) {
+  const rawLines = sql.split('\n'), statements = []; let buf = [];
+  for (const ln of rawLines) { if (!ln.trim().length) continue; buf.push(ln); if (/;\s*$/.test(ln)) { statements.push(buf.join('\n')); buf = []; } }
+  if (buf.length) statements.push(buf.join('\n'));
+  for (let i = 0; i < statements.length; i += 500) db.run(statements.slice(i, i + 500).join('\n'));
+  return statements.length;
+}
+
+// The variants judged. `patched` mirrors A._applyPendingPatch: the served file + buildings/patches/<file>.sql.
+function variants() {
+  const out = [];
+  // a 0-byte *_meta.db is a dev artifact, not a split pair (probe_storey_datum.js applies the same rule)
+  const exists = f => fs.existsSync(f) && fs.statSync(f).size > 0;
+  const add = (building, kind, file, patch) => { if (exists(file)) out.push({ building, kind, file, patch: patch || null }); };
+  for (const b of ['Hospital', 'Terminal', 'Clinic', 'LTU_AHouse', 'Duplex', 'HHS_Office_Federated']) {
+    const meta = path.join(BLD_DIR, b + '_meta.db'), ext = path.join(BLD_DIR, b + '_extracted.db');
+    const live = exists(meta) ? meta : ext;                              // what streaming.js §DB_SPLIT_DETECT serves
+    add(b, exists(meta) ? 'meta' : 'extracted', live);
+    const patch = path.join(PATCH_DIR, path.basename(live) + '.sql');
+    if (exists(patch)) add(b, 'patched-' + (live === meta ? 'meta' : 'extracted'), live, patch);
+    if (b === 'Hospital') add(b, 'extracted', ext);                       // the row #1551 judged — vacuous by construction
+  }
+  add('Hospital', 'silent', SILENT_DB);
+  return out;
+}
+
+async function judge(v, SQL, R) {
+  let db = new SQL.Database(new Uint8Array(fs.readFileSync(v.file)));
+  let patchNote = 'none';
+  if (v.patch) {
+    try { const n = runSqlChunked(db, fs.readFileSync(v.patch, 'utf8')); patchNote = 'applied(' + n + ' statements)'; }
+    catch (e) {   // A._applyPendingPatch returns the ORIGINAL buffer on any throw — mirror that, and say so
+      db.close(); db = new SQL.Database(new Uint8Array(fs.readFileSync(v.file))); patchNote = 'FAILED→unpatched(' + (e && e.message) + ')';
+    }
+  }
+  const sb = TMP.buildSandbox({ tmSrc, SA, SG, CP, GM, SS, LABOR_RATES: R.LABOR_RATES, console });
+  const base = { start: '2026-01-01', laborRates: R.LABOR_RATES, rates: R.RATES, nameOverrides: R.SEQUENCE_NAME_OVERRIDES,
+    defaultRule: R.SEQUENCE_DEFAULT, scheduleGate: SG, shiftHours: T.calendar.hours_per_shift, template: T, displayRemap: sb._tmDisplayRemap };
+  // Tee, never suppress (PRIMAL LAW clause 3): the shipped §STOREY_DATUM line is primary evidence.
+  const captured = []; const q = console.log;
+  console.log = function () { const s = Array.prototype.join.call(arguments, ' '); if (/^§STOREY_DATUM( |_FRAME)/.test(s)) captured.push(s); return q.apply(console, arguments); };
+  let els;
+  try { els = SA._buildScheduleElements(db, R.SEQUENCE_RULES, base); } finally { console.log = q; }
+  const cands = SA._storeyDatumCandidates(db);
+  const choice = SA._chooseStoreyDatum(cands, els.map(e => e.base_z));
+  const bands = {}; els.forEach(e => { bands[e.storey] = (bands[e.storey] || 0) + 1; });
+  const line = captured.filter(s => s.startsWith('§STOREY_DATUM mode=')).pop() || '';
+  const tok = (re) => { const m = line.match(re); return m ? m[1] : null; };
+  const legacyRep = choice.candidates.find(c => c.source === choice.legacySource) || null;
+  const row = {
+    building: v.building, kind: v.kind, file: path.basename(v.file), patch: patchNote,
+    mode: choice.mode, source: choice.source, reason: choice.reason, legacySource: choice.legacySource,
+    changedFrom1551: choice.source !== choice.legacySource,
+    ladderDatums: choice.ladder.length, ladderLo: isFinite(choice.lo) ? choice.lo : null, ladderHi: isFinite(choice.hi) ? choice.hi : null,
+    ladderNames: choice.ladder.map(d => d.name),
+    ezN: choice.ez.n, ezMin: choice.ez.min, ezMedian: choice.ez.median, ezMax: choice.ez.max,
+    bandsUsed: Object.keys(bands).length, elements: els.length,
+    legacyVerdict: legacyRep ? legacyRep.verdict : 'EMPTY', legacyRungsUsed: legacyRep ? legacyRep.rungsUsed : 0,
+    candidates: choice.candidates.map(c => ({ source: c.source, rows: c.rows, datums: c.datums, verdict: c.verdict, rungsUsed: c.rungsUsed, below: c.below, above: c.above })),
+    logMode: tok(/ mode=(\S+)/), logSource: tok(/ source=(\S+)/), logBandsUsed: Number(tok(/ bandsUsed=(\d+)/)), logVs1551: tok(/ vs#1551=(\S+)/),
+    tasks: null, totalDays: null
+  };
+  if (v.building === 'Hospital' && v.kind !== 'extracted') {   // the acceptance shape, on the rows that matter
+    globalThis.APP = { db };
+    try { const res = SA.materializeZones(db, R.SEQUENCE_RULES, base); if (res && res.ok) { row.tasks = res.tasks.length; row.totalDays = res.totalDays; } }
+    finally { delete globalThis.APP; }
+  }
+  db.close();
+  console.log('§STOREY_DATUM_FRAME_ROW ' + v.building + ' ' + v.kind + ' file=' + row.file + ' patch=' + patchNote + ' mode=' + row.mode + ' source=' + row.source +
+    ' ladder=' + row.ladderDatums + (row.ladderLo != null ? '[' + row.ladderLo.toFixed(3) + '..' + row.ladderHi.toFixed(3) + ']' : '') +
+    ' bandsUsed=' + row.bandsUsed + ' elementBaseZ=' + row.ezN + '[' + row.ezMin.toFixed(3) + '..' + row.ezMax.toFixed(3) + ' median=' + row.ezMedian.toFixed(3) + ']' +
+    ' legacy(#1551)=' + row.legacySource + ':' + row.legacyVerdict + '(rungsUsed=' + row.legacyRungsUsed + ')' + ' vs#1551=' + (row.changedFrom1551 ? 'CHANGED' : 'same') +
+    (row.tasks != null ? ' tasks=' + row.tasks + ' totalDays=' + row.totalDays : ''));
+  return row;
+}
+
+const RowSchema = {
+  type: 'object',
+  required: ['building', 'kind', 'mode', 'ladderDatums', 'ezN', 'ezMedian', 'bandsUsed', 'candidates', 'changedFrom1551', 'logSource', 'logBandsUsed'],
+  properties: {
+    building: { type: 'string', minLength: 1 },
+    kind: { type: 'string', enum: ['meta', 'patched-meta', 'extracted', 'patched-extracted', 'silent'] },
+    mode: { type: 'string', enum: ['DECLARED', 'INFERRED'] },
+    source: { type: ['string', 'null'], enum: ['elevation', 'center_z', null] },
+    legacySource: { type: ['string', 'null'], enum: ['elevation', 'center_z', null] },
+    ladderDatums: { type: 'integer', minimum: 0 },
+    ladderLo: { type: ['number', 'null'] }, ladderHi: { type: ['number', 'null'] },
+    ezN: { type: 'integer', minimum: 1 },                       // a row judged over 0 elements is not a row
+    ezMedian: { type: 'number' }, bandsUsed: { type: 'integer', minimum: 1 },
+    candidates: { type: 'array', minItems: 2, items: { type: 'object', required: ['source', 'verdict', 'rungsUsed'],
+      properties: { verdict: { type: 'string', enum: ['EMPTY', 'TOO_FEW', 'NO_ELEMENTS', 'IN_FRAME', 'OUT_OF_FRAME'] } } } },
+    changedFrom1551: { type: 'boolean' },
+    logSource: { type: ['string', 'null'] }, logBandsUsed: { type: 'integer' }
+  },
+  additionalProperties: true
+};
+
+(async () => {
+  let initSqlJs, sqlDist;
+  try { initSqlJs = require('sql.js'); sqlDist = path.dirname(require.resolve('sql.js/dist/sql-wasm.js')); }
+  catch (e) { initSqlJs = require(path.join(HOME, 'bim-ootb', 'node_modules', 'sql.js')); sqlDist = path.join(HOME, 'bim-ootb', 'node_modules', 'sql.js', 'dist'); }
+  const SQL = await initSqlJs({ locateFile: f => path.join(sqlDist, f) });
+  const R = executedRules();
+  const vs = variants();
+  const hasHospitalMeta = vs.some(v => v.building === 'Hospital' && v.kind === 'meta');
+  const hasSilent = vs.some(v => v.kind === 'silent');
+  if (!hasHospitalMeta) {
+    console.log('§WITNESS_STOREY_DATUM_FRAME_VERDICT INCONCLUSIVE — no ' + path.join(BLD_DIR, 'Hospital_meta.db') +
+      ': the split-pair DB the viewer loads is absent, so the defect population was not judged (an extracted-only run is the #1551 blind spot)');
+    return;
+  }
+  const rows = [];
+  for (const v of vs) { console.log('§STOREY_DATUM_FRAME_JUDGE ' + v.building + ' ' + v.kind + ' ' + v.file + (v.patch ? ' + ' + path.basename(v.patch) : '')); rows.push(await judge(v, SQL, R)); }
+
+  // ── the residual between the user's DB and the OCI one, NAMED ──
+  const meta = rows.find(r => r.building === 'Hospital' && r.kind === 'meta');
+  const silent = rows.find(r => r.kind === 'silent');
+  if (meta && silent) {
+    const onlyS = silent.ladderNames.filter(n => meta.ladderNames.indexOf(n) < 0), onlyM = meta.ladderNames.filter(n => silent.ladderNames.indexOf(n) < 0);
+    console.log('§STOREY_DATUM_FRAME_SILENT_VS_META mode=' + meta.mode + '/' + silent.mode + ' source=' + meta.source + '/' + silent.source +
+      ' ladder=' + meta.ladderDatums + '/' + silent.ladderDatums + ' bandsUsed=' + meta.bandsUsed + '/' + silent.bandsUsed +
+      ' tasks=' + meta.tasks + '/' + silent.tasks + ' totalDays=' + meta.totalDays + '/' + silent.totalDays +
+      ' elements=' + meta.elements + '/' + silent.elements + ' silentOnlyLevels=' + JSON.stringify(onlyS) + ' metaOnlyLevels=' + JSON.stringify(onlyM) +
+      ' ladderLo=' + meta.ladderLo.toFixed(3) + '/' + silent.ladderLo.toFixed(3) +
+      ' — same choice on both; the ladder difference is the STC_* rows themselves (meta/patch = pre-#1552 walker, 7 rows at wall-CENTRE datum;' +
+      ' silent = post-#1552 walker, 8 rows at FLOOR datum incl. Level 7A), see 4D_MODEL_INTEGRITY.md §I.6');
+  } else {
+    console.log('§STOREY_DATUM_FRAME_CLAIM silent-matches-meta INCONCLUSIVE — ' + SILENT_DB + ' not present; the user-DB acceptance claim was not judged');
+  }
+
+  const isHosp = r => r.building === 'Hospital' && (r.kind === 'meta' || r.kind === 'patched-meta' || r.kind === 'silent');
+  const w = Witness('storey_datum_frame')
+    .population(() => rows)
+    .schema(RowSchema)
+    .invariant('frame-consistent', rs => rs.filter(r => r.mode === 'DECLARED').every(r => r.ladderLo <= r.ezMedian && r.ezMedian <= r.ladderHi))
+    .invariant('declared-partitions', rs => rs.filter(r => r.mode === 'DECLARED').every(r => r.bandsUsed >= 2))
+    .invariant('hospital-not-collapsed', rs => { const h = rs.filter(isHosp); return h.length >= 1 && h.every(r =>
+      r.mode === 'DECLARED' && r.source === 'center_z' && r.bandsUsed >= 7 &&
+      r.candidates.some(c => c.source === 'elevation' && c.verdict === 'OUT_OF_FRAME') &&
+      r.legacySource === 'elevation' && r.legacyRungsUsed === 1 && r.changedFrom1551 === true); })
+    .invariant('fleet-noop-vs-1551', rs => { const f = rs.filter(r => r.building !== 'Hospital'); return f.length >= 1 && f.every(r => r.changedFrom1551 === false); })
+    .invariant('log-matches-verb', rs => rs.every(r => r.logMode === r.mode && r.logSource === (r.source || 'none') && r.logBandsUsed === r.bandsUsed &&
+      r.logVs1551 === (r.changedFrom1551 ? 'CHANGED(' + r.legacySource + '→' + (r.source || 'INFERRED') + ')' : 'same')))
+    .invariant('extracted-is-vacuous', rs => { const x = rs.filter(r => r.building === 'Hospital' && r.kind === 'extracted'); return x.length === 1 && x[0].mode === 'INFERRED' && x[0].reason === 'NO_DECLARED_STOREYS'; })
+    .redControl(rs => rs.map(r => {
+      const c = Object.assign({}, r, { candidates: r.candidates.map(x => Object.assign({}, x)) });
+      if (c.mode === 'DECLARED') { c.ladderLo = c.ezMedian + 1000; c.ladderHi = c.ezMedian + 1001; }   // trips frame-consistent
+      if (isHosp(c)) { c.source = 'elevation'; c.bandsUsed = 1; c.changedFrom1551 = false; }        // #1551's collapse, trips hospital-not-collapsed
+      if (c.building !== 'Hospital') c.changedFrom1551 = true;                                      // trips fleet-noop-vs-1551
+      return c;
+    }));
+  if (meta && silent) w.invariant('silent-matches-meta', rs => { const m = rs.find(r => r.building === 'Hospital' && r.kind === 'meta'), s = rs.find(r => r.kind === 'silent');
+    return !!m && !!s && m.mode === s.mode && m.source === s.source && m.ladderNames.every(n => s.ladderNames.indexOf(n) >= 0); });
+  const res = w.run();
+  console.log('§WITNESS_STOREY_DATUM_FRAME_VERDICT ' + (res.fail ? 'FAIL' : 'PASS') + ' rows=' + rows.length + ' pass=' + res.pass + ' fail=' + res.fail +
+    (hasSilent ? '' : ' INCONCLUSIVE=silent-matches-meta(' + SILENT_DB + ' missing)'));
+})().catch(e => { console.error('§WITNESS_STOREY_DATUM_FRAME_ERROR ' + (e && e.stack || e)); process.exit(2); });

--- a/viewer/time_machine.js
+++ b/viewer/time_machine.js
@@ -8448,7 +8448,12 @@
   // huts going first before the walls" AFTER a hard reset, because §GANTT_CACHE_HIT served a
   // gantt:v4 entry generated under the old ordering. A hard reset cannot clear it — the entry is in
   // IndexedDB, not the HTTP cache. This bump is that fix's second half.
-  var _GANTT_CACHE_VERSION = 38;   // §TM_REVEAL_TILED (2026-09-02) — kernel_ops timestamps are now tiled inside each bar (CPM order, own-duration width) instead of the per-task affine; a v37 IDB entry still carries the affine layout (dead air 44-71% of every bar), regenerate
+  // §STOREY_DATUM_FRAME (2026-09-03) 38→39: a v38 schedule authored on Hospital_meta.db / the user's
+  // Hospital_silent.db was banded by a storey ladder in the WRONG vertical frame (56 local-frame
+  // elevation rows won over the 7 world-frame center_z rows by emptiness) — 1 band, 7 tasks, 509 d
+  // instead of 8/42/318. schedule_author.js now picks the ladder whose span contains the element
+  // base-Z median; a persisted v38 grid still carries the collapsed ladder, so regenerate.
+  var _GANTT_CACHE_VERSION = 39;   // §STOREY_DATUM_FRAME (2026-09-03) — see above. Previous: 38 §TM_REVEAL_TILED (2026-09-02) — kernel_ops timestamps are now tiled inside each bar (CPM order, own-duration width) instead of the per-task affine; a v37 IDB entry still carries the affine layout (dead air 44-71% of every bar), regenerate
   // was 37:   // §S51 item d — ops now carry the cell stamp (_cell) so the Gantt groups by the schedule's own cells; pre-§S51 kernel_ops lack it, regenerate
   // was 28:   // §CPM_DISPLAY (2026-08-16): display timeline authored by the one-DAG CPM pass
   // was 27:   // §ZONE_DISPLAY_AUTHORING (2026-08-16): task windows authored from


### PR DESCRIPTION
## The defect (live since #1551 merged, 2026-09-02 18:14 +0800)

`schedule_author.js` chose the declared-storey datum column by **emptiness** — `elevation` rows if any, else `center_z`. On the DB the viewer actually loads (`Hospital_meta.db`, the split pair `streaming.js §DB_SPLIT_DETECT` serves; and the user's `~/Downloads/Hospital_silent.db`) the 63 `IfcBuildingStorey` rows are in **two vertical frames**:

| family | rows | column | range | frame |
|---|---|---|---|---|
| federated source storeys | 56 | `elevation` | 0.0 … 34.0 m | LOCAL per-file |
| COMPILED `STC_Level_*` | 7 | `center_z` | 168.7 … 201.4 m | WORLD — where the geometry is (element base-Z 156.6 … 202.8 m) |

Elevation won, every element sat above the top datum, all 63,182 landed in **one band**: 7 tasks / 509 days instead of 8 bands / 42 tasks / 318. The film is 3,118 frames either way, so calendar-per-second went **+60 %** — the user's *"the bake is too fast paced"*. #1551's own verification read "no declared storeys ⇒ byte-identical" on `Hospital_extracted.db`, which has no `spatial_structure` at all — `project_split_db_live_vs_probe_landmine`.

## The rule now
Both families are **candidate sets**. Each ladder is tested against the element base-Z distribution: its span `[d_0, d_last]` must contain the element base-Z **median** (no tolerance constant; a stray element cannot fake a frame — min/max overlap is defeated by one outlier). First in-frame candidate wins, `elevation` before `center_z`, so every building where both are in frame is byte-identical to #1551. No candidate in frame ⇒ the declared path is **refused** and label inference runs, reason on the §-line (degrade, don't disable). `_storeyDatumCandidates` / `_chooseStoreyDatum` are exported so the witness judges the same verb.

## Measured — `scripts/probe_tm_reveal_shipped.js`, `FRAMES=3118 FPS=15`, same engine before → after
| DB the viewer loads | bands | tasks | totalDays | days/frame | Substructure on screen |
|---|---|---|---|---|---|
| Hospital (`Hospital_meta.db`) | **1 → 7** | **7 → 36** | **509 → 334** | **0.163 → 0.107** | 67 f = 4.5 s → **103 f = 6.9 s** |
| user's `Hospital_silent.db` | **1 → 8** | **7 → 41** | **515 → 329** | **0.165 → 0.106** | 67 f → **104 f = 6.9 s** |
| Terminal (`Terminal_meta.db`) | 22 → 22 | 70 → 70 | 101 → 101 | 0.032 | 62 f, same |
| Clinic (`Clinic_meta.db`) | 3 → 3 | 18 → 18 | 136 → 136 | 0.044 | 69 f, same |
| pre-#1551 reference | 8 | 42 | 318 | 0.102 | 108 f = 7.2 s |

## The §-lines (Hospital_meta.db, after)
```
§STOREY_DATUM mode=DECLARED source=center_z declaredStoreys=7 labelsInDB=8 bandsUsed=7 relabelled=14153/63182 ladder=7[168.735..201.429] elementBaseZ=63182[156.606..202.826 median=181.309] rejected=elevation:24[0.000..34.000] vs#1551=CHANGED(elevation→center_z) — …
§STOREY_DATUM_FRAME candidates: elevation:24[0.000..34.000]=OUT_OF_FRAME(rungsUsed=1 below=0 above=63182) center_z:7[168.735..201.429]=IN_FRAME(rungsUsed=7 below=4449 above=2) — …
§STOREY_DATUM_FRAME_REJECT source=elevation ladder=24[0.000..34.000] vs elementBaseZ median=181.309 [156.606..202.826] … — not this geometry's vertical frame; banding on center_z instead
```
Terminal / Clinic / LTU_AHouse / Duplex(+patched) / HHS(+patched) all print `vs#1551=same`.

## Witness — `node viewer/tests/witness_storey_datum_frame.js`
witness_kit contract, red control proven, INCONCLUSIVE when `Hospital_meta.db` is absent. Judges **meta / patched-meta (mirrors `A._applyPendingPatch`) / silent / extracted** — 14 rows: `frame-consistent`, `declared-partitions`, `hospital-not-collapsed` (incl. "#1551's rule on the same data → 1 rung"), `fleet-noop-vs-1551`, `log-matches-verb`, `extracted-is-vacuous`, `silent-matches-meta` — **10/10 PASS**.

Regression: `witness_day0_integrity` / `witness_day0_attribution` re-run on a fresh `cache_4d_run` — per-claim verdicts **identical** to unmodified `main` (both RED on Duplex/HHS before and after; pre-existing, not from this change). `witness_storey_suffix_parity` 7/0, `witness_tpl_model_three_producers` 7/0. CI audits (`audit_sw_precache`, `audit_spec_paths`, `audit_script_tags`, `test_s274_split_db_wiring`) exit 0.

## Also
- `_GANTT_CACHE_VERSION` 38→39 — a persisted v38 grid carries the collapsed ladder; regenerate.
- `sw.js` v1133 (both files precached).

## ⛔ Residual, measured and named (not closed here)
`Hospital_meta.db` and `Hospital_silent.db` now make the same choice but still differ 7 vs 8 bands: meta's `STC_Level_*` rows (and `buildings/patches/Hospital_meta.db.sql` lines 9510-9516) are the **pre-#1552** walker output (7 rows, wall-CENTRE datum, Level 1 = 168.735); silent's are post-#1552 (8 rows incl. Level 7A, FLOOR datum, Level 1 = 166.088). Plus 233 `composed_aggregate` transforms present only in silent. Closing it = regenerating those 7 patch lines from the current walker and shipping via `oci_patch_gate.js --upload` — a production-bucket write, user decision. Full account: bim-compiler `prompts/4D_MODEL_INTEGRITY.md` §I.6.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
