### PR TITLE
feat(cli): §CLI_BAKE_FLAG_OVERRIDE — no argument means the saved path decides, and an override can now say OFF

### DIFF
--- a/cli_silent_bake.js
+++ b/cli_silent_bake.js
@@ -8,6 +8,9 @@
 //   node cli_silent_bake.js --db HospitalAjaibPath --out /tmp/hospital.mp4 \
 //     [--plan NAME | --override file.json]            path source (default: DB cinema_path table)
 //     [--buildup] [--label] [--reveal] [--day tr|tl|br|bl|off]   flags composed onto the path
+//     [--no-buildup] [--no-label] [--no-reveal]       turn a SAVED setting off for this run
+//   With no flag given, the path's OWN saved settings are used (§CPE_FLAGS_PORTABLE) — a path saved
+//   in the viewer bakes exactly as it was authored, with no arguments at all.
 //     [--frames N | --seconds S] [--fps N]            length (default: the plan's own pacing)
 //     [--gpu sw|real|headful] [--chrome-args "..."]   GPU mode (stage-3 feasibility decides)
 //     [--width W --height H] [--port P] [--log FILE] [--profile DIR]
@@ -38,10 +41,29 @@ const MAX_FRAME_MS = +arg('max-frame-ms', 0);              // 0 = off (stage 3 m
 const TIMEOUT_MIN = +arg('timeout-min', 300);
 const PLAN_NAME = arg('plan', null);
 const OV_FILE = arg('override', null);
+// ══ §CLI_BAKE_FLAG_OVERRIDE (2026-09-04, user) ═══════════════════════════════════════════════════
+// USER: "when user saves alt-c setting in path in the DB, during silent bake, user need not pass any
+// argument further and use the stored path settings. Of course user may still pass args to overwrite
+// those settings."
+// THREE STATES, not two. A flag left off the command line must stay UNDEFINED so the stored path's
+// own value survives the merge in cinema_maxq.js's __maxqBake (`if (o.flags[fk] !== undefined)`).
+// Setting it to `false` here would silently overwrite a saved `buildup=1` with off — which is what
+// "no argument passed" must never mean, now that §CPE_FLAGS_PORTABLE makes the saved value real.
+// The `--no-*` forms exist so an override can also turn something OFF: before them the command line
+// could only ever add features, so a path saved with reveal ON could not be baked without it.
+function triState(on, off) {
+  if (has(off)) return false;
+  if (has(on)) return true;
+  return undefined;      // absent — the stored path decides
+}
 const FLAGS = {};
-if (has('buildup')) FLAGS.buildup = true;
-if (has('label')) FLAGS.roomTitle = true;
-if (has('reveal')) FLAGS.reveal = true;
+const _fBuildup = triState('buildup', 'no-buildup');
+const _fLabel = triState('label', 'no-label');
+const _fReveal = triState('reveal', 'no-reveal');
+if (_fBuildup !== undefined) FLAGS.buildup = _fBuildup;
+if (_fLabel !== undefined) FLAGS.roomTitle = _fLabel;
+if (_fReveal !== undefined) FLAGS.reveal = _fReveal;
+// `--day off` is already the documented way to turn the counter off, so it needs no --no- form.
 if (arg('day', null)) FLAGS.dayCounter = arg('day');
 
 const logStream = fs.createWriteStream(LOG, { flags: 'w' });
