### PR TITLE
fix(4d): §TM_PLAYED_LAYER_MIDAIR — the played-layer line judges its own layer (Duplex 0→257, HHS 0→152)

### DIFF
--- a/scripts/lib/tm_played_layer.js
+++ b/scripts/lib/tm_played_layer.js
@@ -20,10 +20,25 @@
 // replications of the played layer would be the same defect class this whole section exists to
 // remove. time_machine.js is READ, never edited.
 //
+// ══ §TM_PLAYED_LAYER_MIDAIR (2026-09-04, bim-compiler prompts/4D_MODEL_INTEGRITY.md §M.5 item 2) ══
+// The §TM_PLAYED_LAYER line used to print `midair=` from `dt.midair` — the CPM-DISPLAY judge's count
+// (the §CPM_DISPLAY number) — on the line that says "these are the instants kernel_ops carries". It
+// was the wrong layer's number: re-judged by the OWNER on the played instants, Hospital META 539 (line
+// said 583), Duplex 257 (line said 0), HHS 152 (line said 0), Terminal META 3133 (said 911). Two
+// buildings reported a clean zero while carrying hundreds — a witness lying about its own subject
+// (PRIMAL LAW clause 4). Now: `midairPlayed=` is the OWNER (SupportSweep.midairAudit, §I "is anything
+// floating?") called over the played map — exactly what probe_tm_reveal_shipped.js judge() does —
+// and `midairCpmDisplay=` is the old number, NAMED. There is no bare `midair=` token on that line any
+// more, so the ambiguity cannot return. When the owner is not in the sandbox the line says UNJUDGED;
+// when the population is empty it says VACUOUS — never a 0 that means nothing.
+// Witness: viewer/tests/witness_tm_played_layer_midair.js.
+//
 // EXPORTS
 //   sliceFn(src, name)          brace-matched source slice, by function name
 //   buildSandbox(deps)          a vm context holding the live TM functions
 //   mirrorInjectGantt(opts)     the injectGantt write-path mirror -> { play, disp, cap, ... }
+//   judgePlayedMidair(sb, twItems, map, guidTask)   the OWNER over a played map (§TM_PLAYED_LAYER_MIDAIR)
+//   describeMidair(mj)          the token the § line prints for that verdict (N | UNJUDGED | VACUOUS)
 'use strict';
 const fs = require('fs'), path = require('path'), vm = require('vm');
 
@@ -76,6 +91,32 @@ function buildSandbox(d) {
   vm.runInContext(code, sb);
   sb.__missing = missing;
   return sb;
+}
+
+// judgePlayedMidair(sb, twItems, map, guidTask) — §TM_PLAYED_LAYER_MIDAIR. THE one place "midair on
+// the played instants" is asked in node. Calls the OWNER — SupportSweep.midairAudit, reached through
+// the sandbox's `_midairAudit` (the same seam injectGantt's own §CPM_DISPLAY audit uses) — over the
+// items injectGantt built, with s/e replaced by the map under judgement. Nothing re-derived: the
+// support relation, the election and the "appears before its support" test are all the owner's.
+// Returns { midair, orphans, guids, judged } or, honestly, { unjudged: reason } / { vacuous: true }.
+function judgePlayedMidair(sb, twItems, map, guidTask) {
+  if (!sb || typeof sb._midairAudit !== 'function')
+    return { midair: null, judged: 0, unjudged: 'SupportSweep.midairAudit not in sandbox — buildSandbox({SS}) was not given support_sweep.js' };
+  const its = [];
+  (twItems || []).forEach(it => {
+    const p = map && map[it.guid]; if (!p) return;
+    its.push(Object.assign({}, it, { s: p.s, e: p.e, task: guidTask ? guidTask[it.guid] : it.task }));
+  });
+  if (!its.length) return { midair: 0, orphans: 0, guids: [], judged: 0, vacuous: true };
+  const ma = sb._midairAudit(its);
+  return { midair: ma.midair, orphans: ma.orphans, guids: ma.guids || [], judged: its.length, ok: ma.ok };
+}
+// describeMidair(mj) — the exact token the § line carries, so a reader can grep ONE spelling.
+function describeMidair(mj) {
+  if (!mj) return 'UNJUDGED';
+  if (mj.unjudged) return 'UNJUDGED';
+  if (mj.vacuous) return 'VACUOUS';
+  return String(mj.midair);
 }
 
 // readDisplayAuthored(db) — the SAME query injectGantt runs (time_machine.js:4967). Never assumed:
