### PR TITLE
perf/purity(erp): §DICT-LAZY — a second dictionary's renderer leaves the core boot path

### DIFF
--- a/erp/idempiere.html
+++ b/erp/idempiere.html
@@ -485,10 +485,14 @@
 <!-- DESCRIPTOR SEAM (IDEMPIERE_2.md §pivot, renderer #2) — one chrome, N dictionaries. AD = first descriptor
      (facets ARE ADParser/ADData/IdmpSession above, verbatim). MUST load after those three. -->
 <script src="erp_descriptor.js?v=1"></script>
-<!-- RENDERER #2 (IDEMPIERE_2.md §pivot) — the Odoo descriptor: registers a 2nd dictionary so ?erp=odoo drives
-     this UNCHANGED chrome over an Odoo model. Reads odoo_model.json + odoo_chain.json (pulled live by
-     odoo_agent/extract_model.js). Inactive unless ?erp=odoo — the AD path is untouched. -->
-<script src="odoo_descriptor.js?v=1"></script>
+<!-- RENDERER #2 (IDEMPIERE_2.md §pivot) — the Odoo descriptor is NOT loaded here any more.
+     §DICT-LAZY (prompts/AGENT_QUEUE.md §CLOSE.4 item 2 — user rule 2026-09-04: "nothing non-core is
+     fetched unless asked for"). It registers a SECOND dictionary; a second dictionary's renderer has no
+     business in the core boot path when nobody asked for it. It is now fetched by _ensureDictionary()
+     in the boot IIFE below, at the moment ?erp=odoo names it, BEFORE ErpDescriptor.use() runs — so the
+     odoo path is unchanged and the default path never touches the file. Kernel purity, not perf.
+     (erp/sw.js still PRECACHES odoo_descriptor.js + odoo_model.json + odoo_chain.json on purpose: that
+     is what makes ?erp=odoo work OFFLINE. Precaching stores; it does not execute, parse, or register.) -->
 <!-- ERP_AUDIT_CHANGELOG Task 2 — resolve audit actor AD_User_ID → real AD_User.Name (NON-INVENT, honest fallback). -->
 <script src="user_names.js?v=1"></script>
 <!-- FRONTEND_LANE_MASTER §2 Item C — Accts-Posted: the frozen read-fold + the lens (pill-alongside). -->
@@ -635,7 +639,37 @@ if (typeof qrcode !== "undefined") window.qrcode = qrcode;
   // so this is behavior-identical today; ErpDescriptor.use('odoo') repoints the whole chrome at renderer #2.
   // ?erp=<name> selects a descriptor before the aliases are cached (renderer #2 entry point). Fallback to the
   // raw AD globals if the seam module failed to load (never a blank chrome).
-  (function () { try { var w = new URLSearchParams(location.search).get('erp'); if (w && window.ErpDescriptor) window.ErpDescriptor.use(w); } catch (e) {} })();
+  // §DICT-LAZY — a NON-CORE dictionary is fetched only when something asks for it by name (user rule,
+  // 2026-09-04). AD is the core dictionary and ships in the boot path; every other one lives here and is
+  // pulled synchronously, at the moment ?erp=<name> names it and before ErpDescriptor.use(<name>) runs —
+  // registration must already have happened by then, which is why this is a sync XHR + eval and not a
+  // <script> append (odoo_descriptor.js itself loads its two JSON artifacts the same synchronous way, for
+  // the same reason: structure.init(db) is called un-awaited at boot). A failed fetch is logged and the
+  // chrome falls through to AD — never a blank screen.
+  var LAZY_DICTS = { odoo: 'odoo_descriptor.js?v=1' };
+  function _ensureDictionary(name) {
+    var src = LAZY_DICTS[name];
+    if (!src) return false;                                   // not a lazy dictionary (e.g. 'ad') — nothing to do
+    var D = window.ErpDescriptor;
+    if (D && typeof D.list === 'function' && D.list().indexOf(name) >= 0) return true;   // already registered
+    try {
+      var x = new XMLHttpRequest(); x.open('GET', src, false); x.send(null);
+      if (x.status < 200 || x.status >= 300) { console.warn('§DICT-LAZY name=' + name + ' src=' + src + ' status=' + x.status + ' — not registered, falling through to AD'); return false; }
+      (0, eval)(x.responseText);
+      console.log('§DICT-LAZY loaded=' + name + ' src=' + src + ' bytes=' + x.responseText.length +
+                  ' (NOT in the boot path — fetched because ?erp=' + name + ' asked for it)');
+      return true;
+    } catch (e) { console.warn('§DICT-LAZY name=' + name + ' load error — ' + e.message + '; falling through to AD'); return false; }
+  }
+  (function () {
+    try {
+      var w = new URLSearchParams(location.search).get('erp');
+      if (w) _ensureDictionary(w);
+      if (w && window.ErpDescriptor) window.ErpDescriptor.use(w);
+      console.log('§DICT-LAZY asked=' + (w || '(none)') + ' deferred=[' + Object.keys(LAZY_DICTS).join(',') + '] registered=[' +
+                  ((window.ErpDescriptor && window.ErpDescriptor.list) ? window.ErpDescriptor.list().join(',') : '?') + ']');
+    } catch (e) {}
+  })();
   var _D = (window.ErpDescriptor && window.ErpDescriptor.active) || null;
   var ADP = _D ? _D.structure : window.ADParser,
       ADD = _D ? _D.data      : window.ADData,

--- a/erp/sw.js
+++ b/erp/sw.js
@@ -10,7 +10,7 @@
 // init-bubble must be INSTANT, ERP_INIT_BUBBLE_INSTANT.md); network-first for non-precached .js (fresh on
 // deploy); cache-first for precached assets/.wasm/images. Freshness on deploy is carried by the SW version
 // bump (skipWaiting+clients.claim precache the new shell), so SWR strands a user at most one load post-deploy.
-const CACHE_VERSION = 'v784';   // bump on each deploy; per-change detail is the git commit message.
+const CACHE_VERSION = 'v785';   // bump on each deploy; per-change detail is the git commit message.
 // v772 (rebase of PR #203 onto origin/main) §INTEG-WIRE-B: disposable-host persistence in-app
 // (erp_replica_client.js + erp_persist_ui.js) — back the books up to a SIGNED snapshot the user
 // owns (signed by the edge key), restore on a FRESH device -> replay recomputes tip == signed


### PR DESCRIPTION
Implementing prompts/AGENT_QUEUE.md §DICT-LAZY, which owns §ERP-SESSION-CLOSE §CLOSE.4 item 2.
The user's rule it serves (2026-09-04): nothing non-core is fetched unless asked for.
Paired bim-compiler commit carries the spec + scripts/witness_dict_lazy.js.

odoo_descriptor.js (10.4 KB) was one of idempiere.html's 84 eager <script> tags: a SECOND
dictionary's renderer, fetched, parsed and registered on every boot, for every user, whether
or not anyone ever asks for it. Kernel purity, not perf.

It is now fetched by _ensureDictionary() in the boot IIFE, at the moment ?erp=<name> names it
and BEFORE ErpDescriptor.use(<name>) runs — registration has to have happened by then, which
is why this is a synchronous XHR + indirect eval and not a <script> append. odoo_descriptor.js
itself already loads its two JSON artifacts the same synchronous way, for the same reason
(structure.init(db) is called un-awaited at boot). A failed fetch is logged and the chrome
falls through to AD — never a blank screen. LAZY_DICTS is the registry; adding renderer #3 is
one line, not one more boot-path script tag.

MEASURED — W-DICT-LAZY judges the NETWORK, not the §-log, because "not registered" and "not
fetched" are different facts and the item is about the fetch:

  BEFORE (plain origin/main @05fd3024):  7 PASS / 3 FAIL
    §DICT-LAZY-WITNESS mode=default fetches=1 registered=[ad,odoo] active=ad
  AFTER:                                10 PASS / 0 FAIL
    §DICT-LAZY-WITNESS mode=default fetches=0 registered=[ad]      active=ad  pageerrors=0
    §DICT-LAZY-WITNESS mode=odoo    fetches=1 registered=[ad,odoo] active=odoo pageerrors=0
    §DICT-LAZY loaded=odoo src=odoo_descriptor.js?v=1 bytes=10361 (NOT in the boot path —
      fetched because ?erp=odoo asked for it)

DELIBERATELY NOT CHANGED: erp/sw.js still precaches odoo_descriptor.js + odoo_model.json +
odoo_chain.json. That is what makes ?erp=odoo work OFFLINE, and precaching stores a file — it
does not execute it, parse it, or register a second dictionary. Dropping it would remove
working functionality to satisfy a rule about the boot path.

Regression: W-DESCRIPTOR-SEAM 7/7 PASS (identical before and after) · W-KIND2-READBACK 3/3
stages PASS on this merged tree. poc_odoo_descriptor.js FAILS IDENTICALLY before and after
(byte-identical output up to the failure): it times out clicking #idmp-login-ok, which is not
visible any more — a STALE WITNESS judging a retired login DOM, pre-existing on origin/main,
reported not fixed. Its first three claims (activeName===odoo, list()===[ad,odoo], facets
present) all pass on the lazy path.

erp/sw.js CACHE_VERSION v784 -> v785.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)