### PR TITLE
feat(clash): §MESH_OVERLAP_DEPTH — exact overlap-solid box per mesh-true pair; label clash mm is mesh-true, not the OBB proxy

### DIFF
--- a/viewer/clash_film.js
+++ b/viewer/clash_film.js
@@ -229,10 +229,11 @@ function setupClashFilm(A) {
           // §P2.4 — stamp tolMm (from the rule that produced this discipline pair) onto the pair record;
           // severityM is already on it. The label reads both at draw time. A pair whose discipline pair
           // has no rule tolerance is left unstamped and counted, so the log shows the gap.
-          var tolStamped = 0;
+          var tolStamped = 0, depthMesh = 0, depthInexact = 0, overlapFlat = 0;
           recs.forEach(function (p) {
             var kk = p.discA < p.discB ? p.discA + '|' + p.discB : p.discB + '|' + p.discA;
             if (tolByPair[kk] != null) { p.tolMm = tolByPair[kk]; tolStamped++; }
+            if (typeof p.depthMeshM === 'number') { depthMesh++; if (!p.overlapExact) depthInexact++; if (p.overlapFlat) overlapFlat++; }   // §MESH_OVERLAP_DEPTH
           });
           var guids = [];
           recs.forEach(function (p) { guids.push(p.guidA, p.guidB); });
@@ -287,7 +288,7 @@ function setupClashFilm(A) {
           console.log('§CLASH_FILM_BUILD discPairs=' + discPairs + ' pairsBroad=' + broad +
             ' trueClash=' + recs.length + ' markers=' + (recs.length * 2) + ' bothPlaced=' + placed +
             ' incomplete=' + skipped + ' falsePositivesExcluded=' + (broad - recs.length) +
-            ' tolStamped=' + tolStamped + '/' + recs.length +
+            ' tolStamped=' + tolStamped + '/' + recs.length + ' depthMesh=' + depthMesh + '/' + recs.length + ' depthInexact=' + depthInexact + ' overlapFlat=' + overlapFlat +
             ' ms=' + ms.toFixed(0) + ' (mesh-true set only — the broad set would assert clashes that do not exist)');
           return A.clashFilm.stats();
         });

--- a/viewer/clash_labels.js
+++ b/viewer/clash_labels.js
@@ -239,7 +239,10 @@ function setupClashLabels(A) {
         if (behind || Math.abs(nx) > 1 || Math.abs(ny) > 1) { rec.skippedFrustum++; continue; }
         var sx = (nx + 1) / 2 * w, sy = (1 - ny) / 2 * h;
         var nm = _names[e.i];
-        var clashMm = (typeof p.severityM === 'number') ? Math.round(p.severityM * 1000) : null;
+        // §MESH_OVERLAP_DEPTH — the mesh-true overlap when the record carries it; the OBB proxy only as a stated fallback
+        var dm = (typeof p.depthMeshM === 'number') ? p.depthMeshM : p.severityM;
+        var clashSrc = (typeof p.depthMeshM === 'number') ? 'mesh' : 'obb';
+        var clashMm = (typeof dm === 'number') ? Math.round(dm * 1000) : null;
         var tolMm = (p.tolMm != null) ? p.tolMm : null;
         var fact = factRow({ tolMm: tolMm, clashMm: clashMm });
         var bw = M.padX * 2 + Math.ceil(Math.max(measure(nm.a, M.fontPx), measure(nm.b, M.fontPx), fact ? measure(fact, M.fontPx) : 0));
@@ -253,7 +256,7 @@ function setupClashLabels(A) {
         for (var q = 0; q < _placed.length; q++) if (overlaps(_placed[q], rect)) { hit = true; break; }
         if (hit) { rec.skippedOverlap++; continue; }
         _placed.push({ i: e.i, pairId: p.pairId, x: x, y: y, w: bw, h: bh, sx: sx, sy: sy,
-          d: e.d, nameA: nm.a, nameB: nm.b, tolMm: tolMm, clashMm: clashMm, alpha: 0 });
+          d: e.d, nameA: nm.a, nameB: nm.b, tolMm: tolMm, clashMm: clashMm, clashSrc: clashSrc, alpha: 0 });
       }
       rec.labelled = _placed.length;
 

--- a/viewer/clash_narrow.js
+++ b/viewer/clash_narrow.js
@@ -53,7 +53,8 @@ function setupClashNarrow(A) {
     if (T) return T;
     T = { m4: new THREE.Matrix4(), m4b: new THREE.Matrix4(), rel: new THREE.Matrix4(), inv: new THREE.Matrix4(),
       e: new THREE.Euler(), q: new THREE.Quaternion(), p: new THREE.Vector3(), one: new THREE.Vector3(1, 1, 1),
-      box: new THREE.Box3(), boxB: new THREE.Box3(), v: new THREE.Vector3(), ray: new THREE.Ray() };
+      box: new THREE.Box3(), boxB: new THREE.Box3(), v: new THREE.Vector3(), ray: new THREE.Ray(),
+      va: new THREE.Vector3(), vb: new THREE.Vector3() };
     return T;
   }
   function heapMB() {
@@ -157,6 +158,85 @@ function setupClashNarrow(A) {
     }
     return { contained: odd >= 2, odd: odd };
   }
