### PR TITLE
feat(erp): §INOUT-CALLOUTS — the two named atoms, and the IsSOTrx coupling they exposed

### DIFF
--- a/erp/ad_callout.js
+++ b/erp/ad_callout.js
@@ -98,7 +98,7 @@
   function dispatch(db, info, ctx) {
     ctx = ctx || {};
     var callouts = readCallout(db, info.table, info.column);
-    var fired = [], absent = [], derived = {}, notes = [];
+    var fired = [], absent = [], derived = {}, notes = [], deferred = [];
     callouts.forEach(function (name) {
       if (!hasHandler(name)) { absent.push(name); return; }                   // Core.getCallout==null analogue
       var out;
@@ -107,8 +107,13 @@
       fired.push(name);
       if (out.derived) for (var k in out.derived) if (Object.prototype.hasOwnProperty.call(out.derived, k)) derived[k] = out.derived[k];
       if (out.note) notes.push(out.note);
+      // §INOUT-CALLOUTS — a handler's NAMED-DEFERRED branches were being dropped on the floor here, which is
+      // exactly the failure the standing rule forbids ("a named-deferred branch is declared in result.deferred,
+      // never silently absent" — the convention stockMoves/CreateFromInvoice already follow). Carried through,
+      // tagged with the handler that declared it, so the caller can print it.
+      if (out.deferred && out.deferred.length) out.deferred.forEach(function (dfr) { deferred.push(name.split('.').slice(-2).join('.') + ': ' + dfr); });
     });
-    return { table: info.table, column: info.column, callouts: callouts, fired: fired, absent: absent, derived: derived, notes: notes };
+    return { table: info.table, column: info.column, callouts: callouts, fired: fired, absent: absent, derived: derived, notes: notes, deferred: deferred };
   }
 
   // coverageScan(db) — of the AD_Column callout population, how many cols/classes does the registry dispatch?

--- a/erp/ad_modelval.js
+++ b/erp/ad_modelval.js
@@ -271,11 +271,19 @@
         // already-set C_DocType_ID) can never fire for a manually-created record — this is the ONLY seam
         // where the per-window signal (ctx.movementtype, threaded from the AD_Tab's own WhereClause, e.g.
         // Material Receipt tab 296's "MovementType IN ('V+')") can reach the new row at all.
+        // §INOUT-CALLOUTS (prompts/AGENT_QUEUE.md §INOUT-CALLOUTS) — IsSOTrx was NESTED inside "MovementType
+        // was empty", so the moment anything ELSE filled MovementType this branch stopped running and the
+        // receipt persisted with NO IsSOTrx. MEASURED the hour CalloutInOut.docType started filling it:
+        //   §RECEIPT-FANOUT receipt=-4 issotrx=undefined …   →   §P2P stage=3 FAIL, "the CreateFrom pane did
+        //   not offer the fresh receipt line -5" (renderCreateFromPicker keeps `String(h.issotrx)==='N'`).
+        // The two facts are independent in the Java too: CalloutInOut.docType sets IsSOTrx from the DocType
+        // (:214-227) and MovementType (:229) as two separate mTab.setValue calls. So derive IsSOTrx from
+        // whatever MovementType the record ENDS UP with, whoever set it — record first, then this pass's own
+        // derivation, then the window signal.
         var r = info.record;
-        if (!r.movementtype && /^[A-Z][+-]$/.test((ctx && ctx.movementtype) || '')) {
-          d(info).movementtype = ctx.movementtype;
-          if (!r.issotrx) d(info).issotrx = ctx.movementtype.charAt(0) === 'C' ? 'Y' : 'N';
-        }
+        if (!r.movementtype && /^[A-Z][+-]$/.test((ctx && ctx.movementtype) || '')) d(info).movementtype = ctx.movementtype;
+        var mtEff = String(r.movementtype || (info.derived && info.derived.movementtype) || (ctx && ctx.movementtype) || '');
+        if (!r.issotrx && /^[A-Z][+-]$/.test(mtEff)) d(info).issotrx = mtEff.charAt(0) === 'C' ? 'Y' : 'N';
         return null;
       }],
       ['MInOut.movementTypeDerive', function (ctx, info) {   // :1306-1308 ∘ getMovementType:1275-1287

--- a/erp/crud_overlay.js
+++ b/erp/crud_overlay.js
@@ -369,6 +369,70 @@
       });
       console.log('§CRUD-CALLOUT host bPartner handler registered (CalloutOrder.bPartner — bill+pricelist default; engine handlers untouched)');
     }
