### PR TITLE
feat(erp): §KIND2-READBACK — a generated document is finally readable by the app that generated it

### DIFF
--- a/erp/ad_modelval.js
+++ b/erp/ad_modelval.js
@@ -80,6 +80,32 @@
       return !!(info.recordOld && info.record && String(info.recordOld[col]) !== String(info.record[col]));
     }
     var H = [
+      ['MOrder.issotrxFromWindow', function (ctx, info) {
+        // Implementing prompts/AGENT_QUEUE.md §KIND2-READBACK — Witness: W-KIND2-READBACK.
+        // The C_Order sibling of MInvoice.issotrxFromWindow (§Fix 4) and MInOut.movementTypeFromWindow
+        // (§Fix 2): the per-window Sales/Purchase signal reaching the NEW record itself. C_Order was the
+        // one of the three that never got it — its only IsSOTrx seam was docTypeTargetDefault below, and
+        // that derives IsSOTrx **only inside `if (!Number(r.c_doctypetarget_id))`**. C_DocTypeTarget_ID is
+        // IsDisplayed='Y' + IsMandatory='Y' on tab 186, so a user filling the form the normal way SETS it,
+        // the branch never runs, and the order persists with NO IsSOTrx at all.
+        // MEASURED (W-KIND2-READBACK first run, 2026-09-04, plain origin/main): a Sales Order authored
+        // through window 143 and Completed to CO was then REFUSED by both KIND-2 generators —
+        //   §AD-PROC-LIVE proc=118 … ok=N reason=order-not-shippable  message="Order is not a Sales Order"
+        //   §AD-PROC-LIVE proc=119 … ok=N reason=order-not-invoiceable message="Order is not a Sales Order"
+        // …because inoutGenGate/invoiceGenGate test `o.issotrx !== 'Y'`, and §CRUD-PERSIST's own column
+        // list for that create carries no `issotrx`.
+        // Java home (EXTRACT, do NOT invent): a new MOrder gets IsSOTrx from the window it is authored in —
+        // MOrder.setInitialDefaults():455 `setIsSOTrx(true)` for the Sales-Order case, and the ctx path
+        // Env.getContext(ctx,WindowNo,"IsSOTrx"). CalloutOrder.docType reads C_DocType.IsSOTrx but only to
+        // pick SO-vs-PO payment/term defaults — it never writes IsSOTrx back onto the tab, so it is NOT
+        // this seam (it is also one of the 139 named-deferred atoms: §CRUD-CALLOUT … absent=[CalloutOrder.docType]).
+        // ctx.issotrx is already threaded by crud_overlay._docCtx from window.APP._createIsSOTrx, which
+        // idempiere.html's buildForm() extracts from the active AD_Tab's own WhereClause
+        // (tab 186 "C_Order.IsSOTrx='Y'" vs tab 294 "…='N'"). Nothing new is read and nothing is invented.
+        var r = info.record;
+        if (!r.issotrx && (ctx && (ctx.issotrx === 'Y' || ctx.issotrx === 'N'))) d(info).issotrx = ctx.issotrx;
+        return null;
+      }],
       ['MOrder.clientNotZero', function (ctx, info) {        // :1195-1199  "AD_Client_ID = 0" → reject
         return Number(info.record.ad_client_id) === 0 ? 'AD_Client_ID = 0' : null;
       }],

--- a/erp/ad_process.js
+++ b/erp/ad_process.js
@@ -381,7 +381,12 @@
       return {
         ok: true, rows: built.lines.length,
         message: '@Created@ = 1 (' + built.lines.length + ' invoice line' + (built.lines.length === 1 ? '' : 's') + ')',
-        result: { ops: ops, lineCount: built.lines.length, header: ops[0], issotrx: ops[0].issotrx, deferredRule: built.deferredRule }
+        // §KIND2-READBACK (prompts/AGENT_QUEUE.md §K2RB.4) — crudMap publishes the spec's OWN engine-internal→
+        // real-column names so the commit seam can translate this op-group into the CRUD vocabulary
+        // crud_core.listTip folds. buildDoc writes `source_id`/`source_line_id` (engine names, not columns);
+        // the spec already knows the columns they stand for. EXTRACT — nothing new is decided here.
+        result: { ops: ops, lineCount: built.lines.length, header: ops[0], issotrx: ops[0].issotrx, deferredRule: built.deferredRule,
+                  crudMap: { docParent: INVOICE_SPEC.parentId, lineParent: INVOICE_SPEC.lineParentId } }
       };
     }, { kind: 'process', action: 'GenerateInvoice' });
   }
