### PR TITLE
fix(4d): §CACHE_DB_KIND — the 4D cache judges the DB the viewer loads, and the key says which

### DIFF
--- a/scripts/cache_4d_run.js
+++ b/scripts/cache_4d_run.js
@@ -43,9 +43,29 @@
 // hours to two measurements that silently disagreed because they ran against different viewer
 // checkouts (4D_MODEL_INTEGRITY.md §H.4).
 //
+// ══ §CACHE_DB_KIND (2026-09-04, bim-compiler prompts/4D_MODEL_INTEGRITY.md §M.0 item 2 / §M.5 item 3)
+//    JUDGE THE DB THE VIEWER LOADS ═══════════════════════════════════════════════════════════════
+// This file resolved `<bld>_extracted.db` by construction. The viewer loads the SPLIT PAIR
+// (`_meta.db` + `_geo.db`) whenever BOTH halves exist — viewer/streaming.js §DB_SPLIT_DETECT /
+// §SPLIT_PAIR_REQUIRED — so for Hospital the persisted run was the 20-label INFERRED grid (its
+// _extracted.db has no spatial_structure), NOT the post-#1641 7-band / 36-task / 334 d grid the
+// viewer plays. That is project_split_db_live_vs_probe_landmine inside clause 5's own instrument:
+// a whole class of "probe-green" claims judged a model nobody plays.
+//   resolveDbFile(bld) mirrors the viewer's rule: META when the pair exists AND the meta file is a
+//   readable SQLite file (buildings/Duplex_meta.db is a 0-byte trap that crashed the probe, §M.0
+//   item 3); otherwise EXTRACTED — and it SAYS WHY (`reason`, `skipped`). DB_KIND=meta|extracted
+//   forces one side, so the extracted run stays reachable for comparison. The cache dir carries
+//   the kind (`<codeKey>_<dbKey>_<kind>`), run.json carries dbFile + dbKind, and §CACHE_DB /
+//   §CACHE_BUILT print them — a stale comparison between the two is impossible to make silently.
+//   scripts/probe_tm_reveal_shipped.js calls THIS resolver (one owner, no second copy).
+//   The mirror (scripts/lib/tm_played_layer.js) is part of the code key too: it produces the
+//   played layer, so a change to it changes what is persisted.
+// Witness: viewer/tests/witness_cache_db_kind.js (W-CDK).
+//
 // Usage:  node scripts/cache_4d_run.js Terminal Hospital        (build if missing)
 //         node scripts/cache_4d_run.js --force Terminal         (rebuild)
 //         node scripts/cache_4d_run.js --list                   (what is cached)
+//         DB_KIND=extracted node scripts/cache_4d_run.js Hospital   (force the whole-db run)
 'use strict';
 const fs = require('fs'), path = require('path'), vm = require('vm'), os = require('os'), crypto = require('crypto');
 const HOME = os.homedir();
@@ -83,35 +103,99 @@ function layerOf(run, id) {
   return { id: want, key: L.key, map: map, desc: L.desc, missing: false };
 }
 
+// §CACHE_DB_KIND: the played-layer mirror is an input — it produces the `play` map this file persists.
+const MIRROR_INPUTS = ['lib/tm_played_layer.js'];
 function codeKey() {
   const h = crypto.createHash('sha1');
   for (const f of INPUTS) h.update(f).update(fs.readFileSync(path.join(V, f)));
+  for (const f of MIRROR_INPUTS) h.update('scripts/' + f).update(fs.readFileSync(path.join(__dirname, f)));
   return h.digest('hex').slice(0, 12);
 }
 function dbKey(file) {
   const st = fs.statSync(file);
   return crypto.createHash('sha1').update(st.size + ':' + st.mtimeMs).digest('hex').slice(0, 12);
 }