+    // §INOUT-CALLOUTS (prompts/AGENT_QUEUE.md §INOUT-CALLOUTS, §ERP-SESSION-CLOSE §CLOSE.4 item 3) — the two
+    // atoms §CLOSE.4 named as "half-built and forced". Both are AD data: ad_column.callout declares
+    // CalloutInOut.bpartner on M_InOut.C_BPartner_ID and CalloutInOut.docType on M_InOut.C_DocType_ID
+    // (queried from ad_seed.db, not assumed). Registered as HOST GLUE for the same reason CalloutOrder.bPartner
+    // is: they need the bundle, and W-CALLOUT PINS the engine's installDefaultHandlers at 6 pure atoms.
+    if (!global.AdCallout.hasHandler('org.compiere.model.CalloutInOut.bpartner')) {
+      global.AdCallout.registerHandler('org.compiere.model.CalloutInOut.bpartner', function (ctx, info) {
+        // Java home (EXTRACT, do NOT invent) — CalloutInOut.bpartner (CalloutInOut.java:264-333):
+        //   its whole field-setting body is inside `if (!IsSOTrx)` (:291) — the RECEIPT side. It sets
+        //   C_BPartner_Location_ID = (select max(l.C_BPartner_Location_ID) … where IsActive='Y') (:274,:294-298)
+        //   and AD_User_ID = ShipTo_User_ID when > 0 else max(active AD_User) (:275-276, :300-307).
+        //   The IsSOTrx branch (:311-320) only fires a CreditLimitOver STATUS EVENT — a UI notification, not a
+        //   field — so it is NAMED-DEFERRED, never silently skipped.
+        // This is the atom that makes a Material Receipt create stop needing C_BPartner_Location_ID typed by
+        // hand (witness_p2p_invoice_match had to type 114 explicitly, with a comment saying real iDempiere
+        // defaults it via this very callout).
+        var r = info.record || {};
+        var bp = Number(r.C_BPartner_ID || r.c_bpartner_id || 0);
+        if (!bp) return { derived: {} };
+        // IsSOTrx is not a field on this form; the per-window signal is MovementType (§Fix 2's own finding —
+        // the M_InOut AD_Tab family splits Shipment 'C-' vs Receipt 'V+' by MovementType, never IsSOTrx).
+        // Read the record first, then that window signal — the same precedence _docCtx uses.
+        var so = null;
+        if (r.IsSOTrx != null || r.issotrx != null) so = String(r.IsSOTrx != null ? r.IsSOTrx : r.issotrx).toUpperCase() === 'Y';
+        if (so == null) { var mt = String((global.APP && global.APP._createMovementType) || r.MovementType || r.movementtype || ''); if (/^[A-Z][+-]$/.test(mt)) so = mt.charAt(0) === 'C'; }
+        if (so === true) return { derived: {}, deferred: ['CreditLimitOver (fireDataStatusEEvent — a UI status event, not a field)'] };
+        var bpd = ctx.bpShipDefaults ? ctx.bpShipDefaults(bp) : null;
+        if (!bpd) return { derived: {}, note: 'no c_bpartner row for ' + bp };
+        var d = {};
+        if (bpd.locationId != null) d.C_BPartner_Location_ID = bpd.locationId;
+        if (bpd.userId != null) d.AD_User_ID = bpd.userId;
+        return { derived: d, note: 'receipt-side location/contact defaulted from BP ' + bp };
+      });
+      console.log('§CRUD-CALLOUT host CalloutInOut.bpartner registered (receipt-side C_BPartner_Location_ID + AD_User_ID default; the SO credit-limit branch is a status event, named-deferred)');
+    }
+    if (!global.AdCallout.hasHandler('org.compiere.model.CalloutInOut.docType')) {
+      global.AdCallout.registerHandler('org.compiere.model.CalloutInOut.docType', function (ctx, info) {
+        // Java home (EXTRACT, do NOT invent) — CalloutInOut.docType (CalloutInOut.java:191-262): reads the
+        // chosen C_DocType's DocBaseType + IsSOTrx, sets IsSOTrx from the doctype when they differ (:214-227)
+        // and MovementType = MInOut.getMovementType(ctx, C_DocType_ID, IsSOTrx, null) (:229).
+        // getMovementType IS ALREADY PORTED, verbatim, as erp_engine.movementTypeOf(docBaseType, issotrx)
+        // (erp_engine.js:302-309) — landed for E-4/stockMoves. This atom calls it; it does not re-derive it
+        // (§CLOSE.4's own words: "its body sets MovementType via the very rule E-4 already ported").
+        // The DocumentNo re-preview branch (:231-258) is NAMED-DEFERRED: _seedDocNoPreview/_previewDocNo
+        // already own DocumentNo-from-sequence on this form, and two writers to one field is the defect.
+        var r = info.record || {};
+        var dt = Number(r.C_DocType_ID || r.c_doctype_id || 0);
+        if (!dt) return { derived: {} };
+        var info2 = ctx.docTypeInfo ? ctx.docTypeInfo(dt) : null;
+        if (!info2) return { derived: {}, note: 'no c_doctype row for ' + dt };
+        var E = global.ERPEngine;
+        if (!E || typeof E.movementTypeOf !== 'function')
+          return { derived: {}, deferred: ['MovementType (erp_engine.movementTypeOf absent — never re-derived here)'] };
+        var d = {}, deferred = [];
+        var mt = E.movementTypeOf(info2.docBaseType, info2.issotrx);
+        if (mt) d.MovementType = mt; else deferred.push('MovementType (DocBaseType ' + info2.docBaseType + ' is not MMS/MMR — getMovementType returns null)');
+        // IsSOTrx is carried too (the Java sets it), even though M_InOut's create form declares no IsSOTrx
+        // field, so nothing applies it today — MOrder/MInOut beforeSave own that column. Derived, not dropped.
+        if (info2.issotrx === 'Y' || info2.issotrx === 'N') d.IsSOTrx = info2.issotrx;
+        deferred.push('DocumentNo re-preview (:231-258 — _seedDocNoPreview already owns this field)');
+        return { derived: d, deferred: deferred, note: 'DocBaseType ' + info2.docBaseType + ' IsSOTrx ' + info2.issotrx + ' -> MovementType ' + mt };
+      });
+      console.log('§CRUD-CALLOUT host CalloutInOut.docType registered (MovementType via erp_engine.movementTypeOf — the E-4 port, not a second derivation)');
+    }
   }
   function fireCreateCallout(e, changedCol) {
     if (!global.AdCallout || typeof withBundle !== 'function' || !e || !changedCol) return;
@@ -381,6 +445,25 @@
           try { var row = b3.prepare('SELECT m_pricelist_id FROM c_bpartner WHERE c_bpartner_id=?').get(Number(bpId));
             return row ? { priceListId: row.m_pricelist_id } : null; } catch (er) { return null; }
         },
