### PR TITLE
Clash HUD build-order fix + per-discipline-pair cards + pullback highlight sync + Measure card

### DIFF
--- a/viewer/cinema_maxq.js
+++ b/viewer/cinema_maxq.js
@@ -1490,17 +1490,17 @@
           console.log('§CPE_RESOURCE_PANEL INCONCLUSIVE reason=' +
             (!_bkState ? 'no-buildup-timeline' : 'no-ops-snapshot') + ' — panel omitted, not blank');
         }
-        // §CPE_BIG_STATS — the second half's cards, built ONCE from real sources. The pie answers
-        // "who is on site today", which is dead after §CPE_BUILDUP_TOPOUT: construction has finished
-        // and no trade is active, so the panel drew nothing for the whole reveal round.
-        if (_roomTitle && A.bigStatsBuild && _bkState) {
-          _bigCards = A.bigStatsBuild(_resOps, _bkState.projectStart, _bkState.projectEnd);
-        }
-      } catch (eR) { _resOps = null; _bigCards = null; console.warn('§CPE_RESOURCE_PANEL_ERR ' + eR.message + ' — panel disabled, bake continues'); }
+      } catch (eR) { _resOps = null; console.warn('§CPE_RESOURCE_PANEL_ERR ' + eR.message + ' — panel disabled, bake continues'); }
       // ══ §CLASH_FILM_P1 — build the markers ONCE, before the first frame ═══════════════════
       // Deliberately BEFORE the loop and never inside it: the narrow phase costs ~2 s on Terminal,
       // and the pair set is static. The markers are a FORECAST (§3b) — they stand from frame 0 over
       // empty ground while the buildup rises around them, so nothing here consults the TM cursor.
+      // §CLASH_HUD_ORDER (2026-09-06, MEP_CLASH_REVEAL_MOVIE.md §PENDING.5 item A — ROOT CAUSE of the
+      // user's "HUD left out Clash stats" report on the full 195.8s film): this block used to run
+      // AFTER §CPE_BIG_STATS below, so `bigStatsBuild()` always read `A.clashFilm.stats().built ===
+      // false` on a fresh page load — the clash film had not been built yet — and §CLASH_HUD_CARD was
+      // silently dropped on EVERY first bake of a tab, `--clash` and pair count notwithstanding. Moved
+      // here, BEFORE §CPE_BIG_STATS, so the card sees the real, already-judged stats.
       var _filmSecFull = (_clip && _clip.out > _clip.in) ? (nFrames / (_clip.out - _clip.in)) / fps : nFrames / fps;
       if (_clash && A.clashFilm && A.clashFilm.build) {
         try { await A.clashFilm.build(); }
@@ -1511,6 +1511,51 @@
       } else if (_clash) {
         console.warn('§CLASH_FILM_BUILD INCONCLUSIVE reason=clash_film.js not loaded — nothing judged');
       }