-function dirFor(bld) { return path.join(ROOT, bld, codeKey() + '_' + dbKey(path.join(BLD, bld + '_extracted.db'))); }
+
+// sqliteProblem(file) — null when the file is a readable SQLite database, else WHY it is not. A
+// 0-byte file, an LFS pointer, a directory and a missing file are four different facts; the resolver
+// reports the one it saw rather than "exists".
+function sqliteProblem(f) {
+  let st;
+  try { st = fs.statSync(f); } catch (e) { return 'missing'; }
+  if (!st.isFile()) return 'not a file';
+  if (st.size === 0) return '0 bytes';
+  try {
+    const fd = fs.openSync(f, 'r'); const b = Buffer.alloc(16);
+    const n = fs.readSync(fd, b, 0, 16, 0); fs.closeSync(fd);
+    const hdr = b.toString('latin1', 0, 15);
+    if (n < 16 || hdr !== 'SQLite format 3')
+      return 'not a SQLite file (header "' + hdr.replace(/[^\x20-\x7e]/g, '?') + '")';
+  } catch (e) { return 'unreadable (' + (e.code || e.message) + ')'; }
+  return null;
+}
+
+// resolveDbFile(bld, want, bldDir) — WHICH DB THE VIEWER LOADS, with the reason. `want` is
+// 'auto' (default; env DB_KIND overrides) | 'meta' | 'extracted'. Returns
+//   { path, kind: 'meta'|'extracted', reason, skipped: [..] }   or   { path: null, kind: null, reason }.
+const DB_KINDS = ['auto', 'meta', 'extracted'];
+function resolveDbFile(bld, want, bldDir) {
+  const dir = bldDir || BLD;
+  want = want || process.env.DB_KIND || 'auto';
+  if (DB_KINDS.indexOf(want) < 0) throw new Error('§CACHE_DB_KIND_UNKNOWN "' + want + '" — known: ' + DB_KINDS.join(' | '));
+  const meta = path.join(dir, bld + '_meta.db'), geo = path.join(dir, bld + '_geo.db'), ext = path.join(dir, bld + '_extracted.db');
+  const mp = sqliteProblem(meta), gp = sqliteProblem(geo), ep = sqliteProblem(ext);
+  const skipped = [];
+  if (want === 'extracted') {
+    return ep ? { path: null, kind: null, reason: 'DB_KIND=extracted but ' + path.basename(ext) + ' ' + ep, skipped }
+              : { path: ext, kind: 'extracted', reason: 'DB_KIND=extracted (forced)', skipped };
+  }
+  if (want === 'meta') {
+    return mp ? { path: null, kind: null, reason: 'DB_KIND=meta but ' + path.basename(meta) + ' ' + mp, skipped }
+              : { path: meta, kind: 'meta', reason: 'DB_KIND=meta (forced' +
+                  (gp ? '; ' + path.basename(geo) + ' ' + gp + ' — the viewer would NOT take split mode here' : '') + ')', skipped };
+  }
+  // auto — the viewer's rule: split mode iff BOTH halves are there (§SPLIT_PAIR_REQUIRED).
+  if (!mp && !gp) {
+    return { path: meta, kind: 'meta', skipped,
+      reason: 'split pair present (' + path.basename(meta) + ' + ' + path.basename(geo) + ') — what streaming.js §DB_SPLIT_DETECT loads' };
+  }
+  if (!mp && gp) skipped.push(path.basename(meta) + ' usable but ' + path.basename(geo) + ' ' + gp + ' (§SPLIT_PAIR_REQUIRED: both halves or neither)');
+  if (mp && mp !== 'missing') skipped.push(path.basename(meta) + ' ' + mp + ' — skipped, not loaded');
+  if (ep) return { path: null, kind: null, skipped,
+    reason: 'no usable db: ' + path.basename(ext) + ' ' + ep + (skipped.length ? '; ' + skipped.join('; ') : '') };
+  return { path: ext, kind: 'extracted', skipped,
+    reason: (skipped.length ? skipped.join('; ') + ' -> ' : 'no split pair -> ') + path.basename(ext) };
+}
+
+// dirFor(bld, want) — the cache dir for the db the viewer loads (or the forced kind). Null when no
+// usable db exists. The KIND is in the name so two runs of one building cannot be confused.
+function dirFor(bld, want) {
+  const r = resolveDbFile(bld, want);
+  if (!r.path) return null;
+  return path.join(ROOT, bld, codeKey() + '_' + dbKey(r.path) + '_' + r.kind);
+}
 
 // read(bld) — what every downstream probe should call. Returns {els, play, sched, tasks, log, dir}
 // or null. SELECT A LAYER WITH layerOf(run) — never reach for `.sched` directly; that key is the
 // unplayed map and reading it unnamed is the defect §CACHE_PLAYED_LAYER removed.