@@ -536,7 +541,12 @@
       return {
         ok: true, rows: built.lines.length,
         message: '@Created@ = 1 (' + built.lines.length + ' shipment line' + (built.lines.length === 1 ? '' : 's') + ')',
-        result: { ops: ops, lineCount: built.lines.length, header: ops[0], movementtype: ops[0].movementtype, deferredRule: built.deferredRule }
+        // §KIND2-READBACK (prompts/AGENT_QUEUE.md §K2RB.4) — crudMap publishes the spec's OWN engine-internal→
+        // real-column names so the commit seam can translate this op-group into the CRUD vocabulary
+        // crud_core.listTip folds. buildDoc writes `source_id`/`source_line_id` (engine names, not columns);
+        // the spec already knows the columns they stand for. EXTRACT — nothing new is decided here.
+        result: { ops: ops, lineCount: built.lines.length, header: ops[0], movementtype: ops[0].movementtype, deferredRule: built.deferredRule,
+                  crudMap: { docParent: SHIPMENT_SPEC.parentId, lineParent: SHIPMENT_SPEC.lineParentId } }
       };
     }, { kind: 'process', action: 'GenerateShipment' });
   }
@@ -566,7 +576,12 @@
       return {
         ok: true, rows: norm.length,
         message: '@C_Order_ID@ generated from project (' + norm.length + ' line' + (norm.length === 1 ? '' : 's') + ')',
-        result: { ops: ops, lineCount: norm.length, header: ops[0], issotrx: 'Y', docsubtypeso: 'WI' }
+        // §KIND2-READBACK (prompts/AGENT_QUEUE.md §K2RB.4) — crudMap publishes the spec's OWN engine-internal→
+        // real-column names so the commit seam can translate this op-group into the CRUD vocabulary
+        // crud_core.listTip folds. buildDoc writes `source_id`/`source_line_id` (engine names, not columns);
+        // the spec already knows the columns they stand for. EXTRACT — nothing new is decided here.
+        result: { ops: ops, lineCount: norm.length, header: ops[0], issotrx: 'Y', docsubtypeso: 'WI',
+                  crudMap: { docParent: GENORDER_SPEC.parentId, lineParent: GENORDER_SPEC.lineParentId } }
       };
     }, { kind: 'process', action: 'GenerateOrder' });
   }

--- a/erp/crud_overlay.js
+++ b/erp/crud_overlay.js
@@ -2059,6 +2059,50 @@
   // (none of these ops are owner-gated — every op is a fresh CREATE, matching commitCrud's own "CREATE has
   // no prior owner to gate" note). K.commitGroup's own atomicity guarantee means every op in the group
   // commits together or none do. cb(result) — result = {committed, gid?, ids?, sealed?, verifyOk?, reason?}.
