### PR TITLE
chore(erp): §HYGIENE-E14 — ad_table_map.js leaves the precache (it is not loadable)

### DIFF
--- a/erp/sw.js
+++ b/erp/sw.js
@@ -10,7 +10,7 @@
 // init-bubble must be INSTANT, ERP_INIT_BUBBLE_INSTANT.md); network-first for non-precached .js (fresh on
 // deploy); cache-first for precached assets/.wasm/images. Freshness on deploy is carried by the SW version
 // bump (skipWaiting+clients.claim precache the new shell), so SWR strands a user at most one load post-deploy.
-const CACHE_VERSION = 'v787';   // bump on each deploy; per-change detail is the git commit message.
+const CACHE_VERSION = 'v789';   // bump on each deploy; per-change detail is the git commit message.
 // v772 (rebase of PR #203 onto origin/main) §INTEG-WIRE-B: disposable-host persistence in-app
 // (erp_replica_client.js + erp_persist_ui.js) — back the books up to a SIGNED snapshot the user
 // owns (signed by the edge key), restore on a FRESH device -> replay recomputes tip == signed
@@ -53,7 +53,12 @@ const PRECACHE_ASSETS = [
   'ad_modelval.js',
   'ad_parser.js',
   'ad_process.js',    // B-5/C-5 — process dispatch spine (window.AdProcess), W-PROC / W-AD-PROC-LIVE
-  'ad_table_map.js',
+  // 'ad_table_map.js' — REMOVED from the precache 2026-09-04 (E-14, prompts/AGENT_QUEUE.md §HYGIENE-E14).
+  // It is the PB bridge module a caller hands to ADData.useBridge(map); the bridge is default OFF
+  // (ad_data.js:8-20) and NO page carries a <script> tag for this file, so precaching it downloaded a
+  // module on every install that could never run. Dormant-by-design, per TRILOGY_STALE_CODE_AUDIT.md —
+  // so the FILE stays; only the unconditional download goes. Whoever turns the bridge on has to add a
+  // script tag anyway, and puts this line back in the same PR.
   'ad_valrule.js',   // §P3 — AD_Val_Rule interpreter feeding the live FK pickers (W-PARITY-VALRULE)
   'vfs_detect.js',    // CONSTRAINT_MITIGATION item 3 — OPFS/IDB detection at boot (§VFS monitor)
   'error_beacon.js',  // SYSTEM_MONITOR_WIDGETS §H — minimal field-error beacon (G2 seed)


### PR DESCRIPTION
Implementing prompts/AGENT_QUEUE.md §HYGIENE-E14, the one genuine action left in
§ERP-SESSION-CLOSE §CLOSE.4 item 5's stale-code audit after verifying the list item by item.
Paired bim-compiler commit carries the full triage table.

ad_table_map.js is the PB bridge module ADData.useBridge(map) takes. The bridge is default OFF
(ad_data.js:8-20) and NO page anywhere carries a <script> tag for this file — grep over every .html
and .js finds exactly one reference: this precache line. So every install downloaded a module that
could never run.

The FILE stays. TRILOGY_STALE_CODE_AUDIT.md calls it dormant-by-design and that is right; only the
unconditional download goes. Whoever turns the bridge on has to add a script tag anyway, and puts
this line back in the same PR.

Same rule as §DICT-LAZY (#1662) one item earlier: nothing non-core is fetched unless asked for.
Nothing else in E-14's list survived verification as an action — 5 named orphans are already gone,
feed_fold.js and chat_lens.* are live dependencies, erp_key_epochs.js is U-E1's unwired roster gate
(a pending USER decision), idempiere_agent.zip is a SHIPPED DOWNLOAD offered by
common/about_diy.js:198, and preview_demo.db is both a real DB-policy violation and the live fixture
of erp/tests/poc_preview_demo.js. The last two are named in the spec, not deleted.

erp/sw.js CACHE_VERSION v787 -> v789 (v788 is #1665's).

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)