### PR TITLE
fix(cpe): §CPE_FLAGS_PORTABLE — the saved path travels with its film flags, not just its geometry

### DIFF
--- a/viewer/effects.js
+++ b/viewer/effects.js
@@ -8743,14 +8743,24 @@ async function setupEffects(A, renderer, scene, camera) {
       // by an older build simply does not have the column and SELECTing it would throw — taking the
       // WHOLE path down over an optional field. Probe the table's own columns first and only ask for
       // what is there. Missing column == every hold 0, which is the documented default anyway.
-      var _hasHold = false;
+      // §CPE_FLAGS_PORTABLE (2026-09-04): buildup/room_title/reveal/day_counter were appended after
+      // hold_sec, so the same one-probe-per-optional-column rule applies — a .db written by any
+      // earlier build simply has neither, and asking for them would take the WHOLE path down over
+      // fields whose absence has a documented default (every flag off, dayCounter unset).
+      var _hasHold = false, _hasFlags = false;
       try {
         var ti = A.dbQuery("PRAGMA table_info(cinema_path)");
-        for (var _ti = 0; _ti < (ti || []).length; _ti++) if (ti[_ti][1] === 'hold_sec') _hasHold = true;
+        for (var _ti = 0; _ti < (ti || []).length; _ti++) {
+          if (ti[_ti][1] === 'hold_sec') _hasHold = true;
+          if (ti[_ti][1] === 'buildup') _hasFlags = true;
+        }
       } catch (eTi) {}
       var rows = A.dbQuery("SELECT seq,ifc_x,ifc_y,ifc_z,dir_x,dir_y,dir_z,len," +
         "total_sec,dive_sec,spin_sec,out_sec,rise_sec," +
-        (_hasHold ? "hold_sec" : "0 AS hold_sec") + " FROM cinema_path ORDER BY seq");
+        (_hasHold ? "hold_sec" : "0 AS hold_sec") + "," +
+        (_hasFlags ? "buildup,room_title,reveal,day_counter"
+                   : "0 AS buildup,0 AS room_title,0 AS reveal,NULL AS day_counter") +
+        " FROM cinema_path ORDER BY seq");
       if (!rows || rows.length < 2) { console.log('§CINEMA_PATH_RESTORE none (0 rows) — derived path'); return; }
       // §CPE_BANDS: rebuilt as bands, so the rigid-straight invariant is restored with the data
       // rather than re-imposed by convention.
@@ -8763,8 +8773,23 @@ async function setupEffects(A, renderer, scene, camera) {
       });
       A._cinemaPathEdit = { bands: bands, diveSec: rows[0][9], spinSec: rows[0][10],
                             outSec: rows[0][11], riseSec: rows[0][12], _total: rows[0][8] };
+      // §CPE_FLAGS_PORTABLE — constant across rows by construction (written from one override), so
+      // row 0 is the value, exactly as the beat seconds above are read. Only SET when the columns
+      // are actually there: an older .db must keep the pre-existing behaviour of leaving these
+      // undefined, so whatever default the consumer already applies still applies.
+      if (_hasFlags) {
+        A._cinemaPathEdit.buildup = !!rows[0][14];
+        A._cinemaPathEdit.roomTitle = !!rows[0][15];
+        A._cinemaPathEdit.reveal = !!rows[0][16];
+        if (rows[0][17] != null && rows[0][17] !== '') A._cinemaPathEdit.dayCounter = String(rows[0][17]);
+      }
       console.log('§CINEMA_PATH_RESTORE bands=' + bands.length + ' total=' + rows[0][8].toFixed(1) +
         's holdCol=' + _hasHold + ' holds=' + bands.filter(function(b) { return b.hold > 0.01; }).length +
+        ' flagCol=' + _hasFlags +
+        (_hasFlags ? ' buildup=' + (rows[0][14] ? 1 : 0) + ' roomTitle=' + (rows[0][15] ? 1 : 0) +
+                     ' reveal=' + (rows[0][16] ? 1 : 0) + ' dayCounter=' + (rows[0][17] || 'unset')
+                   : ' — §CPE_FLAGS_PORTABLE: this .db predates the flag columns, so every film flag' +
+                     ' stays at its consumer default (all off); the path itself is unaffected') +
         ' — authored path in force');
     } catch (e) { console.warn('§CINEMA_PATH_RESTORE_FAIL ' + e.message); }
   }

