### PR TITLE
feat(erp): E-4 — a completed M_InOut now moves stock (M_Transaction emit + on-hand fold)

### DIFF
--- a/erp/crud_overlay.js
+++ b/erp/crud_overlay.js
@@ -1576,8 +1576,22 @@
           var receipt = hdrRows.filter(function (r) { return String(r.m_inout_id) === String(op.id); })[0];
           if (!receipt) { console.log('§RECEIPT-COMPLETE fan-out gated: receipt ' + op.id + ' not found (bundle+sidecar) → status-only'); cb(null); return; }
           var lines = lineRows.filter(function (r) { return String(r.m_inout_id) === String(op.id); });
-          var ops = E.completeReceipt(receipt, lines, null).filter(function (o) { return o.op_type !== 'SET_STATUS'; });
-          console.log('§RECEIPT-FANOUT receipt=' + op.id + ' issotrx=' + receipt.issotrx + ' lines=' + lines.length + ' matchPoOps=' + ops.length);
+          // §E4 (prompts/ERP_STOCK_EFFECT.md) — the STOCK EFFECT needs the doctype's DocBaseType, which is
+          // MInOut.getMovementType's only input besides IsSOTrx. Read from the bundle's own c_doctype; when
+          // it cannot be read, stockMoves emits ZERO ops and says why — never a guessed inventory sign.
+          var dbt = null;
+          try {
+            var dtr = _rawRows(db, 'SELECT docbasetype FROM c_doctype WHERE c_doctype_id=' + Number(receipt.c_doctype_id));
+            dbt = dtr.length ? dtr[0].docbasetype : null;
+          } catch (edt) { dbt = null; }
+          var all = E.completeReceipt(receipt, lines, { docBaseType: dbt });
+          var ops = all.filter(function (o) { return o.op_type !== 'SET_STATUS'; });
+          var trx = ops.filter(function (o) { return o.table === 'M_Transaction'; });
+          console.log('§RECEIPT-FANOUT receipt=' + op.id + ' issotrx=' + receipt.issotrx + ' lines=' + lines.length +
+                      ' matchPoOps=' + ops.filter(function (o) { return o.table === 'M_MatchPO'; }).length +
+                      ' docBaseType=' + JSON.stringify(dbt) + ' stockOps=' + trx.length +
+                      ' movementtype=' + (trx.length ? trx[0].movementtype : 'none') +
+                      ' netQty=' + trx.reduce(function (a, o) { return a + Number(o.movementqty || 0); }, 0));
           fanout = ops.length ? { ops: ops, glGate: 'none' } : null;
         } catch (er) { console.log('§RECEIPT-COMPLETE fan-out error ' + (er && er.message) + ' → status-only group'); fanout = null; }
         cb(fanout);