+      // §CPE_BIG_STATS — the second half's cards, built ONCE from real sources. The pie answers
+      // "who is on site today", which is dead after §CPE_BUILDUP_TOPOUT: construction has finished
+      // and no trade is active, so the panel drew nothing for the whole reveal round. Runs AFTER
+      // §CLASH_FILM_P1 above (§CLASH_HUD_ORDER) so the clash/disc-pair cards see a built film.
+      var _pairCards = [];
+      try {
+        if (_roomTitle && A.bigStatsBuild && _bkState) {
+          _bigCards = A.bigStatsBuild(_resOps, _bkState.projectStart, _bkState.projectEnd);
+          _pairCards = (_bigCards || []).filter(function (c) { return c && c.discPairKey; });
+        }
+      } catch (eBS) { _bigCards = null; console.warn('§CPE_BIG_STATS_ERR ' + eBS.message + ' — cards disabled, bake continues'); }
+      // §CLASH_HUD_PULLBACK_WINDOW (2026-09-06, MEP_CLASH_REVEAL_MOVIE.md §PENDING.5 item C) — derived
+      // from the SAME beat fractions/seconds effects.js already computes on `plan`, never re-baked or
+      // hardcoded. beats.reveal(tV)/beats.rise(tR) bound the combined tail+pullback span; reveal.tailSec
+      // / reveal.riseSec are the UNFOLDED seconds of the tail-caption sub-phase and the true pull-back
+      // sub-phase §CPE_DISCIPLINE_REVEAL_PULLOUT's own comment says are blended across that span.
+      // tailShare recovers where the tail's caption-cycling ends and the true pull-back begins.
+      // Window ends 5s before orbit (plan.beats.rise) per this task's own boundary rule — the sibling
+      // storey-reveal lane owns everything from there on.
+      var _pullbackU = null;
+      if (_clash && plan && plan.beats && plan.durationSec > 0 &&
+          plan.beats.reveal != null && plan.beats.rise != null && plan.beats.rise > plan.beats.reveal) {
+        var _tV = plan.beats.reveal, _tR = plan.beats.rise;
+        var _tailSec = (plan.reveal && plan.reveal.tailSec) || 0;
+        var _riseSec = (plan.reveal && plan.reveal.riseSec) || (plan.sec && plan.sec.rise) || 0;
+        var _tailShare = (_tailSec + _riseSec) > 0 ? _tailSec / (_tailSec + _riseSec) : 0;
+        var _pbStart = _tV + _tailShare * (_tR - _tV);
+        var _pbEnd = _tR - (5 / plan.durationSec);
+        if (_pbEnd > _pbStart) {
+          _pullbackU = { start: _pbStart, end: _pbEnd };
+          console.log('§CLASH_HUD_PULLBACK_WINDOW start=' + _pbStart.toFixed(3) + ' end=' + _pbEnd.toFixed(3) +
+            ' (tV=' + _tV.toFixed(3) + ' tR=' + _tR.toFixed(3) + ' tailSec=' + _tailSec.toFixed(1) +
+            ' riseSec=' + _riseSec.toFixed(1) + ' tailShare=' + _tailShare.toFixed(3) +
+            ' durationSec=' + plan.durationSec.toFixed(1) + ' pairCards=' + _pairCards.length +
+            ') — 5s before orbit reserved for the storey-reveal lane');
+        } else {
+          console.log('§CLASH_HUD_PULLBACK_WINDOW INCONCLUSIVE reason=window-too-short start=' +
+            _pbStart.toFixed(3) + ' end=' + _pbEnd.toFixed(3) + ' — disc-pair highlight/cards skipped for this plan');
+        }
+      } else if (_clash) {
+        console.log('§CLASH_HUD_PULLBACK_WINDOW INCONCLUSIVE reason=' +
+          (!plan ? 'no-plan' : (!plan.beats ? 'no-beats-on-plan' : 'bad-beats')) +
+          ' — disc-pair highlight/cards skipped for this bake');
+      }
+      A._clashHudHighlightLast = null;   // per-bake reset — a prior bake's held highlight must not leak in
       for (var i = 0; i < nFrames; i++) {
         if (_cancel) { console.log('§MAXQ_CANCEL i=' + i); break; }
         // §MAXQ_CONTEXT_LOSS: scene.js's webglcontextlost handler (§S266) sets this — capturing
@@ -1811,7 +1856,33 @@
           // rotation is now EMPTY and the panel is omitted, where before the roster alone would
           // have kept it on screen. That is the user's ruling ("just highlights"), and the §-line
           // below names it rather than leaving a blank corner unexplained.
-          var _si = A.tailPanelAt(_bigCards, i / fps, null);
+          // §CLASH_HUD_PULLBACK_WINDOW / item C (2026-09-06, MEP_CLASH_REVEAL_MOVIE.md §PENDING.5) —
+          // inside the pullback sub-window the tail rotation is FORCED to just the disc-pair cards,
+          // one discipline pair at a time, and clash_film.js's own highlight (setFade) is driven from
+          // the SAME shown card the SAME frame — "the highlighted markers and the flashed number are
+          // the same fact, not two unrelated timers" (dispatch wording). Outside the window (or with
+          // no disc-pair cards to show) the normal all-card rotation below runs exactly as it always
+          // has, and any held highlight is explicitly released on the transition out.
+          var _si;
+          var _inPullback = !!(_pullbackU && _tnFilm >= _pullbackU.start && _tnFilm < _pullbackU.end);
+          if (_inPullback && _pairCards.length) {
+            _si = A.bigStatsAt(_pairCards, _tnFilm * _filmSecFull);
+            if (_si && _si.card && A.clashFilm && A.clashFilm.highlightDiscPair) {
+              if (A._clashHudHighlightLast !== _si.card.discPairKey) {
+                var _hl = A.clashFilm.highlightDiscPair(_si.card.discPairKey);
+                A._clashHudHighlightLast = _si.card.discPairKey;
+                console.log('§CLASH_HUD_HIGHLIGHT frame=' + i + ' pair=' + _si.card.discPairKey +
+                  ' groupSize=' + (_hl && _hl.groupSize) + ' changed=' + (_hl && _hl.changed));
+              }
+            }
+          } else {
+            _si = A.tailPanelAt(_bigCards, i / fps, null);
+            if (_clash && A.clashFilm && A.clashFilm.highlightDiscPair && A._clashHudHighlightLast != null) {
+              A.clashFilm.highlightDiscPair(null);   // leaving the window — drop back to ambient pulsing
+              console.log('§CLASH_HUD_HIGHLIGHT frame=' + i + ' pair=null (window exited/no pair cards) — back to ambient');
+              A._clashHudHighlightLast = null;
+            }
+          }
           if (!A._statTailRosterLogged) {
             A._statTailRosterLogged = true;
             console.log('§CPE_ROSTER_NOT_A_HIGHLIGHT reveal rotation slots=' +

--- a/viewer/clash_film.js
+++ b/viewer/clash_film.js
@@ -405,6 +405,49 @@ function setupClashFilm(A) {
         inScene: !!(_meshA && _meshA.parent) };
     };
     A.clashFilm.pairs = function () { return _pairs; };
+
+    // §CLASH_HUD_PAIR_CARDS (2026-09-06, MEP_CLASH_REVEAL_MOVIE.md §PENDING.5 item B) — the mesh-true
+    // pair set, grouped by discipline pair. Same normalize-order convention this file already uses at
+    // line ~214/252 (a<b ? a+'|'+b : b+'|'+a) — restated locally rather than importing clash_narrow's
+    // private (unexported) `pairIdOf`, so there is one formula, not two names for it. Pure groupby over
+    // data qualifyRows already produced — no new judgment, no new geometry query. Cached because the
+    // pair set is static per bake (same reason _pairs itself is built once).
+    function _discPairKey(p) {
+      var a = p.discA || '?', b = p.discB || '?';
+      return a < b ? (a + '|' + b) : (b + '|' + a);
+    }
+    var _byDiscCache = null, _byDiscCacheLen = -1;
+    A.clashFilm.statsByDiscPair = function () {
+      if (!_built || !_pairs.length) { console.log('§CLASH_HUD_PAIR_CARDS pairs=0 VACUOUS — nothing built to group'); return []; }
+      if (_byDiscCache && _byDiscCacheLen === _pairs.length) return _byDiscCache;
+      var groups = {}, order = [], i, p, a, b, key;
+      for (i = 0; i < _pairs.length; i++) {
+        p = _pairs[i]; a = p.discA || '?'; b = p.discB || '?';
+        key = a < b ? (a + '|' + b) : (b + '|' + a);
+        if (!groups[key]) { groups[key] = { key: key, discA: (a < b ? a : b), discB: (a < b ? b : a), count: 0, indices: [] }; order.push(key); }
+        groups[key].count++; groups[key].indices.push(i);
+      }
+      var out = order.map(function (k) { return groups[k]; }).sort(function (x, y) { return y.count - x.count; });
+      console.log('§CLASH_HUD_PAIR_CARDS pairs=' + out.length + ' [' +
+        out.map(function (g) { return g.key + '=' + g.count; }).join(' ') + ']');
+      _byDiscCache = out; _byDiscCacheLen = _pairs.length;
+      return out;
+    };
+
+    // §CLASH_HUD_PULLBACK_WINDOW / item C — highlight ONE discipline pair solid, fade the rest to
+    // plain ambient pulsing. Pure reuse of the phase-2 per-instance fade channel this file's own
+    // header already documents ("a selected pair must hold solid while every other pair keeps
+    // breathing") — no second highlight mechanism. key=null clears back to all-ambient (every index 0).
+    A.clashFilm.highlightDiscPair = function (key) {
+      if (!_built || !_fade || !_pairs.length) return { changed: 0, groupSize: 0 };
+      var changed = 0, groupSize = 0, i, want;
+      for (i = 0; i < _pairs.length; i++) {
+        want = (key != null && _discPairKey(_pairs[i]) === key) ? 1 : 0;
+        if (want === 1) groupSize++;
+        if (_fade[i] !== want) { A.clashFilm.setFade(i, want); changed++; }
+      }
+      return { changed: changed, groupSize: groupSize };
+    };
     // The severity box of pair i and the box currently placed — what the clamp witness reads.
     A.clashFilm.boxOf = function (i) { return (_nat && i >= 0 && i < _nat.length) ? { naturalM: _nat[i], placedM: _cur[i] } : null; };
     // §CLASH_MARKER_OVERLAP_BOX — what the witness decomposes the instance matrices against
@@ -426,6 +469,7 @@ function setupClashFilm(A) {
       });
       _meshA = _meshB = null; _pairs = []; _fade = null; _built = false; _lastPulse = -1;
       _ctr = _dir = _nat = _cur = null; _rot = _ext = _ax = _sg = null; _legacyBox = 0; _meshTrue = 0; _flat = 0; _updates = 0; _lastClamp = null;
+      _byDiscCache = null; _byDiscCacheLen = -1;   // §CLASH_HUD_PAIR_CARDS — a stale group set must not survive dispose
       console.log('§CLASH_FILM_DISPOSE markers released');
       return true;
     };

