### PR TITLE
revert(cinema): §SUN_ARC_TOPOUT_SNAP — sun elevation back to the single linear 55°→6° crawl (hand-revert of #1685)

### DIFF
--- a/viewer/cinema_maxq.js
+++ b/viewer/cinema_maxq.js
@@ -1643,10 +1643,9 @@
         // clip at film 0.66–0.73). Same bug class §CPE_CLIP_REVEAL_FILM_T fixed for the Reveal above:
         // a clip is fewer frames of the SAME film, so the sun reads the film fraction. A full bake is
         // unchanged (_tFilm(_tn) === _tn when no clip is set).
-        // §SUN_ARC_TOPOUT_SNAP — _revealU is the plan's topout fraction (null if unknown/no beats);
-        // _sunArcStep's own pre-topout branch is untouched when this is passed, only the post-topout
-        // portion of the SAME formula takes the new snap-to-dusk branch (see effects.js).
-        if (A._sunArcStep) A._sunArcStep(_tnFilm, _revealU);
+        // §SUN_ARC_TOPOUT_SNAP REVERTED (2026-09-06): the sun reads the film fraction alone — the linear
+        // 55°→6° arc is the film's own dusk. _revealU still drives the Reveal round and the fill pin below.
+        if (A._sunArcStep) A._sunArcStep(_tnFilm);
         // §SUN_ARC_FILL / §BAKE_FILL_PIN (2026-09-05, effects.js, witness_sun_arc_fill.js): the interior
         // fill — ambient, hemi, fixture point-light scale/budget — is PINNED to the Alt+S baseline on
         // every frame, whatever the arc above just did to the sun (user ruling: "letting alt-s normal,

--- a/viewer/effects.js
+++ b/viewer/effects.js
@@ -2621,24 +2621,15 @@ async function setupEffects(A, renderer, scene, camera) {
   var PHOTO_SUN_ELEVATION_START = 55;  // "high noon" look for an establishing open — not 90 (a
                                         // straight-down sun reads flat/shadowless on a building)
   var PHOTO_SUN_ELEVATION_END = PHOTO_SUN_ELEVATION;
-  // §SUN_ARC_TOPOUT_SNAP (2026-09-06, user: "the good outside building shadow correlation to Sun
-  // angle must not be touched" — bim-compiler prompts/MEP_CLASH_REVEAL_MOVIE.md §SUN_ARC_TOPOUT_SNAP).
-  // `topoutU` is OPTIONAL: omitted (every caller before this change, and the live Cinema Orbit
-  // preview at startCinemaOrbit's step()) returns the ORIGINAL formula, byte-identical, for every
-  // tNorm — zero regression by construction, not by testing alone. Only a caller that passes
-  // `topoutU` (the MaxQ bake, once it knows the plan's topout fraction) gets the new branch, and only
-  // for tNorm PAST that fraction: the pre-topout portion of the SAME call still returns the original
-  // formula unchanged. Past topout, ease from the elevation the arc had already reached down to the
-  // dramatic 6° (PHOTO_SUN_ELEVATION) over a short window instead of crawling there at tNorm=1.
-  var TOPOUT_SNAP_EASE_U = 0.08;   // fraction of the whole film the ease takes, tunable
-  function _sunElevationAt(tNorm, topoutU) {
-    var base = PHOTO_SUN_ELEVATION_START + (PHOTO_SUN_ELEVATION_END - PHOTO_SUN_ELEVATION_START) * tNorm;
-    if (topoutU == null || tNorm <= topoutU) return base;   // pre-topout, or no topout known: unchanged
-    var elAtTopout = PHOTO_SUN_ELEVATION_START + (PHOTO_SUN_ELEVATION_END - PHOTO_SUN_ELEVATION_START) * topoutU;
-    var easeEnd = Math.min(1, topoutU + TOPOUT_SNAP_EASE_U);
-    if (tNorm >= easeEnd || easeEnd <= topoutU) return PHOTO_SUN_ELEVATION_END;   // already dusk, held
-    var u = (tNorm - topoutU) / (easeEnd - topoutU);
-    return elAtTopout + (PHOTO_SUN_ELEVATION_END - elAtTopout) * u;
+  // §SUN_ARC_TOPOUT_SNAP REVERTED (2026-09-06, user: the linear 55°→6° crawl, including how it reads
+  // through the pullout as it reaches dusk, was already correct and was never to be touched — bim-compiler
+  // prompts/MEP_CLASH_REVEAL_MOVIE.md §SUN_ARC_TOPOUT_SNAP, REVERTED line). The sun's elevation is the
+  // one linear formula of tNorm again, for every caller, no second argument. TOPOUT_SNAP_EASE_U stays:
+  // it is the post-topout ease WINDOW that §PL_TOPOUT_UNPIN (_plTopoutWant, the fixtures) reuses; the
+  // sun's own arc no longer reads it.
+  var TOPOUT_SNAP_EASE_U = 0.08;   // fraction of the whole film a post-topout ease takes (fixtures only)
+  function _sunElevationAt(tNorm) {
+    return PHOTO_SUN_ELEVATION_START + (PHOTO_SUN_ELEVATION_END - PHOTO_SUN_ELEVATION_START) * tNorm;
   }
   // updateSky() repositions the sun/sky/fog/lensflare but does NOT touch the shadow map — it has no
   // reason to, every OTHER caller (Time Machine, plain nav) already re-renders continuously. A film
@@ -2647,17 +2638,16 @@ async function setupEffects(A, renderer, scene, camera) {
   // while every shadow stayed frozen at whatever angle was last baked — worse than not animating at
   // all, since the mismatch reads as a bug rather than a static look. Called every frame the sun
   // moves, right after updateSky(), so no frame captures with a stale shadow angle.
-  function _sunArcStep(tNorm, topoutU) {
+  function _sunArcStep(tNorm) {
     if (!A.updateSky) return;
-    var _el = _sunElevationAt(tNorm, topoutU);
+    var _el = _sunElevationAt(tNorm);
     A.updateSky(_el, PHOTO_SUN_AZIMUTH);
     if (A.renderer) A.renderer.shadowMap.needsUpdate = true;
     // §SUN_ARC_FILL reads the elevation this step JUST set — stashed here so the fill compensation
     // below cannot drift from the arc by re-deriving it (one elevation, two consumers).
     A._sunArcElevationDeg = _el;
     console.log('§SUN_ARC_STEP tNorm=' + tNorm.toFixed(3) + ' elevation=' + _el.toFixed(1) +
-      ' (start=' + PHOTO_SUN_ELEVATION_START + ' end=' + PHOTO_SUN_ELEVATION_END + ')' +
-      (topoutU != null ? ' topoutU=' + topoutU.toFixed(3) : ''));
+      ' (start=' + PHOTO_SUN_ELEVATION_START + ' end=' + PHOTO_SUN_ELEVATION_END + ')');
     return _el;
   }
   A._sunArcStep = _sunArcStep;

--- a/viewer/sw.js
+++ b/viewer/sw.js
@@ -137,7 +137,11 @@
 //   the marker is the oriented box of the REAL overlap solid (overlapCenter + overlapA, A's rotation), split red/blue
 //   along the A→B-aligned axis, per-axis 0.30/1.20 m clamp; flat overlaps (<1 mm) are dropped from the film's set
 //   (verdict untouched). viewer/cpe_resource_panel.js — the clash card notes dropped flat touches.
-const CACHE_VERSION = 'v1153';   // bump on each deploy; per-change detail is the git commit message.
+// v1154 (2026-09-06) §SUN_ARC_TOPOUT_SNAP REVERTED (MEP_CLASH_REVEAL_MOVIE.md): viewer/effects.js — the sun's elevation
+//   is the single linear 55°→6° formula of the film fraction again (#1685's post-topout snap removed, user: it was
+//   never to be touched); viewer/cinema_maxq.js — _sunArcStep(_tnFilm) single-argument. TOPOUT_SNAP_EASE_U and the
+//   _revealU wiring stay (the Reveal round and §PL_TOPOUT_UNPIN use them).
+const CACHE_VERSION = 'v1154';   // bump on each deploy; per-change detail is the git commit message.
 // v1128 (2026-09-02) §SUN_FILL_RATIO: viewer/effects.js — the Alt+S staging HDRI
 // (belfast_sunset_puresky_1k) was being pushed onto EVERY material by _reassertPhotoEnvMap, matte
 // concrete and plaster included. IBL is non-directional and is NOT shadow-map-occluded in three.js,

--- a/viewer/tests/witness_sun_arc_linear.js
+++ b/viewer/tests/witness_sun_arc_linear.js
@@ -1,0 +1,84 @@
+#!/usr/bin/env node
+// ⚠ DO NOT REMOVE — §SUN_ARC_TOPOUT_SNAP REVERTED witness (bim-compiler prompts/MEP_CLASH_REVEAL_MOVIE.md,
+// 2026-09-06). Read the log after every run — exit code is not evidence.
+//
+// ISSUE IT PROVES OR DISPROVES: the bake's sun elevation is the ONE linear 55°→6° formula of the film
+// fraction, for every caller, with no second argument that bends it after topout (#1685 added one; the user
+// ruled the original crawl correct and never to be touched). Calls the SHIPPED A._sunArcStep in a real
+// viewer page and checks its returned elevation against the formula at seven film fractions, that a stray
+// second argument changes nothing, and (statically) that cinema_maxq.js calls it with exactly one argument.
+'use strict';
+const fs = require('fs'), path = require('path'), http = require('http'), os = require('os');
+const puppeteer = require('/home/red1/bim-compiler/node_modules/puppeteer');
+const { Witness } = require('../../witness_kit/contract');
+const ROOT = path.resolve(process.env.ROOT || path.join(__dirname, '..', '..'));
+const BLD = process.env.BLD || 'Hospital_silent_local';
+const BLD_DIR = process.env.BLD_DIR || path.join(os.homedir(), 'bim-ootb', 'buildings');
+const GPU = process.env.GPU || 'real';
+const PORT = +(process.env.PORT || 8598);
+const LOAD_MS = +(process.env.LOAD_MS || 900000);
+const LOG = process.env.LOG || '/tmp/witness_sun_arc_linear.log';
+const logStream = fs.createWriteStream(LOG, { flags: 'w' });
+const T0 = Date.now();
+function ts() { return new Date().toISOString().slice(11, 23) + ' +' + ((Date.now() - T0) / 1000).toFixed(1).padStart(7) + 's'; }
+function log(l) { const s = ts() + ' ' + l; logStream.write(s + '\n'); console.log(s); }
+function logRaw(l) { logStream.write(ts() + ' ' + l + '\n'); }
+const MIME = { '.html': 'text/html', '.js': 'text/javascript', '.css': 'text/css', '.json': 'application/json', '.wasm': 'application/wasm', '.db': 'application/octet-stream', '.png': 'image/png', '.jpg': 'image/jpeg', '.svg': 'image/svg+xml', '.hdr': 'application/octet-stream', '.gz': 'application/gzip', '.ico': 'image/x-icon', '.webp': 'image/webp', '.woff2': 'font/woff2' };
+const server = http.createServer((req, res) => { try {
+  const u = decodeURIComponent(req.url.split('?')[0]);
+  let fp = u.startsWith('/buildings/') ? path.join(BLD_DIR, u.slice('/buildings/'.length)) : path.join(ROOT, u.replace(/^\/+/, ''));
+  if (fs.existsSync(fp) && fs.statSync(fp).isDirectory()) fp = path.join(fp, 'index.html');
+  if (!fs.existsSync(fp)) { res.writeHead(404); res.end('404'); return; }
+  res.writeHead(200, { 'Content-Type': MIME[path.extname(fp).toLowerCase()] || 'application/octet-stream', 'Cache-Control': 'no-store' });
+  fs.createReadStream(fp).pipe(res);
+} catch (e) { res.writeHead(500); res.end(String(e)); } });
+function inconclusive(r) { log('§SAL verdict=INCONCLUSIVE reason=' + r + ' — nothing was judged'); log('§WITNESS_SUN_ARC_LINEAR pass=0 fail=0 ran=0 INCONCLUSIVE'); }
+
+(async () => {
+  await new Promise(r => server.listen(PORT, '127.0.0.1', r));
+  const gpuArgs = { sw: ['--use-gl=angle', '--use-angle=swiftshader', '--enable-unsafe-swiftshader'], real: ['--use-angle=gl-egl', '--ignore-gpu-blocklist'] }[GPU] || [];
+  const gpuEnv = GPU === 'real' ? { __EGL_VENDOR_LIBRARY_FILENAMES: '/usr/share/glvnd/egl_vendor.d/10_nvidia.json' } : {};
+  const profile = fs.mkdtempSync(path.join(os.tmpdir(), 'sal-'));
+  const commit = (() => { try { return require('child_process').execFileSync('git', ['-C', ROOT, 'rev-parse', '--short', 'HEAD']).toString().trim(); } catch (e) { return '?'; } })();
+  log(`§SAL_ENV root=${ROOT} commit=${commit} bld=${BLD} gpu=${GPU} log=${LOG}`);
+  const EFFECTS = fs.readFileSync(path.join(ROOT, 'viewer/effects.js'), 'utf8');
+  const MAXQ = fs.readFileSync(path.join(ROOT, 'viewer/cinema_maxq.js'), 'utf8');
+  const START = +(EFFECTS.match(/var PHOTO_SUN_ELEVATION_START = (\d+(?:\.\d+)?)/) || [])[1];
+  const END = +(EFFECTS.match(/var PHOTO_SUN_ELEVATION = (\d+(?:\.\d+)?)/) || [])[1];
+  const browser = await puppeteer.launch({ headless: true, userDataDir: profile, protocolTimeout: 20 * 60 * 1000, env: Object.assign({}, process.env, gpuEnv), args: ['--no-sandbox', '--hide-crash-restore-bubble', '--window-size=1300,840'].concat(gpuArgs) });
+  const page = await browser.newPage(); await page.setViewport({ width: 1280, height: 720 });
+  page.on('console', m => logRaw('[con] ' + m.text()));
+  page.on('pageerror', e => logRaw('[pageerror] ' + e.message));
+  const rows = []; let crashed = false;
+  const claim = (name, ok, detail) => { rows.push({ claim: name, ok: ok ? 1 : 0, detail: String(detail).slice(0, 240) }); log(`§SAL_CLAIM ${name} ${ok ? 'OK' : 'FAIL'} — ${detail}`); };
+  try {
+    if (!(START > END)) { inconclusive(`could not read PHOTO_SUN_ELEVATION_START/END from effects.js (${START}/${END})`); process.exitCode = 2; return; }
+    const url = `http://127.0.0.1:${PORT}/viewer/viewer.html?db=/buildings/${BLD}.db`; log('§SAL_NAV ' + url);
+    await page.goto(url, { waitUntil: 'domcontentloaded', timeout: 120000 });
+    await page.waitForFunction(() => window.APP && window.APP.renderer && typeof window.APP._sunArcStep === 'function' && typeof window.APP.updateSky === 'function', { timeout: LOAD_MS });
+    const TS = [0, 0.1, 0.361, 0.419, 0.441, 0.7, 1];
+    const S = await page.evaluate((ts) => { const A = window.APP; const keep = A._sunArcElevationDeg;
+      const one = ts.map(t => ({ t, el: A._sunArcStep(t), elWithArg: A._sunArcStep(t, 0.361), arity: A._sunArcStep.length }));
+      A._sunArcElevationDeg = keep; return one; }, TS);
+    S.forEach(r => log('§SAL_SAMPLE ' + JSON.stringify(r)));
+    const want = t => START + (END - START) * t;
+    const offLinear = S.filter(r => Math.abs(r.el - want(r.t)) > 1e-9);
+    claim('L1_elevation_is_the_linear_formula_at_every_sample', S.length === TS.length && offLinear.length === 0,
+      `${START}°→${END}° linear: ` + S.map(r => r.t + '→' + r.el.toFixed(2)).join(' ') + (offLinear.length ? ' OFF at ' + offLinear.map(r => r.t + ' (want ' + want(r.t).toFixed(2) + ')').join(',') : ''));
+    claim('L2_a_second_argument_changes_nothing', S.every(r => r.elWithArg === r.el) && S.every(r => r.arity === 1),
+      `_sunArcStep(t, 0.361) === _sunArcStep(t) at every sample: ${S.every(r => r.elWithArg === r.el)}; declared arity=${S[0].arity}`);
+    const call = MAXQ.match(/A\._sunArcStep\(([^)]*)\)/g) || [];
+    claim('L3_bake_calls_the_step_with_the_film_fraction_only', call.length === 1 && /^A\._sunArcStep\(_tnFilm\)$/.test(call[0]), `cinema_maxq.js calls: ${JSON.stringify(call)}`);
+    const body = (EFFECTS.match(/function _sunElevationAt\(([^)]*)\)\s*\{([\s\S]*?)\n  \}/) || []);
+    const oneLiner = body[1] === 'tNorm' && (body[2] || '').trim().split('\n').length === 1 && /return PHOTO_SUN_ELEVATION_START \+ \(PHOTO_SUN_ELEVATION_END - PHOTO_SUN_ELEVATION_START\) \* tNorm;/.test(body[2] || '');
+    claim('L4_formula_source_is_the_single_linear_line', oneLiner, `_sunElevationAt(${body[1]}) body: ${JSON.stringify((body[2] || '').trim())}`);
+  } catch (e) { log('§SAL_ERROR ' + (e && e.stack || e)); inconclusive('exception ' + String(e && e.message).slice(0, 160)); process.exitCode = 2; crashed = true; }
+  finally { try { await browser.close(); } catch (e) {} server.close(); try { fs.rmSync(profile, { recursive: true, force: true }); } catch (e) {} }
+  if (!rows.length || crashed) return;
+  Witness('sun_arc_linear').population(() => rows)
+    .schema({ type: 'object', required: ['claim', 'ok'], properties: { claim: { type: 'string', minLength: 1 }, ok: { type: 'integer', minimum: 0, maximum: 1 }, detail: { type: 'string' } } })
+    .invariant('the bake sun is the single linear 55°→6° formula of the film fraction: matches at every sample, ignores any second argument, one-argument call site, one-line source', rs => rs.every(r => r.ok === 1))
+    .redControl(rs => { const c = rs.map(r => Object.assign({}, r)); if (c[0]) c[0].ok = 0; return c; })
+    .run();
+  logStream.end();
+})();

--- a/viewer/viewer.html
+++ b/viewer/viewer.html
@@ -840,13 +840,13 @@ html.bim-embedded, html.bim-embedded body { background: #0b0b0b; }
 <script src="qrcode.min.js?v=1" onerror="console.warn('§LOAD_FAIL qrcode.min.js — QR sharing disabled')"></script>
 <script src="config.js?v=4" onerror="console.warn('§LOAD_FAIL config.js')"></script>
 <script src="db_resolve.js?v=2" onerror="console.warn('§LOAD_FAIL db_resolve.js')"></script>
-<script src="effects.js?v=38" onerror="console.warn('§LOAD_FAIL effects.js')"></script>
+<script src="effects.js?v=39" onerror="console.warn('§LOAD_FAIL effects.js')"></script>
 <script src="effects_gi_poc.js?v=3" onerror="console.warn('§LOAD_FAIL effects_gi_poc.js')"></script>
 <script src="lib/mp4_mux.js?v=1" onerror="console.warn('§LOAD_FAIL mp4_mux.js — MaxQ falls back to webm')"></script>
 <script src="cinema_path_editor.js?v=16" onerror="console.warn('§LOAD_FAIL cinema_path_editor.js — Alt+C path editing disabled')"></script>
 <script src="cpe_walk.js?v=6" onerror="console.warn('§LOAD_FAIL cpe_walk.js — CPE walk-mode disabled')"></script>
 <script src="cpe_xr.js?v=1" onerror="console.warn('§LOAD_FAIL cpe_xr.js — VR entry disabled')"></script>
-<script src="cinema_maxq.js?v=14" onerror="console.warn('§LOAD_FAIL cinema_maxq.js — Alt+M MaxQ export disabled')"></script>
+<script src="cinema_maxq.js?v=15" onerror="console.warn('§LOAD_FAIL cinema_maxq.js — Alt+M MaxQ export disabled')"></script>
 <script src="input_registry.js?v=1" onerror="console.warn('§LOAD_FAIL input_registry.js')"></script>
 <script src="../common/pill_builder.js?v=1" onerror="console.warn('§LOAD_FAIL pill_builder.js')"></script>
 <script src="list_builder.js?v=1" onerror="console.warn('§LOAD_FAIL list_builder.js')"></script>


### PR DESCRIPTION
User ruling: the original linear crawl was already correct and never to be touched; #1685's post-topout snap came from a wrong starting spec. Hand-reverted against current main (not a mechanical revert — main moved past it).

- `effects.js`: `_sunElevationAt(tNorm)` is the single linear line again; `_sunArcStep(tNorm)` one argument. **Kept:** `TOPOUT_SNAP_EASE_U` (the ease window #1690's fixtures reuse) and the `_revealU` wiring (Reveal round + fill pin).
- `cinema_maxq.js`: `A._sunArcStep(_tnFilm)`.
- Clash-film lane untouched.

**Witness** `witness_sun_arc_linear.js`: `pass=4 fail=0 ran=4` — 55−49·t at seven fractions (34.47° at u=0.419, 6.00° at 1), a second argument changes nothing, one-argument call site, one-line source. Spec section marked ⛔ REVERTED. sw v1154.

🤖 Generated with [Claude Code](https://claude.com/claude-code)