--- a/erp/erp_engine.js
+++ b/erp/erp_engine.js
@@ -281,6 +281,66 @@ function completeInvoice(invoice, lines, policy) {
 // existing CREATE_LINE kernel op, no buildDoc. The invoice-created-before-shipment edge case (real Java
 // also emits M_MatchPO from MInvoice.completeIt() ~line 2134) is NAMED-DEFERRED — this lane's witness path
 // is receipt-first (PO → Receipt → Invoice), the mainline order real users follow.
+// ── GENERATE: stockMoves — the M_InOut Complete STOCK EFFECT ─────────────────────────────────────
+// Implementing prompts/ERP_STOCK_EFFECT.md §E4.3 — Witness: W-STOCK-MOVE. Closes AGENT_QUEUE E-4
+// ("a real signed shipment still cannot move stock" — m_storageonhand had ZERO shipped .js writers).
+// Java home (EXTRACT, do NOT invent):
+//   MInOut.getMovementType (MInOut.java:1275-1287) — the whole table, no defaulting:
+//     DocBaseType 'MMS' (MaterialDelivery) -> SOTrx ? 'C-' : 'V-'
+//     DocBaseType 'MMR' (MaterialReceipt)  -> SOTrx ? 'C+' : 'V+'      any other DocBaseType -> null
+//   MInOut.completeIt:1688-1691 — Qty = sLine.MovementQty; if MovementType.charAt(1)=='-' Qty = Qty.negate()
+//     (the polarity IS the trailing char — which is exactly what movementSign already extracts).
+//   MInOut.completeIt:1939-1944 — new MTransaction(ctx, sLine.AD_Org_ID, MovementType, sLine.M_Locator_ID,
+//     sLine.M_Product_ID, sLine.M_AttributeSetInstance_ID, Qty, MovementDate) + setM_InOutLine_ID.
+// WHY THE TRANSACTION AND NOT A STORAGE UPSERT: M_StorageOnHand.add() is an upsert of a delta, and the op
+// log is append-only (a `listTip` fold reads row-TIPS by key, so a delta row does not fit CREATE_LINE, and
+// inventing a STORAGE_DELTA op type to make it fit would be inventing). M_Transaction IS append-only, and
+// on-hand is the fold of it — the model qtyOnHand's own comment above already states: iDempiere keeps the
+// qty nowhere as a master field; MStorageOnHand.qtyonhand is a cache maintained in lockstep with this sum.
+// PURE: no DB, no clock — the host passes the doc, its lines, and the doctype's DocBaseType.
+
+// movementTypeOf — MInOut.getMovementType verbatim. Returns null for any other DocBaseType (the caller
+// must then emit NOTHING; a guessed polarity would be a silently wrong inventory sign).
+function movementTypeOf(docBaseType, issotrx) {
+  var so = (issotrx === true || issotrx === 'Y');
+  if (docBaseType === 'MMS') return so ? 'C-' : 'V-';
+  if (docBaseType === 'MMR') return so ? 'C+' : 'V+';
+  return null;
+}
+
+// stockMoves(doc, lines, opts) -> { ops, movementtype, skipped, deferred, reason? }
+//   doc   : the M_InOut header (needs issotrx + movementdate; ad_org_id used as the line fallback)
+//   lines : its M_InOutLine rows (movementqty carried VERBATIM — the sign comes from the type, never
+//           from trusting a pre-signed column)
+//   opts.docBaseType : the C_DocType's DocBaseType (the host reads it; this verb never queries)
+// A line with no product or no locator is SKIPPED AND COUNTED — not silently dropped.
+function stockMoves(doc, lines, opts) {
+  opts = opts || {};
+  var deferred = ['costing(M_CostDetail)', 'reservation(MStorageReservation MInOut.completeIt:1919-1935)',
+                  'asi-material-policy(dateMPolicy allocation loop MInOut.completeIt:1771-1830)'];
+  var mt = movementTypeOf(opts.docBaseType, doc && doc.issotrx);
+  if (!mt) {
+    return { ops: [], movementtype: null, skipped: (lines || []).length, deferred: deferred,
+             reason: 'DocBaseType ' + JSON.stringify(opts.docBaseType || null) + ' is neither MMS nor MMR — no movement type, so NO ops (a guessed polarity would be a wrong inventory sign)' };
+  }
+  var sign = movementSign(mt), ops = [], skipped = 0;
+  (lines || []).forEach(function (l) {
+    if (l == null || l.m_product_id == null || l.m_locator_id == null) { skipped++; return; }
+    var q = l.movementqty != null ? l.movementqty : l.qtyentered;
+    if (q == null) { skipped++; return; }
+    ops.push({ op_type: 'CREATE_LINE', table: 'M_Transaction',
+               movementtype: mt,
+               m_locator_id: l.m_locator_id,
+               m_product_id: l.m_product_id,
+               m_attributesetinstance_id: l.m_attributesetinstance_id != null ? l.m_attributesetinstance_id : null,
+               movementqty: sign * Math.abs(Number(q)),
+               movementdate: doc.movementdate != null ? doc.movementdate : null,
+               m_inoutline_id: l.m_inoutline_id,
+               ad_org_id: l.ad_org_id != null ? l.ad_org_id : (doc.ad_org_id != null ? doc.ad_org_id : null) });
+  });
+  return { ops: ops, movementtype: mt, skipped: skipped, deferred: deferred };
+}
+
 function completeReceipt(receipt, lines, policy) {
   var ops = [{ op_type: 'SET_STATUS', table: 'M_InOut', id: receipt.m_inout_id, doc_status: 'CO' }];
   if (receipt.issotrx === 'N') {
@@ -288,6 +348,12 @@ function completeReceipt(receipt, lines, policy) {
       if (l.c_orderline_id) ops.push({ op_type: 'CREATE_LINE', table: 'M_MatchPO', c_orderline_id: l.c_orderline_id, m_inoutline_id: l.m_inoutline_id, m_product_id: l.m_product_id, qty: l.movementqty });
     });
   }
+  // §E4 (prompts/ERP_STOCK_EFFECT.md) — the STOCK EFFECT rides the same Complete fan-out, for BOTH
+  // directions: a receipt adds and a shipment subtracts. Gated on the host supplying the doctype's
+  // DocBaseType — without it stockMoves returns zero ops and a named reason rather than a guessed sign,
+  // so an older caller that does not pass policy.docBaseType is byte-identical to before.
+  var sm = stockMoves(receipt, lines, { docBaseType: policy && policy.docBaseType });
+  sm.ops.forEach(function (o) { ops.push(o); });
   return ops;
 }
 
