### PR TITLE
fix(cpe): §CPE_ROSTER_NOT_A_HIGHLIGHT — the Reveal slides are highlights only, not the last build-up card

### DIFF
--- a/viewer/cinema_maxq.js
+++ b/viewer/cinema_maxq.js
@@ -1707,7 +1707,32 @@
         if (!_inReveal) {
           if (_holdInfo) _resInfo = { info: _holdInfo, pos: _ovPos };   // round 1: hold, never rotate
         } else if (A.tailPanelAt) {
-          var _si = A.tailPanelAt(_bigCards, i / fps, _holdInfo);
+          // ══ §CPE_ROSTER_NOT_A_HIGHLIGHT (2026-09-04, user) ═══════════════════════════════════
+          // USER: "the last card during buildUP gives way to rotating slides highlights. But the
+          // last buildUp went along as part of the highlights. That slide of last buildup, drop
+          // that only. Let highlights be just highlights which are fine."
+          // §CPE_STATS_TAIL made the held crew roster ONE OF the revolving slots so that "nothing
+          // the panel used to say is lost to the cards". That reasoning was about round 1's
+          // content not vanishing — but the roster IS round 1: it is the build-up's last live
+          // composition, frozen. Carrying it into the Reveal rotation puts a build-up slide in
+          // among the finished-building highlights, which is the one thing the Reveal round exists
+          // to stop doing. The crew is not lost: it holds, un-rotated, for the whole of round 1
+          // (the `if (!_inReveal)` branch above), which is where it means something.
+          // `_holdInfo` is still COMPUTED above because round 1 needs it — only the Reveal round's
+          // rotation stops receiving it. Passing null makes tailPanelAt's own `hasRoster` false, so
+          // the rotation is the cards and nothing else; no new constant, no second boundary.
+          // ⚠ DEGRADE NOTE: with no cards built (§CPE_BIG_STATS INCONCLUSIVE — no source), the tail
+          // rotation is now EMPTY and the panel is omitted, where before the roster alone would
+          // have kept it on screen. That is the user's ruling ("just highlights"), and the §-line
+          // below names it rather than leaving a blank corner unexplained.
+          var _si = A.tailPanelAt(_bigCards, i / fps, null);
+          if (!A._statTailRosterLogged) {
+            A._statTailRosterLogged = true;
+            console.log('§CPE_ROSTER_NOT_A_HIGHLIGHT reveal rotation slots=' +
+              (_bigCards ? _bigCards.length : 0) + ' (cards only; the held build-up roster is NOT' +
+              ' one of them — it holds through round 1 instead)' +
+              (_bigCards && _bigCards.length ? '' : ' — NO CARDS: the tail panel is omitted entirely'));
+          }
           if (_si) {
             // §CPE_PIE_FLYOUT_DROP (2026-09-01, user: "during last fly out, the last pie is not
             // needed. Remove to give max space to the revolving highlights."): in the Reveal round
@@ -1715,8 +1740,9 @@
             // full panel width. The boundary is THIS branch's own _inReveal (topoutU / ops-frozen
             // degrade), no new constant, so the drop can never diverge from the rotation. Round 1
             // is untouched: §CPE_PIE_HOLD still owns every frame before the boundary. The crew is
-            // NOT lost — tailPanelAt above still receives _holdInfo, so the roster stays one of
-            // the revolving slots (§CPE_STATS_TAIL), now full-width like the cards.
+            // NOT lost — it holds, un-rotated, for the whole of round 1. (Until 2026-09-04 the
+            // roster also rode along as a revolving slot here; §CPE_ROSTER_NOT_A_HIGHLIGHT above
+            // removed it — a build-up slide is not a finished-building highlight.)
             _statInfo = { shown: _si, pos: _ovPos, held: null };
             A._statTailFrames = (A._statTailFrames || 0) + 1;
             if (!A._statTailLogged) {

--- a/viewer/sw.js
+++ b/viewer/sw.js
@@ -48,7 +48,11 @@
 // stored, so a path saved with Ctrl+S no longer travels with every feature silently OFF. Columns are
 // APPENDED and the reader PRAGMA-probes them, so old and new .db files open in both directions.
 // scene.js?v=59->60, effects.js?v=32->33.
-const CACHE_VERSION = 'v1135';   // bump on each deploy; per-change detail is the git commit message.
+// v1136 (2026-09-04) §CPE_ROSTER_NOT_A_HIGHLIGHT: the Reveal round's revolving rotation is the
+// stat cards ONLY. The held build-up crew roster is no longer one of the slots — it holds,
+// un-rotated, through round 1 where it means something. A build-up slide is not a finished-building
+// highlight (user ruling). cinema_maxq.js?v= bumped in viewer.html.
+const CACHE_VERSION = 'v1136';   // bump on each deploy; per-change detail is the git commit message.
 // v1128 (2026-09-02) §SUN_FILL_RATIO: viewer/effects.js — the Alt+S staging HDRI
 // (belfast_sunset_puresky_1k) was being pushed onto EVERY material by _reassertPhotoEnvMap, matte
 // concrete and plaster included. IBL is non-directional and is NOT shadow-map-occluded in three.js,

--- a/viewer/tests/witness_reveal_roster_not_highlight.js
+++ b/viewer/tests/witness_reveal_roster_not_highlight.js
@@ -1,0 +1,137 @@
+#!/usr/bin/env node
+// witness_reveal_roster_not_highlight.js — W-REVEAL-ROSTER
+//
+// ⚠ DO NOT REMOVE — SCOPE (bim-compiler prompts/CINEMA_PATH_EDITOR.md §CPE_ROSTER_NOT_A_HIGHLIGHT).
+// USER, 2026-09-04: "the last card during buildUP gives way to rotating slides highlights. But the
+// last buildUp went along as part of the highlights. That slide of last buildup, drop that only.
+// Let highlights be just highlights which are fine." Read the log after every run.
+//
+// THE ISSUE THIS PROVES OR DISPROVES: §CPE_STATS_TAIL put the HELD BUILD-UP ROSTER into the Reveal
+// round's revolving rotation as one of its slots. The roster is round 1's last live crew, frozen —
+// so a build-up slide was appearing among the finished-building highlights. This witness asserts
+// the Reveal rotation contains CARDS ONLY, over a full cycle, and that the shipped bake loop is the
+// thing that makes it so.
+//
+// Whitebox, no browser, no bake: `tailPanelAt` is SLICED OUT of the shipped cpe_resource_panel.js
+// by brace matching and driven directly; the bake's call site is read out of the shipped
+// cinema_maxq.js. Nothing is re-typed, so this cannot pass against a copy that is not what ships.
+'use strict';
+const fs = require('fs'), path = require('path'), vm = require('vm');
+const { Witness } = require(path.join(__dirname, '..', '..', 'witness_kit', 'contract.js'));
+
+const panelSrc = fs.readFileSync(path.join(__dirname, '..', 'cpe_resource_panel.js'), 'utf8');
+const maxqSrc = fs.readFileSync(path.join(__dirname, '..', 'cinema_maxq.js'), 'utf8');
+
+function sliceFn(src, marker) {
+  const i = src.indexOf(marker);
+  if (i < 0) return null;
+  let d = 0, open = false;
+  for (let j = i; j < src.length; j++) {
+    if (src[j] === '{') { d++; open = true; }
+    else if (src[j] === '}') { d--; if (open && d === 0) return src.slice(i, j + 1); }
+  }
+  return null;
+}
+const tailSrc = sliceFn(panelSrc, 'A.tailPanelAt = function');
+// CARD_SECONDS is the rotation's own period — READ it, never re-typed here.
+const cardSec = Number((panelSrc.match(/var CARD_SECONDS\s*=\s*([0-9.]+)/) || [])[1]);
+// The bake's Reveal call: what does it hand tailPanelAt as `info`?
+const callMatch = maxqSrc.match(/A\.tailPanelAt\(\s*_bigCards\s*,\s*i\s*\/\s*fps\s*,\s*([A-Za-z_$][\w$]*|null)\s*\)/);
+const callArg = callMatch ? callMatch[1] : null;
+
+// The nine real Hospital/HHS cards, taken verbatim from a real bake's own §CPE_BIG_STATS line.
+const CARDS = ['elements coordinated', 'disciplines federated', 'MEP elements resolved',
+  'MEP on Level 2', 'levels', 'day programme', 'peak workforce',
+  'labour cost committed', 'person-days of labour'].map(l => ({ big: '1', label: l }));
+// A real held roster, the shape resourcePanelHoldAt returns.
+const HELD = { rows: [{ trade: 'MASON', heads: 4 }, { trade: 'MEP', heads: 2 }], totalHeads: 6, heldFromDay: 133 };
+
+function tailFn() {
+  const A = {};
+  const sb = { A, Math, console: { log() {} } };
+  sb.CARD_SECONDS = cardSec;
+  vm.createContext(sb);
+  vm.runInContext('var CARD_SECONDS = ' + cardSec + ';\n' + tailSrc + ';', sb);
+  return A.tailPanelAt;
+}
+
+function population() {
+  if (!tailSrc || !cardSec || !callArg) return [];
+  const tail = tailFn();
+  // The shipped call passes `null`, so that is what the rotation is sampled with. Two full cycles,
+  // several samples per slot, so a roster appearing anywhere in the cycle cannot be missed.
+  const info = (callArg === 'null') ? null : HELD;
+  const rows = [];
+  const cycle = CARDS.length * cardSec;
+  const step = cardSec / 4;
+  for (let t = 0; t < cycle * 2; t += step) {
+    const s = tail(CARDS, t, info);
+    rows.push({
+      t: +t.toFixed(2),
+      kind: !s ? 'none' : (s.roster ? 'roster' : 'card'),
+      label: (s && s.card) ? s.card.label : (s && s.roster ? 'ROSTER' : ''),
+      slots: s ? s.n : 0,
+      callArg: callArg
+    });
+  }
+  return rows;
+}
+
+const schema = {
+  type: 'object',
+  required: ['t', 'kind', 'label', 'slots', 'callArg'],
+  properties: {
+    t: { type: 'number' }, kind: { type: 'string' }, label: { type: 'string' },
+    slots: { type: 'integer' }, callArg: { type: 'string' }
+  }
+};
+
+if (!tailSrc || !cardSec || !callArg) {
+  console.log('§WITNESS_REVEAL_ROSTER_VERDICT INCONCLUSIVE — could not read ' +
+    (!tailSrc ? 'tailPanelAt' : !cardSec ? 'CARD_SECONDS' : "cinema_maxq's tailPanelAt call") +
+    '; nothing judged');
+  process.exit(1);
+}
+
+const w = Witness('REVEAL_ROSTER_NOT_HIGHLIGHT')
+  .population(population)
+  .schema(schema)
+  // G1 — the defect: the build-up roster must never be one of the Reveal slides.
+  .invariant('no-roster-slide', rows => rows.every(r => r.kind !== 'roster'))
+  // G2 — the rotation is exactly the cards, not cards+1.
+  .invariant('slots-equal-cards', rows => rows.every(r => r.slots === CARDS.length))
+  // G3 — nothing else was lost with it: every card still gets its slot in a cycle.
+  .invariant('every-card-still-shown', rows => {
+    const seen = new Set(rows.filter(r => r.kind === 'card').map(r => r.label));
+    return CARDS.every(c => seen.has(c.label));
+  })
+  // G4 — it is the SHIPPED bake loop that makes it so, not this witness's own argument choice.
+  .invariant('bake-passes-null', rows => rows.every(r => r.callArg === 'null'))
+  // RED — the pre-fix bake: the held roster is handed in and takes slot 0 of every cycle.
+  .redControl(rows => {
+    const tail = tailFn();
+    return rows.map(r => {
+      const s = tail(CARDS, r.t, HELD);
+      return Object.assign({}, r, {
+        kind: !s ? 'none' : (s.roster ? 'roster' : 'card'),
+        label: (s && s.card) ? s.card.label : (s && s.roster ? 'ROSTER' : ''),
+        slots: s ? s.n : 0
+      });
+    });
+  });
+
+const res = w.run();
+const rows = population();
+const cardsSeen = new Set(rows.filter(r => r.kind === 'card').map(r => r.label));
+console.log('§REVEAL_ROSTER_ROTATION cards=' + CARDS.length + ' slots=' + (rows[0] ? rows[0].slots : 0) +
+  ' cardSec=' + cardSec + ' samples=' + rows.length + ' rosterSlides=' +
+  rows.filter(r => r.kind === 'roster').length + ' distinctCardsShown=' + cardsSeen.size +
+  ' bakeCallArg=' + callArg);
+const vacuous = rows.length === 0;
+const noop = rows.some(r => r.kind === 'roster');
+console.log('§WITNESS_REVEAL_ROSTER_VERDICT ' +
+  (vacuous ? 'VACUOUS — no rotation sampled'
+   : noop ? 'NO-OP — a roster slide is still in the rotation; the change is not in force'
+   : res.fail === 0 ? 'PASS' : 'FAIL') +
+  ' rows=' + rows.length + ' pass=' + res.pass + ' fail=' + res.fail);
+process.exit(res.fail === 0 && !vacuous && !noop ? 0 : 1);

--- a/viewer/viewer.html
+++ b/viewer/viewer.html
@@ -846,7 +846,7 @@ html.bim-embedded, html.bim-embedded body { background: #0b0b0b; }
 <script src="cinema_path_editor.js?v=15" onerror="console.warn('§LOAD_FAIL cinema_path_editor.js — Alt+C path editing disabled')"></script>
 <script src="cpe_walk.js?v=6" onerror="console.warn('§LOAD_FAIL cpe_walk.js — CPE walk-mode disabled')"></script>
 <script src="cpe_xr.js?v=1" onerror="console.warn('§LOAD_FAIL cpe_xr.js — VR entry disabled')"></script>
-<script src="cinema_maxq.js?v=9" onerror="console.warn('§LOAD_FAIL cinema_maxq.js — Alt+M MaxQ export disabled')"></script>
+<script src="cinema_maxq.js?v=10" onerror="console.warn('§LOAD_FAIL cinema_maxq.js — Alt+M MaxQ export disabled')"></script>
 <script src="input_registry.js?v=1" onerror="console.warn('§LOAD_FAIL input_registry.js')"></script>
 <script src="../common/pill_builder.js?v=1" onerror="console.warn('§LOAD_FAIL pill_builder.js')"></script>
 <script src="list_builder.js?v=1" onerror="console.warn('§LOAD_FAIL list_builder.js')"></script>


### PR DESCRIPTION
USER, 2026-09-04: "the last card during buildUP gives way to rotating slides highlights. But the
last buildUp went along as part of the highlights. That slide of last buildup, drop that only. Let
highlights be just highlights which are fine."

§CPE_STATS_TAIL built the Reveal rotation as [ roster ] + cards, reasoning that "nothing the panel
used to say is lost to the cards". That reasoning was about round 1's content not vanishing — but
the roster IS round 1: it is the build-up's last live crew composition, frozen by §CPE_PIE_HOLD.
Carrying it into the Reveal rotation put a build-up slide among the finished-building highlights,
which is the one thing the Reveal round exists to stop doing.

FIX: the bake's Reveal branch passes `null` where it passed `_holdInfo`, so tailPanelAt's own
`hasRoster` is false and the rotation is the cards and nothing else. No new constant, no second
boundary — the same `_inReveal` that already governs §CPE_PIE_FLYOUT_DROP. `_holdInfo` is still
COMPUTED, because round 1 still holds it un-rotated for every frame before the boundary; only the
Reveal rotation stops receiving it. The stale comment that claimed "the roster stays one of the
revolving slots" is corrected in place rather than left to mislead the next reader.

⚠ DEGRADE NOTE, logged not hidden: with no cards built (§CPE_BIG_STATS INCONCLUSIVE — no source),
the Reveal rotation is now EMPTY and the panel is omitted, where before the roster alone would have
kept it on screen. That is the ruling ("just highlights"), and §CPE_ROSTER_NOT_A_HIGHLIGHT names it
in the log rather than leaving an unexplained blank corner.

Witness: viewer/tests/witness_reveal_roster_not_highlight.js — W-REVEAL-ROSTER 7/7, RED control
detected. Slices tailPanelAt out of the shipped cpe_resource_panel.js by brace matching, reads
CARD_SECONDS from that file and the bake's own call argument out of the shipped cinema_maxq.js
(so the witness cannot pass by choosing its own argument), and samples two full cycles at four
samples per slot using the nine real cards from a live bake's §CPE_BIG_STATS line:
  §REVEAL_ROSTER_ROTATION cards=9 slots=9 cardSec=4.5 samples=72 rosterSlides=0
                          distinctCardsShown=9 bakeCallArg=null
The verdict prints NO-OP (a roster slide still in the rotation) / VACUOUS / INCONCLUSIVE rather
than PASS when nothing was judged. RED control hands the roster back in and G1 fails.

sw v1135->v1136, cinema_maxq.js?v=9->10 in the same PR.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)