### PR TITLE
feat(erp): §AD-FORM-LIVE — the Form spine, and AD_Form 108 (VMatch) end to end

### DIFF
--- a/erp/idempiere.html
+++ b/erp/idempiere.html
@@ -1265,6 +1265,7 @@ if (typeof qrcode !== "undefined") window.qrcode = qrcode;
         row.classList.add('active');
         if (node.action === 'W' && node.windowId) _dirtyGuard(function () { openWindow(Number(node.windowId), node.name); });
         else if ((node.action === 'P' || node.action === 'R') && node.processId) openProcess(Number(node.processId), node.name);  // §AD-PROC-LIVE (B-5/C-5)
+        else if (node.action === 'X' && node.formId) openAdForm(Number(node.formId), node.name);                                  // §AD-FORM-LIVE (E-3)
         else status('"' + node.name + '" — action ' + node.action + ' (window opening only in I1)');
         if (window.innerWidth <= 760) document.body.classList.remove('menu-open');
       });
@@ -2562,6 +2563,252 @@ if (typeof qrcode !== "undefined") window.qrcode = qrcode;
     $('idmp-toolbar').style.display = 'none'; $('idmp-tabstrip').style.display = 'none';
     var c = $('idmp-content'); c.innerHTML = ''; c.appendChild(pane);
   }