--- a/viewer/cpe_resource_panel.js
+++ b/viewer/cpe_resource_panel.js
@@ -317,6 +317,41 @@ function setupCpeResourcePanel(A) {
                       (cf.flat > 0 ? '  ·  ' + cf.flat + ' flat touch' + (cf.flat > 1 ? 'es' : '') + ' dropped' : ''),   // §CLASH_FILM_FLAT_FILTER
                  src: 'clash_film.js §CLASH_FILM_BUILD' });
     }
+    // §CLASH_HUD_PAIR_CARDS (2026-09-06, MEP_CLASH_REVEAL_MOVIE.md §PENDING.5 item B) — ONE card per
+    // discipline pair that actually has a mesh-true clash, extending (not replacing) the single
+    // aggregate card above. Pure groupby already computed in clash_film.js — no new judgment here.
+    // A pair with 0 clashes gets no card (§VACUOUS), same rule every other card in this function keeps.
+    // `discPairKey` rides along unused by the renderer — cinema_maxq.js reads it during the pullback
+    // window to sync the on-screen highlight to whichever of these cards is currently shown.
+    if (A.clashFilm && A.clashFilm.statsByDiscPair) {
+      var pairGroups = A.clashFilm.statsByDiscPair();
+      pairGroups.forEach(function (g) {
+        if (g.count > 0) {
+          out.push({ big: String(g.count), label: g.discA + ' vs ' + g.discB + ' clashes',
+                     sub: 'discipline pair', src: 'clash_film.js pairs() grouped by discA/discB',
+                     discPairKey: g.key });
+        }
+      });
+    }
+    // §MEASURE_HUD_CARD (2026-09-06, MEP_CLASH_REVEAL_MOVIE.md §PENDING.5 item D) — the Measure tool's
+    // OWN saved measurements from THIS page session (A.measureLabels, measure.js), never a building-
+    // wide area/volume figure (a different question the cards above already answer). Dropped entirely
+    // when nobody measured anything this session — never a fabricated "0 measurements" card. A more
+    // durable source exists (UniversalHistory.recordEvent('MEASURE',...) → common/history_bar.js's own
+    // localStorage-backed tree) but its public API exposes no distance/point data, only label/kind —
+    // using it would need a small additive export on that SHARED cross-app module, not built here
+    // (see prompts/MEP_CLASH_REVEAL_MOVIE.md §PENDING.5 item D for the full note).
+    if (A.measureLabels && A.measureLabels.length) {
+      var mDist = [];
+      A.measureLabels.forEach(function (m) {
+        if (m && m.p1 && m.p2 && m.p1.distanceTo) mDist.push(m.p1.distanceTo(m.p2));
+      });
+      var mSub = mDist.length
+        ? mDist.slice(0, 3).map(function (d) { return d.toFixed(2) + 'm'; }).join('  ·  ')
+        : 'area/point measurements (no distance pair)';
+      out.push({ big: String(A.measureLabels.length), label: 'measurements saved this session',
+                 sub: mSub, src: 'measure.js A.measureLabels' });
+    }
     console.log('§CPE_BIG_STATS cards=' + out.length + (out.length
       ? ' [' + out.map(function (c) { return c.label; }).join(' | ') + ']'
       : ' INCONCLUSIVE — no source available (A.db=' + !!A.db + ' ops=' + (ops ? ops.length : 0) + '); panel omitted, not blank'));