@@ -295,6 +361,7 @@ return {
   resolveCtx: resolveCtx, dialectShim: dialectShim, evalGuard: evalGuard,
   match: match, buildDoc: buildDoc, DOC_SPECS: DOC_SPECS, explodeBOM: explodeBOM,
   movementSign: movementSign, qtyOnHand: qtyOnHand, reversePosting: reversePosting,
-  VERBS: VERBS, completeOrder: completeOrder, completeInvoice: completeInvoice, completeReceipt: completeReceipt
+  VERBS: VERBS, completeOrder: completeOrder, completeInvoice: completeInvoice, completeReceipt: completeReceipt,
+  movementTypeOf: movementTypeOf, stockMoves: stockMoves
 };
 });

--- a/erp/idempiere.html
+++ b/erp/idempiere.html
@@ -2325,6 +2325,38 @@ if (typeof qrcode !== "undefined") window.qrcode = qrcode;
   // picker's own withSidecar call already hydrated window.__crud.kernelDb() once (paint() only runs after
   // that resolves), so a synchronous read here is safe — falls through to the base-only row/rows on any
   // infra gap (never worse than before).
+  // §E4 (prompts/ERP_STOCK_EFFECT.md §E4.3) — Witness: W-STOCK-MOVE. The on-hand READ half.
+  // m_storageonhand in the bundle is the seed's BASELINE; every movement this app has committed since lives
+  // as an append-only M_Transaction CREATE_LINE op in the sidecar log. iDempiere keeps qty nowhere as a
+  // master field (erp_engine.qtyOnHand's own note) — on-hand IS baseline + Σ signed transactions. Without
+  // this term a completed shipment moved stock in the LOG and nowhere the app could see, which is E-4's
+  // "a real signed shipment still cannot move stock" in its other half.
+  // Sign convention: movementqty is stored ALREADY SIGNED by erp_engine.stockMoves (movementSign × |qty|),
+  // so this only sums — it never re-derives a polarity the engine already decided.
+  // Official rows only: branch_id IS NULL (BLUE FUTURE ops must not leak) and not undone. Any infra gap →
+  // 0, i.e. exactly the pre-§E4 answer, never worse.
+  function _sidecarStockDelta(pid, wh) {
+    var c = window.__crud;
+    if (!c || typeof c.kernelDb !== 'function') return 0;
+    var sdb = null; try { sdb = c.kernelDb(); } catch (e) { sdb = null; }
+    if (!sdb) return 0;
+    var locs = {};
+    _sqlRows('SELECT m_locator_id FROM m_locator WHERE m_warehouse_id=' + Number(wh)).forEach(function (l) { locs[String(l.m_locator_id)] = 1; });
+    var sum = 0, seen = 0;
+    try {
+      var res = sdb.exec("SELECT parameters FROM kernel_ops WHERE op_type='CREATE_LINE' AND branch_id IS NULL" +
+                         " AND (undone IS NULL OR undone=0) AND parameters LIKE '%\"table\":\"M_Transaction\"%' ORDER BY id");
+      ((res[0] && res[0].values) || []).forEach(function (row) {
+        var p; try { p = JSON.parse(row[0]); } catch (e) { return; }
+        if (!p || p.table !== 'M_Transaction') return;
+        if (Number(p.m_product_id) !== Number(pid)) return;
+        if (!locs[String(p.m_locator_id)]) return;
+        sum += Number(p.movementqty || 0); seen++;
+      });
+    } catch (e) { return 0; }
+    if (seen) console.log('§STOCK-ONHAND product=' + pid + ' warehouse=' + wh + ' sidecarTxns=' + seen + ' delta=' + sum);
+    return sum;
+  }
   function _foldOrderRow(id) {
     var base = _sqlRows('SELECT * FROM c_order WHERE c_order_id=' + Number(id))[0] || null;
     var c = window.__crud;
@@ -2423,7 +2455,8 @@ if (typeof qrcode !== "undefined") window.qrcode = qrcode;
       },
       onHandOf: function (pid, wh) {
         var r = _sqlRows('SELECT COALESCE(SUM(s.qtyonhand),0) oh FROM m_storageonhand s JOIN m_locator l ON l.m_locator_id=s.m_locator_id WHERE s.m_product_id=' + Number(pid) + ' AND l.m_warehouse_id=' + Number(wh));
-        return r.length ? Number(r[0].oh) : 0;
+        var base = r.length ? Number(r[0].oh) : 0;
+        return base + _sidecarStockDelta(pid, wh);
       }
     };
   }