--- a/viewer/scene.js
+++ b/viewer/scene.js
@@ -738,20 +738,42 @@ async function setupScene(A) {
       // ones — a table written by an older build has 13 columns and the reader selects by NAME with
       // a fallback, so both directions of the version skew stay readable (§CPE_PATH_NOT_PORTABLE
       // only just made these files portable at all; do not break that in the next release).
+      // ══ §CPE_FLAGS_PORTABLE (2026-09-04, user: "the HHS silent i have set a stored path which are
+      // all those [buildup/label/reveal ON]" — but the CLI bake of that very .db resolved
+      // `§CLI_BAKE_RESOLVED source=db:cinema_path bands=4 total=61.0s buildup=0 roomTitle=0 reveal=0`).
+      // MEASURED CAUSE, not guessed: the table above stored the path's GEOMETRY and its BEAT SECONDS
+      // and nothing else. The four film flags live on the same `_buildOverride()` object the bands
+      // come from, and the IndexedDB working store keeps them — but the PORTABLE table dropped them,
+      // so a path that travels with the .db arrived with every feature off. The file was not wrong
+      // about the path; it never carried the answer at all.
+      // Appended as columns, never inserted among the existing ones — the same version-skew rule
+      // §CPE_STICK_HOLD's hold_sec already follows, and the reader (effects.js _cpeLoadFromDb)
+      // probes PRAGMA table_info and falls back, so an older .db still opens and a .db written here
+      // still opens in an older build.
       db.run("CREATE TABLE cinema_path (seq INTEGER, ifc_x REAL, ifc_y REAL, ifc_z REAL, " +
              "dir_x REAL, dir_y REAL, dir_z REAL, len REAL, " +
              "total_sec REAL, dive_sec REAL, spin_sec REAL, out_sec REAL, rise_sec REAL, " +
-             "hold_sec REAL)");
-      var stmt = db.prepare("INSERT INTO cinema_path VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?)");
+             "hold_sec REAL, buildup INTEGER, room_title INTEGER, reveal INTEGER, day_counter TEXT)");
+      var stmt = db.prepare("INSERT INTO cinema_path VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)");
       ov.bands.forEach(function(b, i) {
         var p = A.three2ifc(b.c.x, b.c.y, b.c.z);
         var d = A.three2ifcDir(b.d.x, b.d.y, b.d.z);
         stmt.run([i, p.ix, p.iy, p.iz, d.ix, d.iy, d.iz, b.len,
                   ov._total, ov.diveSec, ov.spinSec, ov.outSec, ov.riseSec,
-                  +(b.hold || 0)]);
+                  +(b.hold || 0),
+                  // §CPE_FLAGS_PORTABLE — the film flags, per row (constant across rows, exactly
+                  // like total_sec/dive_sec above; the reader takes them from row 0).
+                  ov.buildup ? 1 : 0, ov.roomTitle ? 1 : 0, ov.reveal ? 1 : 0,
+                  ov.dayCounter == null ? null : String(ov.dayCounter)]);
       });
       stmt.free();
-      console.log('§CINEMA_PATH_SAVE bands=' + ov.bands.length + ' total=' + ov._total.toFixed(1) + 's');
+      // §CPE_FLAGS_PORTABLE — the flags are now part of what a save CLAIMS to have written, so a
+      // path that goes out with every feature off says so here rather than being discovered a bake
+      // later. `dayCounter` absent means the reader's own default, not "off".
+      console.log('§CINEMA_PATH_SAVE bands=' + ov.bands.length + ' total=' + ov._total.toFixed(1) + 's' +
+        ' buildup=' + (ov.buildup ? 1 : 0) + ' roomTitle=' + (ov.roomTitle ? 1 : 0) +
+        ' reveal=' + (ov.reveal ? 1 : 0) + ' dayCounter=' + (ov.dayCounter || 'default') +
+        ' (§CPE_FLAGS_PORTABLE — these travel with the .db now)');
     } catch (e) { console.warn('§CINEMA_PATH_SAVE_FAIL ' + e.message); }
   }
   // prompts/Viewer/SAVE_DB_SCENE_STATE.md §1-4 — camera/display/nav/panel/Find-selection/Time-Machine

--- a/viewer/sw.js
+++ b/viewer/sw.js
@@ -43,7 +43,12 @@
 // nav and bake cannot drift apart), and the camera matrix is refreshed before the cull
 // (§BAKE_FRUSTUM_STALE). An interior pose whose frustum held no fixture centre previously left
 // every §NIGHT_BAKE_POOL slot at intensity 0 — the room lit by flat fill alone. tools.js?v=45->46.
