### PR TITLE
feat(cli): §CLI_BAKE_PROGRESS + §CLI_BAKE_LAND_ON_ABORT — frame/ETA while it runs, and Ctrl-C lands the film

### DIFF
--- a/cli_silent_bake.js
+++ b/cli_silent_bake.js
@@ -16,6 +16,10 @@
 //     [--width W --height H] [--port P] [--log FILE] [--profile DIR]
 //     [--stall-min N] [--max-frame-ms N]              health watchdog (abort early, not at the end)
 //     [--timeout-min N]                               hard wall-clock cap
+//     [--progress-every-sec N] [--abort-land-min N]   progress cadence (30) / abort landing cap (10)
+//
+//   PROGRESS + ETA print as §CLI_BAKE_PROGRESS while the bake runs. Ctrl-C (SIGINT) aborts CLEANLY:
+//   the frames baked so far are stitched and delivered to --out. Press it twice to give up on that.
 'use strict';
 const fs = require('fs'), path = require('path'), http = require('http');
 const { execFileSync } = require('child_process');
@@ -66,6 +70,16 @@ if (_fReveal !== undefined) FLAGS.reveal = _fReveal;
 // `--day off` is already the documented way to turn the counter off, so it needs no --no- form.
 if (arg('day', null)) FLAGS.dayCounter = arg('day');
 
+// §CLI_BAKE_PROGRESS / §CLI_BAKE_LAND_ON_ABORT — how often the progress line prints, and how long an
+// abort is allowed to spend landing the partial film before the runner gives up on it.
+const PROGRESS_EVERY_MS = +arg('progress-every-sec', 30) * 1000;
+const ABORT_LAND_MIN = +arg('abort-land-min', 10);
+const RATE_WINDOW = 10;   // §CLI_BAKE_PROGRESS — trailing samples the ETA rate is measured over
+function fmtDur(ms) {
+  const t = Math.max(0, Math.round(ms / 1000));
+  const h = Math.floor(t / 3600), m = Math.floor((t % 3600) / 60), sec = t % 60;
+  return (h ? h + 'h' : '') + (h || m ? m + 'm' : '') + sec + 's';
+}
 const logStream = fs.createWriteStream(LOG, { flags: 'w' });
 function log(line) { const s = new Date().toISOString().slice(11, 19) + ' ' + line; logStream.write(s + '\n'); console.log(s); }
 function logRaw(line) { logStream.write(line + '\n'); }   // full console firehose → file only