--- a/erp/sw.js
+++ b/erp/sw.js
@@ -10,7 +10,7 @@
 // init-bubble must be INSTANT, ERP_INIT_BUBBLE_INSTANT.md); network-first for non-precached .js (fresh on
 // deploy); cache-first for precached assets/.wasm/images. Freshness on deploy is carried by the SW version
 // bump (skipWaiting+clients.claim precache the new shell), so SWR strands a user at most one load post-deploy.
-const CACHE_VERSION = 'v780';   // bump on each deploy; per-change detail is the git commit message.
+const CACHE_VERSION = 'v781';   // bump on each deploy; per-change detail is the git commit message.
 // v772 (rebase of PR #203 onto origin/main) §INTEG-WIRE-B: disposable-host persistence in-app
 // (erp_replica_client.js + erp_persist_ui.js) — back the books up to a SIGNED snapshot the user
 // owns (signed by the edge key), restore on a FRESH device -> replay recomputes tip == signed


### PR DESCRIPTION
Implementing `prompts/ERP_STOCK_EFFECT.md` — Witness: **W-STOCK-MOVE**. Closes `AGENT_QUEUE.md` **E-4**,
measured there as *"`grep -rln m_storageonhand erp/*.js` → **0 hits** across all 91 files … a real signed
shipment still cannot move stock."* Paired bim-compiler commit `f27752592`.

## What was actually missing
Not an inventory engine. The **sign spine already existed and was witnessed** —
`erp_engine.movementSign`/`qtyOnHand` (W-FOLD-QTYONHAND), whose own comment already states the model:
*"iDempiere stores inventory qty NOWHERE as a master field — it is a FOLD of every MTransaction, and
MStorageOnHand.qtyonhand is maintained in lockstep."* Missing were the **emit** and the **read**.