-function read(bld) {
-  const d = dirFor(bld);
-  if (!fs.existsSync(path.join(d, 'run.json'))) return null;
+function read(bld, want) {
+  const d = dirFor(bld, want);
+  if (!d || !fs.existsSync(path.join(d, 'run.json'))) return null;
   const j = JSON.parse(fs.readFileSync(path.join(d, 'run.json'), 'utf8'));
   return { els: j.els, play: j.play || null, sched: j.sched, display: j.sched,
     playStats: j.playStats || null, storeys: j.storeys || null, tasks: j.tasks || null,
-    dbFile: j.dbFile || null, builtAt: j.builtAt || null,
+    dbFile: j.dbFile || null, dbKind: j.dbKind || null, builtAt: j.builtAt || null,
     log: fs.readFileSync(path.join(d, 'witness.log'), 'utf8'), dir: d };
 }
 
-function build(bld, force) {
-  const d = dirFor(bld);
-  if (!force && fs.existsSync(path.join(d, 'run.json'))) { console.log('§CACHE_HIT ' + bld + ' ' + d); return read(bld); }
-  const file = path.join(BLD, bld + '_extracted.db');
-  if (!fs.existsSync(file)) { console.log('§CACHE_SKIP ' + bld + ' — no db'); return null; }
+function build(bld, force, want) {
+  // §CACHE_DB_KIND — resolve the db the viewer loads, and say which one and why, BEFORE anything runs.
+  const dbf = resolveDbFile(bld, want);
+  if (!dbf.path) { console.log('§CACHE_SKIP ' + bld + ' — ' + dbf.reason); return null; }
+  console.log('§CACHE_DB ' + bld + ' kind=' + dbf.kind + ' file=' + path.basename(dbf.path) + ' reason=' + dbf.reason);
+  const d = dirFor(bld, want);
+  if (!force && fs.existsSync(path.join(d, 'run.json'))) { console.log('§CACHE_HIT ' + bld + ' kind=' + dbf.kind + ' ' + d); return read(bld, want); }
+  const file = dbf.path;
 
   // Modules are loaded FRESH per build so one process building several buildings cannot carry
   // module-level state from one into the next.
@@ -224,9 +308,10 @@ function build(bld, force) {
       fs.mkdirSync(d, { recursive: true });
       fs.writeFileSync(path.join(d, 'witness.log'), lines.join('\n') + '\n');
       fs.writeFileSync(path.join(d, 'run.json'), JSON.stringify({ bld: bld, builtAt: new Date().toISOString(),
-        codeKey: codeKey(), dbFile: path.basename(file), els: els,
+        codeKey: codeKey(), dbFile: path.basename(file), dbKind: dbf.kind, dbReason: dbf.reason, els: els,
         sched: flat, play: play, playStats: playStats, storeys: storeys, tasks: tasks }));
-      console.log('§CACHE_BUILT ' + bld + ' n=' + els.length + ' scheduled=' + Object.keys(flat).length +
+      console.log('§CACHE_BUILT ' + bld + ' dbFile=' + path.basename(file) + ' kind=' + dbf.kind +
+        ' n=' + els.length + ' scheduled=' + Object.keys(flat).length +
         ' logLines=' + lines.length + ' declaredStoreys=' + (storeys ? storeys.length : 'ABSENT') + ' -> ' + d);
       // §CACHE_LAYERS — the cache says, in its own log, which maps it carries and which one plays.
       console.log('§CACHE_LAYERS ' + bld +
@@ -237,12 +322,13 @@ function build(bld, force) {
           ' display_authored=' + playStats.displayAuthored : '') +
         ' — "played" is what the film/scrubber reveal (kernel_ops); "display" is remapSolveToTasks, ' +
         'which viewer/time_machine.js does not read. Select with CACHE.layerOf(run).');
-      return read(bld);
+      return read(bld, want);
     });
 }
 
 module.exports = { read: read, build: build, dirFor: dirFor, codeKey: codeKey,
-  layerOf: layerOf, LAYERS: LAYERS };
+  layerOf: layerOf, LAYERS: LAYERS,
+  resolveDbFile: resolveDbFile, sqliteProblem: sqliteProblem, DB_KINDS: DB_KINDS };
 
 if (require.main === module) {
   const args = process.argv.slice(2);
@@ -253,7 +339,8 @@ if (require.main === module) {
       const rj = path.join(ROOT, b, k, 'run.json');
       if (!fs.existsSync(rj)) continue;
       const st = fs.statSync(rj);
-      console.log('§CACHE_LIST ' + b.padEnd(24) + ' ' + k + '  ' + (st.size / 1048576).toFixed(1) + 'MB  ' +
+      const kind = (k.match(/_(meta|extracted)$/) || [])[1] || 'extracted(legacy, unnamed)';
+      console.log('§CACHE_LIST ' + b.padEnd(24) + ' ' + k.padEnd(36) + ' kind=' + kind.padEnd(26) + (st.size / 1048576).toFixed(1) + 'MB  ' +
         st.mtime.toISOString() + (k.startsWith(codeKey()) ? '  <- CURRENT code' : '  (stale code)'));
     }
     process.exit(0);

--- a/scripts/probe_tm_reveal_shipped.js
+++ b/scripts/probe_tm_reveal_shipped.js
@@ -51,20 +51,16 @@ const T = JSON.parse(fs.readFileSync(path.join(V, 'rates', '4D_template.json'), 
 const tmSrc = fs.readFileSync(path.join(V, 'time_machine.js'), 'utf8');
 // §CACHE_PLAYED_LAYER — the ONE owner of "the played layer, in node" (slicing + injectGantt mirror).
 const TMP = require(path.join(__dirname, 'lib', 'tm_played_layer.js'));
+// §CACHE_DB_KIND — the ONE owner of "which db does the viewer load" (meta when the split pair exists
+// and the meta file is a readable SQLite file, else extracted — with the reason). A 0-byte
+// buildings/Duplex_meta.db used to crash this probe because the local rule was `existsSync(meta)`.
+const CACHE = require(path.join(__dirname, 'cache_4d_run.js'));
 
 function executedRules() {
   const sb = { console: { log() {}, warn() {}, error() {} } };
   vm.createContext(sb);
   vm.runInContext(fs.readFileSync(path.join(V, 'rates.js'), 'utf8'), sb);
   return sb;
-}
-// §S39/§S37-A2 rule (witness_midair_zero.js): prefer <bld>_meta.db, fall back to _extracted.db.
-function resolveDbFile(bld) {
-  const meta = path.join(BLD_DIR, bld + '_meta.db');
-  const ext = path.join(BLD_DIR, bld + '_extracted.db');
-  if (process.env.DB_KIND === 'extracted' && fs.existsSync(ext)) return { path: ext, kind: 'extracted' };
-  if (fs.existsSync(meta)) return { path: meta, kind: 'meta' };
-  return { path: ext, kind: 'extracted' };
 }
 function deciles(vals) {
   const h = new Array(10).fill(0);
@@ -73,8 +69,9 @@ function deciles(vals) {
 }
 
 async function runBuilding(bld, SQL, R) {
-  const dbf = resolveDbFile(bld);
-  if (!fs.existsSync(dbf.path)) { console.log('§TM_REVEAL_SHIPPED_SKIP ' + bld + ' — no db'); return null; }
+  const dbf = CACHE.resolveDbFile(bld, null, BLD_DIR);
+  if (!dbf.path) { console.log('§TM_REVEAL_SHIPPED_SKIP ' + bld + ' — ' + dbf.reason); return null; }
+  console.log('§TM_REVEAL_SHIPPED_RESOLVE ' + bld + ' kind=' + dbf.kind + ' file=' + path.basename(dbf.path) + ' reason=' + dbf.reason);
   const db = new SQL.Database(new Uint8Array(fs.readFileSync(dbf.path)));
   const sb = TMP.buildSandbox({ tmSrc: tmSrc, SA: SA, SG: SG, CP: CP, GM: GM, SS: SS,
     LABOR_RATES: R.LABOR_RATES, console: console });

--- a/viewer/tests/witness_cache_db_kind.js
+++ b/viewer/tests/witness_cache_db_kind.js
@@ -1,0 +1,184 @@
+#!/usr/bin/env node
+// witness_cache_db_kind.js — W-CDK. THE CACHE JUDGES THE DB THE VIEWER LOADS, AND SAYS WHICH.
+//
+// ⚠ DO NOT REMOVE — SCOPE (bim-compiler prompts/4D_MODEL_INTEGRITY.md §M.0 items 2+3, §M.5 items
+// 3+7, 2026-09-04, §CACHE_DB_KIND). Read the log after every run (project Log Mandate).
+//
+// THE ISSUE THIS PROVES OR DISPROVES:
+//   scripts/cache_4d_run.js keyed every persisted run on `<bld>_extracted.db`, while the viewer loads
+//   the split pair `_meta.db` + `_geo.db` whenever both exist (streaming.js §DB_SPLIT_DETECT /
+//   §SPLIT_PAIR_REQUIRED). For Hospital that meant the "persisted run" was the 20-label INFERRED grid
+//   (317 d, 42 tasks), not the post-#1641 7-band grid the viewer plays (334 d, 36 tasks) — the
+//   split-DB live≠probe landmine inside clause 5's own instrument. Separately, buildings/Duplex_meta.db
+//   is a 0-byte file, and scripts/probe_tm_reveal_shipped.js preferred meta on `existsSync` alone, so
+//   sql.js threw and the probe exited 2 on Duplex. One resolver now owns "which db", mirrors the
+//   viewer's rule, refuses an unreadable file WITH the reason, and puts the kind in the cache key.
+//
+// CLAIMS (PASS / FAIL / INCONCLUSIVE — a 0 over an empty population is never a PASS):
+//   C1 PAIR→META     every fleet building with a usable meta AND geo resolves to meta (what the viewer loads).
+//   C2 EMPTY→SKIP    a building whose meta file exists but is unusable resolves to extracted and NAMES why.
+//   C3 FORCED        DB_KIND=extracted still reaches the whole-db run, under a DIFFERENT cache dir.
+//   C4 DIR NAMES IT  every resolvable building's cache dir ends in `_<kind>`.
+//   C5 ONE OWNER     the probe calls CACHE.resolveDbFile and carries no resolver of its own.
+//   C6 RED CONTROL   on a synthetic fixture: 0-byte meta, LFS-pointer meta, meta-without-geo and a
+//                    good pair — the OLD rule (`existsSync(meta)`) picks the trap in 3 of 4 cases,
+//                    the shipped resolver picks it in 0 and states each reason.
+//   C7 END TO END    a real build of Duplex into a throwaway CACHE_4D_DIR writes dbKind/dbFile into
+//                    run.json and prints §CACHE_DB / §CACHE_BUILT with kind=; DB_KIND=meta on Duplex
+//                    is refused with the 0-byte reason; the probe no longer dies on Duplex.
+//
+// Command: node viewer/tests/witness_cache_db_kind.js
+'use strict';
+const fs = require('fs'), path = require('path'), os = require('os'), cp = require('child_process');
+const ROOT = path.join(__dirname, '..', '..');
+const CACHE = require(path.join(ROOT, 'scripts', 'cache_4d_run.js'));
+const BLD_DIR = process.env.BLD_DIR || path.join(os.homedir(), 'bim-ootb', 'buildings');
+
+let pass = 0, fail = 0, inconclusive = 0;
+function claim(id, judged, bad, detail) {
+  const v = judged === 0 ? 'INCONCLUSIVE' : (bad === 0 ? 'PASS' : 'FAIL');
+  if (v === 'PASS') pass++; else if (v === 'FAIL') fail++; else inconclusive++;
+  console.log('§W_CDK ' + id.padEnd(16) + v.padEnd(13) + 'judged=' + String(judged).padEnd(5) + 'bad=' + String(bad).padEnd(5) + (detail || ''));
+  return v;
+}
+
+// ── the fleet as it is on disk ──────────────────────────────────────────────────────────────────
+const names = new Set();
+if (fs.existsSync(BLD_DIR)) fs.readdirSync(BLD_DIR).forEach(f => {
+  const m = f.match(/^(.+)_(meta|extracted)\.db$/); if (m) names.add(m[1]);
+});
+const fleet = Array.from(names).sort().map(b => {
+  const meta = path.join(BLD_DIR, b + '_meta.db'), geo = path.join(BLD_DIR, b + '_geo.db');
+  return { b, metaProblem: CACHE.sqliteProblem(meta), geoProblem: CACHE.sqliteProblem(geo),
+    metaExists: fs.existsSync(meta), r: CACHE.resolveDbFile(b, 'auto', BLD_DIR) };
+});
+fleet.forEach(x => console.log('§W_CDK_FLEET ' + x.b.padEnd(22) + ' meta=' + (x.metaProblem || 'ok').padEnd(10) + ' geo=' + (x.geoProblem || 'ok').padEnd(10) +
+  ' -> kind=' + x.r.kind + ' file=' + (x.r.path ? path.basename(x.r.path) : null) + ' | ' + x.r.reason));
+
+// C1
+{
+  const pop = fleet.filter(x => !x.metaProblem && !x.geoProblem);
+  const bad = pop.filter(x => x.r.kind !== 'meta');
+  claim('C1_PAIR_TO_META', pop.length, bad.length, pop.map(x => x.b + '=' + x.r.kind).join(' '));
+}
+// C2
+{
+  const pop = fleet.filter(x => x.metaExists && x.metaProblem);
+  const bad = pop.filter(x => x.r.kind !== 'extracted' || x.r.reason.indexOf(x.metaProblem) < 0);
+  claim('C2_EMPTY_SKIPPED', pop.length, bad.length, pop.map(x => x.b + ' meta ' + x.metaProblem + ' -> ' + x.r.kind).join(' | ') ||
+    'no building on disk has an unusable meta file today — the synthetic case is C6');
+}
+// C3
+{
+  const pop = fleet.filter(x => x.r.kind === 'meta' && !CACHE.sqliteProblem(path.join(BLD_DIR, x.b + '_extracted.db')));
+  let bad = 0; const det = [];
+  pop.forEach(x => {
+    const f = CACHE.resolveDbFile(x.b, 'extracted', BLD_DIR);
+    const dm = CACHE.dirFor(x.b, 'meta'), de = CACHE.dirFor(x.b, 'extracted');
+    const ok = f.kind === 'extracted' && dm && de && dm !== de && /_meta$/.test(dm) && /_extracted$/.test(de);
+    if (!ok) bad++;
+    det.push(x.b + ':' + f.kind + (ok ? '' : ' ⛔'));
+  });
+  claim('C3_FORCED', pop.length, bad, det.join(' ') + ' — forced kind reaches the whole-db run under its own dir');
+}
+// C4
+{
+  const pop = fleet.filter(x => x.r.path);
+  const bad = pop.filter(x => { const d = CACHE.dirFor(x.b, 'auto'); return !d || !d.endsWith('_' + x.r.kind); });
+  claim('C4_DIR_NAMES_KIND', pop.length, bad.length, pop.map(x => path.basename(CACHE.dirFor(x.b, 'auto') || 'null')).join(' '));
+}
+// C5 — one owner (source gate, brace-free: presence/absence of a declaration is the fact)
+{
+  const probe = fs.readFileSync(path.join(ROOT, 'scripts', 'probe_tm_reveal_shipped.js'), 'utf8');
+  const cache = fs.readFileSync(path.join(ROOT, 'scripts', 'cache_4d_run.js'), 'utf8');
+  const probeOwn = (probe.match(/function resolveDbFile\(/g) || []).length;
+  const probeCalls = (probe.match(/CACHE\.resolveDbFile\(/g) || []).length;
+  const cacheOwn = (cache.match(/function resolveDbFile\(/g) || []).length;
+  const bad = (probeOwn === 0 && probeCalls >= 1 && cacheOwn === 1) ? 0 : 1;
+  claim('C5_ONE_OWNER', 1, bad, 'probe: ownDecl=' + probeOwn + ' callsOwner=' + probeCalls + ' · cache_4d_run ownDecl=' + cacheOwn);
+}
+
+// C6 — RED CONTROL on a synthetic fixture dir
+{
+  const good = path.join(ROOT, 'buildings', 'warehouse_gardenworld.db');   // a real, tiny SQLite file in the repo
+  if (CACHE.sqliteProblem(good)) claim('C6_RED', 0, 0, 'no good SQLite seed at ' + good);
+  else {
+    const dir = fs.mkdtempSync(path.join(process.env.SCRATCH || os.tmpdir(), 'w-cdk-'));
+    const put = (n, src) => { const f = path.join(dir, n); if (src === '') fs.writeFileSync(f, ''); else if (src === 'lfs') fs.writeFileSync(f, 'version https://git-lfs.github.com/spec/v1\noid sha256:0\nsize 1\n'); else fs.copyFileSync(src, f); };
+    put('Z_meta.db', ''); put('Z_geo.db', ''); put('Z_extracted.db', good);                 // the Duplex trap
+    put('Y_meta.db', 'lfs'); put('Y_geo.db', good); put('Y_extracted.db', good);            // an LFS pointer where a db should be
+    put('X_meta.db', good); put('X_extracted.db', good);                                    // meta without its geo half
+    put('W_meta.db', good); put('W_geo.db', good); put('W_extracted.db', good);             // a real split pair
+    put('V_meta.db', ''); put('V_extracted.db', '');                                        // nothing usable at all
+    const cases = [
+      { b: 'Z', want: 'extracted', why: '0 bytes' },
+      { b: 'Y', want: 'extracted', why: 'not a SQLite file' },
+      { b: 'X', want: 'extracted', why: 'SPLIT_PAIR_REQUIRED' },
+      { b: 'W', want: 'meta', why: 'split pair present' },
+      { b: 'V', want: null, why: 'no usable db' },
+    ];
+    let bad = 0, oldTrap = 0; const det = [];
+    cases.forEach(c => {
+      const r = CACHE.resolveDbFile(c.b, 'auto', dir);
+      const oldRule = fs.existsSync(path.join(dir, c.b + '_meta.db')) ? 'meta' : 'extracted';   // the pre-fix probe rule
+      const ok = r.kind === c.want && r.reason.indexOf(c.why) >= 0;
+      if (!ok) bad++;
+      if (oldRule === 'meta' && c.want !== 'meta') oldTrap++;
+      det.push(c.b + ':' + r.kind + (ok ? '' : '⛔(' + r.reason + ')') + ' old=' + oldRule);
+    });
+    try { fs.rmSync(dir, { recursive: true, force: true }); } catch (e) {}
+    // The control is only a control if the OLD rule actually fails on it.
+    claim('C6_RED', oldTrap > 0 ? cases.length : 0, bad,
+      det.join(' | ') + ' — old existsSync(meta) rule walks into ' + oldTrap + ' traps; shipped resolver into ' + (bad ? bad : 0));
+  }
+}
+
+// C7 — END TO END: real build (Duplex, ~2 s) into a throwaway cache root; the probe on Duplex must live.
+{
+  const tmpCache = fs.mkdtempSync(path.join(process.env.SCRATCH || os.tmpdir(), 'w-cdk-cache-'));
+  const env = Object.assign({}, process.env, { CACHE_4D_DIR: tmpCache, BLD_DIR: BLD_DIR });
+  delete env.DB_KIND;
+  const runs = [];
+  function sh(label, cmd, extraEnv) {
+    const r = cp.spawnSync(process.execPath, cmd, { cwd: ROOT, env: Object.assign({}, env, extraEnv || {}), encoding: 'utf8', maxBuffer: 64 * 1048576 });
+    const out = (r.stdout || '') + (r.stderr || '');
+    runs.push({ label, status: r.status, out });
+    return { status: r.status, out };
+  }
+  let judged = 0, bad = 0; const det = [];
+  const dup = path.join(BLD_DIR, 'Duplex_extracted.db');
+  if (CACHE.sqliteProblem(dup)) det.push('Duplex fixture missing — C7 unjudged');
+  else {
+    judged++;
+    const b1 = sh('build', [path.join(ROOT, 'scripts', 'cache_4d_run.js'), 'Duplex']);
+    const dbLine = (b1.out.match(/§CACHE_DB Duplex[^\n]*/) || [''])[0];
+    const builtLine = (b1.out.match(/§CACHE_BUILT Duplex[^\n]*/) || [''])[0];
+    const rjPath = (builtLine.match(/-> (\S+)$/) || [])[1];
+    let rj = null; try { rj = JSON.parse(fs.readFileSync(path.join(rjPath, 'run.json'), 'utf8')); } catch (e) {}
+    const okBuild = b1.status === 0 && /kind=extracted/.test(dbLine) && /0 bytes/.test(dbLine) &&
+      /dbFile=Duplex_extracted\.db kind=extracted/.test(builtLine) && rj && rj.dbKind === 'extracted' && rj.dbFile === 'Duplex_extracted.db' &&
+      rjPath && /_extracted$/.test(rjPath);
+    if (!okBuild) bad++;
+    det.push('build:' + (okBuild ? 'ok' : '⛔') + ' ' + dbLine.slice(0, 110));
+
+    judged++;
+    const b2 = sh('forced-meta', [path.join(ROOT, 'scripts', 'cache_4d_run.js'), 'Duplex'], { DB_KIND: 'meta' });
+    const skip = (b2.out.match(/§CACHE_SKIP Duplex[^\n]*/) || [''])[0];
+    const okSkip = /DB_KIND=meta but Duplex_meta\.db 0 bytes/.test(skip);
+    if (!okSkip) bad++;
+    det.push('DB_KIND=meta:' + (okSkip ? 'refused-with-reason' : '⛔ ' + skip.slice(0, 80)));
+
+    judged++;
+    const p = sh('probe', [path.join(ROOT, 'scripts', 'probe_tm_reveal_shipped.js'), 'Duplex']);
+    const resolveLine = (p.out.match(/§TM_REVEAL_SHIPPED_RESOLVE Duplex[^\n]*/) || [''])[0];
+    const dbL = (p.out.match(/§TM_REVEAL_SHIPPED_DB Duplex[^\n]*/) || [''])[0];
+    const okProbe = p.status === 0 && /kind=extracted/.test(resolveLine) && /0 bytes/.test(resolveLine) && /file=Duplex_extracted\.db kind=extracted/.test(dbL);
+    if (!okProbe) bad++;
+    det.push('probe:' + (okProbe ? 'exit0 ' + resolveLine.slice(0, 90) : '⛔ exit=' + p.status + ' ' + (p.out.match(/§TM_REVEAL_SHIPPED_ERROR[^\n]*/) || [''])[0].slice(0, 120)));
+  }
+  try { fs.rmSync(tmpCache, { recursive: true, force: true }); } catch (e) {}
+  claim('C7_END_TO_END', judged, bad, det.join(' | '));
+}
+
+console.log('§WITNESS_CACHE_DB_KIND pass=' + pass + ' fail=' + fail + ' inconclusive=' + inconclusive + ' codeKey=' + CACHE.codeKey());
+process.exit(fail ? 1 : 0);


### PR DESCRIPTION
bim-compiler prompts/4D_MODEL_INTEGRITY.md §M.0 items 2+3 / §M.5 items 3+7 (2026-09-04).
scripts/cache_4d_run.js resolved `<bld>_extracted.db` by construction while the viewer loads the
split pair `_meta.db` + `_geo.db` whenever both exist (streaming.js §DB_SPLIT_DETECT /
§SPLIT_PAIR_REQUIRED). For Hospital the "persisted run" was therefore the 20-label INFERRED grid
(317 d, 42 tasks), not the post-#1641 7-band grid the viewer plays (334 d, 36 tasks) — the split-DB
live≠probe landmine inside clause 5's own instrument. Separately buildings/Duplex_meta.db is a 0-byte
file and probe_tm_reveal_shipped.js preferred meta on existsSync alone, so sql.js threw (exit 2).

- resolveDbFile(bld, want, bldDir): ONE owner of "which db does the viewer load". Mirrors the viewer's
  rule — meta iff meta AND geo are readable SQLite files (header-checked, so a 0-byte file, an LFS
  pointer or a directory are each refused BY NAME) — else extracted, with `reason` and `skipped`.
  DB_KIND=meta|extracted forces a side so the whole-db run stays reachable for comparison.
- Cache dir is `<codeKey>_<dbKey>_<kind>`; run.json carries dbFile/dbKind/dbReason; §CACHE_DB and
  §CACHE_BUILT print kind=; --list shows kind. scripts/lib/tm_played_layer.js joins the code key
  (it produces the persisted `play` map). All pre-existing cache dirs are therefore stale by name.
- probe_tm_reveal_shipped.js drops its local resolver, calls CACHE.resolveDbFile, prints
  §TM_REVEAL_SHIPPED_RESOLVE with the reason, and SKIPs with the reason instead of dying.
- viewer/tests/witness_cache_db_kind.js (W-CDK, 7 claims): C1 pair→meta on the real fleet (Clinic,
  Hospital, LTU_AHouse, Terminal), C2 the 0-byte Duplex meta is skipped and named, C3 forced kind
  reaches a different dir, C4 every dir ends in its kind, C5 one owner (source gate), C6 RED control
  on a synthetic fixture (the old existsSync rule walks into 4/5 traps, the resolver into 0), C7 end
  to end: a real Duplex build into a throwaway CACHE_4D_DIR + DB_KIND=meta refused with reason + the
  probe exits 0 on Duplex.

MEASURED: §WITNESS_CACHE_DB_KIND pass=7 fail=0 inconclusive=0.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>

Verified before push: W-CDK 7/7, RED control real — the old `existsSync(meta)` rule walks into 4 of 5 traps, the shipped resolver into 0. Also closes the 0-byte `Duplex_meta.db` crash (it is skipped with a stated reason instead of killing the probe), and cache directory names now carry the kind so a stale meta-vs-extracted comparison is impossible.

🤖 Generated with [Claude Code](https://claude.com/claude-code)