+  // _resolveOpRefs — §KIND2-READBACK (prompts/AGENT_QUEUE.md §K2RB.4). A KIND-2 generator commits a NEW
+  // parent document and its lines in ONE group, so a line's parent FK cannot be written by the caller:
+  // a listTip-created row's pk is the SYNTHETIC negated kernel-op id, which does not exist until the
+  // group is staged. The placeholder {__opRef:i} means "the pk of the row op i creates" and is resolved
+  // HERE, inside the same _withFreshSide window commitGroup is about to stage against — so this is a
+  // READ of the id law the kernel already relies on itself, not a prediction across a gap:
+  //   kernel_ops.js:526-530 — "The staged ops will receive ids = max(id)+1..+N on insert … They are
+  //   contiguous because INTEGER PRIMARY KEY auto-increments monotonically and this group is a single
+  //   transaction."
+  // and crud_core.listTip:414 gives a CRUD_CREATE row the pk `-opId`. Hence op i ⇒ pk -(nextId+i).
+  // Returns a COPY (never mutates the caller's ops); an unresolvable ref is left as-is and logged, so a
+  // shape this does not understand fails loudly instead of committing a silent null FK.
+  function _resolveOpRefs(db, ops) {
+    var hasRef = ops.some(function (o) {
+      var f = o && o.fields; if (!f) return false;
+      for (var k in f) if (f.hasOwnProperty(k) && f[k] && typeof f[k] === 'object' && f[k].__opRef != null) return true;
+      return false;
+    });
+    if (!hasRef) return ops;
+    var nextId = null;
+    try { var r = db.exec('SELECT COALESCE(MAX(id),0) FROM kernel_ops'); if (r.length) nextId = Number(r[0].values[0][0]) + 1; } catch (e) { nextId = null; }
+    if (nextId == null) { console.warn('§CRUD-GROUP-OPREF cannot read kernel_ops MAX(id) — leaving refs unresolved'); return ops; }
+    var resolved = 0, unresolved = 0;
+    var out = ops.map(function (o) {
+      if (!o || !o.fields) return o;
+      var f2 = {}, any = false;
+      for (var k in o.fields) if (o.fields.hasOwnProperty(k)) {
+        var v = o.fields[k];
+        if (v && typeof v === 'object' && v.__opRef != null) {
+          var idx = Number(v.__opRef);
+          if (idx >= 0 && idx < ops.length) { f2[k] = -(nextId + idx); resolved++; any = true; continue; }
+          unresolved++;
+        }
+        f2[k] = v;
+      }
+      if (!any && !unresolved) return o;
+      var c = {}; for (var p in o) if (o.hasOwnProperty(p)) c[p] = o[p];
+      c.fields = f2; return c;
+    });
+    console.log('§CRUD-GROUP-OPREF nextId=' + nextId + ' resolved=' + resolved + ' unresolved=' + unresolved +
+                ' (a line\'s parent FK = the synthetic pk listTip will give its header op)');
+    return out;
+  }
+
   function applyOpGroup(ops, cb) {
     cb = cb || function () {};
     if (!ops || !ops.length) { cb({ committed: false, reason: 'empty-group' }); return; }
@@ -2066,7 +2110,7 @@
     withSidecar(function (db) {
       if (!db || !K || typeof K.commitGroup !== 'function') { console.log('§CRUD-GROUP kernel/sql.js absent — cannot commit'); cb({ committed: false, reason: 'kernel/sql.js absent' }); return; }
       _withFreshSide(K, function (freshDb, done) {
-        var groupOps = ops.map(function (o) { return { op_type: o.op_type, params: o }; });
+        var groupOps = _resolveOpRefs(freshDb, ops).map(function (o) { return { op_type: o.op_type, params: o }; });
         Promise.resolve(K.commitGroup(freshDb, groupOps, _commitMeta())).then(function (res) {
           if (!res || res.committed !== true) {
             console.warn('§CRUD-GROUP commitGroup not-committed reason=' + (res && res.reason || '?'));

--- a/erp/idempiere.html
+++ b/erp/idempiere.html
@@ -2940,6 +2940,56 @@ if (typeof qrcode !== "undefined") window.qrcode = qrcode;
       (res.dispatched ? ' ok=' + (res.ok ? 'Y' : 'N') + ' rows=' + res.rows + (res.ok ? '' : ' reason=' + res.reason + ' message=' + JSON.stringify(res.message)) : ' reason=' + res.reason));
     renderProcResult(proc, res);
   }
+  // §CREATEFROM-COMMIT / §KIND2-COMMIT — the ONE translation from ENGINE vocabulary to CRUD vocabulary,
+  // shared by both Confirm & Post seams below (it was written once for CreateFromInvoice in #1654; the
+  // KIND-2 generators need the identical shape, so this is hoisted rather than written a second time).
+  //
+  // WHY IT EXISTS: erp_engine/ad_process propose CREATE_DOCUMENT/CREATE_LINE, but crud_core.listTip —
+  // which every grid, every picker and every crud_overlay.completeFanout* reads through — folds ONLY
+  // CRUD_CREATE/CRUD_UPDATE/CRUD_DELETE. A raw engine op therefore commits to the signed log and is then
+  // INVISIBLE to every reader: signed, verified, unreadable. Measured twice —
+  //   #1654 CreateFromInvoice: §GENPROCESS-CONFIRM committed=Y ops=11 verifyOk=true → §INVOICE-FANOUT lines=0
+  //   W-KIND2-READBACK 2026-09-04: §GENPROCESS-CONFIRM committed=Y ops=2 verifyOk=true → §K2RB stage=2
+  //     readableDocs=0 readableLines=0 (and the same for stage 3)
+  // The target shape is exactly what crud_core.buildOp('create') produces, with stdDefaults from the same
+  // window.APP.* that sessionActor() reads. Every field value is the engine op's own — nothing invented.
+  //
+  // opts (KIND-2 only; omit for a lines-into-an-existing-document result like CreateFromInvoice):
+  //   crudMap    — { docParent, lineParent } published by the handler from its OWN buildDoc spec.
+  //                buildDoc writes the engine-internal names `source_id` (on the document) and
+  //                `source_line_id` (on each line); the spec knows which real columns they stand for
+  //                (c_order_id / c_orderline_id, c_project_id / c_projectline_id). Renamed, never dropped.
+  //   parentFk   — the column linking a line to its NEW parent document (docTable + '_id', the same
+  //                key+'_id' convention crud_overlay.recId uses). Set to the {__opRef:0} placeholder that
+  //                crud_overlay._resolveOpRefs turns into the header row's synthetic pk at commit time —
+  //                it cannot be known here, because that pk IS the header op's kernel id.
+  function _asCrudCreates(ops, opts) {
+    opts = opts || {};
+    var map = opts.crudMap || {}, parentFk = opts.parentFk || null;
+    var docParent = map.docParent ? String(map.docParent).toLowerCase() : null;
+    var lineParent = map.lineParent ? String(map.lineParent).toLowerCase() : null;
+    return ops.map(function (o, i) {
+      var fields = {};
+      Object.keys(o).forEach(function (k) {
+        if (k === 'op_type' || k === 'table' || k === '_sv' || k === '_sigv') return;
+        if (o[k] === undefined) return;
+        var lk = String(k).toLowerCase();
+        if (lk === 'source_id') { if (docParent && o[docParent] === undefined) fields[docParent] = o[k]; return; }
+        if (lk === 'source_line_id') { if (lineParent) fields[lineParent] = o[k]; return; }
+        fields[lk] = o[k];
+      });
+      if (parentFk && i > 0) fields[parentFk] = { __opRef: 0 };   // resolved at commit — see crud_overlay._resolveOpRefs
+      var std = null;
+      try {
+        if (window.APP && (window.APP.actor != null || window.APP.clientId != null))
+          std = { actor: window.APP.actor, clientId: window.APP.clientId, orgId: window.APP.orgId != null ? window.APP.orgId : 0 };
+      } catch (e) { std = null; }
+      var op = { key: String(o.table).toLowerCase(), table: String(o.table).toLowerCase(), verb: 'create',
+                 op_type: 'CRUD_CREATE', fields: fields, cas: null, op_uuid: null };
+      if (std) op.stdDefaults = std;
+      return op;
+    });
+  }
   function renderProcResult(proc, res) {
     var absent = !res.dispatched;
     var pane = el('div', 'idmp-procpane idmp-procresult' + (absent ? ' absent' : ''));
@@ -3019,7 +3069,19 @@ if (typeof qrcode !== "undefined") window.qrcode = qrcode;
       var cfMsg = el('div', 'msg'); cfMsg.style.cssText = 'margin-top:6px';
       cfBtn.addEventListener('click', function () {
         cfBtn.disabled = true; cfBtn.textContent = 'Posting…';
-        window.__crud.applyOpGroup(r.ops, function (out) {
+        // §KIND2-COMMIT (prompts/AGENT_QUEUE.md §KIND2-READBACK) — the same commit-seam translation
+        // §CREATEFROM-COMMIT already does, extended with the one thing CreateFromInvoice did not need:
+        // the parent document does not exist yet, so each line's parent FK is the {__opRef:0} placeholder
+        // crud_overlay._resolveOpRefs resolves to the header row's synthetic pk inside the commit window.
+        // MEASURED before this translation (W-KIND2-READBACK, plain origin/main, 2026-09-04):
+        //   §K2RB stage=2 committedOps=2 rawDocs=1 rawLines=1 readableDocs=0 readableLines=0
+        //   §K2RB stage=3 committedOps=2 rawDocs=1 rawLines=1 readableDocs=0 readableLines=0
+        var k2Parent = String(h.table).toLowerCase() + '_id';       // key+'_id' — crud_overlay.recId's convention
+        var k2Ops = _asCrudCreates(r.ops, { crudMap: r.crudMap, parentFk: k2Parent });
+        console.log('§KIND2-COMMIT translating ' + r.ops.length + ' engine op(s) → CRUD_CREATE for ' +
+                    String(h.table).toLowerCase() + ' + ' + (r.ops.length - 1) + ' line(s) parented on ' + k2Parent +
+                    ' (listTip folds CRUD only; a raw CREATE_DOCUMENT/CREATE_LINE would be unreadable)');
+        window.__crud.applyOpGroup(k2Ops, function (out) {
           if (!out || !out.committed) {
             cfBtn.disabled = false; cfBtn.textContent = 'Confirm & Post';
             cfMsg.textContent = 'Not posted: ' + ((out && out.reason) || 'unknown');
@@ -3068,25 +3130,7 @@ if (typeof qrcode !== "undefined") window.qrcode = qrcode;
       // So translate at the commit seam into exactly the shape crud_core.buildOp('create') produces —
       // same op_type, same fields, same stdDefaults source (window.APP.*, which is what sessionActor()
       // reads). Nothing is invented: every field value is the engine op's own.
-      function _asCrudCreates(ops) {
-        return ops.map(function (o) {
-          var fields = {};
-          Object.keys(o).forEach(function (k) {
-            if (k === 'op_type' || k === 'table' || k === '_sv' || k === '_sigv') return;
-            if (o[k] === undefined) return;
-            fields[String(k).toLowerCase()] = o[k];
-          });
-          var std = null;
-          try {
-            if (window.APP && (window.APP.actor != null || window.APP.clientId != null))
-              std = { actor: window.APP.actor, clientId: window.APP.clientId, orgId: window.APP.orgId != null ? window.APP.orgId : 0 };
-          } catch (e) { std = null; }
-          var op = { key: String(o.table).toLowerCase(), table: String(o.table).toLowerCase(), verb: 'create',
-                     op_type: 'CRUD_CREATE', fields: fields, cas: null, op_uuid: null };
-          if (std) op.stdDefaults = std;
-          return op;
-        });
-      }
+      // (the translation itself is _asCrudCreates above renderProcResult — one implementation, two seams)
       cfb.addEventListener('click', function () {
         cfb.disabled = true; cfb.textContent = 'Posting…';
         var crudOps = _asCrudCreates(r.ops);

--- a/erp/sw.js
+++ b/erp/sw.js
@@ -10,7 +10,7 @@
 // init-bubble must be INSTANT, ERP_INIT_BUBBLE_INSTANT.md); network-first for non-precached .js (fresh on
 // deploy); cache-first for precached assets/.wasm/images. Freshness on deploy is carried by the SW version
 // bump (skipWaiting+clients.claim precache the new shell), so SWR strands a user at most one load post-deploy.
-const CACHE_VERSION = 'v783';   // bump on each deploy; per-change detail is the git commit message.
+const CACHE_VERSION = 'v784';   // bump on each deploy; per-change detail is the git commit message.
 // v772 (rebase of PR #203 onto origin/main) §INTEG-WIRE-B: disposable-host persistence in-app
 // (erp_replica_client.js + erp_persist_ui.js) — back the books up to a SIGNED snapshot the user
 // owns (signed by the edge key), restore on a FRESH device -> replay recomputes tip == signed


### PR DESCRIPTION
Implementing prompts/AGENT_QUEUE.md §KIND2-READBACK (bim-compiler 4b786bc6a's sibling
section), which owns §ERP-SESSION-CLOSE §CLOSE.4 item 1. Paired bim-compiler commit
carries the spec + the witness (scripts/witness_kind2_readback.js).

MEASURED FIRST, as §CLOSE.4 asked. The three shipped live witnesses are green and
SCOPE-BLIND: on the served seed every KIND-2 generate is EMPTY, so no op-group is built,
Confirm & Post is never clicked, and no read-back is attempted.

  poc_genpo_live   PASS rows=0  honest gate rejection, nothing committed
  poc_geninv_live  PASS rows=0  "@Created@ = 0", nothing committed
  poc_genship_live PASS rows=0  "@Created@ = 0", nothing committed

"What is readable today" was therefore not 0 — it was UNMEASURED. W-KIND2-READBACK
reaches a NON-EMPTY generate honestly (C_Order's own AD_Column defaults are
DeliveryRule='F' and InvoiceRule='I'; renderOrderPicker already folds freshly-created
orders) and then reads the result back through crud_core.listTip. On plain origin/main:

  §K2RB stage=2 committedOps=2 rawDocs=1 rawLines=1 readableDocs=0 readableLines=0
  §K2RB stage=3 committedOps=2 rawDocs=1 rawLines=1 readableDocs=0 readableLines=0

Signed, verified, unreadable — the same defect #1654 fixed for CreateFromInvoice, still
live for InOutGenerate and InvoiceGenerate.

A SECOND, EARLIER defect the measurement exposed on the way: a Sales Order authored
through window 143 and Completed was REFUSED by both generators —
"Order is not a Sales Order". C_Order's only IsSOTrx seam was MOrder.docTypeTargetDefault,
which derives it ONLY inside `if (!Number(r.c_doctypetarget_id))`. That column is
IsDisplayed='Y' + IsMandatory='Y' on tab 186, so a user filling the form the normal way
sets it, the branch never runs, and the order persists with no IsSOTrx at all.
MOrder.issotrxFromWindow is the missing sibling of MInvoice.issotrxFromWindow (§Fix 4)
and MInOut.movementTypeFromWindow (§Fix 2): ctx.issotrx was already threaded by
crud_overlay._docCtx from the AD_Tab's own WhereClause; nothing read it onto the record.

THE FIX, at the commit seam §CLOSE.4 named:
- idempiere.html — _asCrudCreates is hoisted out of the CreateFrom branch (one
  implementation, two seams) and gains the parent-link case CreateFromInvoice did not
  need: the parent document does not exist yet.
- crud_overlay.applyOpGroup — _resolveOpRefs turns a {__opRef:i} placeholder into the
  synthetic pk listTip will give op i. Resolved INSIDE the same _withFreshSide window
  commitGroup stages against, off the id law the kernel already states for itself
  (kernel_ops.js:526-530, ids = max(id)+1..+N, contiguous, one transaction) — a read, not
  a prediction. One atomic group; commitGroup's all-or-none guarantee intact.
- ad_process.js — each KIND-2 handler publishes crudMap from its OWN buildDoc spec, so
  the engine-internal source_id/source_line_id are RENAMED to the real columns
  (c_order_id / c_orderline_id, c_project_id / c_projectline_id), never dropped.

AFTER (same witness, same run shape):
  §K2RB stage=2 committedOps=2 readableDocs=1 readableLines=1 linesLinkedToADoc=1 PASS
  §K2RB stage=3 committedOps=2 readableDocs=1 readableLines=1 linesLinkedToADoc=1 PASS

And the row itself, not the count (§CLOSE.7 rule 2 — the FK fold once read 118/118/0
while binding NULL into every column):
  §K2RB-ROW m_inout     = {issotrx:Y, movementtype:C-, c_bpartner_id:118, m_warehouse_id:103, c_order_id:-1, m_inout_id:-4}
  §K2RB-ROW m_inoutline = {c_orderline_id:-2, m_product_id:128, movementqty:1, line:10, m_inout_id:-4}
The witness fails a row that is readable but hollow, not just one that is missing.

Regression, all green from inside this worktree: witness_p2p_invoice_match 4/4 stages ·
poc_genship_live · poc_geninv_live · poc_genpo_live · poc_ad_process_live ·
poc_minout_live · poc_payment_live · poc_ad_displaylogic_live · poc_ad_menu_prf_live ·
W-PARITY-VALRULE 23/23 · W-PARITY-FIELDSET 30/30 · W-PARITY-MANDATORY-CREATE 18/18 ·
W-DOCNO-BRANCH 10/10.

erp/sw.js CACHE_VERSION v783 -> v784.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)