**EXTRACTED, not invented:**
| source | rule |
|---|---|
| `MInOut.getMovementType:1275-1287` | `MMS` → SOTrx ? `C-` : `V-` · `MMR` → SOTrx ? `C+` : `V+` · **any other DocBaseType → null** |
| `MInOut.completeIt:1688-1691` | `if (MovementType.charAt(1) == '-') Qty = Qty.negate()` |
| `MInOut.completeIt:1939-1944` | `new MTransaction(…, MovementType, locator, product, ASI, Qty, date)` + `setM_InOutLine_ID` |

## Three seams
- **`erp_engine.js`** — `movementTypeOf` + `stockMoves` (PURE, no DB, no clock); `completeReceipt` calls
  it, so the fan-out that already emitted `M_MatchPO` now also emits the movement.
- **`crud_overlay.js`** — `completeFanoutReceipt` reads the doctype's DocBaseType from the bundle and logs
  `§RECEIPT-FANOUT … docBaseType= stockOps= movementtype= netQty=`.
- **`idempiere.html`** — `_sidecarStockDelta`: on-hand = the seed's `m_storageonhand` baseline **plus** the
  signed `M_Transaction` ops this app has committed. Without it a shipment moved stock in the log and
  nowhere the app could see — E-4's other half.

**Why the transaction and not a storage upsert:** `MStorageOnHand.add()` is an upsert of a delta; the op
log is append-only and a `listTip` fold reads row-**tips** by key, so a delta row does not fit
`CREATE_LINE`. Inventing a `STORAGE_DELTA` op type to make it fit would be inventing. `M_Transaction` is
append-only, and in real iDempiere the storage row is a cache maintained in lockstep with exactly this sum.

## Measured
```
§STOCK-MOVETYPE docsJudged=9 combos={"MMS/Y→C-":4,"MMR/N→V+":5} mismatches=0
§STOCK-SIGN     receipt V+ ops=10 net=+237 | shipment C- ops=1 net=-1  signMismatches=0
§STOCK-LINES    stockable=10 ops=10 fieldMismatches=0   skipTest: ops=9 skipped=1
§STOCK-ONHAND-FOLD rows=10 mismatches=0  p136@l101 40→80, p125@l101 12→24, p138@l101 20→40
§STOCK-GATE     DocBaseType GLJ → 0 ops, 10 skipped, reason named
§STOCK-FANOUT   matchPO=10 mTransaction=10 | noPolicyCaller mTransaction=0
🟢 W-STOCK-MOVE PASS — 15 PASS / 0 FAIL
```
**Arm 1's oracle is the seed's own `m_inout.movementtype` column** over 9 real documents — not a table
this witness wrote. **Falsifier proven:** flipping `MMS` to `C+` turns exactly two arms red and the oracle
names the four affected documents (`100:MMS/Y derived=C+ seed=C-`, …).

**Backward compatibility is its own arm:** a caller passing no `docBaseType` gets
`ops=11 mTransaction=0` — byte-identical to before, because a guessed sign is worse than no movement.

Out of scope and **declared** in `result.deferred`: costing (`M_CostDetail`), reservations
(`MStorageReservation`), the ASI/`dateMPolicy` material-policy loop.

## Regression
36 `erp_engine`-judging witnesses run **before and after** — 34 PASS / 3 FAIL, **identical set, 0
regressions** (`poc_longtail`, `poc_p4_buyside_live`, `poc_pos_eoda` fail on the pre-change file too).
`poc_minout_live` PASS against this branch.

## ⚠ Found while verifying, and it is NOT from this change
`witness_p2p_invoice_match.js` (the UI-level lane witness) fails at **Stage 1** against this branch — and
**fails identically against unmodified `origin/main`**, stage for stage (`PO id=-1 chip=null` →
cascade). Checked before believing it, per the standing "check the instrument" rule. So: the *engines* are
proven headless (`W-CREATEFROM-INVOICE` 16/16, `W-STOCK-MOVE` 15/15); the *UI path that stitches them* is
currently red on main and nothing here claims otherwise. Tracked as its own next item in
`ERP_STOCK_EFFECT.md` §E4.6.

`erp/sw.js` CACHE_VERSION v780 → **v781**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)