### PR TITLE
fix(cpe): §CPE_TAIL_LIGHTS_ALL_ONLY — the lamps come on for the all-together slot, not for each discipline

### DIFF
--- a/viewer/cinema_maxq.js
+++ b/viewer/cinema_maxq.js
@@ -1559,6 +1559,19 @@
         // loop makes (cinema_path_editor.js's _previewFly) so bake and preview cannot diverge. No-op
         // (returns immediately, does nothing) when reveal is off or tNorm is outside the round.
         if (A.cpeRevealApplyVisual) A.cpeRevealApplyVisual(plan, _tn);
+        // §CPE_TAIL_LIGHTS_ALL_ONLY (2026-09-04, user: "during last part each DISCipline reveal, the
+        // lights are all turned ON that obscures the delicate items scene. Should turn on only during
+        // ALL DISCs"). Set BEFORE _applyPhotoStaging runs for this frame — staging is what turns the
+        // night lights on and rebuilds the glow, so the flag has to be in place when it does, not
+        // after. The answer comes from effects.js's own pure phase function, never re-derived here:
+        // the bake, the editor preview and the witness all read the same one.
+        A._cpeRevealLightsOff = A.cpeRevealLightsOffAt ? A.cpeRevealLightsOffAt(plan, _tn) : false;
+        if (A._cpeRevealLightsOff !== A._cpeRevealLightsOffLast) {
+          A._cpeRevealLightsOffLast = A._cpeRevealLightsOff;
+          console.log('§CPE_TAIL_LIGHTS_ALL_ONLY frame=' + i + '/' + nFrames + ' lights=' +
+            (A._cpeRevealLightsOff ? 'OFF (one-discipline slot — the trade reads on its own)'
+                                   : 'ON (not a one-discipline slot)'));
+        }
         A.startStillRefine();
         // §SUN_ARC_STOMP_FIX (found live, 2026-08-11 — user report "not high noon" on a real
         // HHS_Office_Federated bake): startStillRefine() calls _applyPhotoStaging() synchronously,