+        // §INOUT-CALLOUTS — the two accessors CalloutInOut.bpartner/.docType need, as the SAME kind of
+        // read-the-real-join helper bpDefaults already is. The SQL is the Java's own, transcribed:
+        //   bpShipDefaults ← CalloutInOut.java:274-276 (max active location; ShipTo user else max active user)
+        //   docTypeInfo    ← CalloutInOut.java:197-201 (DocBaseType + IsSOTrx off C_DocType)
+        bpShipDefaults: function (bpId) {
+          try {
+            var row = b3.prepare(
+              "SELECT (SELECT MAX(l.c_bpartner_location_id) FROM c_bpartner_location l WHERE l.c_bpartner_id=p.c_bpartner_id AND l.isactive='Y') AS loc," +
+              " (SELECT MAX(u.ad_user_id) FROM ad_user u WHERE u.c_bpartner_id=p.c_bpartner_id AND u.isactive='Y' AND u.isshipto='Y') AS shipto," +
+              " (SELECT MAX(u.ad_user_id) FROM ad_user u WHERE u.c_bpartner_id=p.c_bpartner_id AND u.isactive='Y') AS anyuser" +
+              " FROM c_bpartner p WHERE p.c_bpartner_id=?").get(Number(bpId));
+            if (!row) return null;
+            return { locationId: row.loc, userId: (Number(row.shipto) > 0 ? row.shipto : row.anyuser) };
+          } catch (er) { return null; }
+        },
+        docTypeInfo: function (dtId) {
+          try { var row = b3.prepare('SELECT docbasetype, issotrx FROM c_doctype WHERE c_doctype_id=?').get(Number(dtId));
+            return row ? { docBaseType: row.docbasetype, issotrx: row.issotrx } : null; } catch (er) { return null; }
+        },
         productPrice: function (pid) {   // forward-compat for a c_orderline create (next leg) — the real price-list join
           try { var row = b3.prepare('SELECT pp.pricestd, pp.pricelist FROM m_productprice pp JOIN m_pricelist_version v ON v.m_pricelist_version_id=pp.m_pricelist_version_id WHERE pp.m_product_id=? LIMIT 1').get(Number(pid));
             return row ? { priceStd: row.pricestd, priceList: row.pricelist } : null; } catch (er) { return null; }
@@ -390,10 +473,19 @@
       var derived = res.derived || {}, applied = [];
       Object.keys(derived).forEach(function (c) {
         var inEl = fhost.querySelector('[data-col="' + c + '"]') || fhost.querySelector('[data-col="' + String(c).toLowerCase() + '"]');
-        if (inEl && !inEl.disabled) { _setVal(inEl, derived[c]); applied.push(c); }
+        // §INOUT-CALLOUTS — a READ-ONLY field is still WRITTEN by a callout. iDempiere's callouts set the
+        // model, not the widget (mTab.setValue(...)); IsReadOnly='Y' stops the USER typing, it does not stop
+        // the engine filling. MEASURED: CalloutInOut.docType derived MovementType='V+' and it was dropped on
+        // the floor, because M_InOut.MovementType is IsReadOnly='Y' on AD_Tab 296 — the very column that tab
+        // is keyed on. Same class for C_OrderLine.QtyOrdered (IsReadOnly='Y' on tab 187), which is exactly
+        // what CalloutOrder.qty exists to fill. gatherVals() reads every field element regardless of
+        // `disabled`, so a value written here reaches the saved record. `(ro)` marks it in the §-log so the
+        // two cases stay distinguishable.
+        if (inEl) { _setVal(inEl, derived[c]); applied.push(c + (inEl.disabled ? '(ro)' : '')); }
       });
       var short = function (n) { return String(n).split('.').slice(-2).join('.'); };
-      console.log('§CRUD-CALLOUT table=' + e.key + ' col=' + changedCol + ' callouts=[' + (res.callouts || []).map(short).join(',') + '] fired=[' + (res.fired || []).map(short).join(',') + '] absent=[' + (res.absent || []).map(short).join(',') + '] derived=' + JSON.stringify(derived) + ' applied=[' + applied.join(',') + ']');
+      console.log('§CRUD-CALLOUT table=' + e.key + ' col=' + changedCol + ' callouts=[' + (res.callouts || []).map(short).join(',') + '] fired=[' + (res.fired || []).map(short).join(',') + '] absent=[' + (res.absent || []).map(short).join(',') + '] derived=' + JSON.stringify(derived) + ' applied=[' + applied.join(',') + ']' +
+        ((res.deferred && res.deferred.length) ? ' deferred=[' + res.deferred.join(' | ') + ']' : ''));
       if (applied.length && typeof applyAdLogic === 'function') try { applyAdLogic(e); } catch (er) {}
     });
   }

