### PR TITLE
fix(cinema): §CPE_REVEAL_LENS_QUAD_OFF — the lens quads honour the one-discipline slot too

### DIFF
--- a/viewer/effects.js
+++ b/viewer/effects.js
@@ -4812,6 +4812,7 @@ async function setupEffects(A, renderer, scene, camera) {
   var _glowLensMeshRect = null, _glowLensMeshRound = null;
   var _glowLensStagedCount = -1;   // §R10 — fixture count the CURRENT quads were built with
   var _glowLensRevealScalar = -1;  // §CPE_REVEAL_LENS_QUAD_OFF — last colour scalar applied (-1 = unset)
+  var _glowLensRevealLogKey = '';  // §CPE_REVEAL_LENS_QUAD_OFF — last LINE emitted, so a re-stage cannot repeat it
 
   // ══ §CPE_REVEAL_LENS_QUAD_OFF (2026-09-04) ═══════════════════════════════════════════════════
   // USER: "On the reveal exit pull away path, i raised about the 'lights quads' always visible
@@ -4840,9 +4841,18 @@ async function setupEffects(A, renderer, scene, camera) {
     var quads = 0;
     if (_glowLensMeshRect && _glowLensMeshRect.material) { _glowLensMeshRect.material.color.setScalar(want); quads += _glowLensMeshRect.count | 0; }
     if (_glowLensMeshRound && _glowLensMeshRound.material) { _glowLensMeshRound.material.color.setScalar(want); quads += _glowLensMeshRound.count | 0; }
-    console.log('§CPE_REVEAL_LENS_QUAD_OFF colorScalar=' + want + ' quads=' + quads +
-      (quads ? (want ? ' — lamps back for the all-together slot' : ' — one-discipline slot, the quads stop drawing')
-             : ' — VACUOUS: nothing staged yet, this transition proves nothing'));
+    // §VAC (R14.0): the applied scalar resets on every _glowLensOff, and a bake tears down and
+    // re-stages EVERY frame — so gating the LOG on the scalar alone repeats the same line ~7x per
+    // frame (measured: 88 lines in the first 12 frames of a Hospital bake, 87 identical and all of
+    // them vacuous). The line is gated on its own content instead: emit only when the
+    // (scalar, staged-or-empty) pair actually changes.
+    var key = want + ':' + (quads > 0 ? 'staged' : 'empty');
+    if (key !== _glowLensRevealLogKey) {
+      _glowLensRevealLogKey = key;
+      console.log('§CPE_REVEAL_LENS_QUAD_OFF colorScalar=' + want + ' quads=' + quads +
+        (quads ? (want ? ' — lamps back for the all-together slot' : ' — one-discipline slot, the quads stop drawing')
+               : ' — VACUOUS: nothing staged yet, this transition proves nothing'));
+    }
     return want;
   }
 

--- a/viewer/effects.js
+++ b/viewer/effects.js
@@ -4811,7 +4811,43 @@ async function setupEffects(A, renderer, scene, camera) {
   var GLOW_LENS_ROUND_ASPECT = 1.25;
   var _glowLensMeshRect = null, _glowLensMeshRound = null;
   var _glowLensStagedCount = -1;   // §R10 — fixture count the CURRENT quads were built with
+  var _glowLensRevealScalar = -1;  // §CPE_REVEAL_LENS_QUAD_OFF — last colour scalar applied (-1 = unset)
+
+  // ══ §CPE_REVEAL_LENS_QUAD_OFF (2026-09-04) ═══════════════════════════════════════════════════
+  // USER: "On the reveal exit pull away path, i raised about the 'lights quads' always visible
+  // obscuring the respective DISCipline display. U did mention before to turn off ie zero the color
+  // so they go invisible."
+  //
+  // §CPE_TAIL_LIGHTS_ALL_ONLY (#1649) already turns the lamps off for a one-discipline slot, and
+  // A._cpeRevealLightsOff is the flag that says so. Before this it was honoured in exactly TWO
+  // places — _glowOn() (the round sprite) and A._nightPLScale = 0 (the real point lights). This
+  // quad path had no guard at all, so its additive quads kept drawing over the trade being revealed.
+  //
+  // ZERO THE COLOUR, DO NOT TEAR DOWN. The quads are InstancedMesh on a MeshBasicMaterial with
+  // AdditiveBlending; three multiplies material.color by instanceColor, so a material colour of 0
+  // makes every instance contribute EXACTLY zero — invisible, with no dispose and no rebuild. That
+  // matters: §R10's stage-keep guard (_teardownStillRefine, keepStaging) deliberately keeps these
+  // quads across bake frames, and tearing them down per slot would pay dispose+rebuild on every
+  // transition and break _glowLensStagedCount's meaning. Same flag, same shape as the round
+  // sprite's guard, applied to the material rather than the lifetime. No new constant.
+  //
+  // Called at the TOP of _glowLensOn, before its already-staged early return, so it runs every
+  // frame on both paths — freshly staged and stage-kept.
+  function _glowLensRevealGate() {
+    var want = A._cpeRevealLightsOff ? 0 : 1;
+    if (_glowLensRevealScalar === want) return want;   // state change only — no per-frame churn
+    _glowLensRevealScalar = want;
+    var quads = 0;
+    if (_glowLensMeshRect && _glowLensMeshRect.material) { _glowLensMeshRect.material.color.setScalar(want); quads += _glowLensMeshRect.count | 0; }
+    if (_glowLensMeshRound && _glowLensMeshRound.material) { _glowLensMeshRound.material.color.setScalar(want); quads += _glowLensMeshRound.count | 0; }
+    console.log('§CPE_REVEAL_LENS_QUAD_OFF colorScalar=' + want + ' quads=' + quads +
+      (quads ? (want ? ' — lamps back for the all-together slot' : ' — one-discipline slot, the quads stop drawing')
+             : ' — VACUOUS: nothing staged yet, this transition proves nothing'));
+    return want;
+  }
+
   function _glowLensOn() {
+    _glowLensRevealGate();   // §CPE_REVEAL_LENS_QUAD_OFF — before the early return, so a stage-kept frame is gated too
     if (_glowLensMeshRect || _glowLensMeshRound) return;
     if (typeof A._nightFixtureWorldPositions !== 'function') return;
     var pos = A._nightFixtureWorldPositions();
@@ -4894,6 +4930,9 @@ async function setupEffects(A, renderer, scene, camera) {
     if (meshRound.instanceColor) meshRound.instanceColor.needsUpdate = true;
     if (rectN) { A.scene.add(meshRect); _glowLensMeshRect = meshRect; }
     if (roundN) { A.scene.add(meshRound); _glowLensMeshRound = meshRound; }
+    // §CPE_REVEAL_LENS_QUAD_OFF — these meshes are BRAND NEW at material colour 1; re-assert the
+    // slot's gate on them (forced, since the cached scalar refers to the meshes just replaced).
+    _glowLensRevealScalar = -1; _glowLensRevealGate();
     // §GLOW_BUILDUP_EARLY_OUT — this logged rect=0 round=0 on all 3,447 frames of the user's
     // Hospital bake. Say it once: a repeated line carrying no new information hides the ones that do.
     if (rectN === 0 && roundN === 0) {
@@ -4906,6 +4945,7 @@ async function setupEffects(A, renderer, scene, camera) {
       ' draw call(s), 0 scene materials touched');
   }
   function _glowLensOff() {
+    _glowLensRevealScalar = -1;   // §CPE_REVEAL_LENS_QUAD_OFF — nothing staged owns a scalar any more
     if (!_glowLensMeshRect && !_glowLensMeshRound) return;
     // Both meshes share ONE PlaneGeometry instance (built fresh each _glowLensOn() call) —
     // dispose it once, off whichever mesh is present, not per-mesh (double-dispose is harmless in

--- a/viewer/sw.js
+++ b/viewer/sw.js
@@ -78,7 +78,12 @@
 // its _origMatrix refs after TM had zero-scaled them and "restored" zero. Also §CPE_CLIP_REVEAL_FILM_T
 // (cinema_maxq.js: the Reveal reads film time, not clip-local time) + dev-only --clip/--tap in
 // cli_silent_bake.js. dlod.js?v, time_machine.js?v, cinema_maxq.js?v bumped in viewer.html.
-const CACHE_VERSION = 'v1141';   // bump on each deploy; per-change detail is the git commit message.
+// v1142 (2026-09-04) §CPE_REVEAL_LENS_QUAD_OFF: the §GLOW_LENS_QUAD path never honoured
+// A._cpeRevealLightsOff — §CPE_TAIL_LIGHTS_ALL_ONLY turned off the round sprite and the point
+// lights for a one-discipline Reveal slot, but the additive lens quads kept drawing over the trade
+// being revealed. Gated by zeroing the material colour (not by teardown, so §R10's stage-keep guard
+// survives). effects.js bumped in viewer.html.
+const CACHE_VERSION = 'v1142';   // bump on each deploy; per-change detail is the git commit message.
 // v1128 (2026-09-02) §SUN_FILL_RATIO: viewer/effects.js — the Alt+S staging HDRI
 // (belfast_sunset_puresky_1k) was being pushed onto EVERY material by _reassertPhotoEnvMap, matte
 // concrete and plaster included. IBL is non-directional and is NOT shadow-map-occluded in three.js,

--- a/viewer/viewer.html
+++ b/viewer/viewer.html
@@ -840,7 +840,7 @@ html.bim-embedded, html.bim-embedded body { background: #0b0b0b; }
 <script src="qrcode.min.js?v=1" onerror="console.warn('§LOAD_FAIL qrcode.min.js — QR sharing disabled')"></script>
 <script src="config.js?v=4" onerror="console.warn('§LOAD_FAIL config.js')"></script>
 <script src="db_resolve.js?v=2" onerror="console.warn('§LOAD_FAIL db_resolve.js')"></script>
-<script src="effects.js?v=36" onerror="console.warn('§LOAD_FAIL effects.js')"></script>
+<script src="effects.js?v=37" onerror="console.warn('§LOAD_FAIL effects.js')"></script>
 <script src="effects_gi_poc.js?v=3" onerror="console.warn('§LOAD_FAIL effects_gi_poc.js')"></script>
 <script src="lib/mp4_mux.js?v=1" onerror="console.warn('§LOAD_FAIL mp4_mux.js — MaxQ falls back to webm')"></script>
 <script src="cinema_path_editor.js?v=15" onerror="console.warn('§LOAD_FAIL cinema_path_editor.js — Alt+C path editing disabled')"></script>


### PR DESCRIPTION
**USER (2026-09-04):** *"On the reveal exit pull away path, i raised about the 'lights quads' always visible obscuring the respective DISCipline display. U did mention before to turn off ie zero the color so they go invisible."*

`§CPE_TAIL_LIGHTS_ALL_ONLY` (#1649) already turns the lamps off for a one-discipline Reveal slot, and `A._cpeRevealLightsOff` is the flag that says so. It was honoured in exactly **two** places — `effects.js` `_glowOn()` (the round glow sprite) and `A._nightPLScale = 0` (the real point lights). The **`§GLOW_LENS_QUAD` path had no guard**, so its additive quads kept drawing over the trade being revealed. They persisted rather than flickered because §R10's stage-keep guard deliberately does not dispose them between bake frames.

**Fix: zero the material colour, do not tear down.** The quads are `InstancedMesh` on a `MeshBasicMaterial` with `AdditiveBlending`, and three multiplies `material.color` by `instanceColor` — so colour 0 makes every instance contribute exactly zero. Invisible, no dispose, no rebuild, §R10's staging guard and `_glowLensStagedCount` both intact. A teardown would instead pay dispose+rebuild on every slot transition. Same flag, same shape as the round sprite's guard, no new constant.

`_glowLensRevealGate()` runs at the **top** of `_glowLensOn`, before its already-staged early return, so a stage-kept frame is gated as well as a freshly staged one. It re-asserts on newly built meshes (they are born at colour 1) and resets on `_glowLensOff`. It logs on **state change only**, and says **VACUOUS** when nothing is staged, so a transition with no quads cannot read as proof.

`§CPE_REVEAL_LENS_QUAD_OFF colorScalar=0|1 quads=<n>`. sw **v1142**, `effects.js?v=37`.

Spec: bim-compiler `prompts/CINEMA_DISCIPLINE_REVEAL.md` §CPE_REVEAL_LENS_QUAD_OFF. A silent Hospital bake against the §BME.11 baseline film is running now.

🤖 Generated with [Claude Code](https://claude.com/claude-code)