--- a/viewer/effects.js
+++ b/viewer/effects.js
@@ -4516,6 +4516,18 @@ async function setupEffects(A, renderer, scene, camera) {
 
   function _glowOn(filterFn) {
     if (!A._glowSpriteEnabled || _glowPoints) return;
+    // §CPE_TAIL_LIGHTS_ALL_ONLY — the lamps' own glow is part of "the lights are all turned ON", so
+    // it goes with the illumination rather than being left burning over a dark room. Checked here,
+    // after the already-staged guard above, so a slot that turns the lights off tears the existing
+    // sprites down through the normal _glowOff path (the caller below) instead of leaving them lit.
+    if (A._cpeRevealLightsOff) {
+      if (!A._cpeTailGlowLogged) {
+        A._cpeTailGlowLogged = true;
+        console.log('§CPE_TAIL_LIGHTS_ALL_ONLY glow suppressed for the one-discipline slots' +
+          ' — the lamps come back for the all-together slot');
+      }
+      return;
+    }
     if (typeof A._nightFixtureWorldPositions !== 'function') return;
     if (A._tmOverlayRegister) A._tmOverlayRegister();   // idempotent — ensures window.__tmOverlaySync exists even without a billboard nameplate
     var allPos = A._nightFixtureWorldPositions();
@@ -4919,6 +4931,12 @@ async function setupEffects(A, renderer, scene, camera) {
       A._nightMaxLights = A._nightMaxLightsStill;
       A._nightNearFadeFloor = A._nightNearFadeFloorStill;   // §NIGHT_NEAR_FADE — no proximity penalty
       A._nightPLScale = A._nightPLScaleStill || 1;          // §STAGED_PL_CUT — staging-only intensity cut
+      // §CPE_TAIL_LIGHTS_ALL_ONLY — a 'tail-one' slot is lit by the room, not by the lamps. Scale 0
+      // rather than a pool teardown on purpose: §NIGHT_BAKE_POOL froze the point-light COUNT for the
+      // whole bake precisely because changing it recompiles every shader in the scene (13-53 s per
+      // frame, measured), and an intensity is a uniform. Same reason the pool's own unused slots
+      // ride at 0 instead of being removed.
+      if (A._cpeRevealLightsOff) A._nightPLScale = 0;
       A._nightUpdateLights();
       // §VAC V2 / §R14.1: MEASURED s5_hospital.log — 2,026 firings, ONE distinct line
       // (`raised to 200 lights, near-fade floor 1 …`). The re-raise itself is required every
@@ -5673,6 +5691,22 @@ async function setupEffects(A, renderer, scene, camera) {
   // actually changed since the last tick — cheap to call every frame.
   A._cpeRevealSavedHidden = null;
   A._cpeRevealVisualKey = null;
+  // ══ §CPE_TAIL_LIGHTS_ALL_ONLY (2026-09-04, user) ═══════════════════════════════════════════════
+  // USER, on a real bake: "during last part each DISCipline reveal, the lights are all turned ON that
+  // obscures the delicate items scene. Should turn on only during ALL DISCs."
+  // The disc parade shows ONE discipline at a time ('tail-one'), and the whole point of those slots
+  // is to read a single trade's delicate geometry on its own. The staged luminaires were lit through
+  // all of it — and the fixtures doing the lighting are themselves hidden by filterDiscs on every
+  // slot that is not their own, so the room was being washed out by lamps that were not even on
+  // screen. The final all-together slot ('tail-all') is where a lit building is the point.
+  // ONE pure function, so the bake, the preview and the witness cannot hold different opinions about
+  // which slots are lit — same "one pure function, two callers" discipline cpeRevealVisualAt keeps.
+  // Everything OUTSIDE the tail (round 1, pull-out, fly-back, round 2, rise proper) is unchanged:
+  // null phase means "not the parade", and the lights stay exactly as they were.
+  A.cpeRevealLightsOffAt = function(plan, tNorm) {
+    var st = (plan && A.cpeRevealVisualAt) ? A.cpeRevealVisualAt(plan, tNorm) : null;
+    return !!(st && st.phase === 'tail-one');
+  };
   A.cpeRevealApplyVisual = function(plan, tNorm) {
     if (typeof A.filterDiscs !== 'function' || !A.hiddenDiscs) return;
     var st = plan ? A.cpeRevealVisualAt(plan, tNorm) : null;

--- a/viewer/sw.js
+++ b/viewer/sw.js
@@ -57,7 +57,12 @@
 // which read as sideways on every corner. The two end turns are sized by the real angle at
 // CINEMA_TURN_DPS, not a fixed seam, because the reveal sub-beats are outside the gaze rate limiter.
 // effects.js?v=33->34.
-const CACHE_VERSION = 'v1137';   // bump on each deploy; per-change detail is the git commit message.
+// v1138 (2026-09-04) §CPE_TAIL_LIGHTS_ALL_ONLY: during the disc parade's ONE-DISCIPLINE slots the
+// staged luminaires and their glow are OFF — the trade's delicate geometry reads on its own instead
+// of being washed out by lamps that filterDiscs has hidden anyway. The all-together slot keeps its
+// lights. Illumination is scaled to 0 rather than torn down, because §NIGHT_BAKE_POOL froze the
+// point-light COUNT for the whole bake on purpose. effects.js?v=34->35, cinema_maxq.js?v=10->11.
+const CACHE_VERSION = 'v1138';   // bump on each deploy; per-change detail is the git commit message.
 // v1128 (2026-09-02) §SUN_FILL_RATIO: viewer/effects.js — the Alt+S staging HDRI
 // (belfast_sunset_puresky_1k) was being pushed onto EVERY material by _reassertPhotoEnvMap, matte
 // concrete and plaster included. IBL is non-directional and is NOT shadow-map-occluded in three.js,

--- a/viewer/tests/witness_tail_lights_all_discs.js
+++ b/viewer/tests/witness_tail_lights_all_discs.js
@@ -1,0 +1,134 @@
+#!/usr/bin/env node
+// witness_tail_lights_all_discs.js — W-TAIL-LIGHTS
+//
+// ⚠ DO NOT REMOVE — SCOPE (bim-compiler prompts/CINEMA_DISCIPLINE_REVEAL.md §CPE_TAIL_LIGHTS_ALL_ONLY).
+// USER, 2026-09-04, on a real bake: "during last part each DISCipline reveal, the lights are all
+// turned ON that obscures the delicate items scene. Should turn on only during ALL DISCs."
+// Read the log after every run.
+//
+// THE ISSUE THIS PROVES OR DISPROVES: the disc parade's one-at-a-time slots ('tail-one') exist to
+// read a single trade's delicate geometry on its own, but the staged luminaires burned through all
+// of them — and filterDiscs hides the very fixtures doing the lighting on every slot that is not
+// their own, so the room was washed out by lamps that were not even on screen. Lights belong to the
+// final all-together slot ('tail-all'). This witness asserts exactly that mapping, over every phase
+// the reveal produces, and that the bake actually honours it.
+//
+// Whitebox, no browser, no bake: `cpeRevealLightsOffAt` and `cpeRevealVisualAt` are SLICED OUT of
+// the shipped effects.js by brace matching and driven against a real plan shape; the three wiring
+// facts are read out of the shipped sources rather than restated here.
+'use strict';
+const fs = require('fs'), path = require('path'), vm = require('vm');
+const { Witness } = require(path.join(__dirname, '..', '..', 'witness_kit', 'contract.js'));
+const fx = fs.readFileSync(path.join(__dirname, '..', 'effects.js'), 'utf8');
+const mq = fs.readFileSync(path.join(__dirname, '..', 'cinema_maxq.js'), 'utf8');
+
+function sliceAssign(src, marker) {
+  const i = src.indexOf(marker);
+  if (i < 0) return null;
+  let d = 0, open = false;
+  for (let j = i; j < src.length; j++) {
+    if (src[j] === '{') { d++; open = true; }
+    else if (src[j] === '}') { d--; if (open && d === 0) return src.slice(i, j + 1) + ';'; }
+  }
+  return null;
+}
+const visSrc = sliceAssign(fx, 'A.cpeRevealVisualAt = function');
+const offSrc = sliceAssign(fx, 'A.cpeRevealLightsOffAt = function');
+const fadeSec = Number((fx.match(/CPE_REVEAL_FADE_SEC\s*=\s*([0-9.]+)/) || [])[1]) || 0;
+
+// WIRING, read from the shipped files — the mapping is worthless if nothing acts on it.
+const wirePL = /if \(A\._cpeRevealLightsOff\) A\._nightPLScale = 0;/.test(fx);
+const wireGlow = /function _glowOn\(filterFn\)[\s\S]{0,900}?if \(A\._cpeRevealLightsOff\) \{/.test(fx);
+const iFlag = mq.indexOf('A._cpeRevealLightsOff = A.cpeRevealLightsOffAt');
+const iStage = mq.indexOf('A.startStillRefine();', iFlag > 0 ? iFlag : 0);
+const wireOrder = iFlag > 0 && iStage > iFlag;   // the flag must be set BEFORE staging rebuilds lights
+
+const PLAN = {
+  beats: { dive: 0.05, spin: 0.1, out: 0.40, pullout: 0.45, flyback: 0.55, reveal: 0.80, rise: 0.95 },
+  reveal: { discs: ['MEP', 'PLUMBING', 'FIRE'], pulloutSec: 1.5, roundSec: 36.1,
+            tailSec: 8, riseSec: 4, qtyCost: {} }
+};
+
+function ctx() {
+  const A = {};
+  const sb = { A, Math, console: { log() {} } };
+  sb.CPE_REVEAL_FADE_SEC = fadeSec;
+  vm.createContext(sb);
+  vm.runInContext('var CPE_REVEAL_FADE_SEC = ' + fadeSec + ';\n' + visSrc + '\n' + offSrc, sb);
+  return A;
+}
+
+function population() {
+  if (!visSrc || !offSrc) return [];
+  const A = ctx();
+  const rows = [];
+  for (let t = 0; t <= 1.0001; t += 0.005) {
+    const tn = +t.toFixed(4);
+    const st = A.cpeRevealVisualAt(PLAN, tn);
+    rows.push({
+      t: tn,
+      phase: st ? st.phase : 'none',
+      nDiscs: st && st.discs ? st.discs.length : 0,
+      lightsOff: !!A.cpeRevealLightsOffAt(PLAN, tn),
+      wirePL, wireGlow, wireOrder
+    });
+  }
+  return rows;
+}
+
+const schema = {
+  type: 'object', required: ['t', 'phase', 'nDiscs', 'lightsOff', 'wirePL', 'wireGlow', 'wireOrder'],
+  properties: {
+    t: { type: 'number' }, phase: { type: 'string' }, nDiscs: { type: 'integer' },
+    lightsOff: { type: 'boolean' }, wirePL: { type: 'boolean' },
+    wireGlow: { type: 'boolean' }, wireOrder: { type: 'boolean' }
+  }
+};
+
+if (!visSrc || !offSrc) {
+  console.log('§WITNESS_TAIL_LIGHTS_VERDICT INCONCLUSIVE — could not slice ' +
+    (!visSrc ? 'cpeRevealVisualAt' : 'cpeRevealLightsOffAt') + ' out of effects.js; nothing judged');
+  process.exit(1);
+}
+
+const w = Witness('TAIL_LIGHTS_ALL_ONLY')
+  .population(population)
+  .schema(schema)
+  // G1 — the ruling, exactly: dark for a one-discipline slot, lit everywhere else.
+  .invariant('off-iff-tail-one', rows => rows.every(r => r.lightsOff === (r.phase === 'tail-one')))
+  // G2 — the all-together slot KEEPS its lights; that is the slot a lit building is the point of.
+  .invariant('tail-all-stays-lit', rows => {
+    const all = rows.filter(r => r.phase === 'tail-all');
+    return all.length > 0 && all.every(r => r.lightsOff === false);
+  })
+  // G3 — nothing outside the parade changed: round 1, pull-out, fly-back, round 2 and rise proper
+  // are all still lit, so this cannot have darkened the film at large.
+  .invariant('outside-parade-untouched', rows =>
+    rows.filter(r => r.phase !== 'tail-one').every(r => r.lightsOff === false))
+  // G4 — the parade actually happened in this population, so G1-G3 are not passing over nothing.
+  .invariant('parade-was-exercised', rows =>
+    rows.some(r => r.phase === 'tail-one') && rows.some(r => r.phase === 'tail-all'))
+  // G5 — the mapping is HONOURED: illumination and glow both read the flag, and the bake sets it
+  // before staging rebuilds the lights. A pure function nothing acts on would pass G1 and change
+  // nothing on screen.
+  .invariant('wired-into-the-bake', rows => rows.every(r => r.wirePL && r.wireGlow && r.wireOrder))
+  // RED — the pre-fix behaviour: the lamps burn through every slot.
+  .redControl(rows => rows.map(r => Object.assign({}, r, { lightsOff: false })));
+
+const res = w.run();
+const rows = population();
+const byPhase = {};
+rows.forEach(r => { byPhase[r.phase] = byPhase[r.phase] || { n: 0, off: 0 };
+  byPhase[r.phase].n++; if (r.lightsOff) byPhase[r.phase].off++; });
+Object.keys(byPhase).forEach(k => console.log('§TAIL_LIGHTS_PHASE phase=' + k +
+  ' samples=' + byPhase[k].n + ' lightsOff=' + byPhase[k].off));
+console.log('§TAIL_LIGHTS_WIRING plScaleZeroed=' + wirePL + ' glowSuppressed=' + wireGlow +
+  ' flagSetBeforeStaging=' + wireOrder);
+const vacuous = rows.length === 0;
+const noop = rows.every(r => !r.lightsOff);
+console.log('§WITNESS_TAIL_LIGHTS_VERDICT ' +
+  (vacuous ? 'VACUOUS — no phase sampled'
+   : noop ? 'NO-OP — no slot ever turns the lights off; the rule is not in force'
+   : res.fail === 0 ? 'PASS' : 'FAIL') +
+  ' rows=' + rows.length + ' pass=' + res.pass + ' fail=' + res.fail);
+process.exit(res.fail === 0 && !vacuous && !noop ? 0 : 1);

--- a/viewer/viewer.html
+++ b/viewer/viewer.html
@@ -840,13 +840,13 @@ html.bim-embedded, html.bim-embedded body { background: #0b0b0b; }
 <script src="qrcode.min.js?v=1" onerror="console.warn('§LOAD_FAIL qrcode.min.js — QR sharing disabled')"></script>
 <script src="config.js?v=4" onerror="console.warn('§LOAD_FAIL config.js')"></script>
 <script src="db_resolve.js?v=2" onerror="console.warn('§LOAD_FAIL db_resolve.js')"></script>
-<script src="effects.js?v=34" onerror="console.warn('§LOAD_FAIL effects.js')"></script>
+<script src="effects.js?v=35" onerror="console.warn('§LOAD_FAIL effects.js')"></script>
 <script src="effects_gi_poc.js?v=3" onerror="console.warn('§LOAD_FAIL effects_gi_poc.js')"></script>
 <script src="lib/mp4_mux.js?v=1" onerror="console.warn('§LOAD_FAIL mp4_mux.js — MaxQ falls back to webm')"></script>
 <script src="cinema_path_editor.js?v=15" onerror="console.warn('§LOAD_FAIL cinema_path_editor.js — Alt+C path editing disabled')"></script>
 <script src="cpe_walk.js?v=6" onerror="console.warn('§LOAD_FAIL cpe_walk.js — CPE walk-mode disabled')"></script>
 <script src="cpe_xr.js?v=1" onerror="console.warn('§LOAD_FAIL cpe_xr.js — VR entry disabled')"></script>
-<script src="cinema_maxq.js?v=10" onerror="console.warn('§LOAD_FAIL cinema_maxq.js — Alt+M MaxQ export disabled')"></script>
+<script src="cinema_maxq.js?v=11" onerror="console.warn('§LOAD_FAIL cinema_maxq.js — Alt+M MaxQ export disabled')"></script>
 <script src="input_registry.js?v=1" onerror="console.warn('§LOAD_FAIL input_registry.js')"></script>
 <script src="../common/pill_builder.js?v=1" onerror="console.warn('§LOAD_FAIL pill_builder.js')"></script>
 <script src="list_builder.js?v=1" onerror="console.warn('§LOAD_FAIL list_builder.js')"></script>


### PR DESCRIPTION
USER, 2026-09-04, on a real bake: "during last part each DISCipline reveal, the lights are all turned
ON that obscures the delicate items scene. Should turn on only during ALL DISCs."

The disc parade's one-at-a-time slots ('tail-one') exist to read a single trade's delicate geometry on
its own. The staged luminaires burned through all of them — and the fixtures doing that lighting are
themselves hidden by filterDiscs on every slot that is not their own, so the room was being washed out
by lamps that were not even on screen. The final all-together slot ('tail-all') is where a lit building
is the point.

ONE PURE FUNCTION decides it — `A.cpeRevealLightsOffAt(plan, tNorm)`, sitting beside cpeRevealVisualAt
and reading its phase, so the bake, the editor preview and the witness cannot hold different opinions
about which slots are lit. Everything OUTSIDE the parade is untouched: round 1, the pull-out, the
fly-back, round 2 and the rise proper all keep their lights, because a null phase means "not the
parade".

TWO HONOUR POINTS, both in effects.js:
- illumination — `A._nightPLScale = 0` for the slot. Scale 0 rather than a pool teardown ON PURPOSE:
  §NIGHT_BAKE_POOL froze the point-light COUNT for the whole bake precisely because changing it
  recompiles every shader in the scene (13-53 s per frame, measured), and an intensity is a uniform.
  Same reason that pool's own unused slots ride at 0 instead of being removed.
- the lamps' own glow — `_glowOn` returns early, after its already-staged guard, so a slot that turns
  the lights off tears the existing sprites down through the normal per-frame teardown rather than
  leaving them burning over a dark room.

The bake sets the flag BEFORE `startStillRefine()` (cinema_maxq.js:1568 vs :1575) because staging is
what turns the night lights on and rebuilds the glow — the flag has to be in place when it runs, not
after. A one-line §CPE_TAIL_LIGHTS_ALL_ONLY logs each transition, not each frame.

Witness: viewer/tests/witness_tail_lights_all_discs.js — W-TAIL-LIGHTS 8/8, RED control detected.
Slices `cpeRevealVisualAt` and `cpeRevealLightsOffAt` out of the shipped effects.js by brace matching,
sweeps tNorm across a real plan shape at 0.005, and READS THE THREE WIRING FACTS out of the shipped
sources rather than restating them — a pure function nothing acts on would satisfy the mapping and
change nothing on screen:
  §TAIL_LIGHTS_PHASE phase=none     samples=132 lightsOff=0
  §TAIL_LIGHTS_PHASE phase=ghost    samples=50  lightsOff=0
  §TAIL_LIGHTS_PHASE phase=tail-one samples=14  lightsOff=14
  §TAIL_LIGHTS_PHASE phase=tail-all samples=5   lightsOff=0
  §TAIL_LIGHTS_WIRING plScaleZeroed=true glowSuppressed=true flagSetBeforeStaging=true
Verdict prints NO-OP / VACUOUS / INCONCLUSIVE rather than PASS when nothing was judged.

sw v1137->v1138, effects.js?v=34->35, cinema_maxq.js?v=10->11 in the same PR.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)