--- a/erp/sw.js
+++ b/erp/sw.js
@@ -10,7 +10,7 @@
 // init-bubble must be INSTANT, ERP_INIT_BUBBLE_INSTANT.md); network-first for non-precached .js (fresh on
 // deploy); cache-first for precached assets/.wasm/images. Freshness on deploy is carried by the SW version
 // bump (skipWaiting+clients.claim precache the new shell), so SWR strands a user at most one load post-deploy.
-const CACHE_VERSION = 'v785';   // bump on each deploy; per-change detail is the git commit message.
+const CACHE_VERSION = 'v786';   // bump on each deploy; per-change detail is the git commit message.
 // v772 (rebase of PR #203 onto origin/main) §INTEG-WIRE-B: disposable-host persistence in-app
 // (erp_replica_client.js + erp_persist_ui.js) — back the books up to a SIGNED snapshot the user
 // owns (signed by the edge key), restore on a FRESH device -> replay recomputes tip == signed


### PR DESCRIPTION
Implementing prompts/AGENT_QUEUE.md §INOUT-CALLOUTS, which owns the two atoms §ERP-SESSION-CLOSE
§CLOSE.4 item 3 calls "half-built and forced". Paired bim-compiler commit carries the spec +
scripts/witness_inout_callout_atoms.js.