@@ -167,16 +208,27 @@ function mirrorInjectGantt(o) {
     // the cache does not.
     const affine = o.wantAffine ? bind(null) : null;
     const r = bind(tiledMap);
+    // §TM_PLAYED_LAYER_MIDAIR — judge THIS map (the instants kernel_ops carries), via the owner. The
+    // CPM-display count is kept, under its own name, so a reader can see both and neither is anonymous.
+    const mj = judgePlayedMidair(sb, twItems, r.map, guidTask);
     const stats = { total: elements.length, clamped: r.clamped, tiled: r.tiled, uncovered: r.uncovered,
-      displayAuthored: displayAuthored, cpm: dt && dt.cpm, midair: dt && dt.midair,
+      displayAuthored: displayAuthored, cpm: dt && dt.cpm,
+      midairPlayed: mj.unjudged ? null : mj.midair, midairPlayedJudged: mj.judged,
+      midairPlayedGuids: mj.guids || [], midairPlayedStatus: describeMidair(mj),
+      midairCpmDisplay: dt && dt.midair,
       applyTiling: !!o.applyTiling, tilingAvailable: typeof sb._tmTilePlayWithinTasks === 'function' };
     log('§TM_PLAYED_LAYER total=' + stats.total + ' clamped=' + r.clamped + ' tiled=' + r.tiled +
         ' uncovered=' + r.uncovered + ' display_authored=' + displayAuthored +
-        ' cpm=' + stats.cpm + ' midair=' + stats.midair +
+        ' cpm=' + stats.cpm +
+        ' midairPlayed=' + describeMidair(mj) + ' judged=' + mj.judged + '/' + stats.total +
+        ' layer=played owner=SupportSweep.midairAudit' +
+        ' midairCpmDisplay=' + stats.midairCpmDisplay + ' (=§CPM_DISPLAY, the CPM-display times, NOT this layer)' +
+        (mj.unjudged ? ' ⛔ ' + mj.unjudged : '') +
         ' (mirrors §TM_ELEMENT_WINDOW_BIND — these are the instants kernel_ops carries)');
     return { ok: true, play: r.map, affine: affine ? affine.map : null, tiledMap: tiledMap,
-      disp: disp, win: win, guidTask: guidTask, winGroups: winGroups, twItems: twItems, stats: stats };
+      disp: disp, win: win, guidTask: guidTask, winGroups: winGroups, twItems: twItems, stats: stats,
+      midairPlayed: mj };
   }
 }
 
-module.exports = { sliceFn, buildSandbox, mirrorInjectGantt, readDisplayAuthored, TM_FNS, DAY_MS };
+module.exports = { sliceFn, buildSandbox, mirrorInjectGantt, readDisplayAuthored, judgePlayedMidair, describeMidair, TM_FNS, DAY_MS };

