### PR TITLE
feat(clash): §PENDING.2/.3/.4 — list depth display, narrowphase cross-caller cache, clash_rules gear

### DIFF
--- a/viewer/clash_narrow.js
+++ b/viewer/clash_narrow.js
@@ -452,6 +452,15 @@ function setupClashNarrow(A) {
   A.clashNarrow.loadTransforms = loadTransforms;
   A.clashNarrow.satDepth = satDepth;
   A.clashNarrow.runs = [];
+  // §CLASH_NARROW_CACHE (MEP_CLASH_REVEAL_MOVIE.md §PENDING.3) — cross-caller pair-verdict cache.
+  // Lives for the page session (setupClashNarrow runs once at boot, not per building — GUIDs are
+  // globally unique per IFC so no cross-building key collision is possible). A definitive verdict
+  // (CLASH/CLEAR) for a guid pair does not change unless the model geometry itself is edited, which
+  // this lane's read-only review flow never does — so the film's build and the interactive LIST
+  // panel's own qualifyRows() call reuse one judgement instead of two full triangle-exact passes.
+  // UNKNOWN verdicts (geometry not yet resident) are deliberately NOT cached — caching a transient
+  // "geometry missing" result would silently freeze it wrong forever once the mesh does load.
+  A.clashNarrow.pairCache = A.clashNarrow.pairCache || {};
   A.clashNarrow.qualifyRows = function (rows, opts) {
     opts = opts || {};
     var label = opts.label || 'pairs';
@@ -459,7 +468,7 @@ function setupClashNarrow(A) {
     _boxRun = new Map();   // fresh local-box cache per run (geometry may change between runs)
     var t0 = performance.now();
     var mem = { heapBeforeMB: heapMB(), heapPeakMB: heapMB(), heapAfterMB: -1 };
-    var counts = { broad: rows.length, obbSurvivors: 0, obbRejected: 0, rotatedSides: 0, meshTrue: 0, contained: 0, meshClear: 0, unknown: 0, truncated: 0 };
+    var counts = { broad: rows.length, obbSurvivors: 0, obbRejected: 0, rotatedSides: 0, meshTrue: 0, contained: 0, meshClear: 0, unknown: 0, truncated: 0, cacheHits: 0, cacheMisses: 0 };
     var pairs = new Array(rows.length);
     if (!rows.length) {
       var empty = { label: label, pairs: pairs, counts: counts, mem: mem, ms: 0, vacuous: true };
@@ -476,8 +485,25 @@ function setupClashNarrow(A) {
     function geoFor(hash) { return hash ? (A.meshCache[hash] || ctx.transient[hash] || null) : null; }
     var MA = new THREE.Matrix4(), MB = new THREE.Matrix4();
     function judge(i) {
-      var c = rows[i], ta = xf[c[0]], tb = xf[c[1]];
-      var rec = { pairId: pairIdOf(c[0], c[1]), guidA: c[0], guidB: c[1], classA: c[2] || '', classB: c[3] || '',
+      var c = rows[i];
+      var cachedPairId = pairIdOf(c[0], c[1]);
+      var cached = A.clashNarrow.pairCache[cachedPairId];
+      if (cached) {
+        counts.cacheHits++;
+        // Mirrors the exact post-testPair classification below (lines ~524-530) — a cache hit must
+        // land in the same counts bucket a fresh judge() of the same pair would.
+        if (cached.stage === 'OBB') counts.obbRejected++;
+        else {
+          counts.obbSurvivors++;
+          if (cached.verdict === VERDICT.CLASH) { counts.meshTrue++; if (cached.reason === REASON.CONT) counts.contained++; if (cached.truncated) counts.truncated++; if (cached.overlapFlat) counts.overlapFlat = (counts.overlapFlat || 0) + 1; }
+          else { counts.meshClear++; if (cached.reason === REASON.TOUCH) counts.touchOnly = (counts.touchOnly || 0) + 1; }
+        }
+        c[9] = cached; pairs[i] = cached;
+        return;
+      }
+      counts.cacheMisses++;
+      var ta = xf[c[0]], tb = xf[c[1]];
+      var rec = { pairId: cachedPairId, guidA: c[0], guidB: c[1], classA: c[2] || '', classB: c[3] || '',
         discA: c[4] || '', discB: c[5] || '', stage: 'BROAD', verdict: VERDICT.UNKNOWN, reason: REASON.NOGEO,
         aabbOverlapM: (typeof c[8] === 'number') ? c[8] : null, obbDepthM: null, severityM: null, triPairs: 0, truncated: false,
         contact: null, contactIfc: null, extentM: 0, bvhReusedA: false, bvhReusedB: false, ms: 0,
@@ -508,6 +534,9 @@ function setupClashNarrow(A) {
         if (rec.verdict === VERDICT.CLASH) { counts.meshTrue++; if (rec.reason === REASON.CONT) counts.contained++; if (rec.truncated) counts.truncated++; if (rec.overlapFlat) counts.overlapFlat = (counts.overlapFlat || 0) + 1; }
         else { counts.meshClear++; if (rec.reason === REASON.TOUCH) counts.touchOnly = (counts.touchOnly || 0) + 1; }
       }
+      // Only a DEFINITIVE verdict is cacheable — an UNKNOWN (geometry not resident yet) may resolve
+      // differently once the mesh loads, so it must be re-tried, never frozen.
+      if (rec.verdict !== VERDICT.UNKNOWN) A.clashNarrow.pairCache[cachedPairId] = rec;
       c[9] = rec; pairs[i] = rec;
     }
     function finish() {
@@ -524,6 +553,12 @@ function setupClashNarrow(A) {
         ' meshTrue=' + counts.meshTrue + ' contained=' + counts.contained + ' touchOnly=' + (counts.touchOnly || 0) + ' unknown=' + counts.unknown + ' aggregateParent=' + (counts.aggregateParent || 0) +
         ' falsePositiveRate=' + fpRate.toFixed(1) + '% ms=' + ms.toFixed(0) + ' msPerPair=' + (judged ? (ms / judged).toFixed(3) : 'n/a') +
         (judged === 0 ? ' VACUOUS' : ''));
+      // §CLASH_NARROW_CACHE (MEP_CLASH_REVEAL_MOVIE.md §PENDING.3) — proves cross-caller reuse
+      // actually happened this run, not just that the cache object exists (a populated-but-never-hit
+      // cache would be a no-op wearing a feature's clothes).
+      console.log('§CLASH_NARROW_CACHE pair=' + label + ' hits=' + counts.cacheHits + ' misses=' + counts.cacheMisses +
+        ' cacheSize=' + Object.keys(A.clashNarrow.pairCache).length +
+        (counts.cacheHits === 0 ? ' NO-OP(first run this session, or all-new pairs)' : ''));
       console.log('§CLASH_OBB pair=' + label + ' rotatedSides=' + counts.rotatedSides + ' rejected=' + counts.obbRejected + (counts.rotatedSides === 0 ? ' VACUOUS(rotation)' : ''));
       if (counts.unknown) console.log('§CLASH_NARROW_UNKNOWN pair=' + label + ' ' + JSON.stringify(counts.unknownBy));
       // §MESH_OVERLAP_DEPTH — how far the SAT proxy (severityM) sits from the mesh-true overlap, this run

--- a/viewer/measure.js
+++ b/viewer/measure.js
@@ -843,6 +843,14 @@ function setupMeasure(A) {
         var tolMm = pairRule ? (pairRule.tolerance_m * 1000).toFixed(0) : '25';
         hdr += '<div style="display:flex;justify-content:space-between;align-items:center">' +
           '<b style="color:#4fc3f7;font-size:12px">' + pairLabel + '</b>' +
+          // \u00a7CLASH_TOL_SOURCING (MEP_CLASH_REVEAL_MOVIE.md \u00a7PENDING.4) \u2014 this slider only ever
+          // changed the tolerance for THIS session's re-query (measure.js ~L925); it never wrote
+          // clash_rules.json, and no per-pair tolerance in that file carries any cited source
+          // (industry standard or otherwise). The gear opens the SAME generic Settings JSON editor
+          // panels.js already ships for clash_rules.json (\u00a7S282c) \u2014 not a new editor \u2014 so a value can
+          // be corrected/documented for every pair, not just re-queried for this one, this session.
+          '<span id="clash-edit-rules" title="edit all discipline-pair tolerances (clash_rules.json)" ' +
+            'style="cursor:pointer;color:#888;font-size:13px;padding:2px 6px" onmouseover="this.style.color=\'#4fc3f7\'" onmouseout="this.style.color=\'#888\'">\u2699</span>' +
           '<span id="clash-list-close" style="cursor:pointer;color:#aaa;font-size:22px;line-height:1;padding:6px">\u2715</span></div>';
         hdr += '<div style="display:flex;align-items:center;gap:4px;margin:2px 0">' +
           '<span style="font-size:9px;color:#aaa">1</span>' +
@@ -883,7 +891,15 @@ function setupMeasure(A) {
         // \u00a7MESH_NARROWPHASE: row[9] = triangle-exact verdict; CLEAR = bbox-only false positive
         var nv = c[9], nvStyle = '', nvTag = '';
         if (nv && nv.verdict === 'CLEAR') { nvStyle = 'text-decoration:line-through;opacity:0.45;'; nvTag = ' <span style="color:#aaa;font-size:9px">bbox-only</span>'; }
-        else if (nv && nv.verdict === 'CLASH') { nvTag = ' <span style="color:#8fef8f;font-size:9px" title="' + nv.reason + '">\u2713</span>'; }
+        else if (nv && nv.verdict === 'CLASH') {
+          nvTag = ' <span style="color:#8fef8f;font-size:9px" title="' + nv.reason + '">\u2713</span>';
+          // \u00a7CLASH_LIST_DEPTH (MEP_CLASH_REVEAL_MOVIE.md \u00a7PENDING.2) \u2014 the mesh-true penetration depth,
+          // same [tol/clash mm] wording the film's own clash_labels.js already draws on-screen; the row
+          // already carries depthMeshM from clash_narrow.js, this is display-only, no new computation.
+          var _cd = (typeof nv.depthMeshM === 'number') ? Math.round(nv.depthMeshM * 1000) : null;
+          var _cf = (A.clashLabels && A.clashLabels.factRow) ? A.clashLabels.factRow({ tolMm: tolMm, clashMm: _cd }) : '';
+          if (_cf) nvTag += ' <span style="color:#888;font-size:9px">' + _cf + '</span>';
+        }
         body +=
           '<span data-clash-idx="' + i + '" style="cursor:pointer;display:block;padding:1px 0;' + ss.style + nvStyle + '">' +
           (ss.icon ? ss.icon : '<span style="color:#888">' + (i + 1) + '</span>') +
@@ -905,6 +921,15 @@ function setupMeasure(A) {
     A._clashListDiv = listDiv;
     A._makeDraggable(listDiv);
     A.measureLabels.push({ div: listDiv, mid: null });
+
+    // §CLASH_TOL_SOURCING — delegated on listDiv (survives _refreshClashList's header innerHTML
+    // replace, unlike a direct listener on the gear span, which would be destroyed the first time
+    // a mesh-qualify pass refreshes the header out from under it).
+    listDiv.addEventListener('click', function(e) {
+      if (!e.target || e.target.id !== 'clash-edit-rules') return;
+      var entry = (A._jsonRegistry || []).filter(function(x) { return x.id === 'clash_rules'; })[0];
+      if (entry && A._openJsonEditor) { console.log('§CLASH_TOL_SOURCING open clash_rules editor'); A._openJsonEditor(entry); }
+    });
 
     // Tolerance slider — re-query on change
     var slider = listDiv.querySelector('#clash-tol-slider');

--- a/viewer/panels.js
+++ b/viewer/panels.js
@@ -2170,6 +2170,11 @@ function setupPanels(A) {
       content.appendChild(hub);
     }
 
+    // §CLASH_TOL_SOURCING (MEP_CLASH_REVEAL_MOVIE.md §PENDING.4) — exposed so a caller outside this
+    // closure (the Clash panel's own header, measure.js) can jump straight into the SAME editor this
+    // hub already uses, instead of a user hunting through Settings to find it. Not a new editor.
+    A._jsonRegistry = _jsonRegistry;
+
     // Open one registered JSON in a SettingsEditor sub-panel.
     // source:'url' (default) -> fetch + localStorage override (editable).
     // source:'db'           -> entry.project() returns the JSON (e.g. captured 4D).
@@ -2252,6 +2257,7 @@ function setupPanels(A) {
         console.warn('§JSON_EDITOR_FAIL ' + entry.id + ' ' + err);
       });
     }
+    A._openJsonEditor = _openJsonEditor;
 
     // PILL_DRAWER_REORGANIZATION.md §FINAL RAIL ORDER: Document(Save,Open) → Navigate → Inspect
     // → Visual FX → Camera/View → Share → Settings, Help. 9 visible icons (rest are pill:false,


### PR DESCRIPTION
Closes the three open §PENDING items in `prompts/MEP_CLASH_REVEAL_MOVIE.md` (bim-compiler).

### 2. Clash panel LIST shows the mesh-true depth
`measure.js` `_renderClashList`: CLASH-verdict rows append the same `[tolMm/clashMm]` fact string the
on-screen film markers already draw, via the now-shared `A.clashLabels.factRow`. Display-only —
`nv.depthMeshM` was already on every row (§MESH_NARROWPHASE), no new computation.

### 3. Cross-caller narrowphase cache
`clash_narrow.js`: `A.clashNarrow.pairCache`, a session-lifetime map keyed `guidA|guidB`. `judge(i)`
checks it first; a hit skips the SAT/triangle-exact test and lands in the same `counts` bucket a fresh
judgment would. Only DEFINITIVE verdicts are cached — UNKNOWN (geometry not resident) is retried, never
frozen wrong. New `§CLASH_NARROW_CACHE` line proves reuse actually happened and prints `NO-OP` at
hits=0, so a cold run can't be misread as a working cache.

### 4. Tolerance sourcing + JSON editor reachability
No standard is cited anywhere for the 25/50/75mm values (grepped the repo: zero hits for Navisworks /
Solibri / ISO 19650 / BIMForum), and none exists to cite — clash tolerances are project-chosen by
convention industry-wide; commonly-quoted values (5mm structural, 20mm ductwork) are the same order of
magnitude. Correct to leave as locally-owned defaults. The editor was already half-built: `panels.js`'s
`_jsonRegistry` had a `clash_rules` entry wired to the generic Settings JSON editor but nothing reached
it from the Clash panel. Exposed `A._jsonRegistry`/`A._openJsonEditor` and added a gear next to the
tolerance slider (delegated click, survives `_refreshClashList`'s innerHTML replacement).

## Verification — real GPU, `Hospital_silent_local`, pair MEP|STR broad=200
```
§CLASH_NARROWPHASE pair=MEP|STR broad=200 ... meshTrue=44 ... ms=121 msPerPair=0.606
§CLASH_NARROW_CACHE pair=MEP|STR hits=0 misses=200 cacheSize=200 NO-OP(first run this session)
§CLASH_NARROWPHASE pair=MEP|STR broad=200 ... meshTrue=44 ... ms=5 msPerPair=0.025
§CLASH_NARROW_CACHE pair=MEP|STR hits=200 misses=0 cacheSize=200
§CP23_RESULT pass1(ms=121.2) pass2(ms=5) sameVerdicts=true gearPresent=true registryHasClashRules=true
§CP23_VERDICT verdict=PASS
```
24x faster warm, byte-identical verdicts cold vs warm — reuse must not change the answer, and doesn't.

**Regression:** `witness_clash_mesh_narrowphase.js`, real GPU, full building, 68,526 broad-phase rows —
run on this branch AND on pristine `main@5daec9e0`: identical on both (`pass=8 fail=2 ran=68526`,
`meshTrue=6749`). The two failures pre-date this work, confirmed on unmodified main; not touched, not
claimed fixed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)