-const CACHE_VERSION = 'v1134';   // bump on each deploy; per-change detail is the git commit message.
+// v1135 (2026-09-04) §CPE_FLAGS_PORTABLE: the building DB's `cinema_path` table now carries the
+// four film flags (buildup, room_title, reveal, day_counter) alongside the path geometry it already
+// stored, so a path saved with Ctrl+S no longer travels with every feature silently OFF. Columns are
+// APPENDED and the reader PRAGMA-probes them, so old and new .db files open in both directions.
+// scene.js?v=59->60, effects.js?v=32->33.
+const CACHE_VERSION = 'v1135';   // bump on each deploy; per-change detail is the git commit message.
 // v1128 (2026-09-02) §SUN_FILL_RATIO: viewer/effects.js — the Alt+S staging HDRI
 // (belfast_sunset_puresky_1k) was being pushed onto EVERY material by _reassertPhotoEnvMap, matte
 // concrete and plaster included. IBL is non-directional and is NOT shadow-map-occluded in three.js,

--- a/viewer/tests/witness_cpe_path_flags_portable.js
+++ b/viewer/tests/witness_cpe_path_flags_portable.js
@@ -1,0 +1,162 @@
+#!/usr/bin/env node
+// witness_cpe_path_flags_portable.js — W-CPE-FLAGS
+//
+// ⚠ DO NOT REMOVE — SCOPE (bim-compiler prompts/CINEMA_PATH_EDITOR.md §CPE_FLAGS_PORTABLE).
+// User, 2026-09-04: "the HHS silent i have set a stored path which are all those" — buildup, label
+// and reveal ON — yet a CLI silent bake of that same .db resolved
+//   §CLI_BAKE_RESOLVED source=db:cinema_path bands=4 total=61.0s buildup=0 roomTitle=0 reveal=0
+// Read the log after every run.
+//
+// THE ISSUE THIS PROVES OR DISPROVES: the PORTABLE store (the building DB's `cinema_path` table)
+// carried the path's geometry and beat seconds but NOT the four film flags, so a path saved with
+// Ctrl+S travelled with every feature off while the IndexedDB working store kept them. This witness
+// round-trips a real override through the SHIPPED writer and the SHIPPED reader over a real sql.js
+// database and asserts the flags survive — and that a pre-flag .db still opens.
+//
+// Whitebox, no browser: `_writeCinemaPathTable` (viewer/scene.js) and `_cpeLoadFromDb`
+// (viewer/effects.js) are SLICED OUT of the shipped files by brace matching and executed against
+// stub A/transform objects — never re-typed, so this cannot pass against a copy that is not shipped.
+'use strict';
+const fs = require('fs'), path = require('path'), vm = require('vm');
+const HOME = require('os').homedir();
+const { Witness } = require(path.join(__dirname, '..', '..', 'witness_kit', 'contract.js'));
+const initSqlJs = require(path.join(HOME, 'bim-ootb', 'node_modules', 'sql.js'));
+
+const sceneSrc = fs.readFileSync(path.join(__dirname, '..', 'scene.js'), 'utf8');
+const fxSrc = fs.readFileSync(path.join(__dirname, '..', 'effects.js'), 'utf8');
+
+function sliceFn(src, marker) {
+  const i = src.indexOf(marker);
+  if (i < 0) return null;
+  let d = 0, open = false;
+  for (let j = i; j < src.length; j++) {
+    if (src[j] === '{') { d++; open = true; }
+    else if (src[j] === '}') { d--; if (open && d === 0) return src.slice(i, j + 1); }
+  }
+  return null;
+}
+const writeSrc = sliceFn(sceneSrc, 'function _writeCinemaPathTable(');
+const readSrc = sliceFn(fxSrc, 'function _cpeLoadFromDb(');
+
+const OV_ON = {
+  bands: [
+    { c: { x: 0, y: 1, z: 2 }, d: { x: 1, y: 0, z: 0 }, len: 3, hold: 0 },
+    { c: { x: 4, y: 5, z: 6 }, d: { x: 0, y: 0, z: 1 }, len: 7, hold: 2.5 }
+  ],
+  _total: 61.0, diveSec: 1.8, spinSec: 0, outSec: 21.8, riseSec: 2.7,
+  buildup: true, roomTitle: true, reveal: true, dayCounter: 'bl'
+};
+const OV_OFF = Object.assign({}, OV_ON, { buildup: false, roomTitle: false, reveal: false, dayCounter: null });
+
+function roundTrip(SQL, ov, legacy) {
+  const db = new SQL.Database();
+  const idf = (x, y, z) => ({ ix: x, iy: y, iz: z, x, y, z });
+  const A = {
+    _cinemaPathEdit: ov,
+    _getCinemaPathEdit: () => ov,
+    three2ifc: idf, three2ifcDir: idf, ifc2three: idf, ifc2threeDir: idf,
+    dbQuery(sql) {
+      const r = db.exec(sql);
+      return r.length ? r[0].values : [];
+    }
+  };
+  if (legacy) {
+    // A .db written by any build before §CPE_FLAGS_PORTABLE: 14 columns, no flag columns.
+    db.run('CREATE TABLE cinema_path (seq INTEGER, ifc_x REAL, ifc_y REAL, ifc_z REAL,' +
+      ' dir_x REAL, dir_y REAL, dir_z REAL, len REAL, total_sec REAL, dive_sec REAL,' +
+      ' spin_sec REAL, out_sec REAL, rise_sec REAL, hold_sec REAL)');
+    ov.bands.forEach((b, i) => db.run('INSERT INTO cinema_path VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?)',
+      [i, b.c.x, b.c.y, b.c.z, b.d.x, b.d.y, b.d.z, b.len,
+       ov._total, ov.diveSec, ov.spinSec, ov.outSec, ov.riseSec, b.hold || 0]));
+  } else {
+    const wsb = { A, db, console: { log() {}, warn() {} } };
+    vm.createContext(wsb);
+    vm.runInContext(writeSrc + '\n_writeCinemaPathTable(db);', wsb);
+  }
+  const rsb = { A, console: { log() {}, warn() {} }, Math };
+  rsb._cpeLoaded = false;
+  vm.createContext(rsb);
+  vm.runInContext('var _cpeLoaded = false;\n' + readSrc + '\n_cpeLoadFromDb();', rsb);
+  const cols = (db.exec("PRAGMA table_info(cinema_path)")[0] || { values: [] }).values.map(r => r[1]);
+  db.close();
+  return { restored: A._cinemaPathEdit, cols };
+}
+
+function population() {
+  if (!writeSrc || !readSrc) return [];
+  const rows = [];
+  for (const [name, ov, legacy] of [['flags-on', OV_ON, false], ['flags-off', OV_OFF, false],
+                                    ['legacy-14-col', OV_ON, true]]) {
+    const r = roundTrip(population._SQL, JSON.parse(JSON.stringify(ov)), legacy);
+    const g = r.restored || {};
+    rows.push({
+      scenario: name,
+      hasFlagCols: r.cols.indexOf('buildup') !== -1,
+      bands: (g.bands || []).length,
+      total: +(g._total || 0).toFixed(1),
+      buildup: g.buildup === undefined ? 'undef' : String(!!g.buildup),
+      roomTitle: g.roomTitle === undefined ? 'undef' : String(!!g.roomTitle),
+      reveal: g.reveal === undefined ? 'undef' : String(!!g.reveal),
+      dayCounter: g.dayCounter === undefined ? 'undef' : String(g.dayCounter)
+    });
+  }
+  return rows;
+}
+
+const schema = {
+  type: 'object',
+  required: ['scenario', 'hasFlagCols', 'bands', 'total', 'buildup', 'roomTitle', 'reveal', 'dayCounter'],
+  properties: {
+    scenario: { type: 'string' }, hasFlagCols: { type: 'boolean' }, bands: { type: 'integer' },
+    total: { type: 'number' }, buildup: { type: 'string' }, roomTitle: { type: 'string' },
+    reveal: { type: 'string' }, dayCounter: { type: 'string' }
+  }
+};
+
+(async () => {
+  population._SQL = await initSqlJs({
+    locateFile: f => path.join(HOME, 'bim-ootb', 'node_modules', 'sql.js', 'dist', f)
+  });
+  if (!writeSrc || !readSrc) {
+    console.log('§WITNESS_CPE_PATH_FLAGS_VERDICT INCONCLUSIVE — could not slice ' +
+      (!writeSrc ? '_writeCinemaPathTable' : '_cpeLoadFromDb') + '; nothing judged');
+    process.exit(1);
+  }
+  const w = Witness('CPE_PATH_FLAGS_PORTABLE')
+    .population(population)
+    .schema(schema)
+    // G1 — the defect: flags set ON when the path was saved must come back ON.
+    .invariant('flags-on-survive', rows => {
+      const r = rows.find(x => x.scenario === 'flags-on');
+      return !!r && r.buildup === 'true' && r.roomTitle === 'true' && r.reveal === 'true' && r.dayCounter === 'bl';
+    })
+    // G2 — OFF must come back OFF, not undefined-as-anything.
+    .invariant('flags-off-survive', rows => {
+      const r = rows.find(x => x.scenario === 'flags-off');
+      return !!r && r.buildup === 'false' && r.roomTitle === 'false' && r.reveal === 'false';
+    })
+    // G3 — version skew: a .db written before the flag columns still restores its PATH, and leaves
+    // the flags undefined so the consumer's own default applies (never throws, never invents true).
+    .invariant('legacy-db-still-loads', rows => {
+      const r = rows.find(x => x.scenario === 'legacy-14-col');
+      return !!r && r.hasFlagCols === false && r.bands === 2 && r.buildup === 'undef';
+    })
+    // G4 — the geometry the flags ride with is unharmed by the schema change.
+    .invariant('path-preserved', rows => rows.every(r => r.bands === 2 && r.total === 61.0))
+    // RED — the pre-fix writer: geometry only, flags dropped on the way out.
+    .redControl(rows => rows.map(r => Object.assign({}, r,
+      { buildup: 'false', roomTitle: 'false', reveal: 'false', dayCounter: 'undef' })));
+
+  const res = w.run();
+  const rows = population();
+  rows.forEach(r => console.log('§CPE_PATH_FLAGS_ROW ' + r.scenario + ' flagCols=' + r.hasFlagCols +
+    ' bands=' + r.bands + ' total=' + r.total + ' buildup=' + r.buildup + ' roomTitle=' + r.roomTitle +
+    ' reveal=' + r.reveal + ' dayCounter=' + r.dayCounter));
+  const noop = rows.every(r => r.buildup === 'undef' || r.buildup === 'false');
+  console.log('§WITNESS_CPE_PATH_FLAGS_VERDICT ' +
+    (rows.length === 0 ? 'VACUOUS — nothing judged'
+     : noop ? 'NO-OP — no scenario ever restored a flag as ON; the columns are not carrying anything'
+     : res.fail === 0 ? 'PASS' : 'FAIL') +
+    ' rows=' + rows.length + ' pass=' + res.pass + ' fail=' + res.fail);
+  process.exit(res.fail === 0 && rows.length > 0 && !noop ? 0 : 1);
+})().catch(e => { console.error('§WITNESS_CPE_PATH_FLAGS_ERROR ' + (e && e.stack || e)); process.exit(2); });