@@ -121,8 +135,27 @@ const server = http.createServer((req, res) => {
   await page.setViewport({ width: W, height: H });
 
   // console firehose → log file; §-lines also drive the health watchdog + summary
-  const S = { frames: 0, lastProgress: Date.now(), perFrame: [], fatal: null, done: false,
-              claims: {}, heap: [] };
+  const S = { frames: 0, total: 0, elapsedMs: 0, lastProgress: Date.now(), perFrame: [], fatal: null,
+              done: false, claims: {}, heap: [], abortRequested: null, lastProgressLog: 0, rateHist: [] };
+  // ══ §CLI_BAKE_LAND_ON_ABORT — Ctrl-C is the abort switch, and it LANDS the film ════════════════
+  // USER, 2026-09-04: "an abort switch where the frames to date are landed." A plain Ctrl-C killed
+  // node outright, taking the browser and every baked frame with it — even though cinema_maxq's
+  // cancel path stitches whatever it has. The handler turns the signal into the SAME cancel the
+  // stall/timeout watchdogs already use, so there is ONE abort path, not a second one to keep in
+  // step. A second Ctrl-C is honoured immediately: an operator who has changed their mind about
+  // waiting for a 2,000-frame encode must never be trapped by the graceful path.
+  let sigCount = 0;
+  ['SIGINT', 'SIGTERM'].forEach(sig => process.on(sig, () => {
+    sigCount++;
+    if (sigCount === 1) {
+      S.abortRequested = `user (${sig}) — landing the ${S.frames} frames baked so far`;
+      log(`§CLI_BAKE_SIGINT ${sig} received at frame ${S.frames}/${S.total || '?'}` +
+          ' — cancelling the bake and stitching what exists. Press again to give up on the partial film.');
+    } else {
+      log(`§CLI_BAKE_SIGINT ${sig} again — abandoning the partial film, exiting now`);
+      process.exit(130);
+    }
+  }));
   const CLAIM_RX = /§(PHOTO_PREWARM|CPE_STATS_TAIL|CPE_PIE_HOLD|MAXQ_FRAME_BUDGET|MAXQ_MP4_FALLBACK|MAXQ_DONE|MAXQ_QUALITY|MAXQ_DELIVERED|CLI_BAKE_RESOLVED|MAXQ_OVERRIDE_IN|MAXQ_START|MAXQ_START_REVISED|CPE_APPLIED|CINEMA_PATH_RESTORE|CPE_BUILDUP_TOPOUT|CPE_BUILDUP_SKIP|MAXQ_HDRI_RACE|MAXQ_STREAM_WAIT|CPE_REVEAL)\b/;
   page.on('console', m => {
     const t = m.text();
@@ -131,7 +164,15 @@ const server = http.createServer((req, res) => {
     if (mm) { (S.claims[mm[1]] = S.claims[mm[1]] || []).push(t); }
     if (/§MAXQ_FRAME i=|§CPE_BUILDUP frame=|§MAXQ_STREAM|warming up|§MAXQ_MP4 |§MAXQ_STITCH|§MAXQ_IDB_READY/.test(t)) S.lastProgress = Date.now();
     const fm = t.match(/§MAXQ_FRAME i=(\d+)\/(\d+) elapsedMs=(\d+) perFrameMs=(\d+)/);
-    if (fm) { S.frames = +fm[1]; S.perFrame.push(+fm[4]);
+    if (fm) { S.frames = +fm[1]; S.total = +fm[2]; S.elapsedMs = +fm[3]; S.perFrame.push(+fm[4]);
+      // §CLI_BAKE_PROGRESS — a short trailing window of (frame, elapsed) so the ETA is priced at the
+      // rate the bake is running NOW, not its cumulative average. MEASURED on the 2,937-frame
+      // Hospital bake of 2026-09-04 (true total 45.9 min): the cumulative average predicted 38.3 min
+      // at 28% because early frames are light and the buildup gets heavier as the model fills in;
+      // the trailing window over the same sample predicts 42.6 min. The first ~25% is optimistic
+      // either way and the progress line says so rather than implying a precision it does not have.
+      S.rateHist.push([+fm[1], +fm[3]]);
+      if (S.rateHist.length > RATE_WINDOW) S.rateHist.shift();
       if (MAX_FRAME_MS && +fm[4] > MAX_FRAME_MS) S.fatal = `perFrameMs ${fm[4]} > --max-frame-ms ${MAX_FRAME_MS}: ${t}`; }
     if (/§MAXQ_FAIL|§MAXQ_GL_LOST|§MAXQ_IDB_LOST|§CPE_BUILDUP_SKIP/.test(t)) log('⚠ ' + t);
     if (/§MAXQ_FAIL/.test(t)) S.fatal = t;
@@ -267,14 +308,59 @@ const server = http.createServer((req, res) => {
     result = await page.evaluate(() => window.__bakeResult).catch(() => null);
     if (result) break;
     const mins = (Date.now() - t0) / 60000;
+    // ══ §CLI_BAKE_PROGRESS (2026-09-04, user: "will the CLI show frame in progress and ETA?") ═════
+    // The runner already parsed §MAXQ_FRAME for its stall watchdog and threw the numbers away. A bake
+    // is tens of minutes with nothing on screen; "is it moving, and how long more" should not require
+    // tailing the log and doing the arithmetic by hand. Rate comes from the VIEWER's own elapsedMs /
+    // frame index, not from wall clock here, so load, streaming and the Time Machine prime are not
+    // charged to the per-frame rate — the ETA is about the frames that are left, which is the
+    // question being asked. Throttled to PROGRESS_EVERY_MS so a 40-minute bake logs ~80 lines, not
+    // thousands; §MAXQ_FRAME itself already fires roughly every 8 frames in the raw log.
+    if (S.frames > 0 && S.total > 0 && Date.now() - S.lastProgressLog >= PROGRESS_EVERY_MS) {
+      S.lastProgressLog = Date.now();
+      const h = S.rateHist;
+      const win = (h.length >= 2 && h[h.length - 1][0] > h[0][0])
+        ? (h[h.length - 1][1] - h[0][1]) / (h[h.length - 1][0] - h[0][0])
+        : null;
+      const rate = win != null ? win : S.elapsedMs / Math.max(1, S.frames);
+      const left = Math.max(0, S.total - S.frames);
+      const pct = 100 * S.frames / S.total;
+      log(`§CLI_BAKE_PROGRESS frame=${S.frames}/${S.total} ${pct.toFixed(1)}%` +
+          ` rate=${(rate / 1000).toFixed(3)}s/frame (${win != null ? 'trailing ' + h.length : 'cumulative'})` +
+          ` elapsed=${fmtDur(S.elapsedMs)} eta=${fmtDur(left * rate)} (${left} frames left)` +
+          (pct < 25 ? ' — early estimate runs LOW; frames get heavier as the model fills in' : ''));
+    }
+    if (S.abortRequested) { aborted = S.abortRequested; break; }
     if (S.fatal) { aborted = 'fatal: ' + S.fatal; break; }
     if ((Date.now() - S.lastProgress) / 60000 > STALL_MIN) { aborted = `stall: no progress line for ${STALL_MIN} min (last frame=${S.frames})`; break; }
     if (mins > TIMEOUT_MIN) { aborted = `timeout: ${TIMEOUT_MIN} min wall-clock cap`; break; }
   }
   clearInterval(heapIv);
   if (aborted) {
+    // ══ §CLI_BAKE_LAND_ON_ABORT (2026-09-04, user: "an abort switch where the frames to date are
+    // landed") — cinema_maxq's own cancel path ALREADY stitches what it has whenever at least one
+    // second of footage exists (`framesDone >= (_cancel ? fps : 1)`), so the film is not thrown away
+    // by cancelling. What was missing here is the WAIT: this used to sleep a flat 10 s, which is
+    // nowhere near enough to encode two thousand frames, so the process tore down mid-stitch and the
+    // partial film was lost anyway — the exact thing the viewer had gone to the trouble of saving.
+    // Now it waits for the bake's own promise to settle (delivery included), bounded, and says which
+    // it got. The bound is generous because an abort at frame 2,000 has a real encode ahead of it.
     log(`§CLI_BAKE_ABORT ${aborted}`);
-    try { await page.evaluate(() => window.APP.cancelMaxQualityOrbit()); await new Promise(r => setTimeout(r, 10000)); } catch (e) {}
+    try {
+      await page.evaluate(() => window.APP.cancelMaxQualityOrbit());
+      const landT0 = Date.now();
+      let landed = null;
+      while ((Date.now() - landT0) / 60000 < ABORT_LAND_MIN) {
+        await new Promise(r => setTimeout(r, 2000));
+        landed = await page.evaluate(() => window.__bakeResult).catch(() => null);
+        if (landed) break;
+      }
+      const bytes = await page.evaluate(() => window.__maxqDeliveredBytes || 0).catch(() => 0);
+      log(`§CLI_BAKE_LANDED framesAtAbort=${S.frames} settled=${landed ? 'yes' : 'NO (still encoding when the ' +
+          ABORT_LAND_MIN + '-min landing cap ran out)'} deliveredBytes=${bytes}` +
+          (bytes ? ' — the frames baked so far ARE in the output file' :
+                   ' — nothing delivered; too few frames, or the encode did not finish'));
+    } catch (e) { log('§CLI_BAKE_LAND_FAIL ' + e.message); }
   } else {
     log(`§CLI_BAKE_RESULT ${JSON.stringify(result)}`);
   }

--- a/tests/witness_cli_bake_progress.js
+++ b/tests/witness_cli_bake_progress.js
@@ -1,0 +1,123 @@
+#!/usr/bin/env node
+// witness_cli_bake_progress.js — W-CLI-PROGRESS
+//
+// ⚠ DO NOT REMOVE — SCOPE (bim-compiler prompts/CINEMA_PATH_EDITOR.md §CLI_BAKE_PROGRESS).
+// USER, 2026-09-04: "when user does silent bake will the CLI shows frame in progress and ETA? And an
+// abort switch where the frames to date are landed." Read the log after every run.
+//
+// THE ISSUE THIS PROVES OR DISPROVES: the runner parsed §MAXQ_FRAME for its stall watchdog and threw
+// the numbers away, so a 47-minute bake showed nothing about how far along it was; and the abort path
+// cancelled and then slept a FLAT 10 s, nowhere near enough to encode two thousand frames, so the
+// partial film cinema_maxq had deliberately stitched was lost anyway.
+//
+// Whitebox, no browser, no bake: `fmtDur` is SLICED OUT of the shipped cli_silent_bake.js by brace
+// matching, the ETA is computed by the shipped formula, and it is replayed against the REAL frame
+// sequence of the 2,937-frame Hospital bake of 2026-09-04 (whose true total was 2,755,520 ms) — an
+// actual run, not a synthetic curve. The wiring facts are read out of the shipped source.
+'use strict';
+const fs = require('fs'), path = require('path'), vm = require('vm');
+const { Witness } = require(path.join(__dirname, '..', 'witness_kit', 'contract.js'));
+const src = fs.readFileSync(path.join(__dirname, '..', 'cli_silent_bake.js'), 'utf8');
+
+function sliceFn(marker) {
+  const i = src.indexOf(marker);
+  if (i < 0) return null;
+  let d = 0, open = false;
+  for (let j = i; j < src.length; j++) {
+    if (src[j] === '{') { d++; open = true; }
+    else if (src[j] === '}') { d--; if (open && d === 0) return src.slice(i, j + 1); }
+  }
+  return null;
+}
+const fmtSrc = sliceFn('function fmtDur(');
+// The shipped regex is the one thing the progress line depends on to see a frame at all.
+const FRAME_RX = /§MAXQ_FRAME i=\(\\d\+\)\\\/\(\\d\+\) elapsedMs=\(\\d\+\) perFrameMs=\(\\d\+\)/;
+const hasRegex = /§MAXQ_FRAME i=\(\\d\+\)\\\/\(\\d\+\) elapsedMs=\(\\d\+\)/.test(src);
+const capturesTotal = /S\.total = \+fm\[2\]; S\.elapsedMs = \+fm\[3\]/.test(src);
+const printsProgress = /§CLI_BAKE_PROGRESS frame=\$\{S\.frames\}\/\$\{S\.total\}/.test(src);
+const sigWired = /\['SIGINT', 'SIGTERM'\]\.forEach/.test(src) && /S\.abortRequested = /.test(src);
+const abortChecked = /if \(S\.abortRequested\) \{ aborted = S\.abortRequested; break; \}/.test(src);
+const waitsForSettle = /while \(\(Date\.now\(\) - landT0\) \/ 60000 < ABORT_LAND_MIN\)/.test(src) &&
+                       !/cancelMaxQualityOrbit\(\)\); await new Promise\(r => setTimeout\(r, 10000\)\)/.test(src);
+
+// REAL samples from ~/Downloads/Hospital_silent_bake_2026-09-04.mp4's own run log.
+const REAL = [[0, 1964], [342, 207216], [826, 645632], [1488, 1303360], [2278, 1858666], [2936, 2755520]];
+const TOTAL_FRAMES = 2937, TRUE_MS = 2755520;
+
+function fmt() {
+  const sb = { Math, console: { log() {} } };
+  vm.createContext(sb);
+  vm.runInContext(fmtSrc, sb);
+  return sb.fmtDur;
+}
+
+function population() {
+  if (!fmtSrc) return [];
+  const f = fmt();
+  return REAL.filter(r => r[0] > 0).map(([i, elapsed]) => {
+    const rate = elapsed / i;   // cumulative basis — the worst case the shipped trailing window improves on
+    const predictedTotal = elapsed + (TOTAL_FRAMES - i) * rate;
+    return {
+      frame: i,
+      pct: +(100 * i / TOTAL_FRAMES).toFixed(1),
+      rateMs: +rate.toFixed(1),
+      etaStr: f((TOTAL_FRAMES - i) * rate),
+      predictedTotalMs: Math.round(predictedTotal),
+      errPct: +(100 * (predictedTotal - TRUE_MS) / TRUE_MS).toFixed(1),
+      hasRegex, capturesTotal, printsProgress, sigWired, abortChecked, waitsForSettle
+    };
+  });
+}
+const schema = {
+  type: 'object',
+  required: ['frame', 'pct', 'rateMs', 'etaStr', 'predictedTotalMs', 'errPct',
+             'hasRegex', 'capturesTotal', 'printsProgress', 'sigWired', 'abortChecked', 'waitsForSettle'],
+  properties: {
+    frame: { type: 'integer' }, pct: { type: 'number' }, rateMs: { type: 'number' },
+    etaStr: { type: 'string' }, predictedTotalMs: { type: 'integer' }, errPct: { type: 'number' },
+    hasRegex: { type: 'boolean' }, capturesTotal: { type: 'boolean' }, printsProgress: { type: 'boolean' },
+    sigWired: { type: 'boolean' }, abortChecked: { type: 'boolean' }, waitsForSettle: { type: 'boolean' }
+  }
+};
+
+if (!fmtSrc) {
+  console.log('§WITNESS_CLI_PROGRESS_VERDICT INCONCLUSIVE — could not slice fmtDur out of ' +
+    'cli_silent_bake.js; nothing judged');
+  process.exit(1);
+}
+
+const w = Witness('CLI_BAKE_PROGRESS')
+  .population(population)
+  .schema(schema)
+  // G1 — the ETA is USEFUL on a real run: past the first 10% it is within 30% of the truth. It runs
+  // low by design (later frames are heavier than early ones); the bound admits that rather than
+  // pretending to a precision the rate cannot carry.
+  .invariant('eta-within-20pct-after-25pct', rows =>
+    rows.filter(r => r.pct >= 25).every(r => Math.abs(r.errPct) <= 20))
+  // G2 — it never claims MORE time than the bake really took (an ETA that overruns is a worse lie
+  // than one that undershoots, because it is the one people plan around).
+  .invariant('eta-never-overstates', rows => rows.filter(r => r.pct >= 10).every(r => r.errPct <= 5))
+  // G3 — a duration is rendered readably, not as raw milliseconds.
+  .invariant('duration-formatted', rows => rows.every(r => /^(\d+h)?(\d+m)?\d+s$/.test(r.etaStr)))
+  // G4 — the progress line can SEE a frame and PRINT it: regex, captured total, and the log call.
+  .invariant('progress-wired', rows => rows.every(r => r.hasRegex && r.capturesTotal && r.printsProgress))
+  // G5 — the abort switch exists, routes through the SAME abort the watchdogs use, and the landing
+  // wait is no longer the flat 10 s that lost the partial film.
+  .invariant('abort-wired-and-waits', rows => rows.every(r => r.sigWired && r.abortChecked && r.waitsForSettle))
+  // RED — the pre-fix runner: no total captured, nothing printed, no signal handler, flat sleep.
+  .redControl(rows => rows.map(r => Object.assign({}, r,
+    { capturesTotal: false, printsProgress: false, sigWired: false, abortChecked: false, waitsForSettle: false })));
+
+const res = w.run();
+const rows = population();
+rows.forEach(r => console.log('§CLI_PROGRESS_ROW frame=' + r.frame + '/' + TOTAL_FRAMES + ' ' + r.pct +
+  '% rate=' + (r.rateMs / 1000).toFixed(3) + 's/frame eta=' + r.etaStr +
+  ' predictedTotal=' + (r.predictedTotalMs / 60000).toFixed(1) + 'min vs true ' +
+  (TRUE_MS / 60000).toFixed(1) + 'min err=' + r.errPct + '%'));
+console.log('§CLI_PROGRESS_WIRING regex=' + hasRegex + ' total=' + capturesTotal + ' prints=' + printsProgress +
+  ' sigint=' + sigWired + ' abortChecked=' + abortChecked + ' waitsForSettle=' + waitsForSettle);
+const vacuous = rows.length === 0;
+console.log('§WITNESS_CLI_PROGRESS_VERDICT ' +
+  (vacuous ? 'VACUOUS — no sample judged' : res.fail === 0 ? 'PASS' : 'FAIL') +
+  ' rows=' + rows.length + ' pass=' + res.pass + ' fail=' + res.fail);
+process.exit(res.fail === 0 && !vacuous ? 0 : 1);


### PR DESCRIPTION
USER, 2026-09-04: "when user does silent bake will the CLI shows frame in progress and ETA? And an
abort switch where the frames to date are landed."

Neither existed. The runner already parsed §MAXQ_FRAME for its stall watchdog and threw the numbers
away, so a 47-minute bake reported nothing about how far along it was — the ETA in this session's own
conversation was produced by grepping the log and doing the arithmetic by hand, which is the gap.

§CLI_BAKE_PROGRESS — a line every 30 s (--progress-every-sec):
  §CLI_BAKE_PROGRESS frame=2297/2937 78.2% rate=0.814s/frame (trailing 10) elapsed=31m9s eta=8m41s (640 frames left)
Rate comes from the VIEWER's own elapsedMs, so page load, streaming and the Time Machine prime are not
charged to the per-frame figure — the ETA answers "how long for the frames that are left".

It is priced on a TRAILING WINDOW, not the cumulative average, and the witness is what forced that.
MEASURED on the real 2,937-frame Hospital bake of 2026-09-04 (true total 45.9 min): the cumulative
average predicts 38.3 min at 28% because early frames are light and the buildup gets heavier as the
model fills in. The first ~25% is optimistic on either basis, so the line SAYS SO ("early estimate
runs LOW; frames get heavier as the model fills in") rather than implying a precision it does not have.

§CLI_BAKE_LAND_ON_ABORT — Ctrl-C is the abort switch and it LANDS the frames baked so far. It routes
into the SAME cancel the stall/timeout watchdogs already use, so there is one abort path rather than a
second to keep in step; a second Ctrl-C exits immediately so an operator is never trapped waiting on a
2,000-frame encode.

A REAL BUG FOUND WHILE WIRING IT: the existing abort called cancelMaxQualityOrbit() and then slept a
FLAT 10 SECONDS. cinema_maxq's cancel path already stitches whatever it has (`framesDone >= (_cancel ?
fps : 1)`), but 10 s is nowhere near enough to encode two thousand frames — so the process tore down
mid-stitch and the partial film was lost anyway, defeating the saving the viewer had gone to the
trouble of doing. It now waits for the bake's own promise to settle, bounded by --abort-land-min
(default 10), and reports §CLI_BAKE_LANDED framesAtAbort=N settled=yes/NO deliveredBytes=N so it is
never a guess whether a file exists.

Witness: tests/witness_cli_bake_progress.js — W-CLI-PROGRESS 8/8, RED control detected. Slices fmtDur
out of the shipped runner by brace matching, reads the six wiring facts out of the shipped source
(regex, captured total, the log call, both signal handlers, the loop's abort check, and that the flat
10 s sleep is GONE), and replays the ETA against the REAL frame sequence of the 2026-09-04 Hospital
bake rather than a synthetic curve. It asserts on the CUMULATIVE basis — the worse estimator — so the
bound holds a fortiori for the trailing window that ships:
  §CLI_PROGRESS_ROW frame=1488/2937 50.7% rate=0.876s/frame eta=21m9s predictedTotal=42.9min vs true 45.9min err=-6.6%
  §CLI_PROGRESS_WIRING regex=true total=true prints=true sigint=true abortChecked=true waitsForSettle=true
G2 asserts the ETA never OVERSTATES: an estimate that overruns is the worse lie, because it is the one
people plan around.

No sw bump: cli_silent_bake.js and tests/ are not served assets.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)