### PR TITLE
fix(erp): §STALE-WITNESSES — poc_odoo_descriptor walks the login card that exists now

### DIFF
--- a/erp/tests/poc_odoo_descriptor.js
+++ b/erp/tests/poc_odoo_descriptor.js
@@ -62,12 +62,41 @@ const server = http.createServer((req, res) => {
   ok('odoo facets expose the contract methods (getMenuTree/readRecords/buildContext)', ident.hasStruct && ident.hasData && ident.hasSess);
 
   // (2) login through the Odoo session facet → menu renders through getMenuTree
-  await page.evaluate(() => {
-    var rows = Array.prototype.slice.call(document.querySelectorAll('#idmp-login-users .idmp-login-user'));
-    var r = rows.find(x => !x.classList.contains('disabled')); if (r) r.click();
-  });
-  await page.waitForTimeout(400);
-  await page.click('#idmp-login-ok');
+  // STALE-INSTRUMENT FIX 2026-09-04 (prompts/AGENT_QUEUE.md §STALE-WITNESSES): this clicked a row in
+  // #idmp-login-users and then #idmp-login-ok. The login card now OPENS AT STEP 0, the tenant switcher
+  // (NEW_CLIENT_MGMT.md P3) — the page logs `§IDEMPIERE login-step0 tenants=1 demos=5` — so step 1 was
+  // still display:none, its user list was EMPTY, and the click hit nothing. #idmp-login-ok then sat
+  // inside a hidden step 2 and the run died on a click timeout that named the button, not the cause.
+  // Walk whatever step is actually visible, in order. Step 0's rows share the .idmp-login-user class
+  // with step 1's, so the RESIDENT tenant is the one WITHOUT .idmp-login-demo (a demo row would switch
+  // the whole dictionary and is not what ?erp=odoo already selected).
+  async function loginWalk() {
+    const vis = id => page.evaluate(i => { const e = document.getElementById(i); return !!e && e.style.display !== 'none'; }, id);
+    if (await vis('idmp-login-step0')) {
+      const picked = await page.evaluate(() => {
+        const rows = Array.prototype.slice.call(document.querySelectorAll('#idmp-login-clients .idmp-login-user'));
+        const r = rows.find(x => !x.classList.contains('idmp-login-demo') && !x.classList.contains('disabled'));
+        if (!r) return null; r.click(); return (r.textContent || '').trim().slice(0, 40);
+      });
+      console.log('§ODOO-LOGINWALK step0 tenant=' + JSON.stringify(picked));
+      if (picked == null) throw new Error('login step 0 is visible but offers no resident tenant row');
+      await page.waitForTimeout(500);
+    }
+    if (await vis('idmp-login-step1')) {
+      const picked = await page.evaluate(() => {
+        const rows = Array.prototype.slice.call(document.querySelectorAll('#idmp-login-users .idmp-login-user'));
+        const r = rows.find(x => !x.classList.contains('disabled'));
+        if (!r) return null; r.click(); return (r.textContent || '').trim().slice(0, 40);
+      });
+      console.log('§ODOO-LOGINWALK step1 user=' + JSON.stringify(picked));
+      if (picked == null) throw new Error('login step 1 is visible but offers no enabled user row');
+      await page.waitForTimeout(500);
+    }
+    await page.waitForSelector('#idmp-login-ok', { state: 'visible', timeout: 10000 });
+    await page.click('#idmp-login-ok');
+    console.log('§ODOO-LOGINWALK step2 ok-clicked');
+  }
+  await loginWalk();
   await page.waitForTimeout(1200);
 
   const menuLeaves = await page.$$eval('#idmp-menu .idmp-row.leaf', els => els.length).catch(() => 0);


### PR DESCRIPTION
Implementing `prompts/AGENT_QUEUE.md §STALE-WITNESSES` (owns `§ERP-SESSION-CLOSE-2 §C2.3` item 3 — the bim-ootb-side one of the four; the other three are bim-compiler scripts, fixed in the paired commit).

## Measured

🔴 `TimeoutError` clicking `#idmp-login-ok` on plain `origin/main` → 🟢 **W-ODOO-DESCRIPTOR 7/7**.

**Not a product defect.** The login card now **opens at step 0**, the tenant switcher (NEW_CLIENT_MGMT.md P3), and the page logs it plainly on every run:

```
§IDEMPIERE login-step0 tenants=1 demos=5
```

The witness clicked a row in `#idmp-login-users` — step 1's list, still `display:none` and **empty** — so the click hit nothing; `#idmp-login-ok` then sat inside a hidden step 2, and the run died on a click timeout that named the **button** rather than the step it never reached.

## Fix

`loginWalk()` walks whichever step is actually visible, in order, and logs what it picked (`§ODOO-LOGINWALK`). Step 0's rows share the `.idmp-login-user` class with step 1's, so the **resident** tenant is the one **without** `.idmp-login-demo` — a demo row would switch the whole dictionary, which is not what `?erp=odoo` already selected. It throws with a specific message if a visible step offers nothing, instead of falling through to a timeout on the next selector.

## The other three (bim-compiler side, for context)

- `poc_pos_live.js` said *"POS pill `#pill-pos` not on the bar (pos-station gate should be TRUE)"*. **The gate was fine.** It served `bim-ootb/erp` as `/`, so every shared module 404'd — `/common/pill_builder.js`, `/common/about_diy.js`, `/common/history_tap.js`, `/common/whole_history.js`, `/viewer/sfx.js`, `/viewer/connect_scene.js` — and the page said so every run: **`§IDMP-PILLS PillBuilder missing — not mounted`**.
- `poc_wh_pos_pick_live.js` / `poc_wh_walk_live.js` — default `ROOT` was `/tmp/wt-poswalk` / `/tmp/wt-spatial`, dev worktrees that no longer exist.

A sweep for that last class found **12 more** witnesses defaulting to a `/tmp/wt-*` path, **every one measured GONE** — listed in full in `§SW.2`, named rather than blind-fixed. One of them is in this repo: `viewer/tests/morpheus_plate_live.js` pins `/tmp/wt-mplate` and is not even overridable.

**Standing lesson (`§C2.4` again): read what the PAGE logged, not what the harness concluded.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)