+  // ══ §MESH_OVERLAP_DEPTH (2026-09-06, bim-compiler MEP_CLASH_REVEAL_MOVIE.md §MESH_OVERLAP_DEPTH) ═══════
+  // The overlap SOLID A∩B, bounded EXACTLY. For triangle meshes every extreme point of A∩B along any axis
+  // is one of: an intersection-segment endpoint (enumerated below), a vertex of A inside B, or a vertex of
+  // B inside A — a planar face piece or a straight edge piece has no interior extreme; its extremes sit on
+  // its boundary, and that boundary is made of exactly those three kinds of point. So the AABB of that
+  // point set, taken in A's frame and again in B's frame, is the exact box of the overlap solid in each
+  // frame. depthMeshM = the THINNEST of the six extents: the penetration for a poke-in, the full cross
+  // dimension for a pass-through, the inner element's thinnest side when contained.
+  // It is NOT the MTV: severityM (SAT) is "how far to move to separate", which for a nested interval is
+  // hA+hB−|d| (S2: 0.4 for a Ø0.2 pipe centred in a 0.6 m beam); the overlap solid there is 0.2 thick.
+  // Both stay on the record; the label reads depthMeshM. The marker's size is NOT changed here.
+  var VERT_CAP = 4096;   // inside-vertex candidates per side; past it the box is flagged inexact, never guessed
+  function extNew() { return { mn: [Infinity, Infinity, Infinity], mx: [-Infinity, -Infinity, -Infinity], n: 0 }; }
+  function extGrow(E, x, y, z) {
+    if (x < E.mn[0]) E.mn[0] = x; if (y < E.mn[1]) E.mn[1] = y; if (z < E.mn[2]) E.mn[2] = z;
+    if (x > E.mx[0]) E.mx[0] = x; if (y > E.mx[1]) E.mx[1] = y; if (z > E.mx[2]) E.mx[2] = z;
+    E.n++;
+  }
+  function extSize(E) { return E.n ? [E.mx[0] - E.mn[0], E.mx[1] - E.mn[1], E.mx[2] - E.mn[2]] : null; }
+  var _pdirs = [[1, 0, 0], [0, 1, 0], [0, 0, 1]];
+  // point-in-mesh by ray parity — the same 3-axis / odd>=2 rule containedIn uses
+  function insideBvh(bt, p, X) {
+    var odd = 0;
+    for (var i = 0; i < 3; i++) {
+      X.ray.origin.copy(p); X.ray.direction.set(_pdirs[i][0], _pdirs[i][1], _pdirs[i][2]);
+      var hits; try { hits = bt.raycast(X.ray, THREE.DoubleSide); } catch (e) { hits = []; }
+      if (hits.length % 2 === 1) odd++;
+    }
+    return odd >= 2;
+  }
+  // outward normal of face f of `geo`, from its own winding (into `out`)
+  var _fa = new THREE.Vector3(), _fb = new THREE.Vector3(), _fc = new THREE.Vector3();
+  function faceNormal(geo, f, out) {
+    var pos = geo.attributes.position, ix = geo.index;
+    var i0 = ix ? ix.getX(f * 3) : f * 3, i1 = ix ? ix.getX(f * 3 + 1) : f * 3 + 1, i2 = ix ? ix.getX(f * 3 + 2) : f * 3 + 2;
+    _fa.fromBufferAttribute(pos, i0); _fb.fromBufferAttribute(pos, i1); _fc.fromBufferAttribute(pos, i2);
+    return out.subVectors(_fb, _fa).cross(_fc.sub(_fa)).normalize();
+  }
+  // point strictly inside a mesh: ray parity (containedIn's rule) AND the nearest-surface test — the point sits
+  // on the inner side of its closest face by at least half an eps. MEASURED Terminal 2026-09-06: parity alone
+  // read wall vertices as "inside" an IfcColumn whose shells overlap (odd hits from a point outside), which
+  // inflated the overlap box to the wall's full length; the nearest face's winding does not have that failure.
+  var _cpTarget = {}, _cpN = new THREE.Vector3(), _cpD = new THREE.Vector3();
+  function insideMesh(bt, geo, p, X) {
+    if (!insideBvh(bt, p, X)) return false;
+    var cp; try { cp = bt.closestPointToPoint(p, _cpTarget); } catch (e) { cp = null; }
+    if (!cp || !(cp.distance >= TOUCH_EPS * 0.5)) return false;
+    faceNormal(geo, cp.faceIndex, _cpN);
+    return _cpD.subVectors(p, cp.point).dot(_cpN) < 0;
+  }
+  // vertices of `geo` (own frame) inside the OTHER mesh: prefiltered by the other's local box (a vertex inside
+  // the other solid is inside its box), then insideMesh against the other's BVH. Grows Eself (own frame) and
+  // Eother (other frame). toOther: own frame → other frame.
+  function vertsInside(geo, otherGeo, otherBox, toOther, Eself, Eother, X) {
+    var pos = geo.attributes && geo.attributes.position, btOther = otherGeo && otherGeo.boundsTree;
+    var r = { n: 0, cand: 0, truncated: false };
+    if (!pos || !btOther) return r;
+    var v = X.va, w = X.vb;
+    for (var i = 0; i < pos.count; i++) {
+      v.fromBufferAttribute(pos, i); w.copy(v).applyMatrix4(toOther);
+      if (!otherBox.containsPoint(w)) continue;
+      if (++r.cand > VERT_CAP) { r.truncated = true; break; }
+      if (!insideMesh(btOther, otherGeo, w, X)) continue;
+      r.n++; extGrow(Eself, v.x, v.y, v.z); extGrow(Eother, w.x, w.y, w.z);
+    }
+    return r;
+  }
+  // the six extents → the record fields. EA in A's frame, EB in B's frame.
+  function overlapFields(out, EA, EB, exact, pts, MA) {
+    var a = extSize(EA), b = extSize(EB);
+    if (!a || !b) return;
+    var all = a.concat(b);
+    out.depthMeshM = Math.min.apply(null, all);
+    out.overlapMaxM = Math.max.apply(null, all);
+    out.overlapA = a; out.overlapB = b; out.overlapExact = !!exact; out.overlapPts = pts;
+    var c = new THREE.Vector3((EA.mn[0] + EA.mx[0]) / 2, (EA.mn[1] + EA.mx[1]) / 2, (EA.mn[2] + EA.mx[2]) / 2).applyMatrix4(MA);
+    out.overlapCenter = { x: c.x, y: c.y, z: c.z };
+  }
+
   // ── §M.2 stage 3d — contact/extent from the intersecting triangle PAIRS (one bvhcast, CLASH only) ──
   // The contact is the mean of the pair INTERSECTION SEGMENTS' midpoints and the extent is the bbox
   // diagonal of their endpoints — NOT triangle centroids: a 3 m cylinder side triangle has its centroid