Both callouts are AD DATA, not a choice: ad_column.callout declares CalloutInOut.bpartner on
M_InOut.C_BPartner_ID and CalloutInOut.docType on M_InOut.C_DocType_ID (queried from ad_seed.db).
Registered as HOST GLUE for the same reason CalloutOrder.bPartner is — they need the bundle, and
W-CALLOUT pins the engine's installDefaultHandlers at 6 pure atoms.

  CalloutInOut.bpartner (CalloutInOut.java:264-333) — the whole field-setting body is inside
    `if (!IsSOTrx)`, the RECEIPT side: C_BPartner_Location_ID = max active location (:274,:294-298),
    AD_User_ID = ShipTo contact else max active user (:275-276,:300-307). This is the field
    witness_p2p_invoice_match still types by hand, with a comment saying real iDempiere defaults it
    via this very callout. The IsSOTrx branch (:311-320) only fires a CreditLimitOver STATUS EVENT —
    named-deferred, not silently skipped.
  CalloutInOut.docType (CalloutInOut.java:191-262) — MovementType via
    erp_engine.movementTypeOf(DocBaseType, IsSOTrx), which IS MInOut.getMovementType already ported
    verbatim for E-4. This atom CALLS it; it does not re-derive it. DocumentNo re-preview
    (:231-258) is named-deferred: _seedDocNoPreview already owns that field, and two writers to one
    field is the defect.

THREE THINGS THE MEASUREMENT FORCED, each a real defect of its own:

1. AdCallout.dispatch DROPPED every handler's result.deferred on the floor — the exact thing the
   standing rule forbids ("a named-deferred branch is declared in result.deferred, never silently
   absent"). Now carried through, tagged with the handler that declared it, and printed by
   §CRUD-CALLOUT.

2. A READ-ONLY field is still WRITTEN by a callout. iDempiere callouts set the MODEL
   (mTab.setValue), not the widget; IsReadOnly='Y' stops the USER typing, not the engine filling.
   Measured: MovementType was derived 'V+' and dropped, because M_InOut.MovementType is
   IsReadOnly='Y' on AD_Tab 296 — the very column that tab is keyed on. Same class for
   C_OrderLine.QtyOrdered (IsReadOnly='Y' on tab 187), which is what CalloutOrder.qty exists to
   fill. gatherVals() reads every field element regardless of `disabled`, so the value reaches the
   saved record. The §-log marks such a write `(ro)`.

3. A REGRESSION THIS CHANGE CAUSED AND THIS COMMIT FIXES. MInOut.movementTypeFromWindow nested
   IsSOTrx inside "MovementType was empty", so the moment the new callout filled MovementType the
   branch stopped running and the receipt persisted with NO IsSOTrx:
     §RECEIPT-FANOUT receipt=-4 issotrx=undefined lines=1 matchPoOps=0
     §P2P stage=3 FAIL — "the CreateFrom pane did not offer the fresh receipt line -5"
       (renderCreateFromPicker keeps `String(h.issotrx)==='N'`), stage=4 PARTIAL
   The two facts are independent in the Java as well (:214-227 sets IsSOTrx, :229 sets MovementType,
   two separate setValue calls), so IsSOTrx now follows whatever MovementType the record ends up
   with, whoever set it. After: `issotrx=N … matchPoOps=1`, stages 3 and 4 PASS again.

MEASURED — W-INOUT-CALLOUT-ATOMS, oracle = ad_seed.db read at run time, never a constant:
  before (plain origin/main): 🔴 1 PASS / 8 FAIL — absent=[CalloutInOut.bpartner], absent=[CalloutInOut.docType]
  after:                      🟢 9 PASS / 0 FAIL
    §CRUD-CALLOUT table=m_inout col=c_bpartner_id fired=[CalloutInOut.bpartner]
      derived={"C_BPartner_Location_ID":114,"AD_User_ID":105} applied=[c_bpartner_location_id,ad_user_id]
    §CRUD-CALLOUT table=m_inout col=c_doctype_id fired=[CalloutInOut.docType]
      derived={"MovementType":"V+","IsSOTrx":"N"} applied=[MovementType(ro)]
      deferred=[CalloutInOut.docType: DocumentNo re-preview (:231-258 — _seedDocNoPreview already owns this field)]

Regression, all green: witness_p2p_invoice_match 4/4 stages · W-KIND2-READBACK 3/3 stages ·
W-PARITY-VALRULE 23/23 · W-PARITY-FIELDSET 30/30 · W-PARITY-MANDATORY-CREATE 18/18 ·
W-DOCNO-BRANCH 10/10 · headless over the shipped bytes: W-CALLOUT · W-MODELVAL · W-MORDER-SAVE ·
W-PROC-SHIP. (poc_callout_harden is an honest ⬜ SKIP — its Postgres oracle is unreachable here,
before and after alike.)

erp/sw.js CACHE_VERSION v785 -> v786.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)