+  // ════════════════════════════════════════════════════════════════════════════════════════════════════════
+  // §AD-FORM-LIVE (prompts/AGENT_QUEUE.md §ADFORM-VMATCH, §ERP-SESSION-CLOSE §CLOSE.4 item 4 / E-3) — the
+  // FORM renderer. 49 AD_Form rows are baked in ad_seed.db and, until now, an 'X' menu leaf fell through to
+  // `status("… action X (window opening only in I1)")`. This is the P/R spine's sibling: the menu leaf
+  // resolves the AD_Form row, dispatches on its OWN Classname, and an unregistered classname shows the same
+  // HONEST "not available" card openProcess already shows — never a blank pane, never a fabricated form.
+  // ONE form is implemented end to end, per §CLOSE.4's own scoping: AD_Form 108
+  // "Matching PO-Receipt-Invoice" (org.compiere.apps.form.VMatch), because it is the READ FACE of the very
+  // three-way match this lane closed at #1654/#1661 — the junctions already exist, so nothing is invented.
+  var _FORM_HANDLERS = {};
+  function _registerForm(classname, fn) { _FORM_HANDLERS[classname] = fn; }
+  function openAdForm(formId, name) {
+    var row = _sqlRows('SELECT ad_form_id, name, classname FROM ad_form WHERE ad_form_id=' + Number(formId))[0] || null;
+    var cls = row ? String(row.classname || '') : '';
+    var handled = !!_FORM_HANDLERS[cls];
+    console.log('§AD-FORM-LIVE open form=' + formId + ' name="' + ((row && row.name) || name || '') + '" classname=' + (cls || '(blank)') +
+                ' handled=' + (handled ? 'Y' : 'N') + ' registered=[' + Object.keys(_FORM_HANDLERS).map(function (c) { return c.split('.').pop(); }).join(',') + ']');
+    if (!row) { status('AD_Form ' + formId + ' not found'); return; }
+    if (handled) { _FORM_HANDLERS[cls](row); return; }
+    // the honest absent card — identical in kind to an unregistered process classname
+    var pane = el('div', 'idmp-procpane idmp-procresult absent');
+    pane.appendChild(el('h3', null, row.name || name || ('Form ' + formId)));
+    pane.appendChild(el('div', 'sub', 'AD_Form ' + formId + ' · classname ' + (cls || '(blank)')));
+    pane.appendChild(el('span', 'ok-chip', 'Not available'));
+    pane.appendChild(el('div', 'msg', 'This AD_Form row is real and the menu leaf reaches it, but no renderer is registered for ' +
+      (cls || 'a blank classname') + ' yet. ' + Object.keys(_FORM_HANDLERS).length + ' of ' +
+      (_sqlRows('SELECT count(*) n FROM ad_form')[0] || { n: 0 }).n + ' forms are implemented.'));
+    var back = el('div', null); var bb = el('button', null, 'Close');
+    bb.style.cssText = 'margin-top:12px;font-size:12.5px;padding:5px 16px;border:1px solid var(--idmp-border);border-radius:6px;background:var(--idmp-panel);cursor:pointer';
+    bb.addEventListener('click', function () {
+      $('idmp-content').innerHTML = '<div id="idmp-placeholder"><div class="big">&#128193;</div>Select a menu item to open a window.</div>'; status('Ready');
+    });
+    back.appendChild(bb); pane.appendChild(back);
+    _showProcPane(pane);
+  }
+
+  // _foldTable — read-the-tip for a whole table: the immutable bundle rows PLUS the signed sidecar's
+  // CRUD_CREATE/UPDATE/DELETE overlay, optionally with each row's latest SET_STATUS. Same primitive pair
+  // (listTip + readTip) renderOrderPicker and renderCreateFromPicker already use — hoisted here so the
+  // match form folds a freshly-authored document exactly like a seed one, instead of a third copy of it.
+  function _foldTable(table, pk, base, withStatus, cb) {
+    var c = window.__crud;
+    if (!c || typeof c.withSidecar !== 'function' || !c.core || typeof c.core.listTip !== 'function') { cb(base); return; }
+    c.withSidecar(function (sdb) {
+      var rows = base;
+      if (sdb) {
+        var folded = null;
+        try { folded = c.core.listTip(sdb, table, pk, base, null); } catch (e) { folded = null; }
+        rows = (folded && folded.rows) || base;
+        if (withStatus && typeof c.core.readTip === 'function')
+          rows.forEach(function (r) { try { var t = c.core.readTip(sdb, table, r[pk], null); if (t != null) r.docstatus = t; } catch (e) {} });
+      }
+      cb(rows);
+    });
+  }
+  // _matchRowsFor — the junction rows for a match table. TWO SOURCES, both real: the bundle's own
+  // M_MatchInv/M_MatchPO rows, and the signed op log — erp_engine.completeInvoice/completeReceipt emit each
+  // junction as a CREATE_LINE op (that is what §P2P stage 4 asserts on), so a match created in THIS session
+  // exists ONLY there. Reading one source and not the other is how this lane's "committed but invisible"
+  // defects happen (§CLOSE.7 rule 1).
+  function _matchRowsFor(table, cb) {
+    var base = _sqlRows('SELECT * FROM ' + table);
+    var c = window.__crud, out = base.slice();
+    var K = (c && typeof c.kernelDb === 'function') ? c.kernelDb() : null;
+    if (K && window.KernelOps && typeof window.KernelOps.replayOps === 'function') {
+      try {
+        window.KernelOps.replayOps(K, 'CREATE_LINE').forEach(function (o) {
+          var p = o.parameters;
+          if (p && String(p.table || '').toLowerCase() === table) {
+            var r = {}; for (var k in p) if (p.hasOwnProperty(k)) r[String(k).toLowerCase()] = p[k];
+            out.push(r);
+          }
+        });
+      } catch (e) {}
+    }
+    console.log('§AD-FORM-MATCH junctions table=' + table + ' bundle=' + base.length + ' oplog=' + (out.length - base.length) + ' total=' + out.length);
+    cb(out);
+  }
+
+  // ── VMatch (AD_Form 108) — Java home, EXTRACT do NOT invent ────────────────────────────────────────────
+  // org.compiere.apps.form.Match (Match.java:301-361 tableInit) picks a SQL pair per direction; the SQL
+  // itself lives on the models as constants, transcribed here field for field:
+  //   Invoice→Receipt   MInvoice.MATCH_TO_RECEIPT_SQL (:85-98) + *_GROUP_BY (:101-110)
+  //   Receipt→Order     MInOut.BASE_MATCHING_SQL (:87-102) with M_MatchPO  + *_TO_ORDER_GROUP_BY (:116-126)
+  //   Receipt→Invoice   the same base with M_MatchInv                       + *_TO_INVOICE_GROUP_BY (:128-141)
+  //   Order→Receipt     MOrder.BASE_MATCHING_SQL (:81-97) with M_MatchPO    + *_TO_RECEIPT_GROUP_BY (:107-124)
+  // The HAVING is the whole semantics: NOT MATCHED = `qty <> SUM(matched)`, MATCHED = `0 <> SUM(matched)`.
+  // Match.getMatchToOptions (:80-96) fixes the legal pairs: Invoice→Shipment, Order→Shipment,
+  // Shipment→{Invoice,Order}. Order→Invoice exists in the model constants but the Java itself says
+  // "only matchToType == MATCH_SHIPMENT is implemented in UI" (:328) — so it is NOT offered here either.
+  // NOT PORTED, NAMED (Match.createMatchRecord :396-468): creating a match by hand. erp_engine's
+  // completeInvoice/completeReceipt already emit every M_MatchInv/M_MatchPO this app has, and a second
+  // writer to one junction is exactly the defect class §INOUT-CALLOUTS just paid a regression to find.
+  // This form is the READ face of that junction; the write leg is declared, not silently missing.
+  var _MATCH_DIRS = {
+    'I>S': {
+      label: 'Invoice → Material Receipt', doc: 'c_invoice', line: 'c_invoiceline', docPk: 'c_invoice_id', linePk: 'c_invoiceline_id',
+      dateCol: 'dateinvoiced', qtyCol: 'qtyinvoiced', docBase: ['API', 'APC'], negBase: ['APC'],
+      match: 'm_matchinv', matchKey: 'c_invoiceline_id', matchNeeds: null,
+      cols: ['Invoice', 'Date', 'BPartner', 'Line', 'Product', 'Qty', 'Matched']
+    },
+    'S>O': {
+      label: 'Material Receipt → Order', doc: 'm_inout', line: 'm_inoutline', docPk: 'm_inout_id', linePk: 'm_inoutline_id',
+      dateCol: 'movementdate', qtyCol: 'movementqty', docBase: ['MMR', 'MMS'], negBase: ['MMS'],
+      match: 'm_matchpo', matchKey: 'm_inoutline_id', matchNeeds: 'm_inoutline_id',
+      cols: ['Receipt', 'Date', 'BPartner', 'Line', 'Product', 'Qty', 'Matched']
+    },
+    'S>I': {
+      label: 'Material Receipt → Invoice', doc: 'm_inout', line: 'm_inoutline', docPk: 'm_inout_id', linePk: 'm_inoutline_id',
+      dateCol: 'movementdate', qtyCol: 'movementqty', docBase: ['MMR', 'MMS'], negBase: ['MMS'],
+      match: 'm_matchinv', matchKey: 'm_inoutline_id', matchNeeds: null,
+      cols: ['Receipt', 'Date', 'BPartner', 'Line', 'Product', 'Qty', 'Matched']
+    },
+    'O>S': {
+      label: 'Order → Material Receipt', doc: 'c_order', line: 'c_orderline', docPk: 'c_order_id', linePk: 'c_orderline_id',
+      dateCol: 'dateordered', qtyCol: 'qtyordered', docBase: ['POO'], negBase: [],
+      match: 'm_matchpo', matchKey: 'c_orderline_id', matchNeeds: 'm_inoutline_id',
+      cols: ['Order', 'Date', 'BPartner', 'Line', 'Product', 'Qty', 'Matched']
+    }
+  };
+  var _MATCH_FROM = [{ k: 'I', n: 'Invoice' }, { k: 'S', n: 'Material Receipt' }, { k: 'O', n: 'Order' }];
+  function _matchToOptions(from) {   // Match.getMatchToOptions:80-96, verbatim
+    if (from === 'I') return ['S'];
+    if (from === 'O') return ['S'];
+    return ['I', 'O'];
+  }
+  _registerForm('org.compiere.apps.form.VMatch', function (form) {
+    var pane = el('div', 'idmp-procpane idmp-procform');
+    pane.appendChild(el('h3', null, form.name));
+    pane.appendChild(el('div', 'sub', 'AD_Form ' + form.ad_form_id + ' · ' + form.classname +
+      ' · read face of M_MatchPO / M_MatchInv (creating a match by hand is named-deferred — the engine owns that junction)'));
+    var ctl = el('div', 'fld');
+    ctl.appendChild(el('label', null, 'Match from'));
+    var fromSel = document.createElement('select'); fromSel.setAttribute('data-match-from', '1');
+    _MATCH_FROM.forEach(function (o) { var op = el('option', null, o.n); op.value = o.k; fromSel.appendChild(op); });
+    ctl.appendChild(fromSel);
+    ctl.appendChild(el('label', null, 'Match to'));
+    var toSel = document.createElement('select'); toSel.setAttribute('data-match-to', '1');
+    ctl.appendChild(toSel);
+    ctl.appendChild(el('label', null, 'Show'));
+    var modeSel = document.createElement('select'); modeSel.setAttribute('data-match-mode', '1');
+    [['N', 'Not Matched'], ['M', 'Matched']].forEach(function (o) { var op = el('option', null, o[1]); op.value = o[0]; modeSel.appendChild(op); });
+    ctl.appendChild(modeSel);
+    pane.appendChild(ctl);
+    var actions = el('div', 'actions');
+    var runBtn = el('button', 'run', 'Refresh'); runBtn.setAttribute('data-match-run', '1');
+    var closeBtn = el('button', null, 'Close');
+    actions.appendChild(runBtn); actions.appendChild(closeBtn); pane.appendChild(actions);
+    var host = el('div', null); host.setAttribute('data-match-host', '1'); pane.appendChild(host);
+    closeBtn.addEventListener('click', function () {
+      $('idmp-content').innerHTML = '<div id="idmp-placeholder"><div class="big">&#128193;</div>Select a menu item to open a window.</div>'; status('Ready');
+    });
+    function paintTo() {
+      var opts = _matchToOptions(fromSel.value);
+      toSel.innerHTML = '';
+      opts.forEach(function (k) { var op = el('option', null, (_MATCH_FROM.filter(function (f) { return f.k === k; })[0] || {}).n); op.value = k; toSel.appendChild(op); });
+    }
+    fromSel.addEventListener('change', function () { paintTo(); run(); });
+    toSel.addEventListener('change', run);
+    modeSel.addEventListener('change', run);
+    runBtn.addEventListener('click', run);
+    function run() {
+      var key = fromSel.value + '>' + toSel.value, dir = _MATCH_DIRS[key];
+      host.innerHTML = '';
+      if (!dir) {
+        host.appendChild(el('div', 'gap', 'Direction ' + key + ' is not offered — Match.getMatchToOptions does not pair those two, and the Java itself notes only Match-to-Receipt is implemented in the UI.'));
+        console.log('§AD-FORM-MATCH dir=' + key + ' offered=N (Match.getMatchToOptions)');
+        return;
+      }
+      var matched = modeSel.value === 'M';
+      // headers: DocStatus IN ('CO','CL') AND the direction's DocBaseType filter — both from the Java's own
+      // INNER JOIN C_DocType (…) clause, applied after the tip fold so a freshly-Completed doc qualifies.
+      var hdrBase = _sqlRows('SELECT * FROM ' + dir.doc);
+      _foldTable(dir.doc, dir.docPk, hdrBase, true, function (hdrs) {
+        var dtBase = {};
+        _sqlRows('SELECT c_doctype_id, docbasetype FROM c_doctype').forEach(function (d) { dtBase[String(d.c_doctype_id)] = d.docbasetype; });
+        var hdrById = {}, kept = 0;
+        hdrs.forEach(function (h) {
+          var st = String(h.docstatus || '').toUpperCase();
+          if (st !== 'CO' && st !== 'CL') return;
+          var base = dtBase[String(h.c_doctype_id)] || null;
+          if (base != null && dir.docBase.indexOf(base) < 0) return;
+          // MInOut's own extra predicate: MMS only counts when IsSOTrx='N' (a vendor RETURN), MMR always
+          if (dir.doc === 'm_inout' && base === 'MMS' && String(h.issotrx) !== 'N') return;
+          h._docbase = base; hdrById[String(h[dir.docPk])] = h; kept++;
+        });
+        var lineBase = _sqlRows('SELECT * FROM ' + dir.line);
+        _foldTable(dir.line, dir.linePk, lineBase, false, function (lns) {
+          _matchRowsFor(dir.match, function (mrows) {
+            var sum = {};
+            mrows.forEach(function (m) {
+              // the Java's CASE: M_MatchPO only counts a row that actually carries the OTHER side's key
+              if (dir.matchNeeds && (m[dir.matchNeeds] == null || m[dir.matchNeeds] === '')) return;
+              var k = m[dir.matchKey]; if (k == null) return;
+              sum[String(k)] = (sum[String(k)] || 0) + Number(m.qty || 0);
+            });
+            var bpName = {}, prName = {}, orgName = {};
+            _sqlRows('SELECT c_bpartner_id, name FROM c_bpartner').forEach(function (r) { bpName[String(r.c_bpartner_id)] = r.name; });
+            _sqlRows('SELECT m_product_id, name FROM m_product').forEach(function (r) { prName[String(r.m_product_id)] = r.name; });
+            _sqlRows('SELECT ad_org_id, name FROM ad_org').forEach(function (r) { orgName[String(r.ad_org_id)] = r.name; });
+            var out = [], scanned = 0;
+            lns.forEach(function (l) {
+              var h = hdrById[String(l[dir.docPk])]; if (!h) return;
+              // the Java's `INNER JOIN M_Product p ON (lin.M_Product_ID=p.M_Product_ID)` — a charge line with
+              // no product is NOT in this form's population, in any direction. An inner join is a filter.
+              if (prName[String(l.m_product_id)] === undefined) return;
+              scanned++;
+              var q = Number(l[dir.qtyCol] || 0);
+              if (dir.negBase.indexOf(h._docbase) >= 0) {
+                // MInvoice: APC negates QtyInvoiced. MInOut: MMS negates MovementQty (and MMS only reaches
+                // here when IsSOTrx='N', which is the same condition the Java's CASE tests).
+                q = -q;
+              }
+              var m = sum[String(l[dir.linePk])] || 0;
+              var keep = matched ? (0 !== m) : (q !== m);     // the HAVING, verbatim
+              if (!keep) return;
+              out.push({ doc: h.documentno, date: h[dir.dateCol], bp: bpName[String(h.c_bpartner_id)] || h.c_bpartner_id,
+                         line: l.line, prod: prName[String(l.m_product_id)] || l.m_product_id, qty: q, matched: m,
+                         org: orgName[String(h.ad_org_id)] || h.ad_org_id });
+            });
+            var t = document.createElement('table'), tr = el('tr');
+            dir.cols.forEach(function (hd, i) { tr.appendChild(el('th', i >= 5 ? 'r' : null, hd)); });
+            t.appendChild(tr);
+            out.forEach(function (r) {
+              tr = el('tr');
+              [r.doc, r.date, r.bp, r.line, r.prod, r.qty, r.matched].forEach(function (cv, i) {
+                tr.appendChild(el('td', i >= 5 ? 'r' : null, cv == null ? '' : String(cv)));
+              });
+              t.appendChild(tr);
+            });
+            host.appendChild(t);
+            host.appendChild(el('div', 'msg', out.length + ' line' + (out.length === 1 ? '' : 's') + ' · ' +
+              (matched ? 'MATCHED (HAVING 0 <> SUM(matched qty))' : 'NOT MATCHED (HAVING qty <> SUM(matched qty))') +
+              ' · ' + kept + ' completed ' + dir.doc + ' header' + (kept === 1 ? '' : 's') + ' in scope, ' + scanned + ' line' + (scanned === 1 ? '' : 's') + ' scanned'));
+            if (!out.length) host.appendChild(el('div', 'gap', 'Nothing to show for this direction and mode — an empty result, not a missing one (' + scanned + ' lines were scanned against ' + Object.keys(sum).length + ' junction keys).'));
+            console.log('§AD-FORM-MATCH dir=' + key + ' mode=' + (matched ? 'matched' : 'notmatched') +
+                        ' headers=' + kept + ' linesScanned=' + scanned + ' junctionKeys=' + Object.keys(sum).length + ' rows=' + out.length);
+          });
+        });
+      });
+    }
+    paintTo();
+    _showProcPane(pane);
+    run();
+  });
+
   // openProcess — the entry for menu P/R leaves + the ?process= deep link (procSet-gated in applySession).
   function openProcess(processId, name) {
     if (!window.AdProcess) { status('Process engine not loaded'); return; }

--- a/erp/sw.js
+++ b/erp/sw.js
@@ -10,7 +10,7 @@
 // init-bubble must be INSTANT, ERP_INIT_BUBBLE_INSTANT.md); network-first for non-precached .js (fresh on
 // deploy); cache-first for precached assets/.wasm/images. Freshness on deploy is carried by the SW version
 // bump (skipWaiting+clients.claim precache the new shell), so SWR strands a user at most one load post-deploy.
-const CACHE_VERSION = 'v786';   // bump on each deploy; per-change detail is the git commit message.
+const CACHE_VERSION = 'v787';   // bump on each deploy; per-change detail is the git commit message.
 // v772 (rebase of PR #203 onto origin/main) §INTEG-WIRE-B: disposable-host persistence in-app
 // (erp_replica_client.js + erp_persist_ui.js) — back the books up to a SIGNED snapshot the user
 // owns (signed by the edge key), restore on a FRESH device -> replay recomputes tip == signed


### PR DESCRIPTION
Implementing prompts/AGENT_QUEUE.md §ADFORM-VMATCH, which owns §ERP-SESSION-CLOSE §CLOSE.4 item 4
(E-3: "49 AD_Form rows baked, no Form renderer. Scope ONE form end to end"). Paired bim-compiler
commit carries the spec + scripts/witness_adform_vmatch.js.

THE SPINE. An 'X' menu leaf used to fall through to
  status('"…" — action X (window opening only in I1)')
It now calls openAdForm(), which resolves the real AD_Form row and dispatches on the row's OWN
Classname — the exact sibling of the W-PROC spine for P/R leaves, including its honesty rule: an
unregistered classname shows the "Not available" card naming the classname and the 1-of-49 count,
never a blank pane and never a fabricated form.

THE ONE FORM: AD_Form 108 "Matching PO-Receipt-Invoice" (org.compiere.apps.form.VMatch), chosen
because it is the READ FACE of the very three-way match this lane closed at #1654/#1661 — the
M_MatchPO/M_MatchInv junctions already exist, so nothing has to be invented to fill it.

EXTRACTED, not designed. org.compiere.apps.form.Match:301-361 picks a SQL pair per direction and
the SQL itself lives on the models as constants, transcribed field for field:
  Invoice→Receipt  MInvoice.MATCH_TO_RECEIPT_SQL:85-98 + GROUP BY/HAVING :101-110
  Receipt→Order    MInOut.BASE_MATCHING_SQL:87-102 (M_MatchPO) + :116-126
  Receipt→Invoice  the same base with M_MatchInv + :128-141
  Order→Receipt    MOrder.BASE_MATCHING_SQL:81-97 (M_MatchPO) + :107-124
The HAVING is the whole semantics — NOT MATCHED = `qty <> SUM(matched)`, MATCHED = `0 <> SUM(matched)`.
Match.getMatchToOptions:80-96 fixes the legal pairs (Invoice→Shipment, Order→Shipment,
Shipment→{Invoice,Order}); Order→Invoice exists in the model constants but the Java itself says
"only matchToType == MATCH_SHIPMENT is implemented in UI" (:328), so it is not offered here either.
The per-direction CASE expressions (APC negates QtyInvoiced; MMS negates MovementQty and only counts
when IsSOTrx='N'; M_MatchPO only counts a junction row that carries the other side's key) and the
`INNER JOIN M_Product` (a charge line with no product is not in the population — an inner join is a
filter) are all carried, not approximated.

Two things the substrate forced, both honest:
- sql.js has no FULL JOIN, so the fold is done in JS over the same inputs — and that is the better
  shape anyway, because the second source below cannot be reached from SQL at all.
- _matchRowsFor reads BOTH the bundle's junction rows AND the signed op log:
  erp_engine.completeInvoice/completeReceipt emit each junction as a CREATE_LINE op (that is what
  §P2P stage 4 asserts on), so a match made in THIS session exists only there. Reading one source
  and not the other is precisely how this lane's "committed but invisible" defects happen.
  Headers and lines fold through listTip/readTip, so a freshly-Completed document is in scope too.
- _foldTable is hoisted from renderCreateFromPicker's inner foldRows rather than copied.

NOT PORTED, NAMED (Match.createMatchRecord:396-468): creating a match by hand. The engine already
emits every M_MatchInv/M_MatchPO this app has, and a second writer to one junction is exactly the
defect class §INOUT-CALLOUTS paid a regression to find this same session. This form is the READ
face; the write leg is declared, not silently missing.

MEASURED — W-ADFORM-VMATCH, oracle = the transcribed Java SQL run by sqlite3 against ad_seed.db:
  before (plain origin/main): 🔴 1 PASS / 2 FAIL, then the harness threw (no form pane exists)
  after:                      🟢 16 PASS / 0 FAIL
    §AD-FORM-LIVE open form=108 classname=org.compiere.apps.form.VMatch handled=Y registered=[VMatch]
    §AD-FORM-MATCH dir=I>S mode=notmatched rows=18   oracle 18
    §AD-FORM-MATCH dir=I>S mode=matched    rows=18   oracle 18
    §AD-FORM-MATCH dir=S>O mode=notmatched rows=0    oracle 0
    §AD-FORM-MATCH dir=S>O mode=matched    rows=21   oracle 21
    §AD-FORM-LIVE open form=104 classname=…VAllocation handled=N  → "Not available" card
  The witness also asserts the two modes are DIFFERENT populations (a renderer that ignored the mode
  would otherwise pass), that the counted rows are actually IN the table, and that the run is not
  vacuous. It refuses to print PASS if the harness threw before every claim was judged.

Regression, all green: witness_p2p_invoice_match 4/4 stages · W-DICT-LAZY 10/10 ·
W-DESCRIPTOR-SEAM 7/7 · W-AD-PROC-LIVE · W-AD-MENU-PRF-LIVE (it already judged X-leaf pruning) ·
W-AD-DISPLAYLOGIC-LIVE 10/10 · W-PROC-SHIP-LIVE · W-PROC-INV-LIVE.

erp/sw.js CACHE_VERSION v786 -> v787.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)