### PR TITLE
fix(bake): §BAKE_INTERIOR_TOPUP — a bake pose whose frustum holds no fixture centre is no longer unlit

### DIFF
--- a/viewer/sw.js
+++ b/viewer/sw.js
@@ -37,7 +37,13 @@
 // over the 7 world-frame center_z rows and collapsed the building to ONE band (7 tasks, 509 d vs
 // 8 bands / 42 tasks / 318 d). Both files are in PRECACHE_ASSETS, so an installed service worker
 // keeps serving the collapse without this bump. Paired with _GANTT_CACHE_VERSION 38→39.
-const CACHE_VERSION = 'v1133';   // bump on each deploy; per-change detail is the git commit message.
+// v1134 (2026-09-04) §BAKE_INTERIOR_TOPUP: the still/bake fixture-light selection is no longer
+// frustum-centre ONLY — a short in-frustum set is topped up to the still budget with the same
+// nearest-to-aim + §NIGHT_SPREAD rule navigation uses (_nightPickNearest, extracted VERBATIM so
+// nav and bake cannot drift apart), and the camera matrix is refreshed before the cull
+// (§BAKE_FRUSTUM_STALE). An interior pose whose frustum held no fixture centre previously left
+// every §NIGHT_BAKE_POOL slot at intensity 0 — the room lit by flat fill alone. tools.js?v=45->46.
+const CACHE_VERSION = 'v1134';   // bump on each deploy; per-change detail is the git commit message.
 // v1128 (2026-09-02) §SUN_FILL_RATIO: viewer/effects.js — the Alt+S staging HDRI
 // (belfast_sunset_puresky_1k) was being pushed onto EVERY material by _reassertPhotoEnvMap, matte
 // concrete and plaster included. IBL is non-directional and is NOT shadow-map-occluded in three.js,