@@ -166,13 +246,15 @@ function setupClashNarrow(A) {
   // Returns { triPairs (every pair the library calls intersecting), penetrating (segments longer than TOUCH_EPS),
   //           touchPairs (coplanar or shorter than TOUCH_EPS), contact, extentM, truncated } — contact/extent from
   //           the PENETRATING segments only.
-  function enumerateContact(btA, btB, rel, MA) {
+  //           §MESH_OVERLAP_DEPTH: EA/EB — the endpoints' extents in A's and (via relInv) B's frame, kept.
+  function enumerateContact(btA, btB, rel, MA, relInv) {
     var n = 0, nSeg = 0, nTouch = 0, truncated = false, sx = 0, sy = 0, sz = 0;
-    var mn = [Infinity, Infinity, Infinity], mx = [-Infinity, -Infinity, -Infinity];
+    var EA = extNew(), EB = extNew(), wv = new THREE.Vector3();
+    var mn = EA.mn, mx = EA.mx;
     var seg = new THREE.Line3();
     function grow(p) {
-      if (p.x < mn[0]) mn[0] = p.x; if (p.y < mn[1]) mn[1] = p.y; if (p.z < mn[2]) mn[2] = p.z;
-      if (p.x > mx[0]) mx[0] = p.x; if (p.y > mx[1]) mx[1] = p.y; if (p.z > mx[2]) mx[2] = p.z;
+      extGrow(EA, p.x, p.y, p.z);
+      if (relInv) { wv.copy(p).applyMatrix4(relInv); extGrow(EB, wv.x, wv.y, wv.z); }
     }
     try {
       btA.bvhcast(btB, rel, { intersectsTriangles: function (t1, t2) {
@@ -188,11 +270,11 @@ function setupClashNarrow(A) {
         if (n >= TRI_PAIR_CAP) { truncated = true; return true; }
         return false;
       } });
-    } catch (e) { return { triPairs: n, penetrating: nSeg, touchPairs: nTouch, truncated: truncated, contact: null, extentM: 0, err: e.message }; }
-    if (!nSeg) return { triPairs: n, penetrating: 0, touchPairs: nTouch, truncated: truncated, contact: null, extentM: 0 };
+    } catch (e) { return { triPairs: n, penetrating: nSeg, touchPairs: nTouch, truncated: truncated, contact: null, extentM: 0, err: e.message, EA: EA, EB: EB }; }
+    if (!nSeg) return { triPairs: n, penetrating: 0, touchPairs: nTouch, truncated: truncated, contact: null, extentM: 0, EA: EA, EB: EB };
     var c = new THREE.Vector3(sx / nSeg, sy / nSeg, sz / nSeg).applyMatrix4(MA);
     var ext = Math.sqrt((mx[0] - mn[0]) * (mx[0] - mn[0]) + (mx[1] - mn[1]) * (mx[1] - mn[1]) + (mx[2] - mn[2]) * (mx[2] - mn[2]));
-    return { triPairs: n, penetrating: nSeg, touchPairs: nTouch, truncated: truncated, contact: { x: c.x, y: c.y, z: c.z }, extentM: ext };
+    return { triPairs: n, penetrating: nSeg, touchPairs: nTouch, truncated: truncated, contact: { x: c.x, y: c.y, z: c.z }, extentM: ext, EA: EA, EB: EB };
   }
   function worldCentroid(geo, M) {
     var bb = localBox(geo);
@@ -212,7 +294,8 @@ function setupClashNarrow(A) {
     var ctx = opts.ctx || { bvhReused: 0, bvhBuiltNew: 0 };
     var X = tmp(), t0 = performance.now();
     var out = { stage: 'BROAD', verdict: VERDICT.UNKNOWN, reason: REASON.NOGEO, aabbOverlapM: null, obbDepthM: null,
-      severityM: null, triPairs: 0, truncated: false, contact: null, extentM: 0, containedOdd: 0, bvhReusedA: false, bvhReusedB: false, ms: 0 };
+      severityM: null, triPairs: 0, truncated: false, contact: null, extentM: 0, containedOdd: 0, bvhReusedA: false, bvhReusedB: false, ms: 0,
+      depthMeshM: null, overlapMaxM: null, overlapA: null, overlapB: null, overlapExact: false, overlapPts: null, overlapCenter: null, depthMs: 0, overlapFlat: false };
     if (!geoA || !geoB) { out.ms = performance.now() - t0; return out; }
     var ab = aabbOverlap(geoA, MA, geoB, MB);
     out.aabbOverlapM = (typeof opts.aabbOverlapM === 'number') ? opts.aabbOverlapM : ab.overlap;
@@ -235,8 +318,28 @@ function setupClashNarrow(A) {
     try { hit = geoA.boundsTree.intersectsGeometry(geoB, X.rel); } catch (e) { out.reason = REASON.NOGEO; out.err = 'intersectsGeometry: ' + (e && e.message); out.ms = performance.now() - t0; return out; }
     var en = null;
     if (hit) {
-      en = enumerateContact(geoA.boundsTree, geoB.boundsTree, X.rel, MA);
+      X.m4b.copy(X.rel).invert();                      // A local → B local
+      en = enumerateContact(geoA.boundsTree, geoB.boundsTree, X.rel, MA, X.m4b);
       out.triPairs = en.triPairs; out.touchPairs = en.touchPairs || 0; out.truncated = en.truncated;
+    }
+    var flat = false;   // §OVERLAP_FLAT annotation (see below)
+    if (hit && en.penetrating > 0) {
+      // §MESH_OVERLAP_DEPTH — curve endpoints (both frames, already in EA/EB) + each side's inside vertices
+      var tD = performance.now();
+      var vA = vertsInside(geoA, geoB, localBox(geoB), X.m4b, en.EA, en.EB, X);
+      var vB = vertsInside(geoB, geoA, localBox(geoA), X.rel, en.EB, en.EA, X);
+      overlapFields(out, en.EA, en.EB, !en.truncated && !vA.truncated && !vB.truncated,
+        { seg: en.penetrating * 2, vertsA: vA.n, vertsB: vB.n, candA: vA.cand, candB: vB.cand }, MA);
+      out.depthMs = performance.now() - tD;
+      // §OVERLAP_FLAT (2026-09-06) — ANNOTATION ONLY, the verdict below is unchanged from main. A column standing
+      // on a slab, or two unit cubes face to face (S7b, RED on main), gives the library edge-length intersection
+      // segments where a side face meets the other's face plane — long, so the "segment > TOUCH_EPS" rule calls
+      // them CLASH. The overlap solid there is FLAT (thinnest extent ~1e-10 m): nothing interpenetrates.
+      // MEASURED 2026-09-06: Terminal 745 of 3703 mesh-true pairs, Hospital 16 of 6733, are flat. Turning this
+      // into the verdict (CLASH requires thickness >= TOUCH_EPS) is a ⛔USER call — MEP_CLASH_REVEAL_MOVIE.md
+      // §MESH_OVERLAP_DEPTH MEASURED — because the witness oracle cannot yet judge multi-shell IFC geometry.
+      flat = (typeof out.depthMeshM === 'number') && out.depthMeshM < TOUCH_EPS;
+      out.overlapFlat = flat;
     }
     if (hit && en.penetrating > 0) {
       out.verdict = VERDICT.CLASH; out.reason = REASON.TRI; out.severityM = depth;
@@ -251,6 +354,16 @@ function setupClashNarrow(A) {
         var inner = ab.bInA ? geoB : geoA, innerM = ab.bInA ? MB : MA;
         out.contact = worldCentroid(inner, innerM);
         var ib = localBox(inner); out.extentM = ib.min.distanceTo(ib.max);
+        // §MESH_OVERLAP_DEPTH — the overlap solid IS the inner element: its box in its own frame, its
+        // vertices' box in the outer frame (every vertex is inside by the verdict; no parity pass needed)
+        var tD2 = performance.now();
+        var Ein = extNew(), Eout = extNew(), posI = inner.attributes && inner.attributes.position;
+        extGrow(Ein, ib.min.x, ib.min.y, ib.min.z); extGrow(Ein, ib.max.x, ib.max.y, ib.max.z);
+        var toOuter = ab.bInA ? X.rel : X.m4;          // B→A when B is inner; A→B (X.m4 = MB⁻¹·MA) when A is inner
+        if (posI) for (var vi = 0; vi < posI.count; vi++) { X.va.fromBufferAttribute(posI, vi).applyMatrix4(toOuter); extGrow(Eout, X.va.x, X.va.y, X.va.z); }
+        overlapFields(out, ab.bInA ? Eout : Ein, ab.bInA ? Ein : Eout, !!posI,
+          { seg: 0, vertsA: ab.bInA ? 0 : (posI ? posI.count : 0), vertsB: ab.bInA ? (posI ? posI.count : 0) : 0, candA: 0, candB: 0 }, MA);
+        out.depthMs = performance.now() - tD2;
       } else {
         out.verdict = VERDICT.CLEAR; out.reason = hit ? REASON.TOUCH : REASON.NONE; if (cont) out.containedOdd = cont.odd;
       }
@@ -367,7 +480,8 @@ function setupClashNarrow(A) {
       var rec = { pairId: pairIdOf(c[0], c[1]), guidA: c[0], guidB: c[1], classA: c[2] || '', classB: c[3] || '',
         discA: c[4] || '', discB: c[5] || '', stage: 'BROAD', verdict: VERDICT.UNKNOWN, reason: REASON.NOGEO,
         aabbOverlapM: (typeof c[8] === 'number') ? c[8] : null, obbDepthM: null, severityM: null, triPairs: 0, truncated: false,
-        contact: null, contactIfc: null, extentM: 0, bvhReusedA: false, bvhReusedB: false, ms: 0 };
+        contact: null, contactIfc: null, extentM: 0, bvhReusedA: false, bvhReusedB: false, ms: 0,
+        depthMeshM: null, overlapMaxM: null, overlapA: null, overlapB: null, overlapExact: false, overlapPts: null, overlapCenter: null, depthMs: 0 };
       var geoA = ta ? geoFor(ta.hash) : null, geoB = tb ? geoFor(tb.hash) : null;
       if (!geoA || !geoB) {
         rec.err = 'geometry: A=' + (ta ? (ta.hash ? (geoA ? 'ok' : 'hash-not-in-cache') : (ta.composed ? 'composed-aggregate-parent' : 'no-hash')) : 'no-transform') +
@@ -382,13 +496,16 @@ function setupClashNarrow(A) {
         rec.stage = v.stage; rec.verdict = v.verdict; rec.reason = v.reason; rec.obbDepthM = v.obbDepthM; rec.severityM = v.severityM;
         rec.triPairs = v.triPairs; rec.touchPairs = v.touchPairs || 0; rec.truncated = v.truncated; rec.contact = v.contact; rec.extentM = v.extentM;
         rec.bvhReusedA = v.bvhReusedA; rec.bvhReusedB = v.bvhReusedB; rec.ms = v.ms; rec.containedOdd = v.containedOdd; if (v.err) rec.err = v.err;
+        rec.depthMeshM = v.depthMeshM; rec.overlapMaxM = v.overlapMaxM; rec.overlapA = v.overlapA; rec.overlapB = v.overlapB;   // §MESH_OVERLAP_DEPTH
+        rec.overlapExact = v.overlapExact; rec.overlapPts = v.overlapPts; rec.overlapCenter = v.overlapCenter; rec.depthMs = v.depthMs;
+        rec.overlapFlat = !!v.overlapFlat;
         if (v.contact && A.three2ifc) { var q = A.three2ifc(v.contact.x, v.contact.y, v.contact.z); rec.contactIfc = { ix: q.ix, iy: q.iy, iz: q.iz }; }
       }
       if (rec.verdict === VERDICT.UNKNOWN) { counts.unknown++; if (rec.reason === REASON.AGG) counts.aggregateParent = (counts.aggregateParent || 0) + 1; var ek = rec.err || 'unknown'; counts.unknownBy = counts.unknownBy || {}; counts.unknownBy[ek] = (counts.unknownBy[ek] || 0) + 1; }
       else if (rec.stage === 'OBB') counts.obbRejected++;
       else {
         counts.obbSurvivors++;
-        if (rec.verdict === VERDICT.CLASH) { counts.meshTrue++; if (rec.reason === REASON.CONT) counts.contained++; if (rec.truncated) counts.truncated++; }
+        if (rec.verdict === VERDICT.CLASH) { counts.meshTrue++; if (rec.reason === REASON.CONT) counts.contained++; if (rec.truncated) counts.truncated++; if (rec.overlapFlat) counts.overlapFlat = (counts.overlapFlat || 0) + 1; }
         else { counts.meshClear++; if (rec.reason === REASON.TOUCH) counts.touchOnly = (counts.touchOnly || 0) + 1; }
       }
       c[9] = rec; pairs[i] = rec;
@@ -409,6 +526,21 @@ function setupClashNarrow(A) {
         (judged === 0 ? ' VACUOUS' : ''));
       console.log('§CLASH_OBB pair=' + label + ' rotatedSides=' + counts.rotatedSides + ' rejected=' + counts.obbRejected + (counts.rotatedSides === 0 ? ' VACUOUS(rotation)' : ''));
       if (counts.unknown) console.log('§CLASH_NARROW_UNKNOWN pair=' + label + ' ' + JSON.stringify(counts.unknownBy));
+      // §MESH_OVERLAP_DEPTH — how far the SAT proxy (severityM) sits from the mesh-true overlap, this run
+      var dn = 0, dInexact = 0, dMsTot = 0, ratios = [], over1p5 = 0, under = 0, dZero = 0;
+      for (var pi = 0; pi < pairs.length; pi++) {
+        var pr = pairs[pi]; if (!pr) continue;
+        dMsTot += pr.depthMs || 0;
+        if (pr.verdict !== VERDICT.CLASH || typeof pr.depthMeshM !== 'number') continue;
+        dn++; if (!pr.overlapExact) dInexact++; if (pr.depthMeshM < TOUCH_EPS) dZero++;
+        if (pr.depthMeshM >= TOUCH_EPS && typeof pr.severityM === 'number') { var rr = pr.severityM / pr.depthMeshM; ratios.push(rr); if (rr >= 1.5) over1p5++; if (rr < 1 - 1e-6) under++; }
+      }
+      ratios.sort(function (a, b) { return a - b; });
+      var med = ratios.length ? ratios[Math.floor(ratios.length / 2)] : null;
+      res.depthProxy = { known: dn, inexact: dInexact, belowTouchEps: dZero, median: med, max: ratios.length ? ratios[ratios.length - 1] : null, satGe1p5x: over1p5, satBelow: under, ms: +dMsTot.toFixed(1) };
+      console.log('§CLASH_DEPTH_PROXY pair=' + label + ' meshTrue=' + counts.meshTrue + ' overlapFlat=' + (counts.overlapFlat || 0) + ' depthKnown=' + dn + ' inexact=' + dInexact + ' belowTouchEps=' + dZero +
+        ' satOverMesh median=' + (med == null ? 'n/a' : med.toFixed(2)) + ' max=' + (ratios.length ? ratios[ratios.length - 1].toFixed(2) : 'n/a') +
+        ' satGe1p5xMesh=' + over1p5 + ' satBelowMesh=' + under + ' depthMs=' + dMsTot.toFixed(0) + (dn === 0 ? ' VACUOUS' : ''));
       var bs = boxStats(); res.boxStats = bs; _boxRun = null;
       console.log('§CLASH_OBB_STALEBOX pair=' + label + ' geometries=' + bs.geometries + ' cachedBoxStale=' + bs.stale + ' maxDeltaM=' + bs.maxDeltaM.toFixed(4) + ' (local box recomputed from positions; the cached geo.boundingBox is never trusted)');
       console.log('§CLASH_NARROW_LOSS pair=' + label + ' broad=' + counts.broad + ' accounted=' + (counts.obbRejected + counts.obbSurvivors + counts.unknown) +
@@ -492,10 +624,43 @@ function setupClashNarrow(A) {
     // S6 — disjoint after a tiny gap on a rotated pair: cube vs 45° cube at (2.5,2.5,0), AABBs do NOT overlap ⇒ still CLEAR (sanity, not a FP case)
     var s6 = testPair(cube2, I, cube2b, mat(2.5, 2.5, 0, Math.PI / 4));
     check('S6_far_pair_clear', 'CLEAR', s6.verdict, s6.verdict === 'CLEAR');
-    [cube2, cube2b, pipe, beam, u1, u2, small].forEach(function (g) { try { if (g.boundsTree && g.disposeBoundsTree) g.disposeBoundsTree(); g.dispose(); } catch (e) {} });
+    // ── §MESH_OVERLAP_DEPTH D-cases: hand-known overlap SOLIDS through the same testPair ──
+    function fx(v) { return (typeof v === 'number') ? v.toFixed(4) : String(v); }
+    function near(v, want, eps) { return typeof v === 'number' && Math.abs(v - want) < eps; }
+    // D5 — §OVERLAP_FLAT: a 0.4×0.4×3 column standing EXACTLY on a 6×0.3×6 slab (bottom face on top face), OBB stage
+    // off so the mesh stage judges it. The side faces cross the slab's top plane along the column's base edges —
+    // 0.4 m segments, so the segment-length rule (unchanged, S7b) says CLASH — and the overlap solid is FLAT:
+    // depthMesh < 1 mm, overlapFlat=true. The verdict is deliberately NOT changed here (⛔USER, see the comment above).
+    var col = mk(new THREE.BoxGeometry(0.4, 3, 0.4)), slab = mk(new THREE.BoxGeometry(6, 0.3, 6));
+    var d5 = testPair(col, mat(0, 1.5, 0, 0), slab, mat(0, -0.15, 0, 0), { skipObb: true });
+    check('D5_column_on_slab_flat_overlap', 'overlapFlat=true depthMesh<0.001 max=0.4000 (verdict unchanged: ' + d5.verdict + ')', 'overlapFlat=' + !!d5.overlapFlat + ' depthMesh=' + fx(d5.depthMeshM) + ' max=' + fx(d5.overlapMaxM) + ' verdict=' + d5.verdict + '@' + d5.stage + ' tri=' + d5.triPairs,
+      d5.overlapFlat === true && typeof d5.depthMeshM === 'number' && d5.depthMeshM < 0.001 && near(d5.overlapMaxM, 0.4, 1e-4));
+    // D6 — the same column sunk 20 mm into the slab ⇒ CLASH, depthMesh=0.020 (SAT agrees here), max=0.4
+    var d6 = testPair(col, mat(0, 1.48, 0, 0), slab, mat(0, -0.15, 0, 0), { skipObb: true });
+    check('D6_column_sunk_20mm', 'CLASH depthMesh=0.0200 max=0.4000', d6.verdict + ' depthMesh=' + fx(d6.depthMeshM) + ' max=' + fx(d6.overlapMaxM) + ' sat=' + fx(d6.severityM) + ' exact=' + d6.overlapExact,
+      d6.verdict === 'CLASH' && near(d6.depthMeshM, 0.02, 1e-4) && near(d6.overlapMaxM, 0.4, 1e-4) && d6.overlapExact === true);
+    // D1 — poke-in: unit cubes offset 0.97 ⇒ overlap solid 0.03×1×1 ⇒ depthMesh=0.030 max=1.000 (SAT agrees: 0.03)
+    var d1 = testPair(u1, I, u2, mat(0.97, 0, 0, 0));
+    check('D1_pokein_depth', 'CLASH depthMesh=0.0300 max=1.0000 exact', d1.verdict + ' depthMesh=' + fx(d1.depthMeshM) + ' max=' + fx(d1.overlapMaxM) + ' sat=' + fx(d1.severityM) + ' exact=' + d1.overlapExact + ' pts=' + JSON.stringify(d1.overlapPts),
+      d1.verdict === 'CLASH' && near(d1.depthMeshM, 0.03, 1e-4) && near(d1.overlapMaxM, 1.0, 1e-4) && d1.overlapExact === true);
+    // D2 — pass-through (S2's pipe/beam): the overlap solid is the Ø0.2 pipe section inside the 0.4-wide beam ⇒
+    // 0.4×0.2×0.2 ⇒ depthMesh=0.2 max=0.4, while SAT says 0.4 (0.1+0.3−0 on y: the MTV of a nested interval) —
+    // the proxy overstates a pass-through 2×. No vertex of either mesh lies inside the other (rings at x=±1.5).
+    check('D2_passthrough_depth_vs_sat', 'depthMesh=0.2000 max=0.4000 sat=0.4000 vertsA=vertsB=0', 'depthMesh=' + fx(s2.depthMeshM) + ' max=' + fx(s2.overlapMaxM) + ' sat=' + fx(s2.severityM) + ' exact=' + s2.overlapExact + ' pts=' + JSON.stringify(s2.overlapPts),
+      near(s2.depthMeshM, 0.2, 2e-3) && near(s2.overlapMaxM, 0.4, 2e-3) && near(s2.severityM, 0.4, 1e-6) && s2.overlapExact === true && s2.overlapPts && s2.overlapPts.vertsA === 0 && s2.overlapPts.vertsB === 0);
+    // D3 — contained (S4's 0.2 cube in the 2 m cube): the overlap solid is the inner cube ⇒ 0.2 on every axis, from the inner element alone
+    check('D3_contained_depth', 'depthMesh=0.2000 max=0.2000 exact', 'depthMesh=' + fx(s4.depthMeshM) + ' max=' + fx(s4.overlapMaxM) + ' sat=' + fx(s4.severityM) + ' exact=' + s4.overlapExact + ' pts=' + JSON.stringify(s4.overlapPts),
+      near(s4.depthMeshM, 0.2, 1e-6) && near(s4.overlapMaxM, 0.2, 1e-6) && s4.overlapExact === true);
+    // D4 — rotated (S5, the 45° cube's edge x+y=1.586 cuts A's corner): overlap = the triangle (1,1),(0.586,1),(1,0.586) × z∈[−1,1].
+    // A frame: 0.414×0.414×2; B frame: 0.293×0.586×2 ⇒ depthMesh=0.2929 (= SAT here, convex) max=2.0. A's corner edge
+    // vertices (1,1,±1) lie ON B's top/bottom faces — boundary points, excluded by insideMesh's half-eps margin by
+    // design (a flush vertex must never inflate the box); the curve endpoints already carry those extremes.
+    check('D4_rotated_corner_depth', 'depthMesh=0.2929 max=2.0000 exact', 'depthMesh=' + fx(s5.depthMeshM) + ' max=' + fx(s5.overlapMaxM) + ' sat=' + fx(s5.severityM) + ' exact=' + s5.overlapExact + ' pts=' + JSON.stringify(s5.overlapPts),
+      near(s5.depthMeshM, 0.29289, 1e-3) && near(s5.overlapMaxM, 2.0, 1e-3) && s5.overlapExact === true);
+    [cube2, cube2b, pipe, beam, u1, u2, small, col, slab].forEach(function (g) { try { if (g.boundsTree && g.disposeBoundsTree) g.disposeBoundsTree(); g.dispose(); } catch (e) {} });
     console.log('§CLASH_NARROW_SELFTEST summary pass=' + pass + ' fail=' + fail + ' bvhReady=' + !!window._bvhReady);
     return { pass: pass, fail: fail, cases: cases };
   };
 
-  console.log('§CLASH_NARROW_INIT wired (no allocation until qualifyRows) triPairCap=' + TRI_PAIR_CAP + ' obbEps=' + OBB_EPS);
+  console.log('§CLASH_NARROW_INIT wired (no allocation until qualifyRows) triPairCap=' + TRI_PAIR_CAP + ' obbEps=' + OBB_EPS + ' vertCap=' + VERT_CAP + ' (§MESH_OVERLAP_DEPTH on)');
 }

--- a/viewer/sw.js
+++ b/viewer/sw.js
@@ -128,7 +128,12 @@
 //   from the pair's severityM); viewer/clash_film.js — stamps tolMm per pair, stats() exposes broad/
 //   falseExcluded; viewer/cpe_resource_panel.js — reveal-round roster gains a "mesh-true clashes
 //   flagged" card read from A.clashFilm.stats(), dropped when the film was never built.
-const CACHE_VERSION = 'v1151';   // bump on each deploy; per-change detail is the git commit message.
+// v1152 (2026-09-06) §MESH_OVERLAP_DEPTH (MEP_CLASH_REVEAL_MOVIE.md): viewer/clash_narrow.js — every mesh-true
+//   CLASH record now carries depthMeshM/overlapMaxM/overlapA/overlapB/overlapExact/overlapCenter, the EXACT
+//   box of the overlap solid (intersection-curve endpoints + inside vertices, both frames); §CLASH_DEPTH_PROXY
+//   reports how far the SAT proxy sat from it. viewer/clash_labels.js — the [tol / clash] row reads the mesh
+//   figure (clashSrc=mesh), the OBB proxy only as a stated fallback. viewer/clash_film.js — build log counts.
+const CACHE_VERSION = 'v1152';   // bump on each deploy; per-change detail is the git commit message.
 // v1128 (2026-09-02) §SUN_FILL_RATIO: viewer/effects.js — the Alt+S staging HDRI
 // (belfast_sunset_puresky_1k) was being pushed onto EVERY material by _reassertPhotoEnvMap, matte
 // concrete and plaster included. IBL is non-directional and is NOT shadow-map-occluded in three.js,

--- a/viewer/tests/witness_clash_film_labels.js
+++ b/viewer/tests/witness_clash_film_labels.js
@@ -161,8 +161,11 @@ function pageProbe(sabotage) {
     // §P2.4 / §CLASH_HUD_CARD (2026-09-06) probes. tolTruth reads what the pair RECORD carries; composite
     // spies ctx.fillText on a real 2D context so the claim is about the string actually written, not a
     // formatter called in isolation; hudCard calls the SHIPPED bigStatsBuild and returns its cards.
+    // §MESH_OVERLAP_DEPTH: the clash figure is depthMeshM when the record carries it (src=mesh), else severityM (src=obb)
     tolTruth: () => pairs().map((p, i) => ({ i: i, discA: p.discA, discB: p.discB, tolMm: (p.tolMm == null ? null : p.tolMm),
-      sevMm: (typeof p.severityM === 'number' ? Math.round(p.severityM * 1000) : null) })),
+      src: (typeof p.depthMeshM === 'number') ? 'mesh' : 'obb',
+      sevMm: (typeof p.depthMeshM === 'number') ? Math.round(p.depthMeshM * 1000) : (typeof p.severityM === 'number' ? Math.round(p.severityM * 1000) : null),
+      obbMm: (typeof p.severityM === 'number' ? Math.round(p.severityM * 1000) : null) })),
     composite: (c, d, fs) => { pose(c, d); const r = A.clashLabels.update(A.camera, fs, W, H);
       const cv = document.createElement('canvas'); cv.width = W; cv.height = H; const ctx = cv.getContext('2d');
       const texts = []; const orig = ctx.fillText;
@@ -257,9 +260,10 @@ function pageProbe(sabotage) {
       if (!a || !b || typeof r.tolerance_m !== 'number') return; const k = a < b ? a + '|' + b : b + '|' + a; if (tolTruth[k] == null) tolTruth[k] = Math.round(r.tolerance_m * 1000); });
     const keyOf = p => (p.discA < p.discB ? p.discA + '|' + p.discB : p.discB + '|' + p.discA);
     const tt = await page.evaluate(() => window.__cll.tolTruth());
-    const tolBad = tt.filter(p => p.tolMm == null || p.tolMm !== tolTruth[keyOf(p)] || p.sevMm == null || !(p.sevMm > 0));
+    const tolBad = tt.filter(p => p.tolMm == null || p.tolMm !== tolTruth[keyOf(p)] || p.sevMm == null || !(p.sevMm >= 0));
+    const srcMesh = tt.filter(p => p.src === 'mesh').length;
     claim('P9a_every_pair_carries_rule_tolerance_and_measured_clash_mm', tt.length > 0 && tolBad.length === 0,
-      `pairs=${tt.length} rules=${Object.keys(tolTruth).length} [${Object.keys(tolTruth).map(k => k + '=' + tolTruth[k] + 'mm').join(' ')}] bad=${tolBad.length}${tolBad.length ? ' e.g. ' + JSON.stringify(tolBad[0]) : ''}`);
+      `pairs=${tt.length} rules=${Object.keys(tolTruth).length} [${Object.keys(tolTruth).map(k => k + '=' + tolTruth[k] + 'mm').join(' ')}] bad=${tolBad.length} clashSrc mesh=${srcMesh} obb=${tt.length - srcMesh}${tolBad.length ? ' e.g. ' + JSON.stringify(tolBad[0]) : ''}`);
     await page.evaluate(() => window.__cll.reset());
     const cmp = await page.evaluate((c, d) => window.__cll.composite(c, d, 0.6), iso.contact, D_CLOSE);
     const isoP = cmp.placed.find(q => q.i === iso.i), isoT = tt.find(p => p.i === iso.i);
@@ -270,7 +274,7 @@ function pageProbe(sabotage) {
     const row3 = j >= 0 ? cmp.texts[j + 2] : null;
     claim('P9b_third_row_composited_is_tolerance_over_measured_clash',
       !!isoP && !!row3 && row3.t === wantRow && row3.y > cmp.texts[j + 1].y && cmp.texts[j + 1].y > cmp.texts[j].y && isoP.h === h3 && h3 !== h2,
-      `placed=${!!isoP} drawn=${cmp.drawn} rows=[${j >= 0 ? cmp.texts.slice(j, j + 3).map(t => '"' + t.t + '"@y' + t.y).join(' ') : 'not found'}] want="${wantRow}" panelH=${isoP ? isoP.h : '-'} (3-row=${h3}, old 2-row=${h2})`);
+      `placed=${!!isoP} drawn=${cmp.drawn} rows=[${j >= 0 ? cmp.texts.slice(j, j + 3).map(t => '"' + t.t + '"@y' + t.y).join(' ') : 'not found'}] want="${wantRow}" src=${isoT ? isoT.src : '-'} obbWouldSay=${isoT ? isoT.obbMm + 'mm' : '-'} panelH=${isoP ? isoP.h : '-'} (3-row=${h3}, old 2-row=${h2})`);
 
     // ── §CLASH_HUD_CARD — the reveal-round roster carries the film's own count, and only once the film exists
     if (!hud0.hasBuilder) claim('H0_hud_card_absent_before_film_built', false, 'INCONCLUSIVE: A.bigStatsBuild is not wired on this page');

--- a/viewer/tests/witness_clash_mesh_narrowphase.js
+++ b/viewer/tests/witness_clash_mesh_narrowphase.js
@@ -152,6 +152,9 @@ function pageProbe() {
           verdict: v ? v.verdict : 'CLASH', reason: v ? v.reason : 'LEGACY_BBOX_ONLY', stage: v ? v.stage : 'BROAD',
           oracleKnown: known, oracleHit: hit, oracleHow: how, aabbOverlapM: (typeof c[8] === 'number') ? c[8] : null,
           obbDepthM: v ? v.obbDepthM : null, triPairs: v ? (v.triPairs | 0) : 0, hasContact: !!(v && v.contact),
+          // §MESH_OVERLAP_DEPTH — the mesh-true overlap beside the SAT proxy it replaces on the label
+          severityM: v ? v.severityM : null, depthMeshM: (v && typeof v.depthMeshM === 'number') ? v.depthMeshM : null,
+          overlapMaxM: (v && typeof v.overlapMaxM === 'number') ? v.overlapMaxM : null, overlapExact: !!(v && v.overlapExact), overlapFlat: !!(v && v.overlapFlat), depthMs: v ? (v.depthMs || 0) : 0,
           classA: c[2] || '', classB: c[3] || '', err: v && v.err ? String(v.err).slice(0, 80) : undefined,
           oracleNote: (!known) ? ('A=' + (ta ? (ta.hash ? (gA ? (gA.boundsTree ? 'ok' : 'no-bvh') : 'hash-not-in-cache') : 'no-hash') : 'no-transform') + ' B=' + (tb ? (tb.hash ? (gB ? (gB.boundsTree ? 'ok' : 'no-bvh') : 'hash-not-in-cache') : 'no-hash') : 'no-transform')) : undefined });
       });
