### PR TITLE
feat(cinema): §P2.4 + §CLASH_HUD_CARD — clash label [tol mm / clash mm] row; reveal roster mesh-true clash card

### DIFF
--- a/viewer/clash_film.js
+++ b/viewer/clash_film.js
@@ -80,6 +80,7 @@ function setupClashFilm(A) {
     // §CLASH_FILM_SKY_WASH — per PAIR: contact (×3), A→B axis (×3), the severity-sized box, the box
     // currently placed. The clamp rewrites a pair's two matrices only when its box actually changes.
     var _ctr = null, _dir = null, _nat = null, _cur = null, _updates = 0, _lastClamp = null;
+    var _broad = 0;         // §CLASH_HUD_CARD: the bbox-only candidate count the mesh stage judged (0 = nothing judged)
     var _camPos = new THREE.Vector3(), _m4 = new THREE.Matrix4(), _sc = new THREE.Matrix4();
 
     A.clashFilm = A.clashFilm || {};
@@ -194,13 +195,17 @@ function setupClashFilm(A) {
         if (rules === null) return null;
         if (!rules || !rules.clash_rules) { console.warn('§CLASH_FILM_BUILD INCONCLUSIVE reason=no clash rules'); return null; }
         var w = A._clashWhereParts ? A._clashWhereParts(rules) : null;
-        var seenPair = {}, allRows = [], broad = 0, discPairs = 0;
+        var seenPair = {}, allRows = [], broad = 0, discPairs = 0, tolByPair = {};
         rules.clash_rules.forEach(function (r) {
           var a = r.source && r.source.discipline, b = r.target && r.target.discipline;
           if (!a || !b) return;
           var k = a < b ? a + '|' + b : b + '|' + a;
           if (seenPair[k]) return;
           seenPair[k] = 1; discPairs++;
+          // §P2.4 (MEP_CLASH_REVEAL_MOVIE.md, 2026-09-06) — the rule's OWN tolerance in mm, kept per
+          // discipline pair; stamped onto every mesh-true pair below for the label's 3rd row. Read
+          // from clash_rules.json, never derived here.
+          if (typeof r.tolerance_m === 'number') tolByPair[k] = Math.round(r.tolerance_m * 1000);
           var rows;
           // storey = null → the WHOLE building. A film is not a storey view.
           try { rows = A._queryClashesPairRtree(null, rules, a, b, 0, w) || []; }
@@ -208,6 +213,7 @@ function setupClashFilm(A) {
           broad += rows.length;
           for (var i = 0; i < rows.length; i++) allRows.push(rows[i]);
         });
+        _broad = broad;
         if (!allRows.length) {
           console.log('§CLASH_FILM_BUILD discPairs=' + discPairs + ' pairsBroad=0 trueClash=0 VACUOUS — this building has no candidate clashes; nothing is judged');
           _built = true;
@@ -220,6 +226,14 @@ function setupClashFilm(A) {
             _built = true;
             return A.clashFilm.stats();
           }
+          // §P2.4 — stamp tolMm (from the rule that produced this discipline pair) onto the pair record;
+          // severityM is already on it. The label reads both at draw time. A pair whose discipline pair
+          // has no rule tolerance is left unstamped and counted, so the log shows the gap.
+          var tolStamped = 0;
+          recs.forEach(function (p) {
+            var kk = p.discA < p.discB ? p.discA + '|' + p.discB : p.discB + '|' + p.discA;
+            if (tolByPair[kk] != null) { p.tolMm = tolByPair[kk]; tolStamped++; }
+          });
           var guids = [];
           recs.forEach(function (p) { guids.push(p.guidA, p.guidB); });
           var xf = A.clashNarrow.loadTransforms(guids);   // §CLASH_FILM_CONTACT_MARKER: placement only — the element bbox is no longer used
@@ -273,6 +287,7 @@ function setupClashFilm(A) {
           console.log('§CLASH_FILM_BUILD discPairs=' + discPairs + ' pairsBroad=' + broad +
             ' trueClash=' + recs.length + ' markers=' + (recs.length * 2) + ' bothPlaced=' + placed +
             ' incomplete=' + skipped + ' falsePositivesExcluded=' + (broad - recs.length) +
+            ' tolStamped=' + tolStamped + '/' + recs.length +
             ' ms=' + ms.toFixed(0) + ' (mesh-true set only — the broad set would assert clashes that do not exist)');
           return A.clashFilm.stats();
         });
@@ -336,6 +351,7 @@ function setupClashFilm(A) {
 
     A.clashFilm.stats = function () {
       return { built: _built, pairs: _pairs.length, markers: _pairs.length * 2,
+        broad: _broad, falseExcluded: Math.max(0, _broad - _pairs.length),   // §CLASH_HUD_CARD
         lastPulse: _lastPulse, uploads: _uploads, periodS: PERIOD_S, peak: PEAK,
         riseS: RISE_S, holdS: HOLD_S, fallS: FALL_S, restS: REST_S,
         markerMaxPx: MARKER_MAX_PX, updates: _updates, lastClamp: _lastClamp,

--- a/viewer/clash_labels.js
+++ b/viewer/clash_labels.js
@@ -98,6 +98,13 @@ function setupClashLabels(A) {
     // A dark halo under the white core holds contrast on both — the same guarantee the plate gives
     // the text. The halo is the plate's black, a touch denser because a 1 px line has no area to spare.
     var LEADER = 'rgba(255,255,255,0.92)', LEADER_HALO = 'rgba(0,0,0,0.55)';
+    // §P2.4 (2026-09-06, user: "[Tolerance mm/Clash mm] below the clash pair in the label") — the 3rd
+    // row is a fact about the PAIR, not a side, so it takes the day counter's CONTEXT register
+    // (rgba(255,255,255,0.62)), not red or blue.
+    var COL_FACT = 'rgba(255,255,255,0.62)';
+    function factRow(q) {
+      return (q && q.tolMm != null && q.clashMm != null) ? '[' + q.tolMm + 'mm / ' + q.clashMm + 'mm]' : '';
+    }
 
     var _pairsRef = null, _near = null, _fade = null, _names = null, _lastFilmS = null, _placed = [];
     var _measureCtx = null, _nameLogged = {};
@@ -147,7 +154,7 @@ function setupClashLabels(A) {
     function metrics(h) {
       var fontPx = Math.max(12, Math.round(h * 0.022));
       var padY = Math.round(fontPx * 0.45), rowGap = Math.round(fontPx * 0.3);
-      var bh = padY * 2 + fontPx * 2 + rowGap;
+      var bh = padY * 2 + fontPx * 3 + rowGap * 2;   // §P2.4: three rows — A, B, [tol / clash]
       return { fontPx: fontPx, padX: Math.round(fontPx * 0.7), padY: padY, rowGap: rowGap, bh: bh,
         off: Math.round(h * 0.035), margin: Math.round(h * 0.028),
         line: Math.max(1, Math.round(h * 0.0015)), halo: Math.max(1, Math.round(h * 0.0015)), dot: Math.max(2, Math.round(h * 0.004)),
@@ -232,7 +239,10 @@ function setupClashLabels(A) {
         if (behind || Math.abs(nx) > 1 || Math.abs(ny) > 1) { rec.skippedFrustum++; continue; }
         var sx = (nx + 1) / 2 * w, sy = (1 - ny) / 2 * h;
         var nm = _names[e.i];
-        var bw = M.padX * 2 + Math.ceil(Math.max(measure(nm.a, M.fontPx), measure(nm.b, M.fontPx)));
+        var clashMm = (typeof p.severityM === 'number') ? Math.round(p.severityM * 1000) : null;
+        var tolMm = (p.tolMm != null) ? p.tolMm : null;
+        var fact = factRow({ tolMm: tolMm, clashMm: clashMm });
+        var bw = M.padX * 2 + Math.ceil(Math.max(measure(nm.a, M.fontPx), measure(nm.b, M.fontPx), fact ? measure(fact, M.fontPx) : 0));
         var bh = M.bh;
         var x = sx + M.off, y = sy - M.off - bh;     // up-right of the anchor …
         if (x + bw > w - M.margin) x = sx - M.off - bw;   // … or up-left when the right side would leave the frame
@@ -243,7 +253,7 @@ function setupClashLabels(A) {
         for (var q = 0; q < _placed.length; q++) if (overlaps(_placed[q], rect)) { hit = true; break; }
         if (hit) { rec.skippedOverlap++; continue; }
         _placed.push({ i: e.i, pairId: p.pairId, x: x, y: y, w: bw, h: bh, sx: sx, sy: sy,
-          d: e.d, nameA: nm.a, nameB: nm.b, alpha: 0 });
+          d: e.d, nameA: nm.a, nameB: nm.b, tolMm: tolMm, clashMm: clashMm, alpha: 0 });
       }
       rec.labelled = _placed.length;
 
@@ -319,6 +329,8 @@ function setupClashLabels(A) {
         ctx.textBaseline = 'middle'; ctx.textAlign = 'left'; ctx.font = font(M.fontPx);
         ctx.fillStyle = COL_A; ctx.fillText(q.nameA, q.x + M.padX, q.y + M.padY + M.fontPx / 2);
         ctx.fillStyle = COL_B; ctx.fillText(q.nameB, q.x + M.padX, q.y + M.padY + M.fontPx + M.rowGap + M.fontPx / 2);
+        var fact = factRow(q);   // §P2.4 — 3rd row; empty (not a placeholder) when the pair carries no figures
+        if (fact) { ctx.fillStyle = COL_FACT; ctx.fillText(fact, q.x + M.padX, q.y + M.padY + (M.fontPx + M.rowGap) * 2 + M.fontPx / 2); }
         n++;
       }
       ctx.restore();
@@ -326,6 +338,7 @@ function setupClashLabels(A) {
     };
 
     A.clashLabels.placed = function () { return _placed.slice(); };
+    A.clashLabels.factRow = factRow;   // §P2.4 — the witness reads the exact string the draw pass writes
     A.clashLabels.stats = function () {
       var s = {}; for (var k in _stats) s[k] = _stats[k];
       s.topN = TOP_N; s.rankMarginM = RANK_MARGIN_M; s.fadeS = FADE_S; s.pairs = _pairsRef ? _pairsRef.length : 0;

--- a/viewer/cpe_resource_panel.js
+++ b/viewer/cpe_resource_panel.js
@@ -305,6 +305,17 @@ function setupCpeResourcePanel(A) {
       out.push({ big: Math.round(A._hrCost.personDays).toLocaleString(), label: 'person-days of labour',
                  src: '§HR_COST' });
     }
+    // §CLASH_HUD_CARD (2026-09-06, MEP_CLASH_REVEAL_MOVIE.md; user: "the HUD info be in") — the
+    // mesh-true clash count the film ALREADY built (A.clashFilm.stats()), never re-counted here.
+    // Dropped when the film was never built or judged no bbox candidate at all — absent, not a zero.
+    // pairs=0 with broad>0 is a real judged fact (every candidate CLEAR at mesh level) and is shown.
+    var cf = (A.clashFilm && A.clashFilm.stats) ? A.clashFilm.stats() : null;
+    if (cf && cf.built && cf.broad > 0) {
+      var falsePct = Math.round((cf.falseExcluded / cf.broad) * 1000) / 10;
+      out.push({ big: String(cf.pairs), label: 'mesh-true clashes flagged',
+                 sub: cf.broad.toLocaleString() + ' bbox candidates  ·  ' + falsePct + '% false at mesh level',
+                 src: 'clash_film.js §CLASH_FILM_BUILD' });
+    }
     console.log('§CPE_BIG_STATS cards=' + out.length + (out.length
       ? ' [' + out.map(function (c) { return c.label; }).join(' | ') + ']'
       : ' INCONCLUSIVE — no source available (A.db=' + !!A.db + ' ops=' + (ops ? ops.length : 0) + '); panel omitted, not blank'));

--- a/viewer/sw.js
+++ b/viewer/sw.js
@@ -123,7 +123,12 @@
 // fraction, the sun arc eases to the dramatic 6° Alt+S angle over a short window instead of crawling
 // there at the film's last frame; the pre-topout formula is an untouched code branch (zero regression
 // to the outdoor shadow-to-sun-angle correlation during active construction). Fill/PL pin unchanged.
-const CACHE_VERSION = 'v1150';   // bump on each deploy; per-change detail is the git commit message.
+// v1151 (2026-09-06) §P2.4 + §CLASH_HUD_CARD (MEP_CLASH_REVEAL_MOVIE.md): viewer/clash_labels.js — the
+//   clash label gains a 3rd row "[tolerance mm / clash mm]" (rule tolerance from clash_rules.json, clash
+//   from the pair's severityM); viewer/clash_film.js — stamps tolMm per pair, stats() exposes broad/
+//   falseExcluded; viewer/cpe_resource_panel.js — reveal-round roster gains a "mesh-true clashes
+//   flagged" card read from A.clashFilm.stats(), dropped when the film was never built.
+const CACHE_VERSION = 'v1151';   // bump on each deploy; per-change detail is the git commit message.
 // v1128 (2026-09-02) §SUN_FILL_RATIO: viewer/effects.js — the Alt+S staging HDRI
 // (belfast_sunset_puresky_1k) was being pushed onto EVERY material by _reassertPhotoEnvMap, matte
 // concrete and plaster included. IBL is non-directional and is NOT shadow-map-occluded in three.js,

--- a/viewer/tests/witness_clash_film_labels.js
+++ b/viewer/tests/witness_clash_film_labels.js
@@ -158,6 +158,21 @@ function pageProbe(sabotage) {
     markerSolid: (idx, period) => { const mesh = A.scene.children.find(o => o.userData && o.userData.clashFilmSide === 'A'); if (!mesh) return null;
       const read = t => { A.clashFilm.update(t); const a = mesh.instanceColor.array; return { sel: +a[idx * 3].toFixed(6), amb: +a[(idx === 0 ? 1 : 0) * 3].toFixed(6) }; };
       return { a: read(period / 4), b: read(3 * period / 4), fade: A.clashLabels.fadeOf(idx) }; },
+    // §P2.4 / §CLASH_HUD_CARD (2026-09-06) probes. tolTruth reads what the pair RECORD carries; composite
+    // spies ctx.fillText on a real 2D context so the claim is about the string actually written, not a
+    // formatter called in isolation; hudCard calls the SHIPPED bigStatsBuild and returns its cards.
+    tolTruth: () => pairs().map((p, i) => ({ i: i, discA: p.discA, discB: p.discB, tolMm: (p.tolMm == null ? null : p.tolMm),
+      sevMm: (typeof p.severityM === 'number' ? Math.round(p.severityM * 1000) : null) })),
+    composite: (c, d, fs) => { pose(c, d); const r = A.clashLabels.update(A.camera, fs, W, H);
+      const cv = document.createElement('canvas'); cv.width = W; cv.height = H; const ctx = cv.getContext('2d');
+      const texts = []; const orig = ctx.fillText;
+      ctx.fillText = function (t, x, y) { texts.push({ t: String(t), x: Math.round(x), y: Math.round(y) }); return orig.apply(this, arguments); };
+      const drawn = A.clashLabelsCompositeOntoCanvas(ctx, W, H, r.placed.map(q => Object.assign({}, q, { alpha: 1 })));
+      return { drawn: drawn, texts: texts, placed: r.placed.map(q => ({ i: q.i, pairId: q.pairId, tolMm: q.tolMm, clashMm: q.clashMm, x: q.x, y: q.y, w: q.w, h: q.h, nameA: q.nameA, nameB: q.nameB })) }; },
+    hudCard: () => { const st = A.clashFilm.stats(); const has = typeof A.bigStatsBuild === 'function';
+      const cards = has ? (A.bigStatsBuild([], 0, 0) || []) : null;
+      return { hasBuilder: has, cards: cards ? cards.map(c => ({ big: c.big, label: c.label, sub: c.sub || '', src: c.src })) : null,
+        stats: { built: st.built, pairs: st.pairs, broad: st.broad, falseExcluded: st.falseExcluded } }; },
     pathProfile: (n) => {
       A.camera.position.copy(camLoad.p); A.controls.target.copy(camLoad.t); A.camera.lookAt(camLoad.t); A.camera.updateMatrixWorld(true); A.controls.update();
       try { if (typeof A.cinemaPathPlan === 'function') A.cinemaPathPlan(60); } catch (e) {}
@@ -203,6 +218,8 @@ function pageProbe(sabotage) {
     if (!has) { inconclusive('clash_labels.js not wired — A.clashLabels.update / A.clashLabelsCompositeOntoCanvas absent'); process.exitCode = 2; return; }
     await page.evaluate(pageProbe, SABOTAGE);
     const sz = await page.evaluate(() => window.__cll.size()); log(`§CLL_FRAME ${sz.W}x${sz.H}`);
+    // §CLASH_HUD_CARD H0 — read the roster BEFORE the film is built: the card must be absent (dropped, not a zero)
+    const hud0 = await page.evaluate(() => window.__cll.hudCard());
     const st = await page.evaluate(() => window.__cll.build());
     log(`§CLL_BUILT pairs=${st.pairs} markers=${st.markers} periodS=${st.periodS}`);
     if (!st.pairs) { inconclusive(`trueClash=0 on ${BLD} — a building with no clashes proves nothing about a clash label (VACUOUS)`); process.exitCode = 2; return; }
@@ -230,6 +247,43 @@ function pageProbe(sabotage) {
     const D_CLOSE = +Math.max(0.5, Math.min(5, iso.isolationM * 0.4)).toFixed(2);
     const FAR_D = +Math.max(30, iso.isolationM * 3, 20.6).toFixed(1);
     log(`§CLL_PROBE_DIST close=${D_CLOSE}m far=${FAR_D}m (far is arbitrary-but-large, not a module constant)`);
+
+    // ── §P2.4 — the label's 3rd row: [rule tolerance mm / measured clash mm]. Truth for the tolerance is
+    // clash_rules.json read from DISK here (first rule per discipline pair, the same first-wins the film
+    // build applies); truth for the clash is the pair's own severityM (the marker is already sized from it).
+    const rulesJson = JSON.parse(fs.readFileSync(path.join(ROOT, 'viewer/clash_rules.json'), 'utf8'));
+    const tolTruth = {};
+    (rulesJson.clash_rules || []).forEach(r => { const a = r.source && r.source.discipline, b = r.target && r.target.discipline;
+      if (!a || !b || typeof r.tolerance_m !== 'number') return; const k = a < b ? a + '|' + b : b + '|' + a; if (tolTruth[k] == null) tolTruth[k] = Math.round(r.tolerance_m * 1000); });
+    const keyOf = p => (p.discA < p.discB ? p.discA + '|' + p.discB : p.discB + '|' + p.discA);
+    const tt = await page.evaluate(() => window.__cll.tolTruth());
+    const tolBad = tt.filter(p => p.tolMm == null || p.tolMm !== tolTruth[keyOf(p)] || p.sevMm == null || !(p.sevMm > 0));
+    claim('P9a_every_pair_carries_rule_tolerance_and_measured_clash_mm', tt.length > 0 && tolBad.length === 0,
+      `pairs=${tt.length} rules=${Object.keys(tolTruth).length} [${Object.keys(tolTruth).map(k => k + '=' + tolTruth[k] + 'mm').join(' ')}] bad=${tolBad.length}${tolBad.length ? ' e.g. ' + JSON.stringify(tolBad[0]) : ''}`);
+    await page.evaluate(() => window.__cll.reset());
+    const cmp = await page.evaluate((c, d) => window.__cll.composite(c, d, 0.6), iso.contact, D_CLOSE);
+    const isoP = cmp.placed.find(q => q.i === iso.i), isoT = tt.find(p => p.i === iso.i);
+    const wantRow = isoT ? '[' + tolTruth[keyOf(isoT)] + 'mm / ' + isoT.sevMm + 'mm]' : null;
+    let j = -1; for (let k = 0; k + 2 < cmp.texts.length && isoP; k++) if (cmp.texts[k].t === isoP.nameA && cmp.texts[k + 1].t === isoP.nameB) { j = k; break; }
+    const fpx = Math.max(12, Math.round(sz.H * 0.022)), pY = Math.round(fpx * 0.45), rG = Math.round(fpx * 0.3);
+    const h3 = pY * 2 + fpx * 3 + rG * 2, h2 = pY * 2 + fpx * 2 + rG;
+    const row3 = j >= 0 ? cmp.texts[j + 2] : null;
+    claim('P9b_third_row_composited_is_tolerance_over_measured_clash',
+      !!isoP && !!row3 && row3.t === wantRow && row3.y > cmp.texts[j + 1].y && cmp.texts[j + 1].y > cmp.texts[j].y && isoP.h === h3 && h3 !== h2,
+      `placed=${!!isoP} drawn=${cmp.drawn} rows=[${j >= 0 ? cmp.texts.slice(j, j + 3).map(t => '"' + t.t + '"@y' + t.y).join(' ') : 'not found'}] want="${wantRow}" panelH=${isoP ? isoP.h : '-'} (3-row=${h3}, old 2-row=${h2})`);
+
+    // ── §CLASH_HUD_CARD — the reveal-round roster carries the film's own count, and only once the film exists
+    if (!hud0.hasBuilder) claim('H0_hud_card_absent_before_film_built', false, 'INCONCLUSIVE: A.bigStatsBuild is not wired on this page');
+    else claim('H0_hud_card_absent_before_film_built', hud0.stats.built === false && hud0.cards !== null && !hud0.cards.some(c => c.label === 'mesh-true clashes flagged'),
+      `before build: built=${hud0.stats.built} cards=${hud0.cards ? hud0.cards.length : 'null'} [${hud0.cards ? hud0.cards.map(c => c.label).join(' | ') : ''}]`);
+    const hud1 = await page.evaluate(() => window.__cll.hudCard());
+    const card = hud1.cards ? hud1.cards.find(c => c.label === 'mesh-true clashes flagged') : null;
+    const wantPct = hud1.stats.broad > 0 ? Math.round((hud1.stats.falseExcluded / hud1.stats.broad) * 1000) / 10 : null;
+    if (!hud1.hasBuilder) claim('H1_hud_card_reads_the_film_count', false, 'INCONCLUSIVE: A.bigStatsBuild is not wired on this page');
+    else claim('H1_hud_card_reads_the_film_count',
+      !!card && card.big === String(st.pairs) && hud1.stats.pairs === st.pairs && hud1.stats.broad > st.pairs
+        && card.sub.replace(/,/g, '').indexOf(String(hud1.stats.broad)) >= 0 && card.sub.indexOf(wantPct + '%') >= 0 && hud1.stats.falseExcluded === hud1.stats.broad - st.pairs,
+      `card=${card ? '"' + card.big + ' ' + card.label + ' — ' + card.sub + '" src=' + card.src : 'ABSENT'} film pairs=${st.pairs} broad=${hud1.stats.broad} falseExcluded=${hud1.stats.falseExcluded} wantPct=${wantPct}`);
 
     // P1 — rank correctness, NO distance limit at all: the module's `eligiblePairs` equals the TRUE
     // top-N nearest pairs by plain 3D distance (computed independently in the browser, not trusted from
@@ -337,7 +391,7 @@ function pageProbe(sabotage) {
   if (!rows.length || crashed) return;
   Witness('clash_film_labels').population(() => rows)
     .schema({ type: 'object', required: ['claim', 'ok'], properties: { claim: { type: 'string', minLength: 1 }, ok: { type: 'integer', minimum: 0, maximum: 1 }, detail: { type: 'string' } } })
-    .invariant('every §CLASH_FILM_P2 claim holds: names extracted, rank selection (top-N, no distance limit, read from the module) with rank-anchored hysteresis and no strobe, occlusion never consulted and a hidden pair labelled, genuine out-of-frustum release (not a sticky edge-clamp) that recovers, no panel overlap, constant size, fade seam', rs => rs.every(r => r.ok === 1))
+    .invariant('every §CLASH_FILM_P2 claim holds (+ §P2.4 3rd row [tol mm / clash mm] composited from the rule and severityM, + §CLASH_HUD_CARD present only once the film is built and equal to its count): names extracted, rank selection (top-N, no distance limit, read from the module) with rank-anchored hysteresis and no strobe, occlusion never consulted and a hidden pair labelled, genuine out-of-frustum release (not a sticky edge-clamp) that recovers, no panel overlap, constant size, fade seam', rs => rs.every(r => r.ok === 1))
     .redControl(rs => { const c = rs.map(r => Object.assign({}, r)); if (c[0]) c[0].ok = 0; return c; })
     .run();
   logStream.end();

--- a/viewer/viewer.html
+++ b/viewer/viewer.html
@@ -865,14 +865,14 @@ html.bim-embedded, html.bim-embedded body { background: #0b0b0b; }
 <script src="cpe_room_title.js?v=1" onerror="console.warn('§LOAD_FAIL cpe_room_title.js — room titles disabled')"></script>
 <script src="cpe_day_counter.js?v=1" onerror="console.warn('§LOAD_FAIL cpe_day_counter.js — day counter disabled')"></script>
 <script src="cpe_path_overview.js?v=1" onerror="console.warn('§LOAD_FAIL cpe_path_overview.js — path overview disabled')"></script>
-<script src="cpe_resource_panel.js?v=2" onerror="console.warn('§LOAD_FAIL cpe_resource_panel.js — resource panel disabled')"></script>
+<script src="cpe_resource_panel.js?v=3" onerror="console.warn('§LOAD_FAIL cpe_resource_panel.js — resource panel disabled')"></script>
 <script src="tour.js?v=17" onerror="console.warn('§LOAD_FAIL tour.js')"></script>
 <script src="clash_report.js?v=1" onerror="console.warn('§LOAD_FAIL clash_report.js')"></script>
 <script src="clash_snag.js?v=1" onerror="console.warn('§LOAD_FAIL clash_snag.js')"></script>
 <script src="clash_matrix.js?v=2" onerror="console.warn('§LOAD_FAIL clash_matrix.js')"></script>
 <script src="clash_narrow.js?v=1" onerror="console.warn('§LOAD_FAIL clash_narrow.js')"></script>
-<script src="clash_film.js?v=3" onerror="console.warn('§LOAD_FAIL clash_film.js')"></script>
-<script src="clash_labels.js?v=3" onerror="console.warn('§LOAD_FAIL clash_labels.js')"></script>
+<script src="clash_film.js?v=4" onerror="console.warn('§LOAD_FAIL clash_film.js')"></script>
+<script src="clash_labels.js?v=4" onerror="console.warn('§LOAD_FAIL clash_labels.js')"></script>
 <script src="measure.js?v=52" onerror="console.warn('§LOAD_FAIL measure.js')"></script>
 <script src="sitecam.js?v=7" onerror="console.warn('§LOAD_FAIL sitecam.js')"></script>
 <script src="share.js?v=2" onerror="console.warn('§LOAD_FAIL share.js')"></script>


### PR DESCRIPTION
Spec: bim-compiler `prompts/MEP_CLASH_REVEAL_MOVIE.md` §P2.4, §CLASH_HUD_CARD (2026-09-06, user request).

**What changes for the viewer**
- Clash label (film) gains a 3rd row `[<rule tolerance> mm / <measured clash> mm]` under the pair names, HUD context colour. Tolerance is the rule's own `tolerance_m` from `clash_rules.json`; clash is the pair's `severityM` (still the OBB proxy — the mesh-true depth pass is next and the label reads whatever the record carries).
- Reveal-round roster gains a card: `271 · mesh-true clashes flagged · 1,478 bbox candidates · 81.7% false at mesh level` (Hospital). Dropped, not zero, when the film was never built.

**Witness** `viewer/tests/witness_clash_film_labels.js` — `§WITNESS_CLASH_FILM_LABELS pass=4 fail=0 ran=19` (was 15):
- P9a every pair's `tolMm` equals `clash_rules.json` read from disk; `clashMm > 0` (271/271)
- P9b `ctx.fillText` spied on a real 2D context: 3rd row composited = `[50mm / 344mm]` for the isolated pair, below row 2, panel h 72 px (3-row) not 51 (old 2-row)
- H0 card absent before the film is built (5 cards, none clash)
- H1 card big == film pairs (271), sub carries broad (1,478) + pct (81.7%)
- Regression: markers witness 14/14, reveal-roster witness 72/72, eslint clean. sw v1151.

🤖 Generated with [Claude Code](https://claude.com/claude-code)