### PR DESCRIPTION
## Summary
Fixes the user-reported "the HUD info left out the Measure and Clash stats" from the full 195.8s Hospital film bake.

- **Root cause found for the missing Clash HUD card**: `bigStatsBuild()` ran *before* `A.clashFilm.build()` on every fresh page load, so `A.clashFilm.stats().built` was always `false` when the card checked it — silently dropped on every first bake of a tab, `--clash` and pair count notwithstanding. Reordered so the film builds first.
- **New per-discipline-pair clash cards** (`clash_film.js` `statsByDiscPair()` — a pure groupby over the already-judged mesh-true pairs, no new geometry judgment) extend the existing single aggregate clash card in `cpe_resource_panel.js`'s `bigStatsBuild()`.
- **Pullback-window highlight sync**: during the derived pull-back sub-window (ending 5s before `orbit`, per the boundary shared with the sibling storey-reveal lane), the HUD's card rotation is forced to cycle the discipline-pair cards, and `clash_film.js`'s existing per-instance `setFade` channel highlights that exact pair's markers on the same frame — "the highlighted markers and the flashed number are the same fact, not two unrelated timers."
- **Measure tool "saved measurements" card**: reads `A.measureLabels` (count + real distances), dropped when empty. Caveat (documented in the PR and the lane's spec file): this will rarely/never populate in an unattended CLI silent bake, since `cli_silent_bake.js` always launches a fresh throwaway browser profile — more useful in the interactive Alt+M live preview.

## Verification
Real GPU, `Hospital_silent_local.db`, two clean `--clip` bakes (`fileOk=true`, no aborts):
- `§CLASH_FILM_BUILD` now completes *before* `§CPE_BIG_STATS` runs (build-order fix confirmed).
- `§CLASH_HUD_PAIR_CARDS pairs=7 [FP|MEP=81 ARC|STR=66 MEP|STR=38 FP|STR=38 ARC|ELEC=29 ELEC|MEP=14 ELEC|STR=4]` — sums exactly to `trueClash=270`.
- `§CLASH_HUD_PULLBACK_WINDOW start=0.801 end=0.933` derived fresh from `plan.beats`/`plan.reveal` (not hardcoded).
- `§CLASH_HUD_HIGHLIGHT` fires 5 correct pair transitions inside the window, each `groupSize` matching the card's own count, ending with a clean release to ambient (`pair=null ... back to ambient`) before the window closes — no stale highlight leaks into orbit.
- Measure card correctly absent (empty `A.measureLabels` in a fresh headless profile) — vacuous-drop working as designed, not a bug.

Full design + proof log excerpts: `prompts/MEP_CLASH_REVEAL_MOVIE.md` §PENDING.5 (bim-compiler repo).

One pre-existing, unrelated bug found and flagged (not fixed): `cinema_maxq.js`'s `_inReveal` gate compares the clip-local frame fraction against a full-film beat fraction, so on a `--clip` bake starting deep into the film the Reveal round engages later than it should. Does not affect a full (non-clip) production bake.

## Test plan
- [x] `node --check` on all three modified files
- [x] Real-GPU `--clip` bake, step 1 (cheap probe) — fresh beat/window numbers logged
- [x] Real-GPU `--clip` bake, step 2 (0.79–0.94 window) — full highlight/card sync proof, clean exit, `fileOk=true`
- [ ] Full unclipped production bake (not run this session — the `--clip` verification already exercises every code path this PR touches; a full bake is a much longer GPU cost for the same proof)

🤖 Generated with [Claude Code](https://claude.com/claude-code)