@@ -177,7 +180,7 @@ function pageProbe() {
   const browser = await puppeteer.launch({ headless: true, userDataDir: profile, protocolTimeout: 30 * 60 * 1000, env: Object.assign({}, process.env, gpuEnv),
     args: ['--no-sandbox', '--hide-crash-restore-bubble', '--window-size=1300,840', '--enable-precise-memory-info'].concat(gpuArgs) });
   const page = await browser.newPage(); await page.setViewport({ width: 1280, height: 720 });
-  page.on('console', m => { const t = m.text(); logRaw('[con] ' + t); if (/§CLASH_(NARROWPHASE|OBB |NARROW_LOSS|MEM|NARROW_SELFTEST|BBOX_FP|NARROW_INIT)|§BVH_(INIT|DEFERRED|SELFTEST)|§CLASH_RTREE ready|§CONTRACT_CHECK/.test(t)) console.log('  ' + t); });
+  page.on('console', m => { const t = m.text(); logRaw('[con] ' + t); if (/§CLASH_(NARROWPHASE|OBB |NARROW_LOSS|MEM|NARROW_SELFTEST|BBOX_FP|NARROW_INIT|DEPTH_PROXY)|§BVH_(INIT|DEFERRED|SELFTEST)|§CLASH_RTREE ready|§CONTRACT_CHECK/.test(t)) console.log('  ' + t); });
   page.on('pageerror', e => logRaw('[pageerror] ' + e.message));
   let R = null, ready = null;
   try {
@@ -216,6 +219,20 @@ function pageProbe() {
       log(`§CLASH_NARROWPHASE pair=TOTAL building=${BLD} LEGACY — no clash_narrow.js on this ROOT; every broad row is reported as a clash`);
     }
     log(`§CMN_PARITY sampled=${R.parity.sampled} maxDiff=${R.parity.maxDiff.toExponential(2)} missing=${R.parity.missing}`);
+    // §MESH_OVERLAP_DEPTH — TOTAL: how wrong the SAT proxy was on THIS building, from the records (measured, logged, not gated);
+    // a flat overlap (thinnest extent < 1 mm) is a touch the segment-length rule still calls CLASH — counted, verdict unchanged (⛔USER)
+    {
+      const cl = R.records.filter(r => r.verdict === 'CLASH' && r.stage === 'MESH');
+      const known = cl.filter(r => typeof r.depthMeshM === 'number');
+      const solid = known.filter(r => r.depthMeshM >= 0.001 && typeof r.severityM === 'number');
+      const ratios = solid.map(r => r.severityM / r.depthMeshM).sort((a, b) => a - b);
+      const med = ratios.length ? ratios[Math.floor(ratios.length / 2)] : null;
+      const worst = solid.slice().sort((a, b) => (b.severityM / b.depthMeshM) - (a.severityM / a.depthMeshM)).slice(0, 5);
+      log(`§CLASH_DEPTH_PROXY pair=TOTAL building=${BLD} meshTrue=${cl.length} depthKnown=${known.length} missing=${cl.length - known.length} overlapFlat=${known.filter(r => r.overlapFlat).length} inexact=${known.filter(r => !r.overlapExact).length}` +
+        ` satOverMesh median=${med == null ? 'n/a' : med.toFixed(2)} max=${ratios.length ? ratios[ratios.length - 1].toFixed(2) : 'n/a'} satGe1p5xMesh=${ratios.filter(x => x >= 1.5).length} satGe3xMesh=${ratios.filter(x => x >= 3).length} satBelowMesh=${ratios.filter(x => x < 1 - 1e-6).length}` +
+        ` depthMsTotal=${R.records.reduce((a, r) => a + (r.depthMs || 0), 0).toFixed(0)}${known.length === 0 ? ' VACUOUS' : ''}`);
+      worst.forEach(r => log(`§CLASH_DEPTH_PROXY_WORST pair=${r.pairId} cls=${r.classA}|${r.classB} sat=${(r.severityM * 1000).toFixed(0)}mm mesh=${(r.depthMeshM * 1000).toFixed(0)}mm max=${(r.overlapMaxM * 1000).toFixed(0)}mm ratio=${(r.severityM / r.depthMeshM).toFixed(2)} exact=${r.overlapExact}`));
+    }
     // name every disagreement and every unknown, so a red line says WHICH pair and WHY (never re-derive from memory)
     const i3 = R.records.filter(r => r.verdict === 'CLEAR' && r.oracleKnown && r.oracleHit);
     const i1 = R.records.filter(r => r.verdict === 'CLASH' && r.oracleKnown && !r.oracleHit);
@@ -241,7 +258,8 @@ function pageProbe() {
     .invariant('I2 no silent loss — one record per broad-phase candidate, verdict from the enum', rs => rs.length === R.broadTotal && rs.every(r => ['CLASH', 'CLEAR', 'UNKNOWN'].includes(r.verdict)))
     .invariant('I3 every CLEAR is really clear — oracle finds no intersection and no containment', rs => rs.filter(r => r.verdict === 'CLEAR' && r.oracleKnown).every(r => !r.oracleHit))
     .invariant('I4 DB-derived world matrix equals the live scene matrix (getMatrixAt) on the sample', () => R.parity.sampled > 0 && R.parity.maxDiff < 1e-5)
-    .invariant('I5 the hand-known synthetic cases (S1-S8, incl. the touch policy) pass through the same testPair', () => !!R.selfTest && R.selfTest.fail === 0 && R.selfTest.pass >= 10)
+    .invariant('I5 the hand-known synthetic cases (S1-S8 incl. the touch policy, D1-D6 the overlap solids) pass through the same testPair', () => !!R.selfTest && R.selfTest.fail === 0 && R.selfTest.pass >= 16)
+    .invariant('I6 §MESH_OVERLAP_DEPTH every MESH-stage CLASH carries a finite depthMeshM >= 0 with overlapMaxM >= depthMeshM', rs => { const cl = rs.filter(r => r.verdict === 'CLASH' && r.stage === 'MESH'); return cl.length > 0 && cl.every(r => typeof r.depthMeshM === 'number' && isFinite(r.depthMeshM) && r.depthMeshM >= 0 && typeof r.overlapMaxM === 'number' && r.overlapMaxM >= r.depthMeshM - 1e-9); })
     .invariant('I6 every CLASH verdict carries a world contact point for the film lane', rs => rs.filter(r => r.verdict === 'CLASH' && r.reason !== 'LEGACY_BBOX_ONLY').every(r => r.hasContact))
     .redControl(rs => { const c = rs.map(r => Object.assign({}, r)); const i = c.findIndex(r => r.verdict === 'CLASH' && r.oracleKnown); if (i >= 0) c[i].oracleHit = false; else if (c[0]) { c[0].verdict = 'CLASH'; c[0].oracleKnown = true; c[0].oracleHit = false; } return c; })
     .run();

--- a/viewer/viewer.html
+++ b/viewer/viewer.html
@@ -870,9 +870,9 @@ html.bim-embedded, html.bim-embedded body { background: #0b0b0b; }
 <script src="clash_report.js?v=1" onerror="console.warn('§LOAD_FAIL clash_report.js')"></script>
 <script src="clash_snag.js?v=1" onerror="console.warn('§LOAD_FAIL clash_snag.js')"></script>
 <script src="clash_matrix.js?v=2" onerror="console.warn('§LOAD_FAIL clash_matrix.js')"></script>
-<script src="clash_narrow.js?v=1" onerror="console.warn('§LOAD_FAIL clash_narrow.js')"></script>
-<script src="clash_film.js?v=4" onerror="console.warn('§LOAD_FAIL clash_film.js')"></script>
-<script src="clash_labels.js?v=4" onerror="console.warn('§LOAD_FAIL clash_labels.js')"></script>
+<script src="clash_narrow.js?v=2" onerror="console.warn('§LOAD_FAIL clash_narrow.js')"></script>
+<script src="clash_film.js?v=5" onerror="console.warn('§LOAD_FAIL clash_film.js')"></script>
+<script src="clash_labels.js?v=5" onerror="console.warn('§LOAD_FAIL clash_labels.js')"></script>
 <script src="measure.js?v=52" onerror="console.warn('§LOAD_FAIL measure.js')"></script>
 <script src="sitecam.js?v=7" onerror="console.warn('§LOAD_FAIL sitecam.js')"></script>
 <script src="share.js?v=2" onerror="console.warn('§LOAD_FAIL share.js')"></script>


### PR DESCRIPTION
Spec: bim-compiler `prompts/MEP_CLASH_REVEAL_MOVIE.md` §MESH_OVERLAP_DEPTH (2026-09-06; user's catch: `severityM` was 100% the OBB/SAT proxy).

**What changes for the viewer**
- The film label's `[tol mm / clash mm]` row now shows the mesh-true overlap. The Hospital pair the label shows reads `[50mm / 50mm]`; the OBB proxy said **344 mm**.
- Every mesh-true pair record carries the exact box of the overlap solid `A∩B` (`depthMeshM` = thinnest extent, `overlapMaxM`, `overlapA/B`, `overlapCenter`, `overlapExact`, `overlapFlat`). **Verdicts are unchanged** (Terminal 3,703 / Hospital 6,749 / film 271 — identical to main). Marker size unchanged.

**Measured** (real GPU, both buildings): SAT proxy vs mesh-true — Hospital median **2.78×** overstatement, ≥3× on 3,185 of 6,749 pairs, worst 600× (11.2 m SAT for a 19 mm overlap); Terminal median 1.11×, worst 329×. Flat overlaps (thinnest extent < 1 mm — touches the segment-length rule still calls CLASH): **752 Terminal / 37 Hospital / 1 in the film**. Cost 0.6 ms/pair.

**Witness** `witness_clash_mesh_narrowphase.js`: new **I6** (every MESH-stage CLASH carries finite `depthMeshM ≥ 0`, `overlapMaxM ≥ depthMeshM`) — RED on main's module, GREEN here on both buildings; selfTest D1–D6 hand-known overlap solids (poke-in 30 mm, pass-through pipe 200 mm where SAT says 400, contained, rotated corner 292.9 mm, column-on-slab flat, column sunk 20 mm) all PASS. `witness_clash_film_labels.js` P9a/P9b read the mesh figure: 19/19. Markers 14/14. eslint clean. sw v1152.

**Pre-existing RED on main, not from this PR** (same numbers with this witness on plain `origin/main`): S7b (face-to-face cubes judged CLASH, tri=64 touch=56), I3 (223 Terminal / 326 Hospital OBB-stage rejects the oracle's own segment rule calls hits), I1 n=2 Terminal.

**⛔USER, deliberately not done:** making `overlapFlat` the verdict (CLASH requires ≥ 1 mm thickness) fixes S7b and drops 752/37 pairs, but three oracle formulations tried this session each disagreed with the module on 190–240 multi-shell IFC pairs (layered walls, 1.6–4.2k-vertex columns) where the geometry shows real overlap. Trail in the spec.

🤖 Generated with [Claude Code](https://claude.com/claude-code)