--- a/scripts/probe_tm_reveal_shipped.js
+++ b/scripts/probe_tm_reveal_shipped.js
@@ -104,7 +104,11 @@ async function runBuilding(bld, SQL, R) {
   if (!mp.ok) { console.log('§TM_REVEAL_SHIPPED_FAIL ' + bld + ' ' + mp.reason); db.close(); return null; }
   const disp = mp.disp, win = mp.win, guidTask = mp.guidTask, twItems = mp.twItems, winGroups = mp.winGroups;
   const op = mp.affine, opFix = mp.play, tiled = mp.tiledMap;
-  console.log('§TM_REVEAL_SHIPPED_DISPLAY ' + bld + ' cpm=' + mp.stats.cpm + ' midair=' + mp.stats.midair +
+  // §TM_PLAYED_LAYER_MIDAIR: this number is the CPM-DISPLAY judge's (§CPM_DISPLAY), named as such. The
+  // played-layer verdict is §TM_REVEAL_JUDGE map=CANDIDATE-tiled below (and now §TM_PLAYED_LAYER's own
+  // midairPlayed=, from the same owner).
+  console.log('§TM_REVEAL_SHIPPED_DISPLAY ' + bld + ' cpm=' + mp.stats.cpm + ' midairCpmDisplay=' + mp.stats.midairCpmDisplay +
+    ' midairPlayed=' + mp.stats.midairPlayedStatus +
     ' (cpm=reuse means injectGantt replayed the hook\'s CPM timeline, exactly as the browser cold-open does)');
   console.log('§TM_REVEAL_SHIPPED_BIND ' + bld + ' total=' + mp.stats.total + ' clamped=' + mp.stats.clamped +
     ' uncovered=' + mp.stats.uncovered + ' tiled=' + mp.stats.tiled + ' display_authored=' + mp.stats.displayAuthored +

--- a/viewer/tests/witness_tm_played_layer_midair.js
+++ b/viewer/tests/witness_tm_played_layer_midair.js
@@ -1,0 +1,164 @@
+#!/usr/bin/env node
+// witness_tm_played_layer_midair.js — W-PLM. THE §TM_PLAYED_LAYER LINE JUDGES ITS OWN LAYER.
+//
+// ⚠ DO NOT REMOVE — SCOPE (bim-compiler prompts/4D_MODEL_INTEGRITY.md §M.5 item 2, 2026-09-04,
+// §TM_PLAYED_LAYER_MIDAIR). Read the log after every run (project Log Mandate).
+//
+// THE ISSUE THIS PROVES OR DISPROVES:
+//   scripts/lib/tm_played_layer.js printed `midair=` on the §TM_PLAYED_LAYER line from `dt.midair` —
+//   the CPM-DISPLAY judge's count — under the words "these are the instants kernel_ops carries". The
+//   OWNER (SupportSweep.midairAudit, §I "is anything floating?") re-judged on the played instants says
+//   Duplex 257 where the line said 0, HHS 152 where it said 0, Hospital META 539 where it said 583.
+//   A witness that reports the wrong layer's number under its own name is worse than no witness
+//   (PRIMAL LAW clause 4). This file holds the line: the number printed as the played layer's midair
+//   IS the owner's verdict over the played map, the CPM-display number is printed under its own name,
+//   and the line can say UNJUDGED / VACUOUS instead of a meaningless 0.
+//
+// CLAIMS (PASS / FAIL / INCONCLUSIVE — a 0 over an empty population is never a PASS):
+//   C1 NAMED       the § line carries `midairPlayed=` AND `midairCpmDisplay=` and NO bare `midair=`.
+//   C2 OWNER       midairPlayed equals SupportSweep.midairAudit (the real module, called here) over
+//                  the played map — the mirror and the owner cannot disagree.
+//   C3 SUBJECT     anti-vacuous: on this fixture the two numbers DIFFER, i.e. the old line really was
+//                  reporting a different subject (INCONCLUSIVE, not FAIL, if a fixture happens to tie).
+//   C4 RED         a played map with ONE extra element pulled 2 d before its elected support (an
+//                  element that supports nothing itself, so exactly one verdict can change) is judged
+//                  midairPlayed + 1 — the judge moves with the map it is pointed at.
+//   C5 HONEST      with no owner in the sandbox the token is UNJUDGED; with no items it is VACUOUS.
+//
+// Command: node viewer/tests/witness_tm_played_layer_midair.js [Building]     (default Duplex)
+'use strict';
+const fs = require('fs'), path = require('path'), vm = require('vm'), os = require('os');
+const ROOT = path.join(__dirname, '..', '..');
+const V = path.join(ROOT, 'viewer');
+const BLD_DIR = process.env.BLD_DIR || path.join(os.homedir(), 'bim-ootb', 'buildings');
+const BLD = process.argv[2] || 'Duplex';
+const DAY_MS = 86400000;
+
+const TMP = require(path.join(ROOT, 'scripts', 'lib', 'tm_played_layer.js'));
+const SG = require(path.join(V, 'schedule_gate.js')); global.ScheduleGate = SG;
+const SA = require(path.join(V, 'schedule_author.js'));
+const SS = require(path.join(V, 'support_sweep.js')); global.SupportSweep = SS;
+const CP = require(path.join(V, 'cpm_schedule.js')); global.CpmSchedule = CP;
+const GM = require(path.join(V, 'gantt_model.js')); global.GanttModel = GM;
+globalThis.RoomWalker = require(path.join(V, 'lib', 'room_walker.js'));
+globalThis.LevelDeriver = require(path.join(V, 'lib', 'level_deriver.js'));
+globalThis.LocationAxis = require(path.join(V, 'location_axis.js'));
+const T = JSON.parse(fs.readFileSync(path.join(V, 'rates', '4D_template.json'), 'utf8'));
+const tmSrc = fs.readFileSync(path.join(V, 'time_machine.js'), 'utf8');
+
+let pass = 0, fail = 0, inconclusive = 0;
+function claim(id, verdict, detail) {
+  if (verdict === 'PASS') pass++; else if (verdict === 'FAIL') fail++; else inconclusive++;
+  console.log('§W_PLM ' + id.padEnd(12) + verdict.padEnd(13) + (detail || ''));
+}
+function executedRules() {
+  const sb = { console: { log() {}, warn() {}, error() {} } };
+  vm.createContext(sb); vm.runInContext(fs.readFileSync(path.join(V, 'rates.js'), 'utf8'), sb);
+  return sb;
+}
+
+(async () => {
+  let mp = null;
+  const dbf = path.join(BLD_DIR, BLD + '_extracted.db');
+  if (!fs.existsSync(dbf)) { claim('C0_FIXTURE', 'INCONCLUSIVE', 'no fixture at ' + dbf); return done(); }
+  const initSqlJs = require(path.join(ROOT, 'node_modules', 'sql.js'));
+  const SQL = await initSqlJs({ locateFile: f => path.join(ROOT, 'node_modules', 'sql.js', 'dist', f) });
+  const R = executedRules();
+  const db = new SQL.Database(new Uint8Array(fs.readFileSync(dbf)));
+
+  // The run — the same configuration scripts/cache_4d_run.js persists (template, real rates, the
+  // displayRemap hook, SupportSweep loaded). The § log is teed, never suppressed (PRIMAL LAW clause 3).
+  const seen = [];
+  const _log = console.log;
+  console.log = function () { const s = Array.prototype.join.call(arguments, ' '); seen.push(s); _log(s); };
+  const sb = TMP.buildSandbox({ tmSrc: tmSrc, SA: SA, SG: SG, CP: CP, GM: GM, SS: SS, LABOR_RATES: R.LABOR_RATES, console: console });
+  const base = { start: '2026-01-01', laborRates: R.LABOR_RATES, rates: R.RATES, nameOverrides: R.SEQUENCE_NAME_OVERRIDES,
+    defaultRule: R.SEQUENCE_DEFAULT, scheduleGate: SG, shiftHours: T.calendar.hours_per_shift, template: T, db: db,
+    displayRemap: sb._tmDisplayRemap };
+  const elements = SA._buildScheduleElements(db, R.SEQUENCE_RULES, base);
+  globalThis.APP = { db: db };
+  const res = SA.materializeZones(db, R.SEQUENCE_RULES, base);
+  if (!res || !res.ok || !res.tasks) { console.log = _log; claim('C0_RUN', 'INCONCLUSIVE', 'materializeZones failed ' + JSON.stringify(res && res.reason)); return done(); }
+  const tasks = res.tasks.map(t => ({ id: t.id, sDays: t.sDays, eDays: t.eDays, phase: t.phase, storey: t.storey, guids: t.guids }));
+  mp = TMP.mirrorInjectGantt({ sb: sb, elements: elements, tasks: tasks, db: db, startISO: base.start, applyTiling: true, log: console.log });
+  delete globalThis.APP;
+  console.log = _log;
+  if (!mp.ok) { claim('C0_MIRROR', 'INCONCLUSIVE', mp.reason); return done(); }
+  const line = seen.filter(l => l.indexOf('§TM_PLAYED_LAYER ') === 0).pop() || '';
+  const tplModel = seen.filter(l => l.indexOf('§TPL_MODEL') === 0).pop() || '';
+  console.log('§W_PLM_POPULATION ' + BLD + ' elements=' + elements.length + ' tasks=' + tasks.length +
+    ' model=' + (tplModel.indexOf('model=template') >= 0 ? 'template' : 'NOT-TEMPLATE') +
+    ' line=' + (line ? line.slice(0, 200) : '(NO §TM_PLAYED_LAYER LINE)'));
+
+  // ── C1 NAMED ────────────────────────────────────────────────────────────────────────────────────
+  {
+    const hasPlayed = /\bmidairPlayed=/.test(line), hasCpm = /\bmidairCpmDisplay=/.test(line);
+    const bare = /\smidair=/.test(line);
+    claim('C1_NAMED', !line ? 'INCONCLUSIVE' : (hasPlayed && hasCpm && !bare ? 'PASS' : 'FAIL'),
+      'midairPlayed=' + hasPlayed + ' midairCpmDisplay=' + hasCpm + ' bareMidairToken=' + bare +
+      ' — a bare midair= is the anonymous number this witness exists to keep dead');
+  }
+
+  // ── C2 OWNER — the real module, over the played map, must equal what the line printed ─────────
+  const items = mp.twItems.map(it => Object.assign({}, it, { s: mp.play[it.guid].s, e: mp.play[it.guid].e, task: mp.guidTask[it.guid] }));
+  const owner = SS.midairAudit(items);
+  const printed = (line.match(/midairPlayed=(\S+)/) || [])[1];
+  {
+    const ok = printed === String(owner.midair) && mp.stats.midairPlayed === owner.midair;
+    claim('C2_OWNER', items.length === 0 ? 'INCONCLUSIVE' : (ok ? 'PASS' : 'FAIL'),
+      'owner SupportSweep.midairAudit(played)=' + owner.midair + ' line=' + printed + ' stats=' + mp.stats.midairPlayed +
+      ' judged=' + items.length);
+  }
+
+  // ── C3 SUBJECT — the number the line USED to print is a different subject on this fixture ──────
+  {
+    const cpm = mp.stats.midairCpmDisplay;
+    const v = (typeof cpm !== 'number') ? 'INCONCLUSIVE' : (cpm !== owner.midair ? 'PASS' : 'INCONCLUSIVE');
+    claim('C3_SUBJECT', v, 'midairCpmDisplay=' + cpm + ' midairPlayed=' + owner.midair +
+      (v === 'PASS' ? ' — the old line reported the former under the latter\'s name' :
+        ' — equal on this fixture, so this run cannot show the old line was lying (it still cannot lie now: C1/C2)'));
+  }
+
+  // ── C4 RED CONTROL — move one supported, non-supporting element 2 d before its support ─────────
+  {
+    const G = SS.contactGraph(items);
+    const des = SS.designatedSupport(items, G);
+    const isSupport = new Set(); des.forEach(s => { if (s >= 0) isSupport.add(s); });
+    let victim = -1;
+    for (let i = 0; i < items.length; i++) {
+      const s = des[i];
+      if (s < 0 || isSupport.has(i)) continue;                 // must be supported, and support nothing
+      if (items[s].s > items[i].s + 1) continue;                // already midair — moving it changes nothing
+      victim = i; break;
+    }
+    if (victim < 0) claim('C4_RED', 'INCONCLUSIVE', 'no supported non-supporting element on ' + BLD + ' to break');
+    else {
+      const mutated = Object.assign({}, mp.play);
+      const sup = items[des[victim]];
+      const dur = mp.play[items[victim].guid].e - mp.play[items[victim].guid].s;
+      mutated[items[victim].guid] = { s: sup.s - 2 * DAY_MS, e: sup.s - 2 * DAY_MS + Math.max(60000, dur) };
+      const mj = TMP.judgePlayedMidair(sb, mp.twItems, mutated, mp.guidTask);
+      claim('C4_RED', mj.midair === owner.midair + 1 ? 'PASS' : 'FAIL',
+        'victim=' + items[victim].cls + ' ' + items[victim].guid.slice(0, 8) + ' pulled 2 d before its support ' + sup.cls +
+        ' → judge says ' + mj.midair + ' (expected ' + (owner.midair + 1) + ')');
+    }
+  }
+
+  // ── C5 HONEST — UNJUDGED without an owner, VACUOUS without items ────────────────────────────────
+  {
+    const noOwner = TMP.judgePlayedMidair({ _midairAudit: undefined }, mp.twItems, mp.play, mp.guidTask);
+    const noItems = TMP.judgePlayedMidair(sb, [], {}, {});
+    const ok = TMP.describeMidair(noOwner) === 'UNJUDGED' && noOwner.midair === null &&
+      TMP.describeMidair(noItems) === 'VACUOUS' && noItems.judged === 0;
+    claim('C5_HONEST', ok ? 'PASS' : 'FAIL', 'noOwner→' + TMP.describeMidair(noOwner) + ' noItems→' + TMP.describeMidair(noItems));
+  }
+  db.close();
+  done();
+
+  function done() {
+    console.log('§WITNESS_TM_PLAYED_LAYER_MIDAIR pass=' + pass + ' fail=' + fail + ' inconclusive=' + inconclusive +
+      ' building=' + BLD + ' midairPlayed=' + (mp && mp.stats ? mp.stats.midairPlayedStatus : 'n/a') +
+      ' midairCpmDisplay=' + (mp && mp.stats ? mp.stats.midairCpmDisplay : 'n/a'));
+    process.exit(fail ? 1 : 0);
+  }
+})().catch(e => { console.error('§W_PLM_ERROR ' + (e && e.stack || e)); process.exit(2); });


### PR DESCRIPTION
## §M.5 item 2 — `§TM_PLAYED_LAYER midair=` printed the WRONG layer's number

`scripts/lib/tm_played_layer.js:171` reported `dt.midair` — the CPM-DISPLAY judge's count — on the line that says *"these are the instants kernel_ops carries"*. The OWNER (`SupportSweep.midairAudit`, §I "is anything floating?") re-judged on the played map: **Duplex 257 (line said 0), HHS 152 (line said 0)**, Hospital META 539 (said 583), Terminal META 3133 (said 911). Two buildings reported a clean zero while carrying hundreds.

### What changed
- `judgePlayedMidair(sb, twItems, map, guidTask)` — the one place the question is asked in node; calls the owner through the sandbox `_midairAudit` seam exactly as `probe_tm_reveal_shipped.js judge()` does. Nothing re-derived.
- `§TM_PLAYED_LAYER … midairPlayed=N judged=n/total layer=played owner=SupportSweep.midairAudit midairCpmDisplay=M` — **no bare `midair=` token remains**. `UNJUDGED` when the owner is absent, `VACUOUS` when there are no items.
- `stats.midair` removed (→ `midairPlayed` / `midairCpmDisplay`); probe's `§TM_REVEAL_SHIPPED_DISPLAY` relabelled.
- New witness `viewer/tests/witness_tm_played_layer_midair.js` (W-PLM): C1 named · C2 owner agrees · C3 anti-vacuous · **C4 RED control** (+1 exactly when one supported non-supporting element is pulled 2 d before its support) · C5 UNJUDGED/VACUOUS reported.

### Evidence (§-log, this branch)
```
§TM_PLAYED_LAYER total=1119 … midairPlayed=257 judged=1119/1119 layer=played owner=SupportSweep.midairAudit midairCpmDisplay=0 …
§WITNESS_TM_PLAYED_LAYER_MIDAIR pass=5 fail=0 inconclusive=0 building=Duplex midairPlayed=257 midairCpmDisplay=0
§TM_PLAYED_LAYER total=6839 … midairPlayed=152 judged=6839/6839 … midairCpmDisplay=0 …
§WITNESS_TM_PLAYED_LAYER_MIDAIR pass=5 fail=0 inconclusive=0 building=HHS_Office_Federated midairPlayed=152 midairCpmDisplay=0
§W_PLM C4_RED      PASS  victim=IfcWall … pulled 2 d before its support IfcBeam → judge says 258 (expected 258)
```
Persisted `~/.cache/bim4d` logs written before this carry the old line — re-persisted by the cache re-key PR (§M.5 item 3).

🤖 Generated with [Claude Code](https://claude.com/claude-code)