--- a/viewer/tests/witness_bake_interior_topup.js
+++ b/viewer/tests/witness_bake_interior_topup.js
@@ -1,0 +1,164 @@
+#!/usr/bin/env node
+// witness_bake_interior_topup.js — W-BAKE-TOPUP
+//
+// ⚠ DO NOT REMOVE — SCOPE (bim-compiler prompts/PHOTOREAL_STILL_RENDER.md §BAKE_INTERIOR_TOPUP).
+// User, 2026-09-04, on a live Hospital Alt+C bake: "the indoor is gloomy and not lively" — while
+// "outside the scene of the building is very lively". Read the log after every run.
+//
+// THE ISSUE THIS PROVES OR DISPROVES: during a still/bake fold, tools.js `_nightUpdateLights`
+// selected fixture point lights by FRUSTUM-CENTRE CONTAINMENT ONLY. An interior pose is the case
+// that test answers wrong — the troffers lighting the room you stand in sit overhead or behind the
+// eye — so the set came back short, or empty; and with §NIGHT_BAKE_POOL an empty set means every
+// pooled slot rides at intensity 0, i.e. the room is lit by flat fill alone. This witness asserts
+// the in-frustum set is TOPPED UP to the still budget and is never truncated.
+//
+// Whitebox, no browser: `_nightPickNearest` and `_nightUpdateLights` are SLICED OUT of the shipped
+// viewer/tools.js by brace matching and executed against stub THREE/A objects — never re-typed, so
+// the witness cannot pass against a copy that is not what ships.
+'use strict';
+const fs = require('fs'), path = require('path'), vm = require('vm');
+const { Witness } = require(path.join(__dirname, '..', '..', 'witness_kit', 'contract.js'));
+
+const TOOLS = path.join(__dirname, '..', 'tools.js');
+const src = fs.readFileSync(TOOLS, 'utf8');
+
+function sliceFrom(marker) {
+  const i = src.indexOf(marker);
+  if (i < 0) return null;
+  let d = 0, open = false;
+  for (let j = i; j < src.length; j++) {
+    if (src[j] === '{') { d++; open = true; }
+    else if (src[j] === '}') { d--; if (open && d === 0) return src.slice(i, j + 1); }
+  }
+  return null;
+}
+// The spread constant lives beside the helper in tools.js — READ it, never re-typed here.
+const spreadM = (src.match(/var NIGHT_SPREAD_MIN_M\s*=\s*([0-9.]+)/) || [])[1];
+const pickSrc = sliceFrom('function _nightPickNearest(');
+const updSrc = sliceFrom('A._nightUpdateLights = function() {');
+
+function V(x, y, z) { return { x, y, z }; }
+function makeCtx(scn) {
+  const pool = scn.fixtures.map((f, i) => Object.assign(V(f[0], f[1], f[2]), { __guid: 'F' + i }));
+  const inFrustumSet = new Set(pool.filter(scn.inFrustum));
+  const scene = { add() {}, remove() {} };
+  const A = {
+    _nightMode: true, _nightFixtures: pool, _nightBakePool: null,
+    _maxqActive: !!scn.bake, _nightStillBoost: true, _stillRefineActive: !!scn.still,
+    _nightMaxLights: scn.budget, _nightNearFadeFloor: 1, _nightPLScale: 1,
+    _nightLights: [], scene,
+    camera: {
+      position: Object.assign(V(0, 0, 0), { distanceTo: () => 10 }),
+      projectionMatrix: {}, matrixWorldInverse: {}, updateMatrixWorld() { this._refreshed = true; }
+    },
+    controls: { target: V(10, 0, 0) },
+    _nightFixtureWorldPositions: () => pool,
+    markDirty() {}
+  };
+  const THREE = {
+    Frustum: function () {
+      this.setFromProjectionMatrix = function () {};
+      this.containsPoint = function (p) {
+        for (const q of inFrustumSet) if (q.x === p.x && q.y === p.y && q.z === p.z) return true;
+        return false;
+      };
+    },
+    Matrix4: function () { this.multiplyMatrices = function () { return this; }; },
+    Vector3: function (x, y, z) { return V(x, y, z); },
+    PointLight: function () {
+      this.intensity = 0; this.position = { copy() {} }; this.color = { set() {} };
+      this.dispose = function () {};
+    }
+  };
+  const sandbox = { A, THREE, console: { log() {} }, Set, Math,
+    NIGHT_SPREAD_MIN_M: Number(spreadM),
+    NIGHT_LIGHT_INTENSITY: 2.5, NIGHT_LIGHT_RANGE: 12, NIGHT_LIGHT_DECAY: 2 };
+  vm.createContext(sandbox);
+  vm.runInContext(pickSrc + '\nvar _ntuLastLine = null;\n' + updSrc + ';', sandbox);
+  A._nightUpdateLights();
+  return { A, pool, inFrustumN: inFrustumSet.size };
+}
+
+function grid(n) { const a = []; for (let i = 0; i < n; i++) a.push([i * 5, 0, 0]); return a; }
+function litCount(A) {
+  if (A._nightBakePool) return A._nightBakePool.filter(l => l.intensity > 0).length;
+  return A._nightLights.length;
+}
+
+const SCENARIOS = [
+  { name: 'bake-interior-frustum-short', fixtures: grid(40), budget: 50, bake: true, still: true,
+    inFrustum: (p, i) => i < 3 },
+  { name: 'bake-interior-frustum-empty', fixtures: grid(40), budget: 50, bake: true, still: true,
+    inFrustum: () => false },
+  { name: 'bake-wide-frustum-full', fixtures: grid(80), budget: 50, bake: true, still: true,
+    inFrustum: (p, i) => i < 60 },
+  { name: 'alt-s-frustum-short', fixtures: grid(40), budget: 50, bake: false, still: true,
+    inFrustum: (p, i) => i < 2 },
+  { name: 'nav-no-still', fixtures: grid(40), budget: 24, bake: false, still: false,
+    inFrustum: () => false }
+];
+
+function population() {
+  if (!pickSrc || !updSrc) return [];
+  return SCENARIOS.map(scn => {
+    const r = makeCtx(scn);
+    return {
+      scenario: scn.name,
+      still: !!scn.still,
+      fixtures: scn.fixtures.length,
+      budget: scn.budget,
+      inFrustum: r.inFrustumN,
+      lit: litCount(r.A),
+      refreshed: !!r.A.camera._refreshed
+    };
+  });
+}
+
+const schema = {
+  type: 'object',
+  required: ['scenario', 'still', 'fixtures', 'budget', 'inFrustum', 'lit', 'refreshed'],
+  properties: {
+    scenario: { type: 'string' }, still: { type: 'boolean' }, fixtures: { type: 'integer' },
+    budget: { type: 'integer' }, inFrustum: { type: 'integer' }, lit: { type: 'integer' },
+    refreshed: { type: 'boolean' }
+  }
+};
+
+const w = Witness('BAKE_INTERIOR_TOPUP')
+  .population(population)
+  .schema(schema)
+  // G1 — the defect itself: a still/bake pose whose frustum is SHORT of the budget must still be
+  // lit to the budget (or to every fixture there is, whichever is smaller).
+  .invariant('topup-fills-budget', rows => rows.filter(r => r.still && r.inFrustum < r.budget)
+    .every(r => r.lit === Math.min(r.fixtures, r.budget)))
+  // G2 — the user's exact symptom: frustum finds NO fixture centre, and the room is still lit.
+  .invariant('empty-frustum-still-lit', rows => rows.filter(r => r.still && r.inFrustum === 0)
+    .every(r => r.lit > 0))
+  // G3 — the top-up must never TRUNCATE what the frustum genuinely found.
+  .invariant('no-truncation', rows => rows.filter(r => r.still && r.inFrustum > r.budget)
+    .every(r => r.lit >= r.inFrustum))
+  // G4 — navigation is untouched by the extraction (§NIGHT_PICK_NEAREST called with empty `already`).
+  .invariant('nav-unchanged', rows => rows.filter(r => !r.still)
+    .every(r => r.lit === Math.min(r.fixtures, r.budget)))
+  // G5 — §BAKE_FRUSTUM_STALE: the still/bake branch refreshes the camera matrix before culling.
+  .invariant('frustum-matrix-refreshed', rows => rows.filter(r => r.still).every(r => r.refreshed))
+  // RED — the pre-fix behaviour: the set is whatever the frustum found, no top-up.
+  .redControl(rows => rows.map(r => Object.assign({}, r,
+    r.still ? { lit: r.inFrustum, refreshed: false } : {})));
+
+if (!pickSrc || !updSrc || spreadM === undefined) {
+  console.log('§WITNESS_BAKE_INTERIOR_TOPUP_VERDICT INCONCLUSIVE — could not slice ' +
+    (!pickSrc ? '_nightPickNearest' : '_nightUpdateLights') + ' out of viewer/tools.js; nothing judged');
+  process.exit(1);
+}
+const res = w.run();
+const rows = population();
+rows.forEach(r => console.log('§BAKE_INTERIOR_TOPUP_ROW ' + r.scenario + ' fixtures=' + r.fixtures +
+  ' budget=' + r.budget + ' inFrustum=' + r.inFrustum + ' lit=' + r.lit + ' matrixRefreshed=' + r.refreshed));
+const noop = rows.filter(r => r.still).every(r => r.lit === r.inFrustum);
+console.log('§WITNESS_BAKE_INTERIOR_TOPUP_VERDICT ' +
+  (rows.length === 0 ? 'VACUOUS — no scenario judged'
+   : noop ? 'NO-OP — the top-up never changed a single selection; it is not in force'
+   : res.fail === 0 ? 'PASS' : 'FAIL') +
+  ' rows=' + rows.length + ' pass=' + res.pass + ' fail=' + res.fail);
+process.exit(res.fail === 0 && rows.length > 0 && !noop ? 0 : 1);

