### PR TITLE
chore(bake): §CLI_BAKE_LOG_TS — every line in a bake log carries a timestamp

### DIFF
--- a/cli_silent_bake.js
+++ b/cli_silent_bake.js
@@ -89,8 +89,15 @@ function fmtDur(ms) {
   return (h ? h + 'h' : '') + (h || m ? m + 'm' : '') + sec + 's';
 }
 const logStream = fs.createWriteStream(LOG, { flags: 'w' });
-function log(line) { const s = new Date().toISOString().slice(11, 19) + ' ' + line; logStream.write(s + '\n'); console.log(s); }
-function logRaw(line) { logStream.write(line + '\n'); }   // full console firehose → file only
+// §CLI_BAKE_LOG_TS (2026-09-04, user: "it be good if it has some timestamp") — ONE clock format for
+// every line in the file. The CLI's own lines already carried HH:MM:SS; the page-console firehose,
+// which is the bulk of a bake log and the half that carries the § evidence, carried none — so a
+// §-line could not be placed against a §CLI_BAKE_PROGRESS frame without counting lines. Milliseconds
+// because the bake renders ~1 frame/s and dozens of console lines land inside the same second.
+const _t0 = Date.now();
+function _ts() { const d = new Date(); return d.toISOString().slice(11, 23) + ' +' + ((Date.now() - _t0) / 1000).toFixed(1).padStart(7) + 's'; }
+function log(line) { const s = _ts() + ' ' + line; logStream.write(s + '\n'); console.log(s); }
+function logRaw(line) { logStream.write(_ts() + ' ' + line + '\n'); }   // full console firehose → file only
 
 // ── static server (serves the checkout; symlinked buildings/ resolve normally) ──
 const MIME = { '.html': 'text/html', '.js': 'text/javascript', '.mjs': 'text/javascript',


### PR DESCRIPTION
**USER (2026-09-04, watching the Hospital bake run):** *"i see a baking log in progress. It be good if it has some timestamp"*.

The CLI's own lines (`log()`) already carried `HH:MM:SS`. The page-console firehose (`logRaw()` — `[con]`, `[pageerror]`, `[heap]`) carried none — and that is the bulk of the file and the half that carries the `§` evidence. In `Hospital_silent_bake_2026-09-05.log`, 38,800 lines, only ~250 were timestamped. Placing a `§` line against a `§CLI_BAKE_PROGRESS` frame meant counting line numbers by hand — which is exactly how `§BME.8`'s *"§DLOD_REFS at log line 658, AFTER §MAXQ_FRAME i=0"* had to be read.

One clock for the whole file now: `HH:MM:SS.mmm` plus elapsed `+NNN.Ns` since process start.
- **milliseconds** because the bake renders ~1 frame/s and dozens of console lines land inside the same second;
- **elapsed** because a bake log is read as *"how far in did this happen"*, not as wall-clock.

```
09:10:04.349 +   93.7s §CLI_BAKE_PROGRESS frame=11/2937
09:10:04.355 +   93.7s [con] §DLOD_DISABLE reason=time-machine
```

Nothing parses these prefixes — the only other `[con]` writers are three witnesses, which write their own logs — so no consumer changes. `cli_silent_bake.js` is a dev CLI and is not a served asset, so no `sw.js` bump.

Branched off fresh `origin/main` because #1660 was squash-merged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)