### PR TITLE
fix(erp): §AZ.3 — nest idempiere_agent.zip, and the instruction it made runnable

### DIFF
--- a/erp/tests/poc_agent_zip_sync.js
+++ b/erp/tests/poc_agent_zip_sync.js
@@ -82,6 +82,24 @@ res.forEach(function (r) {
   verdict(offered, 'D1: ' + r.zip + ' is still offered by common/about_diy.js or erp/erp_picker.js');
 });
 
+// E — THE INSTRUCTION THE APP PRINTS MUST BE RUNNABLE ON THE FILE THE APP SERVES.
+// This is the claim that was RED before §AZ.3 was answered: common/about_diy.js has ALWAYS told the user
+// `cd idempiere_agent && …` while idempiere_agent.zip put migrate_agent.js at the ROOT — there was no
+// directory to cd into, and the three files landed loose in the user's current directory. A download and
+// the sentence next to it are one contract; checking only that the file exists is checking half of it.
+res.forEach(function (r) {
+  var block = (about.split('file: \'erp/' + r.zip + '\'')[1] || about.split(r.zip)[1] || '').slice(0, 400);
+  var m = block.match(/cd ([A-Za-z0-9_.-]+)/);
+  if (!m) { verdict(true, 'E1: ' + r.zip + ' — its offer prints no `cd`, so there is nothing to disagree with'); return; }
+  var content = B.contentOf(fs.readFileSync(path.join(B.ERP, r.zip)));
+  var tops = {};
+  Object.keys(content).forEach(function (k) { tops[k.indexOf('/') >= 0 ? k.slice(0, k.indexOf('/')) : '(root)'] = 1; });
+  var top = Object.keys(tops);
+  verdict(top.length === 1 && top[0] === m[1],
+    'E1: ' + r.zip + ' — the `cd ' + m[1] + '` the app prints is a real folder inside the zip',
+    'instruction=cd ' + m[1] + ' zipTopLevel=[' + top.join(',') + ']');
+});
+
 console.log('\n' + (fails === 0 ? '🟢 W-AGENT-ZIP-SYNC PASS' : '🔴 W-AGENT-ZIP-SYNC FAIL (' + fails + ')') +
   ' — both downloads are built from their source directories, keep their shipped shape, and build deterministically.');
 process.exit(fails === 0 ? 0 : 1);

--- a/erp/tools/build_agent_zips.js
+++ b/erp/tools/build_agent_zips.js
@@ -21,12 +21,14 @@
 var fs = require('fs'), path = require('path'), zlib = require('zlib'), crypto = require('crypto');
 
 var ERP = path.join(__dirname, '..');
-// SHAPE IS PER-BUNDLE, ON PURPOSE. The two shipped zips are NOT alike: idempiere_agent.zip is FLAT
-// (migrate_agent.js at the root) and odoo_agent.zip nests everything under `odoo_agent/` plus a directory
-// entry. Extracting one litters the cwd and the other does not — a real, user-visible difference. Each
-// bundle keeps the shape it already ships with, so rebuilding changes nothing a user sees; the
-// inconsistency is a decision for the owner, recorded in §AZ.3, not something to "tidy" silently here.
-var BUNDLES = [{ dir: 'idempiere_agent', zip: 'idempiere_agent.zip', prefix: '' },
+// SHAPE IS PER-BUNDLE, and both are now NESTED. §AZ.3 asked the owner whether idempiere_agent.zip should
+// stop being FLAT; answered YES, 2026-09-04. It is not only cosmetic — the shipped instruction for that
+// download has ALWAYS said `cd idempiere_agent && npm install && node migrate_agent.js --masters`
+// (common/about_diy.js:199) while the zip put migrate_agent.js at the ROOT, so there was no directory to
+// cd into and the three files landed loose in whatever directory the user was standing in. Nesting makes
+// the instruction the app already prints CORRECT. `prefix` stays per-bundle so the shape is stated data,
+// never an assumption baked into the writer.
+var BUNDLES = [{ dir: 'idempiere_agent', zip: 'idempiere_agent.zip', prefix: 'idempiere_agent/' },
                 { dir: 'odoo_agent', zip: 'odoo_agent.zip', prefix: 'odoo_agent/' }];
 // A FIXED DOS timestamp (1980-01-01 00:00), so the bytes depend on CONTENT only. A real mtime would make
 // every rebuild a different file and turn the drift check into noise.


### PR DESCRIPTION
Implementing `prompts/AGENT_QUEUE.md §AZ.3`, answered by the owner: **yes, nest `idempiere_agent.zip`** like `odoo_agent.zip` already is. Acting on it showed the question was never cosmetic.

## The instruction the app printed was not runnable on the file the app served

`common/about_diy.js:199` has **always** told the user, verbatim:

```
cd idempiere_agent && npm install && node migrate_agent.js --masters
```

…while the zip put `migrate_agent.js` at the **root**. There was no `idempiere_agent` directory to `cd` into, and the three files landed loose in whatever directory the user was standing in. `odoo_agent.zip`'s `cd odoo_agent` was correct, which is why only one of the pair was broken.

## A download and the sentence next to it are one contract

`W-AGENT-ZIP-SYNC` checked only half of it — that the file exists and matches its source — so it stayed **green over a command that could not run**. New claim **E1** closes that: it parses the `cd <name>` out of the offer in `common/about_diy.js` and asserts `<name>/` is the zip's single top-level entry.

## Measured

| | flat (before) | nested (this branch) |
|---|---|---|
| `E1` idempiere | 🔴 `instruction=cd idempiere_agent zipTopLevel=[(root)]` | 🟢 `zipTopLevel=[idempiere_agent]` |
| `E1` odoo | 🟢 | 🟢 |
| W-AGENT-ZIP-SYNC | 11 PASS / 0 FAIL | 🟢 **13 PASS / 0 FAIL** |

Verified by extracting **both** zips into one empty directory: it now holds exactly `idempiere_agent/` and `odoo_agent/`, nothing loose, and each folder `diff -r`s clean against its source directory.

`prefix` stays **per-bundle data** rather than becoming a hardcoded rule in the writer — the shape of a shipped artefact should be stated, not assumed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