--- a/viewer/tools.js
+++ b/viewer/tools.js
@@ -1673,6 +1673,51 @@ function setupTools(A) {
     return A._nightFixturePositions;
   };
 
+  // §NIGHT_PICK_NEAREST (extracted 2026-09-04 by §BAKE_INTERIOR_TOPUP from the nav branch of
+  // _nightUpdateLights below, VERBATIM) — the navigation selection rule, moved out so a second
+  // caller can reuse it instead of growing a parallel one: score every candidate by distance to a
+  // point HALFWAY between the eye and the look-at (§S277d), take them nearest-first while skipping
+  // anything within NIGHT_SPREAD_MIN_M of one already picked (§NIGHT_SPREAD), then fill any
+  // remainder ignoring spacing so the budget is always fully used. `already` is the set the caller
+  // has ALREADY placed (the still/bake in-frustum set) — its members are excluded from the pick,
+  // counted against `limit`, and honoured by the spread test, so a top-up lands AWAY from the
+  // lights that are already there. Nav passes `already` empty and is behaviourally identical to
+  // the inline code this replaces. Lifted from the parked bim-ootb PR #1327 (§BAKE_INTERIOR_LIGHTS).
+  var NIGHT_SPREAD_MIN_M = 4;
+  function _nightPickNearest(pool, limit, already) {
+    var picked = already ? already.slice() : [];
+    if (picked.length >= limit) return picked;
+    var camPos = A.camera.position;
+    var _tgt = A.controls ? A.controls.target : camPos;
+    var _aim = {
+      x: camPos.x + (_tgt.x - camPos.x) * 0.5,
+      y: camPos.y + (_tgt.y - camPos.y) * 0.5,
+      z: camPos.z + (_tgt.z - camPos.z) * 0.5
+    };
+    var have = new Set(picked);
+    var sorted = [];
+    for (var pi = 0; pi < pool.length; pi++) {
+      var p = pool[pi];
+      if (have.has(p)) continue;
+      var dx = p.x - _aim.x, dy = p.y - _aim.y, dz = p.z - _aim.z;
+      sorted.push({ pos: p, dist2: dx * dx + dy * dy + dz * dz });
+    }
+    sorted.sort(function(a, b) { return a.dist2 - b.dist2; });
+    for (var si = 0; si < sorted.length && picked.length < limit; si++) {
+      var cand = sorted[si].pos;
+      var tooClose = picked.some(function(pk) {
+        var ddx = pk.x - cand.x, ddy = pk.y - cand.y, ddz = pk.z - cand.z;
+        return (ddx * ddx + ddy * ddy + ddz * ddz) < NIGHT_SPREAD_MIN_M * NIGHT_SPREAD_MIN_M;
+      });
+      if (!tooClose) { picked.push(cand); have.add(cand); }
+    }
+    for (var si2 = 0; si2 < sorted.length && picked.length < limit; si2++) {
+      if (!have.has(sorted[si2].pos)) { picked.push(sorted[si2].pos); have.add(sorted[si2].pos); }
+    }
+    return picked;
+  }
+  var _ntuLastLine = null;   // §BAKE_INTERIOR_TOPUP — run-length guard, this runs once per baked frame
+
   A._nightUpdateLights = function() {
     // §NIGHT_BAKE_POOL teardown — first update after a bake releases the frozen pool. Checked
     // BEFORE the _nightMode gate so a night-off session still cleans up.
@@ -1701,13 +1746,40 @@ function setupTools(A) {
       // rather than a flat count cap; a still pays this cost once, not every frame. 200 is a
       // sanity ceiling against a pathological wide aerial shot with hundreds in frame at once —
       // not a deliberate creative limit.
+      // §BAKE_FRUSTUM_STALE (from PR #1327) — refresh the camera's world matrix BEFORE reading
+      // matrixWorldInverse. cinema_maxq.js's bake loop sets camera.position/controls.target for the
+      // new pose and calls startStillRefine() BEFORE any render of that pose, so an unrefreshed
+      // matrixWorldInverse culls this frame's fixtures against the PREVIOUS frame's view.
+      A.camera.updateMatrixWorld();
       var frustum = new THREE.Frustum();
       var vpMatrix = new THREE.Matrix4().multiplyMatrices(A.camera.projectionMatrix, A.camera.matrixWorldInverse);
       frustum.setFromProjectionMatrix(vpMatrix);
       var inView = allPos.filter(function(p) {
         return frustum.containsPoint(new THREE.Vector3(p.x, p.y, p.z));
       });
-      needed = inView.slice(0, 200).map(function(p) { return { pos: p }; });
+      // ══ §BAKE_INTERIOR_TOPUP (2026-09-04, user: "the indoor is gloomy and not lively" on a live
+      // Hospital Alt+C bake; same defect the parked PR #1327 §BAKE_INTERIOR_LIGHTS measured on a
+      // headless Duplex bake — 18 fixture lights at frame 0, 0 from frame 1 on) ═══════════════════
+      // The frustum test asks whether a fixture's CENTRE falls inside the view. An interior pose is
+      // exactly the case it answers wrong: the troffers lighting the room you stand in are overhead
+      // or behind the eye, so the set comes back short — or empty, and then EVERY pool slot below
+      // rides at intensity 0 and the room is lit by flat fill alone. That is structural, not a tuning
+      // question: §STAGED_PL_CUT scales this set, and scaling zero is zero.
+      // FIX: the in-frustum set is never truncated — it is TOPPED UP to the still budget with the
+      // same nearest-to-aim + §NIGHT_SPREAD rule navigation already uses (_nightPickNearest above),
+      // which is why Fly/handsfree always looked right while the bake did not. One selection rule,
+      // not a second mechanism. A frame whose frustum already fills the budget is unchanged.
+      var _tuLimit = Math.max(0, A._nightMaxLights || 0);
+      var _picked = inView.slice(0, 200);
+      var _inViewN = _picked.length;
+      if (_picked.length < _tuLimit) _picked = _nightPickNearest(allPos, _tuLimit, _picked);
+      if (_picked.length !== _inViewN || _inViewN === 0) {
+        var _tuLine = '§BAKE_INTERIOR_TOPUP inFrustum=' + _inViewN + ' toppedUpTo=' + _picked.length +
+          ' budget=' + _tuLimit + ' fixtures=' + allPos.length +
+          (_inViewN === 0 ? ' — frustum found NO fixture centre at this pose; without the top-up this frame had zero fixture light' : '');
+        if (_tuLine !== _ntuLastLine) { _ntuLastLine = _tuLine; console.log(_tuLine); }
+      }
+      needed = _picked.map(function(p) { return { pos: p }; });
     } else if (allPos.length <= A._nightMaxLights) {
       // Small building — place ALL fixtures, no culling
       needed = allPos.map(function(p) { return { pos: p }; });
@@ -1717,38 +1789,14 @@ function setupTools(A) {
       // transfer ahead as you move). Pure camera-nearest clustered them all at the eye; pure
       // orbit-target clustered them at building centre. Debounced by the controls 'change'
       // listener (>5m move) so small orbits don't thrash the set.
-      var _tgt = A.controls ? A.controls.target : camPos;
-      var _aim = {
-        x: camPos.x + (_tgt.x - camPos.x) * 0.5,
-        y: camPos.y + (_tgt.y - camPos.y) * 0.5,
-        z: camPos.z + (_tgt.z - camPos.z) * 0.5
-      };
-      var sorted = allPos.map(function(p) {
-        var dx = p.x - _aim.x, dy = p.y - _aim.y, dz = p.z - _aim.z;
-        return { pos: p, dist2: dx*dx + dy*dy + dz*dz };
-      }).sort(function(a, b) { return a.dist2 - b.dist2; });
       // §NIGHT_SPREAD (2026-08-07, user: "not in dense area, if two sources nearby spread out to
-      // cover further line of sight") — greedy nearest-first, but skip a candidate within
-      // NIGHT_SPREAD_MIN_M of one already picked, so the 24-light budget reaches further down a
-      // corridor instead of bunching on one dense cluster right at the camera. If spacing can't
-      // fill the budget (not enough distant candidates), a second pass fills the rest ignoring
-      // spacing — the budget is always fully used, spacing is a preference, not a hard cutoff.
-      var NIGHT_SPREAD_MIN_M = 4;
-      var picked = [];
-      for (var si = 0; si < sorted.length && picked.length < A._nightMaxLights; si++) {
-        var cand = sorted[si].pos;
-        var tooClose = picked.some(function(pk) {
-          var ddx = pk.x - cand.x, ddy = pk.y - cand.y, ddz = pk.z - cand.z;
-          return (ddx * ddx + ddy * ddy + ddz * ddz) < NIGHT_SPREAD_MIN_M * NIGHT_SPREAD_MIN_M;
-        });
-        if (!tooClose) picked.push(cand);
-      }
-      if (picked.length < A._nightMaxLights) {
-        for (var si2 = 0; si2 < sorted.length && picked.length < A._nightMaxLights; si2++) {
-          if (picked.indexOf(sorted[si2].pos) === -1) picked.push(sorted[si2].pos);
-        }
-      }
-      needed = picked.map(function(p) { return { pos: p }; });
+      // cover further line of sight") — greedy nearest-first, skipping a candidate within
+      // NIGHT_SPREAD_MIN_M of one already picked, then a second pass fills the rest ignoring
+      // spacing: the budget is always fully used, spacing is a preference, not a hard cutoff.
+      // §BAKE_INTERIOR_TOPUP (2026-09-04): this rule now lives in _nightPickNearest above, called
+      // with an EMPTY `already` set here — behaviourally identical to the inline code it replaces —
+      // so the bake top-up and navigation cannot drift into two different selection rules.
+      needed = _nightPickNearest(allPos, A._nightMaxLights, []).map(function(p) { return { pos: p }; });
     }
     // ══ §NIGHT_BAKE_POOL (2026-09-01, found by the first headless CLI bake — bim-compiler
     // prompts/CINEMA_PATH_EDITOR.md §CLI_SILENT_BAKE stage 4): during a MaxQ bake the in-frustum

--- a/viewer/viewer.html
+++ b/viewer/viewer.html
@@ -859,7 +859,7 @@ html.bim-embedded, html.bim-embedded body { background: #0b0b0b; }
 <script src="streaming.js?v=69" onerror="console.warn('§LOAD_FAIL streaming.js')"></script>
 <script src="dlod.js?v=8" onerror="console.warn('§LOAD_FAIL dlod.js')"></script>
 <script src="panels.js?v=44" onerror="console.warn('§LOAD_FAIL panels.js')"></script>
-<script src="tools.js?v=45" onerror="console.warn('§LOAD_FAIL tools.js')"></script>
+<script src="tools.js?v=46" onerror="console.warn('§LOAD_FAIL tools.js')"></script>
 <script src="picking.js?v=30" onerror="console.warn('§LOAD_FAIL picking.js')"></script>
 <script src="hover_name.js?v=1" onerror="console.warn('§LOAD_FAIL hover_name.js — hover-name disabled')"></script>
 <script src="cpe_room_title.js?v=1" onerror="console.warn('§LOAD_FAIL cpe_room_title.js — room titles disabled')"></script>


### PR DESCRIPTION
User, 2026-09-04, on a live Hospital Alt+C bake: "the indoor is gloomy and not lively", alongside
"outside the scene of the building is very lively". The exterior/interior split is the tell — and it
is structural, not a tuning question.

tools.js `_nightUpdateLights`'s still/bake branch (§NIGHT_STILL_FRUSTUM) selected fixture point
lights by FRUSTUM-CENTRE CONTAINMENT ONLY, with no floor. An interior pose is exactly the case that
test answers wrong: the troffers lighting the room you stand in are overhead or behind the eye, so
the set comes back short — or empty. Since §NIGHT_BAKE_POOL froze the pool size, an empty set no
longer disposes the lights, it leaves EVERY slot at intensity 0, so the room is lit by flat
ambient+hemi fill alone. §STAGED_PL_CUT scales that set; scaling zero is zero, which is why the
fixture-scale lever could never have reached this.

Exterior surfaces lose almost nothing when the fixtures go dark (they have the sun, and photo
staging turns its shadow casting on), while an interior loses everything that is not flat fill.
Same mechanism explains both halves of the user's report.

FIX — reuse, not reinvention:
- The in-frustum set is TOPPED UP to the still budget with the SAME nearest-to-aim + §NIGHT_SPREAD
  rule navigation already uses, extracted VERBATIM as `_nightPickNearest` (§NIGHT_PICK_NEAREST) so
  nav and bake cannot drift into two selection rules. Nav calls it with an empty `already` set and
  is behaviourally identical. No new constant.
- The in-frustum set is NEVER truncated — the top-up only fills the remainder.
- §BAKE_FRUSTUM_STALE: `camera.updateMatrixWorld()` before reading matrixWorldInverse. The bake sets
  the pose and calls startStillRefine() BEFORE any render of it, so the cull was running against the
  previous frame's view.

Lifted from the parked PR #1327 (§BAKE_INTERIOR_LIGHTS, 2026-08-12), which measured the same defect
on a headless Duplex bake — 18 fixture lights at frame 0, 0 from frame 1 on, intensity sum
127.39 -> 82.39 = exactly 18 x NIGHT_LIGHT_INTENSITY. That PR is 312 commits behind main and its
triage note (2026-09-02) records effects.js as a NON-mechanical conflict against §NIGHT_BAKE_POOL /
§STAGED_PL_CUT. This change takes only the tools.js half, which does not conflict: the effects.js
re-arm gate it also fixed reads `A._nightLights.length`, and §NIGHT_BAKE_POOL already keeps that
non-zero for the whole bake, so the self-latching zero is masked there. #1327's remaining halves
(the re-arm gates, and §BAKE_LIGHT_BUILDUP_GATE which would gate lights on Time Machine placement)
are deliberately NOT taken here — the buildup gate REMOVES interior light and needs its own decision.

Witness: viewer/tests/witness_bake_interior_topup.js — W-BAKE-TOPUP 8/8, RED control detected,
slices `_nightPickNearest` and `_nightUpdateLights` out of the shipped tools.js by brace matching
(never re-typed) and reads NIGHT_SPREAD_MIN_M from the file rather than hardcoding it. Verdict line
prints NO-OP / VACUOUS / INCONCLUSIVE rather than PASS when nothing was judged.
  §BAKE_INTERIOR_TOPUP_ROW bake-interior-frustum-empty fixtures=40 budget=50 inFrustum=0 lit=40
  §BAKE_INTERIOR_TOPUP_ROW bake-interior-frustum-short fixtures=40 budget=50 inFrustum=3 lit=40
  §BAKE_INTERIOR_TOPUP_ROW bake-wide-frustum-full   fixtures=80 budget=50 inFrustum=60 lit=60
  §BAKE_INTERIOR_TOPUP_ROW nav-no-still             fixtures=40 budget=24 inFrustum=0  lit=24

sw v1133->v1134, tools.js?v=45->46 in the same PR.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)