### PR TITLE
fix(cinema): §SUN_ARC_TOPOUT_SNAP — dramatic dusk angle only after topout

### DIFF
--- a/viewer/cinema_maxq.js
+++ b/viewer/cinema_maxq.js
@@ -1643,7 +1643,10 @@
         // clip at film 0.66–0.73). Same bug class §CPE_CLIP_REVEAL_FILM_T fixed for the Reveal above:
         // a clip is fewer frames of the SAME film, so the sun reads the film fraction. A full bake is
         // unchanged (_tFilm(_tn) === _tn when no clip is set).
-        if (A._sunArcStep) A._sunArcStep(_tnFilm);
+        // §SUN_ARC_TOPOUT_SNAP — _revealU is the plan's topout fraction (null if unknown/no beats);
+        // _sunArcStep's own pre-topout branch is untouched when this is passed, only the post-topout
+        // portion of the SAME formula takes the new snap-to-dusk branch (see effects.js).
+        if (A._sunArcStep) A._sunArcStep(_tnFilm, _revealU);
         // §SUN_ARC_FILL / §BAKE_FILL_PIN (2026-09-05, effects.js, witness_sun_arc_fill.js): the interior
         // fill — ambient, hemi, fixture point-light scale/budget — is PINNED to the Alt+S baseline on
         // every frame, whatever the arc above just did to the sun (user ruling: "letting alt-s normal,

