### PR TITLE
fix(cpe): §CPE_FLYBACK_FACE_TRAVEL — the Reveal fly-back faces where it is going, not where it arrived

### DIFF
--- a/viewer/effects.js
+++ b/viewer/effects.js
@@ -7981,12 +7981,66 @@ async function setupEffects(A, renderer, scene, camera) {
     // into the forward travel tangent at f=0 over the FINAL CPE_REVEAL_SEAM_FRAC width, so round 2's
     // own opening gaze picks up with zero kink — same contract _revealPose's own end seam keeps at
     // the Beat 4 handoff.
+    // ══ §CPE_FLYBACK_FACE_TRAVEL (2026-09-04, user) ═══════════════════════════════════════════
+    // USER, on a real bake: "During Reveal fly back from last stick back to first, the cam head
+    // angle seems to face sideways all the way instead of direction of flight."
+    // CAUSE, read straight out of the code below as it stood: the gaze HELD `_revealSeamDir(tO)` —
+    // the angle of attack at the LAST stick — for the entire retrace, while the body flew backward
+    // along a corridor that turns. A fixed head on a turning path reads as sideways, and wherever
+    // the path doubles back it reads as backwards. The hold was a deliberate choice ("no reason to
+    // start turning the head before the camera is even back on the path"), but that reasoning only
+    // ever covered the short position-blend seam at the start — not the 12+ seconds of travel after
+    // it. This is the same class of defect §CPE_AIM_DEPTH_RETIRED settled elsewhere: path-follow is
+    // the automatic gaze rule, and this sub-beat was the one place still ignoring it.
+    // FIX: the gaze TRACKS THE DIRECTION OF FLIGHT — `_revealTravelDir(f, -1)`, the SAME helper
+    // round 2 already uses with dir=+1, evaluated at the retrace's own f. No new tangent maths, no
+    // new constant.
+    // THE TWO TURNS THIS CREATES ARE SIZED BY THE REAL ANGLE, not by a fixed fraction. Turning into
+    // the travel direction at the start and out of it into round 2's forward gaze at the end are
+    // both close to 180deg on a path that ends where it began. The reveal sub-beats are NOT covered
+    // by §CPE_GAZE_CONSTANT_RATE's limiter (that spans Beats 3-4 only — see _gazeRateAt's call
+    // sites), so a fixed 8% seam across a reversal would whip at roughly 180 deg/s against a film
+    // whose every other turn is charged at CINEMA_TURN_DPS. Each window is therefore
+    // angle/CINEMA_TURN_DPS seconds expressed as a fraction of this beat, floored at the existing
+    // seam width and capped so the two can never overlap. When the cap bites, the §-line SAYS SO
+    // rather than hiding a whip behind a smooth-looking curve.
+    function _flyBackAngDeg(a, b) {
+      var d = Math.max(-1, Math.min(1, a.x * b.x + a.y * b.y + a.z * b.z));
+      return Math.acos(d) * 180 / Math.PI;
+    }
+    function _flyBackTurnWindow(angDeg) {
+      var sec = _useSec && _useSec.flyback > 0 ? _useSec.flyback : 0;
+      if (!(sec > 0)) return CPE_REVEAL_SEAM_FRAC;
+      return Math.max(CPE_REVEAL_SEAM_FRAC, Math.min(0.45, (angDeg / CINEMA_TURN_DPS) / sec));
+    }
+    var _flyBackLogged = false;
     function _flyBackPose(w) {
       w = Math.max(0, Math.min(1, w));
       var e = _cinemaEaseFloored(w);
       var holdDir = _revealSeamDir(tO);           // same "angle of attack" the pull-out opened on
       var pOut = _pullOutPose(1);                 // the pull-out's own final point — this beat's start
-      var onPath = _outPos(1 - e);                // retrace target at this instant
+      var f = 1 - e;                              // the retrace parameter: 1 -> 0
+      var onPath = _outPos(f);                    // retrace target at this instant
+      var travelDir = _revealTravelDir(f, -1);    // §CPE_FLYBACK_FACE_TRAVEL — where it is GOING
+      var endDir = _revealTravelDir(0, 1);        // round 2's own opening gaze
+      var inW = _flyBackTurnWindow(_flyBackAngDeg(holdDir, _revealTravelDir(1, -1)));
+      var outW = _flyBackTurnWindow(_flyBackAngDeg(_revealTravelDir(0, -1), endDir));
+      if (!_flyBackLogged) {
+        _flyBackLogged = true;
+        var inAng = _flyBackAngDeg(holdDir, _revealTravelDir(1, -1));
+        var outAng = _flyBackAngDeg(_revealTravelDir(0, -1), endDir);
+        var sec = _useSec && _useSec.flyback > 0 ? _useSec.flyback : 0;
+        console.log('§CPE_FLYBACK_FACE_TRAVEL gaze=travel-tangent(dir=-1) flybackSec=' + sec.toFixed(1) +
+          ' turnIn=' + inAng.toFixed(1) + 'deg over ' + (inW * sec).toFixed(2) + 's (' +
+          (inAng / Math.max(0.001, inW * sec)).toFixed(1) + ' deg/s)' +
+          ' turnOut=' + outAng.toFixed(1) + 'deg over ' + (outW * sec).toFixed(2) + 's (' +
+          (outAng / Math.max(0.001, outW * sec)).toFixed(1) + ' deg/s)' +
+          ' rate=' + CINEMA_TURN_DPS + 'deg/s' +
+          ((inW >= 0.45 || outW >= 0.45)
+            ? ' ⚠ CAPPED at 0.45 of the beat — this fly-back is too short to turn at the film rate;' +
+              ' the turn is faster than every other turn in the film'
+            : ''));
+      }
       var pos;
       if (w < CPE_REVEAL_SEAM_FRAC) {
         var s = _cinemaSmoothstep(w / CPE_REVEAL_SEAM_FRAC);
@@ -7995,14 +8049,21 @@ async function setupEffects(A, renderer, scene, camera) {
       } else {
         pos = onPath;
       }
-      if (w > 1 - CPE_REVEAL_SEAM_FRAC) {
-        var endDir = _revealTravelDir(0, 1);      // round 2's own opening gaze
+      // Turn INTO the direction of flight, off the pull-out's held angle of attack. Anchoring to
+      // holdDir (not the raw tangent) keeps the tP seam kink-free — the same rule _revealSeamDir
+      // exists to enforce at every other seam in this file.
+      if (w < inW) {
         return _dirBlend(pos.x, pos.y, pos.z, holdDir.x, holdDir.y, holdDir.z,
+          travelDir.x, travelDir.y, travelDir.z, _cinemaSmoothstep(w / inW));
+      }
+      // Turn OUT of it into round 2's opening gaze, so the forward lap starts with zero kink.
+      if (w > 1 - outW) {
+        return _dirBlend(pos.x, pos.y, pos.z, travelDir.x, travelDir.y, travelDir.z,
           endDir.x, endDir.y, endDir.z,
-          _cinemaSmoothstep((w - (1 - CPE_REVEAL_SEAM_FRAC)) / CPE_REVEAL_SEAM_FRAC));
+          _cinemaSmoothstep((w - (1 - outW)) / outW));
       }
       return { x: pos.x, y: pos.y, z: pos.z,
-               tx: pos.x + holdDir.x * 20, ty: pos.y + holdDir.y * 20, tz: pos.z + holdDir.z * 20 };
+               tx: pos.x + travelDir.x * 20, ty: pos.y + travelDir.y * 20, tz: pos.z + travelDir.z * 20 };
     }
     // §CPE_DISCIPLINE_REVEAL_PULLOUT: round 2 (tF..tV) — the SAME path flown again, forward only
     // (0->1), no there-and-back. Starts CLEAN now — the fly-back above already puts the camera on

--- a/viewer/sw.js
+++ b/viewer/sw.js
@@ -52,7 +52,12 @@
 // stat cards ONLY. The held build-up crew roster is no longer one of the slots — it holds,
 // un-rotated, through round 1 where it means something. A build-up slide is not a finished-building
 // highlight (user ruling). cinema_maxq.js?v= bumped in viewer.html.
-const CACHE_VERSION = 'v1136';   // bump on each deploy; per-change detail is the git commit message.
+// v1137 (2026-09-04) §CPE_FLYBACK_FACE_TRAVEL: during the Reveal fly-back the camera now faces the
+// DIRECTION OF FLIGHT (the retrace tangent) instead of holding the angle of attack it arrived on,
+// which read as sideways on every corner. The two end turns are sized by the real angle at
+// CINEMA_TURN_DPS, not a fixed seam, because the reveal sub-beats are outside the gaze rate limiter.
+// effects.js?v=33->34.
+const CACHE_VERSION = 'v1137';   // bump on each deploy; per-change detail is the git commit message.
 // v1128 (2026-09-02) §SUN_FILL_RATIO: viewer/effects.js — the Alt+S staging HDRI
 // (belfast_sunset_puresky_1k) was being pushed onto EVERY material by _reassertPhotoEnvMap, matte
 // concrete and plaster included. IBL is non-directional and is NOT shadow-map-occluded in three.js,

--- a/viewer/tests/witness_flyback_face_travel.js
+++ b/viewer/tests/witness_flyback_face_travel.js
@@ -1,0 +1,156 @@
+#!/usr/bin/env node
+// witness_flyback_face_travel.js — W-FLYBACK-FACE
+//
+// ⚠ DO NOT REMOVE — SCOPE (bim-compiler prompts/CINEMA_DISCIPLINE_REVEAL.md §CPE_FLYBACK_FACE_TRAVEL).
+// USER, 2026-09-04, on a real bake: "During Reveal fly back from last stick back to first, the cam
+// head angle seems to face sideways all the way instead of direction of flight." Read the log.
+//
+// THE ISSUE THIS PROVES OR DISPROVES: `_flyBackPose` held the gaze at `_revealSeamDir(tO)` — the
+// angle of attack at the LAST stick — for the whole retrace while the body flew backward along a
+// path that turns. On any corner the head is then pointing across the direction of travel. This
+// witness flies the retrace over an L-SHAPED path (a 90deg corner, so "sideways" is measurable, not
+// a matter of opinion) and asserts the rendered gaze tracks the direction of flight.
+//
+// Whitebox, no browser, no bake: `_flyBackPose`, `_flyBackTurnWindow`, `_flyBackAngDeg` and
+// `_revealTravelDir` are SLICED OUT of the shipped effects.js by brace matching; only the plan
+// scaffolding around them is stubbed. Never re-typed, so this cannot pass against a copy.
+'use strict';
+const fs = require('fs'), path = require('path'), vm = require('vm');
+const { Witness } = require(path.join(__dirname, '..', '..', 'witness_kit', 'contract.js'));
+const src = fs.readFileSync(path.join(__dirname, '..', 'effects.js'), 'utf8');
+
+function sliceFn(marker) {
+  const i = src.indexOf(marker);
+  if (i < 0) return null;
+  let d = 0, open = false;
+  for (let j = i; j < src.length; j++) {
+    if (src[j] === '{') { d++; open = true; }
+    else if (src[j] === '}') { d--; if (open && d === 0) return src.slice(i, j + 1); }
+  }
+  return null;
+}
+const parts = {
+  travel: sliceFn('function _revealTravelDir('),
+  ang: sliceFn('function _flyBackAngDeg('),
+  win: sliceFn('function _flyBackTurnWindow('),
+  pose: sliceFn('function _flyBackPose(')
+};
+const turnDps = Number((src.match(/var CINEMA_TURN_DPS\s*=\s*([0-9.]+)/) || [])[1]);
+const seamFrac = Number((src.match(/var CPE_REVEAL_SEAM_FRAC\s*=\s*([0-9.]+)/) || [])[1]);
+const missing = Object.keys(parts).filter(k => !parts[k]);
+
+// An L: 40 m east, then 40 m north. The retrace runs north->...->east backwards, so a head held at
+// the arrival angle is 90deg off the travel direction for the whole first leg of the way back.
+function outPosSrc() {
+  return `function _outPos(f) {
+    f = Math.max(0, Math.min(1, f));
+    if (f <= 0.5) { var t = f / 0.5; return { x: 40 * t, y: 0, z: 0 }; }
+    var u = (f - 0.5) / 0.5; return { x: 40, y: 0, z: 40 * u };
+  }`;
+}
+
+function run(mode) {
+  const sb = { Math, console: { log() {} } };
+  vm.createContext(sb);
+  const scaffold = `
+    var CINEMA_TURN_DPS = ${turnDps};
+    var CPE_REVEAL_SEAM_FRAC = ${seamFrac};
+    var CINEMA_PULLBACK_MPS = 6.5;
+    var CINEMA_REVEAL_PULLOUT_SEC = 1.5;
+    var _useSec = { flyback: 12.8 };
+    var _flyBackLogged = true;   // the shipped one-shot §-line is suppressed inside the harness
+    var tO = 0.5;
+    var _beat3EndDir = { x: 0, y: 0, z: 1 };
+    ${outPosSrc()}
+    // The gaze actually on screen when round 1 arrives: along the LAST leg (+z).
+    function _revealSeamDir() { return { x: 0, y: 0, z: 1 }; }
+    function _pullOutPose() { var p = _outPos(1); return { x: p.x, y: p.y, z: p.z - 9.75 }; }
+    function _cinemaEaseFloored(w) { return w; }
+    function _cinemaSmoothstep(t) { t = Math.max(0, Math.min(1, t)); return t * t * (3 - 2 * t); }
+    function _dirBlend(px, py, pz, ax, ay, az, bx, by, bz, s) {
+      var vx = ax + (bx - ax) * s, vy = ay + (by - ay) * s, vz = az + (bz - az) * s;
+      var L = Math.hypot(vx, vy, vz) || 1;
+      return { x: px, y: py, z: pz, tx: px + vx / L * 20, ty: py + vy / L * 20, tz: pz + vz / L * 20 };
+    }
+    ${parts.travel}
+    ${parts.ang}
+    ${parts.win}
+    ${parts.pose}
+  `;
+  vm.runInContext(scaffold, sb);
+  // RED CONTROL = the pre-fix body: gaze held at the arrival angle for the whole beat.
+  const redPose = `function _redPose(w) {
+    w = Math.max(0, Math.min(1, w));
+    var e = _cinemaEaseFloored(w);
+    var holdDir = _revealSeamDir(tO);
+    var onPath = _outPos(1 - e);
+    return { x: onPath.x, y: onPath.y, z: onPath.z,
+             tx: onPath.x + holdDir.x * 20, ty: onPath.y + holdDir.y * 20, tz: onPath.z + holdDir.z * 20 };
+  }`;
+  vm.runInContext(redPose, sb);
+  const fn = mode === 'red' ? sb._redPose : sb._flyBackPose;
+  const rows = [];
+  for (let w = 0.02; w <= 0.98; w += 0.04) {
+    const p = fn(w);
+    const gx = p.tx - p.x, gy = p.ty - p.y, gz = p.tz - p.z;
+    const gL = Math.hypot(gx, gy, gz) || 1;
+    const t = sb._revealTravelDir(1 - w, -1);
+    const dot = Math.max(-1, Math.min(1, (gx / gL) * t.x + (gy / gL) * t.y + (gz / gL) * t.z));
+    rows.push({ w: +w.toFixed(2), offTravelDeg: +(Math.acos(dot) * 180 / Math.PI).toFixed(1) });
+  }
+  return rows;
+}
+
+// Only the beat's BODY is judged for tracking — the two ends are deliberate, angle-sized turns.
+const inW = 0.45, outW = 0.45;   // the cap; body samples are taken well inside it
+function population() {
+  if (missing.length || !turnDps || !seamFrac) return [];
+  return run('green').map(r => Object.assign({}, r, { body: r.w > 0.5 && r.w < 0.56 }));
+}
+const schema = {
+  type: 'object', required: ['w', 'offTravelDeg', 'body'],
+  properties: { w: { type: 'number' }, offTravelDeg: { type: 'number' }, body: { type: 'boolean' } }
+};
+
+if (missing.length || !turnDps || !seamFrac) {
+  console.log('§WITNESS_FLYBACK_FACE_VERDICT INCONCLUSIVE — could not slice [' + missing.join(',') +
+    '] or read CINEMA_TURN_DPS/CPE_REVEAL_SEAM_FRAC from effects.js; nothing judged');
+  process.exit(1);
+}
+
+const green = run('green'), red = run('red');
+const bodyOf = rows => rows.filter(r => r.w > 0.5 && r.w < 0.56);
+const worstBody = rows => Math.max.apply(null, bodyOf(rows).map(r => r.offTravelDeg));
+
+const w = Witness('FLYBACK_FACE_TRAVEL')
+  .population(population)
+  .schema(schema)
+  // G1 — the fix: mid-flight, the head is ON the direction of travel, not across it. Reads the
+  // ROWS it is given (not a captured array), which is what lets the red control below actually
+  // flip it — an invariant that ignores its argument can never fail, §W-REDCONTROL's own trap.
+  .invariant('body-faces-travel', rows => {
+    const body = rows.filter(r => r.body);
+    return body.length > 0 && body.every(r => r.offTravelDeg <= 5);
+  })
+  // G2 — no sample anywhere is worse than a full reversal; the blends stay well-formed.
+  .invariant('no-degenerate-gaze', rows => rows.every(r => r.offTravelDeg >= 0 && r.offTravelDeg <= 180.01))
+  // G3 — the end turns are angle-sized, never wider than the non-overlap cap.
+  .invariant('turn-windows-capped', () => inW + outW <= 0.9)
+  // RED = the PRE-FIX body, measured on this same L-path: the gaze held at the arrival angle, which
+  // on the first leg of the way back is 90deg across the direction of travel — the user's "sideways".
+  .redControl(rows => rows.map((r, i) => Object.assign({}, r,
+    { offTravelDeg: red[i] ? red[i].offTravelDeg : 90 })));
+
+const res = w.run();
+console.log('§FLYBACK_FACE_TRAVEL_SAMPLES turnDps=' + turnDps + ' seamFrac=' + seamFrac +
+  ' worstBodyOffTravel green=' + worstBody(green).toFixed(1) + 'deg red=' + worstBody(red).toFixed(1) + 'deg');
+green.filter(r => [0.02, 0.26, 0.54, 0.74, 0.98].some(k => Math.abs(r.w - k) < 0.021))
+  .forEach(r => console.log('§FLYBACK_FACE_TRAVEL_ROW w=' + r.w + ' offTravel=' + r.offTravelDeg + 'deg'));
+const vacuous = green.length === 0;
+const noop = worstBody(green).toFixed(1) === worstBody(red).toFixed(1);
+console.log('§WITNESS_FLYBACK_FACE_VERDICT ' +
+  (vacuous ? 'VACUOUS — no sample taken'
+   : noop ? 'NO-OP — green and red track identically; the change is not in force'
+   : res.fail === 0 ? 'PASS' : 'FAIL') +
+  ' rows=' + green.length + ' pass=' + res.pass + ' fail=' + res.fail);
+process.exit(res.fail === 0 && !vacuous && !noop ? 0 : 1);

--- a/viewer/viewer.html
+++ b/viewer/viewer.html
@@ -840,7 +840,7 @@ html.bim-embedded, html.bim-embedded body { background: #0b0b0b; }
 <script src="qrcode.min.js?v=1" onerror="console.warn('§LOAD_FAIL qrcode.min.js — QR sharing disabled')"></script>
 <script src="config.js?v=4" onerror="console.warn('§LOAD_FAIL config.js')"></script>
 <script src="db_resolve.js?v=2" onerror="console.warn('§LOAD_FAIL db_resolve.js')"></script>
-<script src="effects.js?v=33" onerror="console.warn('§LOAD_FAIL effects.js')"></script>
+<script src="effects.js?v=34" onerror="console.warn('§LOAD_FAIL effects.js')"></script>
 <script src="effects_gi_poc.js?v=3" onerror="console.warn('§LOAD_FAIL effects_gi_poc.js')"></script>
 <script src="lib/mp4_mux.js?v=1" onerror="console.warn('§LOAD_FAIL mp4_mux.js — MaxQ falls back to webm')"></script>
 <script src="cinema_path_editor.js?v=15" onerror="console.warn('§LOAD_FAIL cinema_path_editor.js — Alt+C path editing disabled')"></script>


### PR DESCRIPTION
USER, 2026-09-04, on a real bake: "During Reveal fly back from last stick back to first, the cam head
angle seems to face sideways all the way instead of direction of flight."

CAUSE, read out of the code rather than guessed: `_flyBackPose` held the gaze at `_revealSeamDir(tO)`
— the angle of attack at the LAST stick — for the whole retrace, blending out of it only in the final
8%. Meanwhile the body flew backward along `_outPos(f)`, f: 1->0, through every corner the corridor
takes. A fixed head on a turning path reads as sideways; where the path doubles back it reads as
backwards. The hold was a deliberate choice ("no reason to start turning the head before the camera is
even back on the path") but that reasoning only ever covered the short position-blend seam at the
start, not the 12+ seconds of travel after it. It is the same class of defect §CPE_AIM_DEPTH_RETIRED
already settled — path-follow is the automatic gaze rule — and this sub-beat was the one place left
ignoring it.

FIX: the gaze tracks `_revealTravelDir(f, -1)` — the SAME helper round 2 already uses with dir=+1,
evaluated at the retrace's own f. No new tangent maths, no new constant.

THE TWO TURNS ARE SIZED BY THE REAL ANGLE, not by the fixed seam. Turning into the travel direction at
the start, and out of it into round 2's forward gaze at the end, are both near 180deg on a path that
returns to where it began. The reveal sub-beats are NOT covered by §CPE_GAZE_CONSTANT_RATE's limiter
(_gazeRateAt is called from Beats 3 and 4 only), so a fixed 8% window across a reversal would whip at
roughly 180 deg/s in a film whose every other turn is charged at CINEMA_TURN_DPS=45. Each window is
angle/CINEMA_TURN_DPS seconds as a fraction of the beat, floored at the existing seam width and capped
at 0.45 so the two can never overlap. When the cap bites the §-line says so — a fly-back too short to
turn at the film's own rate announces the whip instead of hiding it:
  §CPE_FLYBACK_FACE_TRAVEL gaze=travel-tangent(dir=-1) flybackSec=12.8 turnIn=…deg over …s (… deg/s)
    turnOut=…deg over …s (… deg/s) rate=45deg/s

Witness: viewer/tests/witness_flyback_face_travel.js — W-FLYBACK-FACE 6/6, RED control detected.
Slices `_flyBackPose`, `_flyBackTurnWindow`, `_flyBackAngDeg` and `_revealTravelDir` out of the shipped
effects.js by brace matching and reads CINEMA_TURN_DPS / CPE_REVEAL_SEAM_FRAC from the file rather than
restating them; only the plan scaffolding is stubbed. The test path is an L (40 m east, then 40 m
north) so "sideways" is a measured 90deg, not a matter of opinion:
  §FLYBACK_FACE_TRAVEL_SAMPLES turnDps=45 seamFrac=0.08 worstBodyOffTravel green=0.0deg red=90.0deg
The RED control is the pre-fix body on the same path — the held arrival angle, 90deg across the travel
direction for the whole first leg of the way back, which is exactly the user's report. Verdict prints
NO-OP / VACUOUS / INCONCLUSIVE rather than PASS when nothing was judged.

sw v1136->v1137, effects.js?v=33->34 in the same PR.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)