--- a/viewer/viewer.html
+++ b/viewer/viewer.html
@@ -840,7 +840,7 @@ html.bim-embedded, html.bim-embedded body { background: #0b0b0b; }
 <script src="qrcode.min.js?v=1" onerror="console.warn('§LOAD_FAIL qrcode.min.js — QR sharing disabled')"></script>
 <script src="config.js?v=4" onerror="console.warn('§LOAD_FAIL config.js')"></script>
 <script src="db_resolve.js?v=2" onerror="console.warn('§LOAD_FAIL db_resolve.js')"></script>
-<script src="effects.js?v=32" onerror="console.warn('§LOAD_FAIL effects.js')"></script>
+<script src="effects.js?v=33" onerror="console.warn('§LOAD_FAIL effects.js')"></script>
 <script src="effects_gi_poc.js?v=3" onerror="console.warn('§LOAD_FAIL effects_gi_poc.js')"></script>
 <script src="lib/mp4_mux.js?v=1" onerror="console.warn('§LOAD_FAIL mp4_mux.js — MaxQ falls back to webm')"></script>
 <script src="cinema_path_editor.js?v=15" onerror="console.warn('§LOAD_FAIL cinema_path_editor.js — Alt+C path editing disabled')"></script>
@@ -852,7 +852,7 @@ html.bim-embedded, html.bim-embedded body { background: #0b0b0b; }
 <script src="list_builder.js?v=1" onerror="console.warn('§LOAD_FAIL list_builder.js')"></script>
 <script src="settings_editor.js?v=1" onerror="console.warn('§LOAD_FAIL settings_editor.js')"></script>
 <script src="../common/history_tap.js?v=7" onerror="console.warn('§LOAD_FAIL history_tap.js')"></script>
-<script src="scene.js?v=59" onerror="console.warn('§LOAD_FAIL scene.js')"></script>
+<script src="scene.js?v=60" onerror="console.warn('§LOAD_FAIL scene.js')"></script>
 <script src="panel_nav.js?v=1" onerror="console.warn('§LOAD_FAIL panel_nav.js')"></script>
 <script src="helpers.js?v=6" onerror="console.warn('§LOAD_FAIL helpers.js')"></script>
 <script src="silhouette_refine.js?v=1" onerror="console.warn('§LOAD_FAIL silhouette_refine.js')"></script>


### PR DESCRIPTION
User, 2026-09-04: "the HHS silent i have set a stored path which are all those" — buildup, label and
reveal ON. A CLI silent bake of that same .db disagreed:

  §CLI_BAKE_RESOLVED source=db:cinema_path bands=4 total=61.0s buildup=0 roomTitle=0 reveal=0

MEASURED CAUSE, not guessed. `cinema_path` in HHS_Office_Federated_silent.db has 14 columns — seq,
ifc_x/y/z, dir_x/y/z, len, total_sec, dive_sec, spin_sec, out_sec, rise_sec, hold_sec. There is
nowhere in that schema for buildup, roomTitle, reveal or dayCounter. The flags live on the same
_buildOverride() object the bands come from and the IndexedDB working store keeps them, but
scene.js `_writeCinemaPathTable` only ever wrote geometry + beat seconds, so the PORTABLE copy — the
one that travels inside the .db, and the only one a CLI bake or another machine can see — arrived
with every feature off. The stored path was not wrong; it never carried the answer at all.

This is the documented split doing half its job: cinema_path_editor.js:2179 states IndexedDB is the
working store and the DB table is "the PORTABLE format ... so the plan travels with the file". A
format that drops four of the fields it is asked to carry is not portable.

FIX, following this table's OWN version-skew convention (the one §CPE_STICK_HOLD set when it
appended hold_sec):
- scene.js — four columns APPENDED, never inserted among the existing ones:
  buildup INTEGER, room_title INTEGER, reveal INTEGER, day_counter TEXT.
- effects.js `_cpeLoadFromDb` — PRAGMA table_info probe (the same one hold_sec already uses) and a
  0/NULL fallback in the SELECT, so a .db written by ANY earlier build still opens rather than
  throwing on a missing column and taking the whole path down over an optional field. Flags are only
  SET when the columns exist, so an old file keeps the consumer's own defaults instead of having
  `false` invented for it.
- Both §-lines now report the flags: a save that writes every feature off says so at save time
  instead of being discovered a bake later, and §CINEMA_PATH_RESTORE names flagCol=false explicitly
  on a pre-flag file rather than silently defaulting.

NOT changed: the IndexedDB working store (it already carried the flags — that is why the editor and
the `--plan NAME` route always looked right), the path geometry, the beat seconds, and the CLI's own
--buildup/--label/--reveal overrides, which still compose on top of whatever the path resolves to.

Witness: viewer/tests/witness_cpe_path_flags_portable.js — W-CPE-FLAGS 7/7, RED control detected.
Slices `_writeCinemaPathTable` and `_cpeLoadFromDb` out of the shipped scene.js/effects.js by brace
matching (never re-typed) and round-trips a real override through a real sql.js database:
  §CPE_PATH_FLAGS_ROW flags-on      flagCols=true  bands=2 total=61 buildup=true  roomTitle=true  reveal=true  dayCounter=bl
  §CPE_PATH_FLAGS_ROW flags-off     flagCols=true  bands=2 total=61 buildup=false roomTitle=false reveal=false dayCounter=undef
  §CPE_PATH_FLAGS_ROW legacy-14-col flagCols=false bands=2 total=61 buildup=undef roomTitle=undef  reveal=undef dayCounter=undef
The verdict line prints NO-OP / VACUOUS / INCONCLUSIVE rather than PASS when nothing was judged.

⚠ Existing .db files are NOT retro-fixed by this — HHS_Office_Federated_silent.db still has 14
columns and will still resolve every flag off until the path is re-saved from a build carrying this
change. The CLI's --buildup --label --reveal remain the way to bake an already-saved file with the
flags on.

sw v1134->v1135, scene.js?v=59->60, effects.js?v=32->33 in the same PR.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)