### PR TITLE
feat(cinema): §CLASH_MARKER_OVERLAP_BOX + §CLASH_FILM_FLAT_FILTER — marker is the real overlap solid's oriented box; flat touches leave the film

### DIFF
--- a/viewer/clash_film.js
+++ b/viewer/clash_film.js
@@ -80,22 +80,34 @@ function setupClashFilm(A) {
     // §CLASH_FILM_SKY_WASH — per PAIR: contact (×3), A→B axis (×3), the severity-sized box, the box
     // currently placed. The clamp rewrites a pair's two matrices only when its box actually changes.
     var _ctr = null, _dir = null, _nat = null, _cur = null, _updates = 0, _lastClamp = null;
+    // §CLASH_MARKER_OVERLAP_BOX — per PAIR: A's rotation (×4, quaternion), the per-axis clamped extents of
+    // the overlap solid in A's frame (×3), the split axis (0..2) and its sign (+1 = blue half on +axis).
+    var _rot = null, _ext = null, _ax = null, _sg = null, _legacyBox = 0;
     var _broad = 0;         // §CLASH_HUD_CARD: the bbox-only candidate count the mesh stage judged (0 = nothing judged)
+    var _meshTrue = 0, _flat = 0;   // §CLASH_FILM_FLAT_FILTER: the verdict count, and how many flat touches the film dropped
     var _camPos = new THREE.Vector3(), _m4 = new THREE.Matrix4(), _sc = new THREE.Matrix4();
+    var _q = new THREE.Quaternion(), _p3 = new THREE.Vector3(), _s3 = new THREE.Vector3(), _axW = new THREE.Vector3();
 
     A.clashFilm = A.clashFilm || {};
 
-    // The ONE place a marker pair is placed: two boxes of world size `box` straddling the contact
-    // along the A→B axis — red on A's side, blue on B's (§CLASH_FILM_CONTACT_MARKER).
+    // The ONE place a marker pair is placed (§CLASH_MARKER_OVERLAP_BOX, 2026-09-06, MEP_CLASH_REVEAL_MOVIE.md):
+    // the ORIENTED BOX OF THE REAL OVERLAP SOLID — centre = overlapCenter, rotation = A's world rotation,
+    // per-axis size = the clamped overlapA extents — split into two halves along the A-frame axis most
+    // aligned with the A→B direction: red half on A's side, blue on B's (the §CLASH_FILM_CONTACT_MARKER
+    // pair reading, kept). `box` is the target LARGEST extent; the whole box scales uniformly by
+    // box/naturalM so the per-frame screen clamp (§CLASH_FILM_SKY_WASH) shrinks it toward its centre.
     function placePair(i, box) {
-      var i3 = i * 3, cx = _ctr[i3], cy = _ctr[i3 + 1], cz = _ctr[i3 + 2];
-      var dx = _dir[i3], dy = _dir[i3 + 1], dz = _dir[i3 + 2];
-      _sc.makeScale(box, box, box);
-      _m4.makeTranslation(cx - dx * box * 0.55, cy - dy * box * 0.55, cz - dz * box * 0.55);
-      _meshA.setMatrixAt(i, _m4.multiply(_sc));
-      _sc.makeScale(box, box, box);
-      _m4.makeTranslation(cx + dx * box * 0.55, cy + dy * box * 0.55, cz + dz * box * 0.55);
-      _meshB.setMatrixAt(i, _m4.multiply(_sc));
+      var i3 = i * 3, i4 = i * 4, k = _ax[i], sg = _sg[i] || 1;
+      var s = (_nat[i] > 0) ? box / _nat[i] : 0;
+      var ex = _ext[i3] * s, ey = _ext[i3 + 1] * s, ez = _ext[i3 + 2] * s;
+      _q.set(_rot[i4], _rot[i4 + 1], _rot[i4 + 2], _rot[i4 + 3]);
+      _axW.set(k === 0 ? 1 : 0, k === 1 ? 1 : 0, k === 2 ? 1 : 0).applyQuaternion(_q);
+      var full = k === 0 ? ex : (k === 1 ? ey : ez), half = full / 2, off = full / 4;
+      _s3.set(k === 0 ? half : ex, k === 1 ? half : ey, k === 2 ? half : ez);
+      _p3.set(_ctr[i3] - _axW.x * off * sg, _ctr[i3 + 1] - _axW.y * off * sg, _ctr[i3 + 2] - _axW.z * off * sg);
+      _meshA.setMatrixAt(i, _m4.compose(_p3, _q, _s3));
+      _p3.set(_ctr[i3] + _axW.x * off * sg, _ctr[i3 + 1] + _axW.y * off * sg, _ctr[i3 + 2] + _axW.z * off * sg);
+      _meshB.setMatrixAt(i, _m4.compose(_p3, _q, _s3));
       _cur[i] = box;
     }
 
@@ -221,6 +233,12 @@ function setupClashFilm(A) {
         }
         return A.clashNarrow.qualifyRows(allRows, { label: 'film' }).then(function (run) {
           var recs = (run && run.pairs) ? run.pairs.filter(function (p) { return p && p.verdict === 'CLASH'; }) : [];
+          // §CLASH_FILM_FLAT_FILTER (2026-09-06, Option 3 of §TOUCH_BY_THICKNESS): the FILM drops pairs whose
+          // overlap solid is flat (thinnest extent < 1 mm — a touch the segment-length rule still calls
+          // CLASH). The narrowphase verdict itself is untouched; this is the film's own set.
+          _meshTrue = recs.length;
+          recs = recs.filter(function (p) { return p.overlapFlat !== true; });
+          _flat = _meshTrue - recs.length;
           if (!recs.length) {
             console.log('§CLASH_FILM_BUILD discPairs=' + discPairs + ' pairsBroad=' + broad + ' trueClash=0 VACUOUS — every candidate is CLEAR at mesh level; nothing to draw');
             _built = true;
@@ -254,10 +272,19 @@ function setupClashFilm(A) {
           // So the marker is now the CLASH, not the element: two small boxes straddling the contact
           // point along the A→B axis — red on A's side, blue on B's — sized from the penetration
           // depth, not the element. Same red/blue pair reading, at the place that is actually wrong.
+          // ══ §CLASH_MARKER_OVERLAP_BOX (2026-09-06) — the marker is now the oriented box of the REAL
+          // overlap solid (§MESH_OVERLAP_DEPTH's overlapCenter + overlapA, in A's frame, A's rotation from
+          // the same worldMatrix the narrowphase used). Per-axis size clamped to [MARKER_MIN_M, MARKER_MAX_M]
+          // — the cube's own 0.30/1.20 m rule, per axis: a 25 mm overlap is drawn 0.30 m thick so it is
+          // visible; a 5 m through-run is capped at 1.20 m so the marker stays the clash, not the element.
+          // A record without the overlap box (none on Hospital) keeps the old severity cube: legacyBox=N.
           var m4 = new THREE.Matrix4(), sc = new THREE.Matrix4(), placed = 0, skipped = 0;
           var pA = new THREE.Vector3(), pB = new THREE.Vector3(), dir = new THREE.Vector3();
+          var qA = new THREE.Quaternion(), tmpP = new THREE.Vector3(), tmpS = new THREE.Vector3(), axw = new THREE.Vector3();
           _ctr = new Float32Array(recs.length * 3); _dir = new Float32Array(recs.length * 3);
           _nat = new Float32Array(recs.length); _cur = new Float32Array(recs.length);
+          _rot = new Float32Array(recs.length * 4); _ext = new Float32Array(recs.length * 3);
+          _ax = new Int8Array(recs.length); _sg = new Int8Array(recs.length); _legacyBox = 0;
           for (var i = 0; i < recs.length; i++) {
             var p = recs[i], ta = xf[p.guidA], tb = xf[p.guidB];
             if (!p.contact || !ta || !tb) {
@@ -265,19 +292,37 @@ function setupClashFilm(A) {
               _meshB.setMatrixAt(i, sc.makeScale(0, 0, 0));
               _nat[i] = 0; skipped++; continue;
             }
-            A.clashNarrow.worldMatrix(ta, m4); pA.setFromMatrixPosition(m4);
+            A.clashNarrow.worldMatrix(ta, m4); pA.setFromMatrixPosition(m4); m4.decompose(tmpP, qA, tmpS);
             A.clashNarrow.worldMatrix(tb, m4); pB.setFromMatrixPosition(m4);
             dir.subVectors(pB, pA);
             if (dir.lengthSq() < 1e-9) dir.set(0, 1, 0); else dir.normalize();
-            // Size from the PENETRATION (severityM), not the element and not extentM — extentM is
-            // how FAR the intersection runs (79 m for a wall-on-foundation join) and would put us
-            // straight back to lighting up the building.
-            var sM = (typeof p.severityM === 'number' && p.severityM > 0) ? p.severityM : 0.2;
-            var box = Math.max(MARKER_MIN_M, Math.min(sM * 2, MARKER_MAX_M));
-            _ctr[i * 3] = p.contact.x; _ctr[i * 3 + 1] = p.contact.y; _ctr[i * 3 + 2] = p.contact.z;
+            var hasBox = !!(p.overlapCenter && p.overlapA && p.overlapA.length === 3);
+            var e0, e1, e2, c;
+            if (hasBox) {
+              e0 = Math.max(MARKER_MIN_M, Math.min(p.overlapA[0], MARKER_MAX_M));
+              e1 = Math.max(MARKER_MIN_M, Math.min(p.overlapA[1], MARKER_MAX_M));
+              e2 = Math.max(MARKER_MIN_M, Math.min(p.overlapA[2], MARKER_MAX_M));
+              c = p.overlapCenter;
+            } else {
+              // legacy: the severity cube at the contact — sized from the PENETRATION (severityM), never the element
+              var sM = (typeof p.severityM === 'number' && p.severityM > 0) ? p.severityM : 0.2;
+              e0 = e1 = e2 = Math.max(MARKER_MIN_M, Math.min(sM * 2, MARKER_MAX_M));
+              c = p.contact; _legacyBox++;
+            }
+            // split axis: the A-frame axis most aligned with A→B; sign so the blue half lands on B's side
+            var bestK = 0, bestD = -1, bestSign = 1;
+            for (var k = 0; k < 3; k++) {
+              axw.set(k === 0 ? 1 : 0, k === 1 ? 1 : 0, k === 2 ? 1 : 0).applyQuaternion(qA);
+              var dd = axw.dot(dir);
+              if (Math.abs(dd) > bestD) { bestD = Math.abs(dd); bestK = k; bestSign = dd < 0 ? -1 : 1; }
+            }
+            _ctr[i * 3] = c.x; _ctr[i * 3 + 1] = c.y; _ctr[i * 3 + 2] = c.z;
             _dir[i * 3] = dir.x; _dir[i * 3 + 1] = dir.y; _dir[i * 3 + 2] = dir.z;
-            _nat[i] = box;                                 // the severity box — the clamp only ever shrinks it
-            placePair(i, box);
+            _rot[i * 4] = qA.x; _rot[i * 4 + 1] = qA.y; _rot[i * 4 + 2] = qA.z; _rot[i * 4 + 3] = qA.w;
+            _ext[i * 3] = e0; _ext[i * 3 + 1] = e1; _ext[i * 3 + 2] = e2;
+            _ax[i] = bestK; _sg[i] = bestSign;
+            _nat[i] = Math.max(e0, e1, e2);               // the largest clamped extent — the clamp only ever shrinks it
+            placePair(i, _nat[i]);
             placed++;
           }
           _meshA.instanceMatrix.needsUpdate = true; _meshB.instanceMatrix.needsUpdate = true;
@@ -287,7 +332,7 @@ function setupClashFilm(A) {
           var ms = performance.now() - t0;
           console.log('§CLASH_FILM_BUILD discPairs=' + discPairs + ' pairsBroad=' + broad +
             ' trueClash=' + recs.length + ' markers=' + (recs.length * 2) + ' bothPlaced=' + placed +
-            ' incomplete=' + skipped + ' falsePositivesExcluded=' + (broad - recs.length) +
+            ' incomplete=' + skipped + ' falsePositivesExcluded=' + (broad - _meshTrue) + ' flatExcluded=' + _flat + ' legacyBox=' + _legacyBox +
             ' tolStamped=' + tolStamped + '/' + recs.length + ' depthMesh=' + depthMesh + '/' + recs.length + ' depthInexact=' + depthInexact + ' overlapFlat=' + overlapFlat +
             ' ms=' + ms.toFixed(0) + ' (mesh-true set only — the broad set would assert clashes that do not exist)');
           return A.clashFilm.stats();
@@ -352,7 +397,8 @@ function setupClashFilm(A) {
 
     A.clashFilm.stats = function () {
       return { built: _built, pairs: _pairs.length, markers: _pairs.length * 2,
-        broad: _broad, falseExcluded: Math.max(0, _broad - _pairs.length),   // §CLASH_HUD_CARD
+        broad: _broad, meshTrue: _meshTrue, flat: _flat, falseExcluded: Math.max(0, _broad - _meshTrue),   // §CLASH_HUD_CARD / §CLASH_FILM_FLAT_FILTER
+        legacyBox: _legacyBox,
         lastPulse: _lastPulse, uploads: _uploads, periodS: PERIOD_S, peak: PEAK,
         riseS: RISE_S, holdS: HOLD_S, fallS: FALL_S, restS: REST_S,
         markerMaxPx: MARKER_MAX_PX, updates: _updates, lastClamp: _lastClamp,
@@ -361,6 +407,12 @@ function setupClashFilm(A) {
     A.clashFilm.pairs = function () { return _pairs; };
     // The severity box of pair i and the box currently placed — what the clamp witness reads.
     A.clashFilm.boxOf = function (i) { return (_nat && i >= 0 && i < _nat.length) ? { naturalM: _nat[i], placedM: _cur[i] } : null; };
+    // §CLASH_MARKER_OVERLAP_BOX — what the witness decomposes the instance matrices against
+    A.clashFilm.centerOf = function (i) { return (_ctr && i >= 0 && i * 3 < _ctr.length) ? { x: _ctr[i * 3], y: _ctr[i * 3 + 1], z: _ctr[i * 3 + 2] } : null; };
+    A.clashFilm.markerOf = function (i) {
+      if (!_ext || i < 0 || i >= _nat.length) return null;
+      return { ext: [_ext[i * 3], _ext[i * 3 + 1], _ext[i * 3 + 2]], axis: _ax[i], sign: _sg[i], naturalM: _nat[i], placedM: _cur[i], minM: MARKER_MIN_M, maxM: MARKER_MAX_M };
+    };
 
     // IDEMPOTENT: cinema_maxq calls this on the normal exit AND in its outer finally (the THROW
     // path — update() mid-loop can throw), so the second call must be a silent no-op, not a second
@@ -373,7 +425,7 @@ function setupClashFilm(A) {
         m.geometry.dispose(); m.material.dispose();
       });
       _meshA = _meshB = null; _pairs = []; _fade = null; _built = false; _lastPulse = -1;
-      _ctr = _dir = _nat = _cur = null; _updates = 0; _lastClamp = null;
+      _ctr = _dir = _nat = _cur = null; _rot = _ext = _ax = _sg = null; _legacyBox = 0; _meshTrue = 0; _flat = 0; _updates = 0; _lastClamp = null;
       console.log('§CLASH_FILM_DISPOSE markers released');
       return true;
     };

--- a/viewer/cpe_resource_panel.js
+++ b/viewer/cpe_resource_panel.js
@@ -313,7 +313,8 @@ function setupCpeResourcePanel(A) {
     if (cf && cf.built && cf.broad > 0) {
       var falsePct = Math.round((cf.falseExcluded / cf.broad) * 1000) / 10;
       out.push({ big: String(cf.pairs), label: 'mesh-true clashes flagged',
-                 sub: cf.broad.toLocaleString() + ' bbox candidates  ·  ' + falsePct + '% false at mesh level',
+                 sub: cf.broad.toLocaleString() + ' bbox candidates  ·  ' + falsePct + '% false at mesh level' +
+                      (cf.flat > 0 ? '  ·  ' + cf.flat + ' flat touch' + (cf.flat > 1 ? 'es' : '') + ' dropped' : ''),   // §CLASH_FILM_FLAT_FILTER
                  src: 'clash_film.js §CLASH_FILM_BUILD' });
     }
     console.log('§CPE_BIG_STATS cards=' + out.length + (out.length

--- a/viewer/sw.js
+++ b/viewer/sw.js
@@ -133,7 +133,11 @@
 //   box of the overlap solid (intersection-curve endpoints + inside vertices, both frames); §CLASH_DEPTH_PROXY
 //   reports how far the SAT proxy sat from it. viewer/clash_labels.js — the [tol / clash] row reads the mesh
 //   figure (clashSrc=mesh), the OBB proxy only as a stated fallback. viewer/clash_film.js — build log counts.
-const CACHE_VERSION = 'v1152';   // bump on each deploy; per-change detail is the git commit message.
+// v1153 (2026-09-06) §CLASH_MARKER_OVERLAP_BOX + §CLASH_FILM_FLAT_FILTER (MEP_CLASH_REVEAL_MOVIE.md): viewer/clash_film.js —
+//   the marker is the oriented box of the REAL overlap solid (overlapCenter + overlapA, A's rotation), split red/blue
+//   along the A→B-aligned axis, per-axis 0.30/1.20 m clamp; flat overlaps (<1 mm) are dropped from the film's set
+//   (verdict untouched). viewer/cpe_resource_panel.js — the clash card notes dropped flat touches.
+const CACHE_VERSION = 'v1153';   // bump on each deploy; per-change detail is the git commit message.
 // v1128 (2026-09-02) §SUN_FILL_RATIO: viewer/effects.js — the Alt+S staging HDRI
 // (belfast_sunset_puresky_1k) was being pushed onto EVERY material by _reassertPhotoEnvMap, matte
 // concrete and plaster included. IBL is non-directional and is NOT shadow-map-occluded in three.js,

--- a/viewer/tests/witness_clash_film_labels.js
+++ b/viewer/tests/witness_clash_film_labels.js
@@ -175,7 +175,8 @@ function pageProbe(sabotage) {
     hudCard: () => { const st = A.clashFilm.stats(); const has = typeof A.bigStatsBuild === 'function';
       const cards = has ? (A.bigStatsBuild([], 0, 0) || []) : null;
       return { hasBuilder: has, cards: cards ? cards.map(c => ({ big: c.big, label: c.label, sub: c.sub || '', src: c.src })) : null,
-        stats: { built: st.built, pairs: st.pairs, broad: st.broad, falseExcluded: st.falseExcluded } }; },
+        stats: { built: st.built, pairs: st.pairs, broad: st.broad, falseExcluded: st.falseExcluded, meshTrue: st.meshTrue, flat: st.flat },
+        flatInFilm: pairs().filter(p => p.overlapFlat === true).length }; },
     pathProfile: (n) => {
       A.camera.position.copy(camLoad.p); A.controls.target.copy(camLoad.t); A.camera.lookAt(camLoad.t); A.camera.updateMatrixWorld(true); A.controls.update();
       try { if (typeof A.cinemaPathPlan === 'function') A.cinemaPathPlan(60); } catch (e) {}
@@ -286,8 +287,12 @@ function pageProbe(sabotage) {
     if (!hud1.hasBuilder) claim('H1_hud_card_reads_the_film_count', false, 'INCONCLUSIVE: A.bigStatsBuild is not wired on this page');
     else claim('H1_hud_card_reads_the_film_count',
       !!card && card.big === String(st.pairs) && hud1.stats.pairs === st.pairs && hud1.stats.broad > st.pairs
-        && card.sub.replace(/,/g, '').indexOf(String(hud1.stats.broad)) >= 0 && card.sub.indexOf(wantPct + '%') >= 0 && hud1.stats.falseExcluded === hud1.stats.broad - st.pairs,
-      `card=${card ? '"' + card.big + ' ' + card.label + ' — ' + card.sub + '" src=' + card.src : 'ABSENT'} film pairs=${st.pairs} broad=${hud1.stats.broad} falseExcluded=${hud1.stats.falseExcluded} wantPct=${wantPct}`);
+        && card.sub.replace(/,/g, '').indexOf(String(hud1.stats.broad)) >= 0 && card.sub.indexOf(wantPct + '%') >= 0 && hud1.stats.falseExcluded === hud1.stats.broad - hud1.stats.meshTrue
+        && (hud1.stats.flat === 0 || card.sub.indexOf(hud1.stats.flat + ' flat touch') >= 0),
+      `card=${card ? '"' + card.big + ' ' + card.label + ' — ' + card.sub + '" src=' + card.src : 'ABSENT'} film pairs=${st.pairs} meshTrue=${hud1.stats.meshTrue} flat=${hud1.stats.flat} broad=${hud1.stats.broad} falseExcluded=${hud1.stats.falseExcluded} wantPct=${wantPct}`);
+    // §CLASH_FILM_FLAT_FILTER P9c — the film's set carries no flat overlap, and the count it dropped reconciles with the verdict count
+    claim('P9c_film_drops_flat_overlaps', hud1.stats.meshTrue >= st.pairs && hud1.stats.flat === hud1.stats.meshTrue - st.pairs && hud1.flatInFilm === 0,
+      `meshTrue=${hud1.stats.meshTrue} film pairs=${st.pairs} flat dropped=${hud1.stats.flat} flat still in film=${hud1.flatInFilm}${hud1.stats.flat === 0 ? ' (no flat pair on this building — the filter was not exercised, the reconciliation was)' : ''}`);
 
     // P1 — rank correctness, NO distance limit at all: the module's `eligiblePairs` equals the TRUE
     // top-N nearest pairs by plain 3D distance (computed independently in the browser, not trusted from

--- a/viewer/tests/witness_clash_film_markers.js
+++ b/viewer/tests/witness_clash_film_markers.js
@@ -89,9 +89,23 @@ function pageProbe() {
     // W6 — §CLASH_FILM_SKY_WASH: put the camera at distance d from pair 0's contact, run one update,
     // and read the box that was actually PLACED against the one severity would have given. The
     // projected height in px is s / (2·d·tan(fov/2)) · h — the number the clamp exists to bound.
+    // §CLASH_MARKER_OVERLAP_BOX W11 — decompose both halves of every pair and return them beside the record's own
+    // overlapCenter/overlapA and A's rotation from clashNarrow.worldMatrix (the witness's arithmetic, not the module's)
+    markerGeometry: () => { const P = A.clashFilm.pairs(); const mA = A.scene.children.find(o => o.userData && o.userData.clashFilmSide === 'A');
+      const mB = A.scene.children.find(o => o.userData && o.userData.clashFilmSide === 'B'); if (!mA || !mB) return null;
+      const m4 = new THREE.Matrix4(), p = new THREE.Vector3(), q = new THREE.Quaternion(), s = new THREE.Vector3();
+      const dec = (m, i) => { m.getMatrixAt(i, m4); m4.decompose(p, q, s); return { p: p.toArray(), q: q.toArray(), s: s.toArray() }; };
+      const out = []; const xf = A.clashNarrow.loadTransforms(P.map(r => r.guidA));
+      for (let i = 0; i < P.length; i++) { const r = P[i], ta = xf[r.guidA]; if (!ta || !r.overlapCenter || !r.overlapA) { out.push({ i, skip: true }); continue; }
+        A.clashNarrow.worldMatrix(ta, m4); m4.decompose(p, q, s); const rotA = q.toArray();
+        const tb = A.clashNarrow.loadTransforms([r.guidB])[r.guidB]; let dir = null;
+        if (tb) { const pa = new THREE.Vector3().setFromMatrixPosition(A.clashNarrow.worldMatrix(ta, m4)); const pb = new THREE.Vector3().setFromMatrixPosition(A.clashNarrow.worldMatrix(tb, m4)); dir = pb.sub(pa); if (dir.lengthSq() < 1e-9) dir.set(0, 1, 0); dir.normalize(); dir = dir.toArray(); }
+        out.push({ i, a: dec(mA, i), b: dec(mB, i), rotA, dir, center: [r.overlapCenter.x, r.overlapCenter.y, r.overlapCenter.z], ext: r.overlapA.slice(), box: A.clashFilm.boxOf(i), mk: A.clashFilm.markerOf(i) }); }
+      return out; },
     clampAt: (d) => { const p = A.clashFilm.pairs()[0]; if (!p || !p.contact) return null;
       const cam = A.camera, keep = { p: cam.position.clone(), t: A.controls.target.clone() };
-      const c = new THREE.Vector3(p.contact.x, p.contact.y, p.contact.z);
+      const c0 = (A.clashFilm.centerOf && A.clashFilm.centerOf(0)) || p.contact;
+      const c = new THREE.Vector3(c0.x, c0.y, c0.z);
       cam.position.set(c.x + d, c.y, c.z); A.controls.target.copy(c); A.controls.update(); cam.updateMatrixWorld(true);
       A.clashFilm.update(0);
       const b = A.clashFilm.boxOf(0), st = A.clashFilm.stats(), h = A.renderer.domElement.height;
@@ -114,7 +128,9 @@ function pageProbe() {
       const tHold = st.riseS + st.holdS / 2;         // deterministic peak of the pulse envelope
       A.clashFilm.update(tHold);
 
-      const contact = new THREE.Vector3(p.contact.x, p.contact.y, p.contact.z);
+      // §CLASH_MARKER_OVERLAP_BOX: the marker sits at the overlap box's centre (centerOf), which is not the contact point
+      const c0 = (A.clashFilm.centerOf && A.clashFilm.centerOf(idx)) || p.contact;
+      const contact = new THREE.Vector3(c0.x, c0.y, c0.z);
       const DIR = new THREE.Vector3(1, 0.35, 0.8).normalize();   // same fixed approach direction convention as witness_clash_film_labels.js
       const D = 5;
       const camPos = contact.clone().addScaledVector(DIR, D);
@@ -279,6 +295,39 @@ function pageProbe() {
         near.placedPx <= capPx + 1 && near.placedM < near.naturalM && near.naturalPx > capPx && far.placedM === far.naturalM,
         `at ${near.d} m: severity box ${near.naturalM} m would be ${near.naturalPx} px, placed ${near.placedM} m = ${near.placedPx} px (cap ${capPx} px @${near.h}, clamped=${near.clampedN}); ` +
         `at ${far.d} m: placed ${far.placedM} m = severity ${far.naturalM} m (untouched)`);
+    }
+
+    // W11 — §CLASH_MARKER_OVERLAP_BOX: the two halves ARE the record's overlap box. Expected values are built
+    // here from the record + worldMatrix (per-axis clamp to [minM,maxM], split axis = A-frame axis most aligned
+    // with A→B, halves offset ±quarter along it, blue on B's side, uniform scale placedM/naturalM).
+    {
+      const g = await page.evaluate(() => window.__cf.markerGeometry());
+      if (!g) claim('W11_marker_is_the_overlap_box', false, 'INCONCLUSIVE: marker meshes not found');
+      else {
+        const rot = (q, v) => { const [x, y, z, w] = q; const ix = w * v[0] + y * v[2] - z * v[1], iy = w * v[1] + z * v[0] - x * v[2], iz = w * v[2] + x * v[1] - y * v[0], iw = -x * v[0] - y * v[1] - z * v[2];
+          return [ix * w + iw * -x + iy * -z - iz * -y, iy * w + iw * -y + iz * -x - ix * -z, iz * w + iw * -z + ix * -y - iy * -x]; };
+        const dot = (a, b) => a[0] * b[0] + a[1] * b[1] + a[2] * b[2];
+        let judged = 0, bad = [], skipped = 0;
+        for (const r of g) {
+          if (r.skip) { skipped++; continue; }
+          judged++;
+          const mn = r.mk.minM, mx = r.mk.maxM, sc = r.box.naturalM > 0 ? r.box.placedM / r.box.naturalM : 0;
+          const ext = r.ext.map(e => Math.max(mn, Math.min(e, mx)));
+          let k = 0, best = -1, sg = 1;
+          for (let j = 0; j < 3; j++) { const ax = rot(r.rotA, [j === 0 ? 1 : 0, j === 1 ? 1 : 0, j === 2 ? 1 : 0]); const d = dot(ax, r.dir); if (Math.abs(d) > best) { best = Math.abs(d); k = j; sg = d < 0 ? -1 : 1; } }
+          const axW = rot(r.rotA, [k === 0 ? 1 : 0, k === 1 ? 1 : 0, k === 2 ? 1 : 0]);
+          const wantS = ext.map((e, j) => (j === k ? e / 2 : e) * sc), off = ext[k] / 4 * sc;
+          const wantA = r.center.map((c, j) => c - axW[j] * off * sg), wantB = r.center.map((c, j) => c + axW[j] * off * sg);
+          const tol = 1e-4, near = (u, v) => u.every((x, j) => Math.abs(x - v[j]) < tol);
+          const qOk = Math.abs(Math.abs(dot(r.a.q, r.rotA) + r.a.q[3] * r.rotA[3]) - 1) < 1e-4 && Math.abs(Math.abs(dot(r.b.q, r.rotA) + r.b.q[3] * r.rotA[3]) - 1) < 1e-4;
+          const ok = qOk && near(r.a.s, wantS) && near(r.b.s, wantS) && near(r.a.p, wantA) && near(r.b.p, wantB) && Math.abs(r.box.naturalM - Math.max(ext[0], ext[1], ext[2])) < 1e-6;
+          if (!ok && bad.length < 3) bad.push({ i: r.i, k, sg, sc: +sc.toFixed(4), gotS: r.a.s.map(x => +x.toFixed(4)), wantS: wantS.map(x => +x.toFixed(4)), gotA: r.a.p.map(x => +x.toFixed(4)), wantA: wantA.map(x => +x.toFixed(4)), gotB: r.b.p.map(x => +x.toFixed(4)), wantB: wantB.map(x => +x.toFixed(4)), qOk });
+          if (!ok) bad.push({ i: r.i });
+        }
+        const nbad = bad.filter(b => b.k === undefined).length;
+        claim('W11_marker_is_the_overlap_box', judged > 0 && nbad === 0 && skipped === 0,
+          `pairs judged=${judged} skipped(no overlap box)=${skipped} mismatched=${nbad}${nbad ? ' e.g. ' + JSON.stringify(bad.find(b => b.k !== undefined)) : ''}`);
+      }
     }
 
     // W7-W10 — §CLASH_FILM_SHINE_THROUGH: real occluder, real render, real pixel readback.

--- a/viewer/viewer.html
+++ b/viewer/viewer.html
@@ -865,13 +865,13 @@ html.bim-embedded, html.bim-embedded body { background: #0b0b0b; }
 <script src="cpe_room_title.js?v=1" onerror="console.warn('§LOAD_FAIL cpe_room_title.js — room titles disabled')"></script>
 <script src="cpe_day_counter.js?v=1" onerror="console.warn('§LOAD_FAIL cpe_day_counter.js — day counter disabled')"></script>
 <script src="cpe_path_overview.js?v=1" onerror="console.warn('§LOAD_FAIL cpe_path_overview.js — path overview disabled')"></script>
-<script src="cpe_resource_panel.js?v=3" onerror="console.warn('§LOAD_FAIL cpe_resource_panel.js — resource panel disabled')"></script>
+<script src="cpe_resource_panel.js?v=4" onerror="console.warn('§LOAD_FAIL cpe_resource_panel.js — resource panel disabled')"></script>
 <script src="tour.js?v=17" onerror="console.warn('§LOAD_FAIL tour.js')"></script>
 <script src="clash_report.js?v=1" onerror="console.warn('§LOAD_FAIL clash_report.js')"></script>
 <script src="clash_snag.js?v=1" onerror="console.warn('§LOAD_FAIL clash_snag.js')"></script>
 <script src="clash_matrix.js?v=2" onerror="console.warn('§LOAD_FAIL clash_matrix.js')"></script>
 <script src="clash_narrow.js?v=2" onerror="console.warn('§LOAD_FAIL clash_narrow.js')"></script>
-<script src="clash_film.js?v=5" onerror="console.warn('§LOAD_FAIL clash_film.js')"></script>
+<script src="clash_film.js?v=6" onerror="console.warn('§LOAD_FAIL clash_film.js')"></script>
 <script src="clash_labels.js?v=5" onerror="console.warn('§LOAD_FAIL clash_labels.js')"></script>
 <script src="measure.js?v=52" onerror="console.warn('§LOAD_FAIL measure.js')"></script>
 <script src="sitecam.js?v=7" onerror="console.warn('§LOAD_FAIL sitecam.js')"></script>


### PR DESCRIPTION
Spec: bim-compiler `prompts/MEP_CLASH_REVEAL_MOVIE.md` §CLASH_MARKER_OVERLAP_BOX, §CLASH_FILM_FLAT_FILTER (2026-09-06; items 1 and 3 of the relayed review).

**What changes in the film**
- Each clash marker is now the **oriented box of the real overlap solid** (`overlapCenter` + `overlapA` from #1688, A's rotation), split into the red/blue halves along the A→B-aligned axis. Per-axis size clamped to the cube's old 0.30/1.20 m rule, so a 25 mm overlap stays visible and a 5 m through-run stays a marker, not the element.
- Pairs whose overlap solid is flat (< 1 mm) are dropped from the film's set after the verdict (Option 3): Hospital 271 → **270**, card reads "… · 1 flat touch dropped". Narrowphase verdicts untouched.

**Witness** — markers **W11**: all 270 pairs' two halves decomposed and matched against the record + `worldMatrix` (rotation, per-axis size, midpoint, separation, blue toward B), 0 mismatches; W6/W7 re-aimed at the box centre; `pass=4 fail=0 ran=15`. Labels **P9c** + H1 on `meshTrue`: `pass=4 fail=0 ran=20`. eslint clean. sw v1153.

🤖 Generated with [Claude Code](https://claude.com/claude-code)