--- a/viewer/effects.js
+++ b/viewer/effects.js
@@ -2621,8 +2621,24 @@ async function setupEffects(A, renderer, scene, camera) {
   var PHOTO_SUN_ELEVATION_START = 55;  // "high noon" look for an establishing open — not 90 (a
                                         // straight-down sun reads flat/shadowless on a building)
   var PHOTO_SUN_ELEVATION_END = PHOTO_SUN_ELEVATION;
-  function _sunElevationAt(tNorm) {
-    return PHOTO_SUN_ELEVATION_START + (PHOTO_SUN_ELEVATION_END - PHOTO_SUN_ELEVATION_START) * tNorm;
+  // §SUN_ARC_TOPOUT_SNAP (2026-09-06, user: "the good outside building shadow correlation to Sun
+  // angle must not be touched" — bim-compiler prompts/MEP_CLASH_REVEAL_MOVIE.md §SUN_ARC_TOPOUT_SNAP).
+  // `topoutU` is OPTIONAL: omitted (every caller before this change, and the live Cinema Orbit
+  // preview at startCinemaOrbit's step()) returns the ORIGINAL formula, byte-identical, for every
+  // tNorm — zero regression by construction, not by testing alone. Only a caller that passes
+  // `topoutU` (the MaxQ bake, once it knows the plan's topout fraction) gets the new branch, and only
+  // for tNorm PAST that fraction: the pre-topout portion of the SAME call still returns the original
+  // formula unchanged. Past topout, ease from the elevation the arc had already reached down to the
+  // dramatic 6° (PHOTO_SUN_ELEVATION) over a short window instead of crawling there at tNorm=1.
+  var TOPOUT_SNAP_EASE_U = 0.08;   // fraction of the whole film the ease takes, tunable
+  function _sunElevationAt(tNorm, topoutU) {
+    var base = PHOTO_SUN_ELEVATION_START + (PHOTO_SUN_ELEVATION_END - PHOTO_SUN_ELEVATION_START) * tNorm;
+    if (topoutU == null || tNorm <= topoutU) return base;   // pre-topout, or no topout known: unchanged
+    var elAtTopout = PHOTO_SUN_ELEVATION_START + (PHOTO_SUN_ELEVATION_END - PHOTO_SUN_ELEVATION_START) * topoutU;
+    var easeEnd = Math.min(1, topoutU + TOPOUT_SNAP_EASE_U);
+    if (tNorm >= easeEnd || easeEnd <= topoutU) return PHOTO_SUN_ELEVATION_END;   // already dusk, held
+    var u = (tNorm - topoutU) / (easeEnd - topoutU);
+    return elAtTopout + (PHOTO_SUN_ELEVATION_END - elAtTopout) * u;
   }
   // updateSky() repositions the sun/sky/fog/lensflare but does NOT touch the shadow map — it has no
   // reason to, every OTHER caller (Time Machine, plain nav) already re-renders continuously. A film
@@ -2631,16 +2647,17 @@ async function setupEffects(A, renderer, scene, camera) {
   // while every shadow stayed frozen at whatever angle was last baked — worse than not animating at
   // all, since the mismatch reads as a bug rather than a static look. Called every frame the sun
   // moves, right after updateSky(), so no frame captures with a stale shadow angle.
-  function _sunArcStep(tNorm) {
+  function _sunArcStep(tNorm, topoutU) {
     if (!A.updateSky) return;
-    var _el = _sunElevationAt(tNorm);
+    var _el = _sunElevationAt(tNorm, topoutU);
     A.updateSky(_el, PHOTO_SUN_AZIMUTH);
     if (A.renderer) A.renderer.shadowMap.needsUpdate = true;
     // §SUN_ARC_FILL reads the elevation this step JUST set — stashed here so the fill compensation
     // below cannot drift from the arc by re-deriving it (one elevation, two consumers).
     A._sunArcElevationDeg = _el;
     console.log('§SUN_ARC_STEP tNorm=' + tNorm.toFixed(3) + ' elevation=' + _el.toFixed(1) +
-      ' (start=' + PHOTO_SUN_ELEVATION_START + ' end=' + PHOTO_SUN_ELEVATION_END + ')');
+      ' (start=' + PHOTO_SUN_ELEVATION_START + ' end=' + PHOTO_SUN_ELEVATION_END + ')' +
+      (topoutU != null ? ' topoutU=' + topoutU.toFixed(3) : ''));
     return _el;
   }
   A._sunArcStep = _sunArcStep;

--- a/viewer/sw.js
+++ b/viewer/sw.js
@@ -119,7 +119,11 @@
 // depth-texture-backed WebGLRenderTarget) is disposed and handed back to the GPU on still-mode exit
 // instead of retained, so repeated Alt+S sessions no longer accumulate a 128 MiB map / 64 MB live RT
 // at rest.
-const CACHE_VERSION = 'v1149';   // bump on each deploy; per-change detail is the git commit message.
+// v1150 (2026-09-06) §SUN_ARC_TOPOUT_SNAP: effects.js/cinema_maxq.js — past the plan's topout
+// fraction, the sun arc eases to the dramatic 6° Alt+S angle over a short window instead of crawling
+// there at the film's last frame; the pre-topout formula is an untouched code branch (zero regression
+// to the outdoor shadow-to-sun-angle correlation during active construction). Fill/PL pin unchanged.
+const CACHE_VERSION = 'v1150';   // bump on each deploy; per-change detail is the git commit message.
 // v1128 (2026-09-02) §SUN_FILL_RATIO: viewer/effects.js — the Alt+S staging HDRI
 // (belfast_sunset_puresky_1k) was being pushed onto EVERY material by _reassertPhotoEnvMap, matte
 // concrete and plaster included. IBL is non-directional and is NOT shadow-map-occluded in three.js,

--- a/viewer/viewer.html
+++ b/viewer/viewer.html
@@ -840,13 +840,13 @@ html.bim-embedded, html.bim-embedded body { background: #0b0b0b; }
 <script src="qrcode.min.js?v=1" onerror="console.warn('§LOAD_FAIL qrcode.min.js — QR sharing disabled')"></script>
 <script src="config.js?v=4" onerror="console.warn('§LOAD_FAIL config.js')"></script>
 <script src="db_resolve.js?v=2" onerror="console.warn('§LOAD_FAIL db_resolve.js')"></script>
-<script src="effects.js?v=37" onerror="console.warn('§LOAD_FAIL effects.js')"></script>
+<script src="effects.js?v=38" onerror="console.warn('§LOAD_FAIL effects.js')"></script>
 <script src="effects_gi_poc.js?v=3" onerror="console.warn('§LOAD_FAIL effects_gi_poc.js')"></script>
 <script src="lib/mp4_mux.js?v=1" onerror="console.warn('§LOAD_FAIL mp4_mux.js — MaxQ falls back to webm')"></script>
 <script src="cinema_path_editor.js?v=16" onerror="console.warn('§LOAD_FAIL cinema_path_editor.js — Alt+C path editing disabled')"></script>
 <script src="cpe_walk.js?v=6" onerror="console.warn('§LOAD_FAIL cpe_walk.js — CPE walk-mode disabled')"></script>
 <script src="cpe_xr.js?v=1" onerror="console.warn('§LOAD_FAIL cpe_xr.js — VR entry disabled')"></script>
-<script src="cinema_maxq.js?v=13" onerror="console.warn('§LOAD_FAIL cinema_maxq.js — Alt+M MaxQ export disabled')"></script>
+<script src="cinema_maxq.js?v=14" onerror="console.warn('§LOAD_FAIL cinema_maxq.js — Alt+M MaxQ export disabled')"></script>
 <script src="input_registry.js?v=1" onerror="console.warn('§LOAD_FAIL input_registry.js')"></script>
 <script src="../common/pill_builder.js?v=1" onerror="console.warn('§LOAD_FAIL pill_builder.js')"></script>
 <script src="list_builder.js?v=1" onerror="console.warn('§LOAD_FAIL list_builder.js')"></script>


### PR DESCRIPTION
## Summary
- Past the plan's topout fraction (construction complete), the sun arc now eases to the fixed 6° Alt+S angle over a short window instead of crawling there linearly at the film's last frame.
- Pre-topout portion of `_sunElevationAt` is an untouched code branch — zero regression to the outdoor shadow-to-sun-angle correlation during active construction, by construction.
- Live Cinema Orbit preview passes no `topoutU` and is unaffected.
- `§BAKE_FILL_PIN` (ambient/hemi/PL fill) untouched — this is sun-timing only, not a fix for PL/floor contrast (separate, unresolved).

## User constraints honored
- "I do not want any regress. The good outside building shadow correlation to Sun angle must not be touched." — pre-topout formula is byte-identical, verified by code construction not just testing.
- "The internal will be livelier with PLs real play seen." — NOT solved by this PR; flagged as open in the spec.

Spec: `bim-compiler prompts/MEP_CLASH_REVEAL_MOVIE.md` §SUN_ARC_TOPOUT_SNAP

## Test plan
- [x] `node --check` on all 4 changed files
- [ ] Verification clip 1:22–1:32 (fly-back-in, past topout) — pending, will attach numbers/clip

🤖 Generated with [Claude Code](https://claude.com/claude-code)