@@ -185,7 +207,25 @@ const server = http.createServer((req, res) => {
 
   // buildup needs an existing schedule; a fresh profile has no gantt cache — run the SHIPPED
   // generation verb (same one a real Time Machine open runs) BEFORE the bake asks.
-  if (FLAGS.buildup) {
+  // §CLI_BAKE_FLAG_OVERRIDE — the gate must ask what the bake WILL ACTUALLY DO, not what the command
+  // line asked for. Since §CPE_FLAGS_PORTABLE the buildup can come from the saved path with no flag
+  // on the command line at all, and gating the prime on FLAGS.buildup alone meant such a run reached
+  // the bake with no timeline primed — the exact case the warning below exists for. Resolution order
+  // here MIRRORS __maxqBake's own merge (CLI wins, else the stored path), and the stored value is read
+  // through the SHIPPED lazy loader (`cinemaPathPlan` triggers `_cpeLoadFromDb`, then
+  // `_getCinemaPathEdit`) rather than a second reader — guarded on `a.db` for the same reason
+  // __maxqBake guards it: probing before the DB is open latches `_cpeLoaded` and blinds the session.
+  const willBuildup = await page.evaluate((f) => {
+    if (f.buildup !== undefined) return { on: !!f.buildup, src: 'cli' };
+    const a = window.APP;
+    if (!a || !a.db) return { on: false, src: 'no-db-yet' };
+    try { if (typeof a.cinemaPathPlan === 'function') a.cinemaPathPlan(60); } catch (e) {}
+    const st = (a._getCinemaPathEdit && a._getCinemaPathEdit()) || null;
+    return { on: !!(st && st.buildup), src: st ? 'stored-path' : 'no-stored-path' };
+  }, FLAGS);
+  log(`§CLI_BAKE_BUILDUP_RESOLVED on=${willBuildup.on ? 1 : 0} source=${willBuildup.src}` +
+      ' — decides whether the Time Machine is primed before the bake asks for a timeline');
+  if (willBuildup.on) {
     const tm = await page.evaluate(async () => {
       if (typeof window.tmActivateForBake !== 'function') return 'no-hook';
       const t0 = performance.now();

--- a/tests/witness_cli_bake_flag_override.js
+++ b/tests/witness_cli_bake_flag_override.js
@@ -1,0 +1,142 @@
+#!/usr/bin/env node
+// witness_cli_bake_flag_override.js — W-CLI-FLAGS
+//
+// ⚠ DO NOT REMOVE — SCOPE (bim-compiler prompts/CINEMA_PATH_EDITOR.md §CLI_BAKE_FLAG_OVERRIDE).
+// USER, 2026-09-04: "when user saves alt-c setting in path in the DB, during silent bake, user need
+// not pass any argument further and use the stored path settings. Of course user may still pass args
+// to overwrite those settings." Read the log after every run.
+//
+// THE ISSUE THIS PROVES OR DISPROVES: the command line must be THREE-state, not two. A flag left off
+// has to stay `undefined` so the saved path's own value survives __maxqBake's merge; forcing `false`
+// would silently overwrite a saved buildup=1 with off, which is exactly what "pass no argument" must
+// never mean. And an override has to be able to turn a saved setting OFF, which before --no-* it
+// could not — the command line could only ever ADD features.
+//
+// Whitebox, no browser, no bake: `triState` is SLICED OUT of the shipped cli_silent_bake.js by brace
+// matching and driven with real argv shapes; the merge rule and the prime gate are read out of the
+// shipped cinema_maxq.js / cli_silent_bake.js rather than restated here.
+'use strict';
+const fs = require('fs'), path = require('path'), vm = require('vm');
+const { Witness } = require(path.join(__dirname, '..', 'witness_kit', 'contract.js'));
+
+const cliSrc = fs.readFileSync(path.join(__dirname, '..', 'cli_silent_bake.js'), 'utf8');
+const maxqSrc = fs.readFileSync(path.join(__dirname, '..', 'viewer', 'cinema_maxq.js'), 'utf8');
+
+function sliceFn(src, marker) {
+  const i = src.indexOf(marker);
+  if (i < 0) return null;
+  let d = 0, open = false;
+  for (let j = i; j < src.length; j++) {
+    if (src[j] === '{') { d++; open = true; }
+    else if (src[j] === '}') { d--; if (open && d === 0) return src.slice(i, j + 1); }
+  }
+  return null;
+}
+const triSrc = sliceFn(cliSrc, 'function triState(');
+// __maxqBake must merge only DEFINED keys, or the tri-state is pointless downstream.
+const mergeGuard = /if \(o\.flags\[fk\] !== undefined\) ov\[fk\] = o\.flags\[fk\];/.test(maxqSrc);
+// The Time Machine prime must be gated on the RESOLVED answer, not on the raw CLI flag.
+const primeOnResolved = /if \(willBuildup\.on\) \{/.test(cliSrc) &&
+                        !/if \(FLAGS\.buildup\) \{/.test(cliSrc);
+
+function triFor(argvList) {
+  const sb = { argv: argvList, console: { log() {} } };
+  vm.createContext(sb);
+  vm.runInContext(
+    'function has(name) { return argv.indexOf("--" + name) >= 0; }\n' + triSrc +
+    '\nvar _r = { buildup: triState("buildup","no-buildup"), label: triState("label","no-label"),' +
+    ' reveal: triState("reveal","no-reveal") };', sb);
+  return sb._r;
+}
+function kind(v) { return v === undefined ? 'undef' : String(v); }
+
+// What the bake ends up with, applying the SHIPPED merge rule to a stored path.
+function merged(storedOn, cli) {
+  return cli === undefined ? storedOn : cli;
+}
+
+const CASES = [
+  { name: 'no-args-stored-on', argv: [], storedBuildup: true },
+  { name: 'no-args-stored-off', argv: [], storedBuildup: false },
+  { name: 'force-on-over-stored-off', argv: ['--buildup'], storedBuildup: false },
+  { name: 'force-off-over-stored-on', argv: ['--no-buildup'], storedBuildup: true },
+  { name: 'both-flags-off-wins', argv: ['--buildup', '--no-buildup'], storedBuildup: true }
+];
+
+function population() {
+  if (!triSrc) return [];
+  return CASES.map(c => {
+    const t = triFor(c.argv);
+    return {
+      scenario: c.name,
+      argv: c.argv.join(' ') || '(none)',
+      cliBuildup: kind(t.buildup),
+      cliLabel: kind(t.label),
+      cliReveal: kind(t.reveal),
+      storedBuildup: c.storedBuildup,
+      effectiveBuildup: !!merged(c.storedBuildup, t.buildup),
+      mergeGuard: mergeGuard,
+      primeOnResolved: primeOnResolved
+    };
+  });
+}
+
+const schema = {
+  type: 'object',
+  required: ['scenario', 'argv', 'cliBuildup', 'cliLabel', 'cliReveal', 'storedBuildup',
+             'effectiveBuildup', 'mergeGuard', 'primeOnResolved'],
+  properties: {
+    scenario: { type: 'string' }, argv: { type: 'string' }, cliBuildup: { type: 'string' },
+    cliLabel: { type: 'string' }, cliReveal: { type: 'string' }, storedBuildup: { type: 'boolean' },
+    effectiveBuildup: { type: 'boolean' }, mergeGuard: { type: 'boolean' },
+    primeOnResolved: { type: 'boolean' }
+  }
+};
+
+if (!triSrc) {
+  console.log('§WITNESS_CLI_BAKE_FLAGS_VERDICT INCONCLUSIVE — could not slice triState out of ' +
+    'cli_silent_bake.js; nothing judged');
+  process.exit(1);
+}
+
+const w = Witness('CLI_BAKE_FLAG_OVERRIDE')
+  .population(population)
+  .schema(schema)
+  // G1 — the user's headline: no arguments at all means the saved path decides, either way.
+  .invariant('absent-flag-defers-to-stored', rows => rows
+    .filter(r => r.argv === '(none)')
+    .every(r => r.cliBuildup === 'undef' && r.effectiveBuildup === r.storedBuildup))
+  // G2 — an override can still turn a feature ON over a saved off.
+  .invariant('cli-can-force-on', rows => {
+    const r = rows.find(x => x.scenario === 'force-on-over-stored-off');
+    return !!r && r.cliBuildup === 'true' && r.effectiveBuildup === true;
+  })
+  // G3 — and OFF over a saved on, which was impossible before --no-*.
+  .invariant('cli-can-force-off', rows => {
+    const r = rows.find(x => x.scenario === 'force-off-over-stored-on');
+    return !!r && r.cliBuildup === 'false' && r.effectiveBuildup === false;
+  })
+  // G4 — the tri-state only means anything if the shipped merge skips undefined keys.
+  .invariant('shipped-merge-skips-undefined', rows => rows.every(r => r.mergeGuard === true))
+  // G5 — the Time Machine prime follows the RESOLVED answer, so a stored-path buildup is primed
+  // even with no flag on the command line (the case that reached a bake with no timeline).
+  .invariant('prime-gated-on-resolved', rows => rows.every(r => r.primeOnResolved === true))
+  // RED — the pre-fix two-state parse: absent means false, and off is unreachable.
+  .redControl(rows => rows.map(r => Object.assign({}, r, {
+    cliBuildup: r.cliBuildup === 'true' ? 'true' : 'false',
+    effectiveBuildup: r.cliBuildup === 'true',
+    primeOnResolved: false
+  })));
+
+const res = w.run();
+const rows = population();
+rows.forEach(r => console.log('§CLI_BAKE_FLAGS_ROW ' + r.scenario + ' argv="' + r.argv +
+  '" cli.buildup=' + r.cliBuildup + ' stored=' + r.storedBuildup + ' effective=' + r.effectiveBuildup));
+console.log('§CLI_BAKE_FLAGS_WIRING mergeGuardPresent=' + mergeGuard + ' primeGatedOnResolved=' + primeOnResolved);
+const noop = rows.every(r => r.cliBuildup !== 'undef');
+console.log('§WITNESS_CLI_BAKE_FLAGS_VERDICT ' +
+  (rows.length === 0 ? 'VACUOUS — no case judged'
+   : noop ? 'NO-OP — no case ever produced an undefined flag; the tri-state is not in force'
+   : res.fail === 0 ? 'PASS' : 'FAIL') +
+  ' rows=' + rows.length + ' pass=' + res.pass + ' fail=' + res.fail);
+process.exit(res.fail === 0 && rows.length > 0 && !noop ? 0 : 1);


### PR DESCRIPTION
USER, 2026-09-04: "when user saves alt-c setting in path in the DB, during silent bake, user need not
pass any argument further and use the stored path settings. Of course user may still pass args to
overwrite those settings."

The first half already worked as of §CPE_FLAGS_PORTABLE (#1645) and is proven live on the user's own
re-saved Hospital DB, baking with no flags at all:

  §CINEMA_PATH_RESTORE bands=4 total=278.8s holdCol=true flagCol=true buildup=1 roomTitle=1 reveal=1 dayCounter=tl
  §CLI_BAKE_RESOLVED source=db:cinema_path bands=4 total=278.8s buildup=1 roomTitle=1 reveal=1 dayCounter=tl

Two real gaps in the second half:

1. THE COMMAND LINE COULD ONLY EVER ADD FEATURES. `--buildup/--label/--reveal` set true; there was no
   way to say false, so a path saved with reveal ON could not be baked without it — an "override" that
   only works in one direction. Added `--no-buildup`, `--no-label`, `--no-reveal`. (`--day off` already
   covered the counter, so it needs no --no- form.) The parse is now genuinely THREE-state via a
   `triState()` helper: absent stays `undefined` so __maxqBake's own merge
   (`if (o.flags[fk] !== undefined)`) leaves the stored value alone. Writing `false` for an absent flag
   would silently overwrite a saved buildup=1 with off — the exact thing "pass no argument" must never
   mean now that the saved value is real.

2. THE TIME MACHINE PRIME ASKED THE WRONG QUESTION — a real defect, found by reading the running
   Hospital bake's log. The prime that gives the bake a timeline was gated on `FLAGS.buildup`, i.e. on
   the COMMAND LINE. Since #1645 the buildup can come from the saved path with no flag passed, and
   such a run reached the bake with no prime — the case the block's own warning ("buildup will be
   skipped by the bake (no timeline)") exists for. It is now gated on a RESOLVED answer that mirrors
   __maxqBake's merge order (CLI wins, else the stored path), read through the SHIPPED lazy loader
   (`cinemaPathPlan` triggers `_cpeLoadFromDb`, then `_getCinemaPathEdit`) and guarded on `a.db` for
   the same reason __maxqBake guards it — probing before the DB is open latches `_cpeLoaded` and
   blinds the session. New line names the source:
     §CLI_BAKE_BUILDUP_RESOLVED on=1 source=stored-path
   NOT A CRISIS on the current run: the Hospital bake in flight has a schedule already in its DB, so
   cinema_maxq's own silent load covered it (§TIME_MACHINE ON — 63415 ops, 309 days). The gap bites a
   building whose DB carries a saved path with buildup ON but no schedule yet.

Witness: tests/witness_cli_bake_flag_override.js — W-CLI-FLAGS 8/8, RED control detected. Slices
`triState` out of the shipped cli_silent_bake.js by brace matching and reads BOTH wiring facts out of
the shipped sources rather than restating them — __maxqBake's undefined-skipping merge, and that the
prime is gated on the resolved answer and no longer on FLAGS.buildup:
  §CLI_BAKE_FLAGS_ROW no-args-stored-on        argv="(none)"                cli.buildup=undef stored=true  effective=true
  §CLI_BAKE_FLAGS_ROW no-args-stored-off       argv="(none)"                cli.buildup=undef stored=false effective=false
  §CLI_BAKE_FLAGS_ROW force-on-over-stored-off argv="--buildup"             cli.buildup=true  stored=false effective=true
  §CLI_BAKE_FLAGS_ROW force-off-over-stored-on argv="--no-buildup"          cli.buildup=false stored=true  effective=false
  §CLI_BAKE_FLAGS_ROW both-flags-off-wins      argv="--buildup --no-buildup" cli.buildup=false stored=true effective=false
  §CLI_BAKE_FLAGS_WIRING mergeGuardPresent=true primeGatedOnResolved=true
Verdict prints NO-OP / VACUOUS / INCONCLUSIVE rather than PASS when nothing was judged.

No sw bump: cli_silent_bake.js and tests/ are not served assets.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)