### PR TITLE
feat(cinema): Measure to the end — §29 indoor beats, §37 walkable storey cards + datum second life, datum Z-anchor fix

### DIFF
--- a/eslint.globals.json
+++ b/eslint.globals.json
@@ -134,6 +134,7 @@
   "setupCpeFlythruDatum": "readonly",
   "setupCpeSlabBeat": "readonly",
   "setupCpeLinearBeat": "readonly",
+  "setupCpeIndoorBeats": "readonly",
   "setupCpeFlythruDims": "readonly",
   "setupCpePathOverview": "readonly",
   "setupCpeResourcePanel": "readonly",

--- a/viewer/cinema_maxq.js
+++ b/viewer/cinema_maxq.js
@@ -1548,6 +1548,8 @@
       if (_measure && A.flythruDatumBuild) {
         try { A.flythruDatumBuild(); }
         catch (eFDB) { console.warn('§FLYTHRU_DATUM_BUILD failed: ' + (eFDB && eFDB.message) + ' — the film bakes without the datum'); }
+        // §37.2 — the datum's second life over the finished building, on the pull-out→flyback stretch.
+        try { if (A.flythruDatumSetLife2 && plan && plan.beats) A.flythruDatumSetLife2(plan.beats.flyback * _filmSecFull, (plan.beats.rise - ((plan.storeyReveal && plan.storeyReveal.on && plan.storeyReveal.windowFrac > 0) ? plan.storeyReveal.windowFrac : 0)) * _filmSecFull); } catch (eL2) {}
       }
       // §SLAB_BEAT (bim-compiler prompts/MEP_CLASH_REVEAL_MOVIE.md §26) — ONE floor plate marked as it
       // is laid: depth-tested tint + X, shine-through label. Rides Measure with the datum. Needs the

--- a/viewer/cinema_maxq.js
+++ b/viewer/cinema_maxq.js
@@ -798,6 +798,10 @@
       try { A.linearBeatCompositeOntoCanvas(ctx, w, h, _fcFilmSec); }
       catch (eLBC) { if (!A._linearBeatWarned) { A._linearBeatWarned = true; console.warn('§LINEAR_BEAT_DRAW failed: ' + (eLBC && eLBC.message)); } }
     }
+    if (A._flythruDatumOn && A.indoorBeatsCompositeOntoCanvas) {
+      try { A.indoorBeatsCompositeOntoCanvas(ctx, w, h, _fcFilmSec); }
+      catch (eIBC) { if (!A._indoorBeatsWarned) { A._indoorBeatsWarned = true; console.warn('§INDOOR_BEAT_DRAW failed: ' + (eIBC && eIBC.message)); } }
+    }
     if (lblInfo && lblInfo.placed && lblInfo.placed.length && A.clashLabelsCompositeOntoCanvas) try {
       A.clashLabelsCompositeOntoCanvas(ctx, w, h, lblInfo.placed);
     } catch (eCLd) {
@@ -1559,6 +1563,11 @@
         try { A.linearBeatBuild(plan, _filmSecFull, _bkState, _filmSecFull); }
         catch (eLB) { console.warn('§LINEAR_BEAT_BUILD failed: ' + (eLB && eLB.message) + ' — the film bakes without the linear beat'); }
       }
+      // §INDOOR_BEATS (§29) — hall walkable area, stair going, door type, clear height, inside the dive→out window. Rides Measure.
+      if (_measure && A.indoorBeatsBuild) {
+        try { A.indoorBeatsBuild(plan, _filmSecFull, _bkState); }
+        catch (eIB) { console.warn('§INDOOR_BEAT_BUILD failed: ' + (eIB && eIB.message) + ' — the film bakes without the indoor beats'); }
+      }
       if (_clash && A.clashFilm && A.clashFilm.build) {
         try { await A.clashFilm.build(); }
         catch (eCF) { console.warn('§CLASH_FILM_BUILD failed: ' + (eCF && eCF.message) + ' — the film bakes without markers'); }
@@ -1766,6 +1775,10 @@
         if (_measure && A.slabBeatAt) {
           try { A.slabBeatAt(_tnFilm * _filmSecFull); }
           catch (eSBA) { if (!A._slabBeatAtWarned) { A._slabBeatAtWarned = true; console.warn('§SLAB_BEAT_AT failed frame=' + i + ': ' + (eSBA && eSBA.message)); } }
+        }
+        if (_measure && A.indoorBeatsAt) {
+          try { A.indoorBeatsAt(_tnFilm * _filmSecFull); }
+          catch (eIBA) { if (!A._indoorBeatsAtWarned) { A._indoorBeatsAtWarned = true; console.warn('§INDOOR_BEAT_AT failed frame=' + i + ': ' + (eIBA && eIBA.message)); } }
         }
         if (A.flythruCuesApplyVisual) {
           try { A._flythruFilmSec = _tnFilm * _filmSecFull; A.flythruCuesApplyVisual(A._flythruFilmSec); }
@@ -2246,6 +2259,7 @@
       try { if (A.flythruCuesDispose) A.flythruCuesDispose(); } catch (eFD) {}
       try { if (A.slabBeatDispose) A.slabBeatDispose(); } catch (eSBD) {}   // §SLAB_BEAT — restores the tint, removes X + label
       try { if (A.linearBeatDispose) A.linearBeatDispose(); } catch (eLBD) {}
+      try { if (A.indoorBeatsDispose) A.indoorBeatsDispose(); } catch (eIBD) {}
       _workPacingReset();
       // §CLASH_FILM_P2 — say what the labels did over the whole film (VACUOUS if the camera never
       // came within 4 m of a pair), then release the selector's state with the markers.
@@ -2324,6 +2338,7 @@
       try { if (A.flythruCuesDispose) A.flythruCuesDispose(); } catch (eFD2) {}
       try { if (A.slabBeatDispose) A.slabBeatDispose(); } catch (eSBD2) {}
       try { if (A.linearBeatDispose) A.linearBeatDispose(); } catch (eLBD2) {}
+      try { if (A.indoorBeatsDispose) A.indoorBeatsDispose(); } catch (eIBD2) {}
       try { _workPacingReset(); } catch (e5) {}
       // §CLASH_FILM_P1 — same restore on the THROW path (review of #1678): a throw inside the loop
       // skips the in-try dispose above and would leave the marker InstancedMeshes in the user's

--- a/viewer/cpe_flythru_datum.js
+++ b/viewer/cpe_flythru_datum.js
@@ -38,6 +38,17 @@ function setupCpeFlythruDatum(A) {
   var _grp = null, _built = false, _info = null, _faces = null, _lines = null;
   var _sides = null, _camFar = null, _lastDrawn = null;   // §36 W1 — decided once per datum life, reset on dispose
   var _enteredAt = null, _envBox = null;                    // §20.8 — the drawing ends when the camera enters the envelope
+  var _life2 = null, _life2Started = null, _life2End = 0, _life2LeftAt = null, _life2Logged = false, _sheetGroundY = 0;   // §37.2 — the second life over the finished building
+  // §37.2 — the second life's SEARCH window: from flyback to the storey-reveal window. MEASURED 2026-09-08 (Hospital): the
+  // pull-out and pull-back are flown INSIDE the building's plan (below the roof) from 69 s to 148.6 s, so "out→flyback" holds no
+  // exterior frame at all; the first exterior frame is 148.6 s, at the start of the reveal round. So the life STARTS at the first
+  // exterior frame inside this window, HOLDS as long as the opening did (max(6, 0.094·film)), fades 2 s, and never runs into the
+  // storey-reveal window. A path with no exterior frame in the window prints VACUOUS at the end of the film.
+  A.flythruDatumSetLife2 = function (fromSec, toSec) {
+    _life2 = (isFinite(fromSec) && isFinite(toSec) && toSec - fromSec > 3.0) ? { from: fromSec, to: toSec } : null;
+    console.log('§FLYTHRU_DATUM_LIFE2 ' + (_life2 ? 'search=' + fromSec.toFixed(2) + '-' + toSec.toFixed(2) + 's (flyback → storey-reveal); starts at the first exterior frame, holds like the opening, fades 2 s'
+                                            : 'VACUOUS — flyback→storey-reveal is ' + (isFinite(fromSec) && isFinite(toSec) ? (toSec - fromSec).toFixed(2) + ' s' : 'undefined') + ', no second life'));
+  };
   // §20.8 / §36 W1 — ONE lifetime rule for the 3D planes and the 2D annotation: up from second 0, held through
   // the dive, faded over 2 s after it — AND gone 0.6 s after the camera ENTERS the structural envelope. Inside
   // the building the setting-out sheet has nothing to say and its non-depth-tested 2D marks were re-admitted
@@ -48,21 +59,41 @@ function setupCpeFlythruDatum(A) {
     var T = window.THREE, cam = A.camera;
     if (_lines && _lines.ext && T && cam && typeof A.ifc2three === 'function') {
       if (!_envBox) {
-        // the TOP of "inside" is the highest storey the drawing itself marks (Hospital: Level 7 at 34.0 m), not the
-        // bbox top (47 m — a plant tower): above the roof line, looking down, the sheet still reads.
-        var e = _lines.ext, zTop = e[5];
+        // ONE definition of "inside the building", for both lives: the COLUMN GRID's plan (gx/gy extents — the structural
+        // box reaches 30 m past it on Hospital, foundation walls) below the highest storey the drawing itself marks
+        // (Hospital: Level 7 at 34.0 m, not the 47 m plant tower): above the roof line, looking down, the sheet still reads.
+        var e = _lines.ext, zTop = e[5], gx = _lines.gx || [], gy = _lines.gy || [];
         if (_lines.levels && _lines.levels.length) { zTop = -Infinity; for (var li = 0; li < _lines.levels.length; li++) zTop = Math.max(zTop, _lines.levels[li].z); if (!isFinite(zTop) || zTop <= e[4]) zTop = e[5]; }
-        var a1 = A.ifc2three(e[0], e[2], e[4]), b1 = A.ifc2three(e[1], e[3], zTop);
+        var px0 = gx.length > 1 ? gx[0] : e[0], px1 = gx.length > 1 ? gx[gx.length - 1] : e[1], py0 = gy.length > 1 ? gy[0] : e[2], py1 = gy.length > 1 ? gy[gy.length - 1] : e[3];
+        var a1 = A.ifc2three(px0, py0, e[4]), b1 = A.ifc2three(px1, py1, zTop);
+        _sheetGroundY = A.ifc2three(0, 0, e[4]).y;
         _envBox = new T.Box3(new T.Vector3(Math.min(a1.x, b1.x), Math.min(a1.y, b1.y), Math.min(a1.z, b1.z)),
                              new T.Vector3(Math.max(a1.x, b1.x), Math.max(a1.y, b1.y), Math.max(a1.z, b1.z)));
       }
       if (_enteredAt == null && _envBox.containsPoint(cam.position)) {
         _enteredAt = filmSec;
         console.log('§FLYTHRU_DATUM_ENTRY filmSec=' + filmSec.toFixed(2) + ' cam=(' + cam.position.x.toFixed(1) + ',' + cam.position.y.toFixed(1) + ',' + cam.position.z.toFixed(1) +
-          ') — camera inside the structural envelope (plan footprint, below the top storey rule); the setting-out drawing fades over 0.6 s and stays off (§20.8)' + (filmSec < 0.05 ? ' ⚠ AT THE OPENING: the film starts inside the building' : ''));
+          ') — camera inside the building (column-grid plan, below the top storey rule); the setting-out drawing fades over 0.6 s and stays off (§20.8)' + (filmSec < 0.05 ? ' ⚠ AT THE OPENING: the film starts inside the building' : ''));
       }
     }
     if (_enteredAt != null) op = Math.min(op, Math.max(0, 1 - (filmSec - _enteredAt) / 0.6));
+    // §37.2 — the second life: [out, flyback], ramp 1 s in, fade 2 s out, only while the camera is OUTSIDE the envelope.
+    // The first frame of this life re-decides the sides once (the camera is elsewhere now) — see the compositor.
+    if (_life2 && filmSec >= _life2.from && filmSec <= _life2.to && _envBox && cam) {
+      // "Outside" for the second life = outside the SAME building box the entry latch uses, and above the ground grid.
+      var outside = !_envBox.containsPoint(cam.position) && cam.position.y >= _sheetGroundY;
+      if (outside && _life2Started == null) {
+        _life2Started = filmSec; _sides = null; _camFar = null; _lastDrawn = null;
+        _life2End = Math.min(_life2.to, filmSec + holdTo + 2.0);
+        if (!_life2Logged) { _life2Logged = true; console.log('§FLYTHRU_DATUM_LIFE2 start filmSec=' + filmSec.toFixed(2) + ' end=' + _life2End.toFixed(2) + 's (hold ' + holdTo.toFixed(1) + 's + 2 s fade) — the setting-out sheet over the FINISHED building; sides re-decided once for this life'); }
+      }
+      if (_life2Started != null) {
+        if (!outside && _life2LeftAt == null) { _life2LeftAt = filmSec; console.log('§FLYTHRU_DATUM_LIFE2 camera re-entered the building at ' + filmSec.toFixed(2) + 's — second life fades'); }
+        var op2 = Math.min(1, (filmSec - _life2Started) / 1.0, Math.max(0, (_life2End - filmSec) / 2.0));
+        if (_life2LeftAt != null) op2 = Math.min(op2, Math.max(0, 1 - (filmSec - _life2LeftAt) / 0.6));
+        op = Math.max(op, op2);
+      }
+    }
     return op;
   }
 
@@ -688,7 +719,7 @@ function setupCpeFlythruDatum(A) {
     A._flythruDatumLast = { drawn: n, bubbles: _bub, bubblesTotal: _lines.gx.length + _lines.gy.length + _lvz.length,
                             figures: _figs, overalls: _ov, filmSec: filmSec, dDrawn: _dDrawn, sidesChanged: _sidesChanged,
                             sidesKey: _sides.key, sidesNowKey: sidesNow.key, decidedAt: _sides.decidedAt,
-                            behind: { bubbles: [rX.behindB, rY.behindB, rZ.behindB], figures: [rX.behindF, rY.behindF, rZ.behindF] }, enteredAt: _enteredAt, op: op };
+                            behind: { bubbles: [rX.behindB, rY.behindB, rZ.behindB], figures: [rX.behindF, rY.behindF, rZ.behindF] }, enteredAt: _enteredAt, op: op, life: (_life2Started != null && filmSec >= _life2Started ? 2 : 1) };
     _lastDrawn = n;
     console.log('§FLYTHRU_DATUM_MARKS ' + (n ? 'drawn=' + n : 'NOTHING drawn=0') + ' filmSec=' + filmSec.toFixed(2) +
       ' IN-PLANE (no screen-space sizing, no register, no ranks, no clamping)' +
@@ -713,7 +744,7 @@ function setupCpeFlythruDatum(A) {
       // how the count moved since the last frame, and whether a per-frame decision WOULD have flipped.
       ' dropped=[behindCam bubbles X/Y/Z=' + rX.behindB + '/' + rY.behindB + '/' + rZ.behindB +
       ' figures=' + rX.behindF + '/' + rY.behindF + '/' + rZ.behindF + '] dDrawn=' + (_dDrawn == null ? 'first' : (_dDrawn >= 0 ? '+' : '') + _dDrawn) +
-      ' sidesChanged=' + (_sidesChanged ? 1 : 0) + ' decidedAt=' + _sides.decidedAt.toFixed(2) + 's');
+      ' sidesChanged=' + (_sidesChanged ? 1 : 0) + ' decidedAt=' + _sides.decidedAt.toFixed(2) + 's life=' + (_life2Started != null && filmSec >= _life2Started ? 2 : 1));
     return n;
   };
 
@@ -737,7 +768,7 @@ function setupCpeFlythruDatum(A) {
     if (_grp && A.scene) { A.scene.remove(_grp); _grp.children.forEach(function (o) { if (o.geometry) o.geometry.dispose(); if (o.material) o.material.dispose(); }); }
     // §36 W1/W3 — a dispose is a full reset, so the §33 gate can rebuild the datum at the opening it actually
     // chose (ribbon width and side decisions both read the camera at build/first composite).
-    _grp = null; _built = false; _info = null; _faces = null; _lines = null; _sides = null; _camFar = null; _lastDrawn = null; _enteredAt = null; _envBox = null;
+    _grp = null; _built = false; _info = null; _faces = null; _lines = null; _sides = null; _camFar = null; _lastDrawn = null; _enteredAt = null; _envBox = null; _life2Started = null; _life2LeftAt = null; _life2Logged = false;
   };
   console.log('§FLYTHRU_DATUM_INIT wired (ground grid + ONE upright with storey rules; depth-tested, occluded by the build)');
 }

--- a/viewer/cpe_flythru_datum.js
+++ b/viewer/cpe_flythru_datum.js
@@ -176,10 +176,28 @@ function setupCpeFlythruDatum(A) {
       var lo = Math.min.apply(null, st.levels.map(function (L) { return L.z; }));
       var hi = Math.max.apply(null, st.levels.map(function (L) { return L.z; }));
       st.levels.forEach(function (L) { L.zRaw = L.z; });   // the number a drawing prints
-      if (lo < zLo - 1 || hi > zHi + 1) { off = zLo - lo; st.levels.forEach(function (L) { L.z += off; }); }
+      var _offSrc = 'none';
+      if (lo < zLo - 1 || hi > zHi + 1) {
+        // ⚠ ANCHOR TO THE STOREYS' OWN SLABS, NOT TO THE LOWEST ELEMENT. MEASURED 2026-09-08 (§36 W5): `zLo - lo`
+        // took the footing bottom (156.61) as Level 1's zero, while Level 1's slab top is 165.81 — every storey rule
+        // was drawn 9.2 m too low, the camera landing on Level 1 read as "Level 3", and the indoor hall used the
+        // wrong storey's raster. For each level NAME, the largest planar slab on that storey gives slabTop − elevation;
+        // the median over storeys is the offset (Hospital: 165.81 on 9 of 9 storeys, spread 0.08 m). Falls back to the
+        // old rule only when no storey has a slab, and says so.
+        var _fits = [];
+        try {
+          var _sl = q("SELECT m.storey, t.center_z + t.bbox_z/2, t.bbox_x*t.bbox_y FROM elements_meta m JOIN element_transforms t ON m.guid=t.guid " +
+                      "WHERE m.ifc_class IN ('IfcSlab','IfcSlabStandardCase') AND t.bbox_z < 0.5*MIN(t.bbox_x,t.bbox_y)");
+          var _top = {}; _sl.forEach(function (v) { var k = String(v[0]); if (!_top[k] || v[2] > _top[k].a) _top[k] = { z: +v[1], a: v[2] }; });
+          st.levels.forEach(function (L) { var k = String(L.name || ''); if (_top[k]) _fits.push(_top[k].z - L.zRaw); });
+        } catch (eZ) {}
+        if (_fits.length) { _fits.sort(function (a, b) { return a - b; }); off = _fits[_fits.length >> 1]; _offSrc = 'slabs(n=' + _fits.length + ', spread=' + (_fits[_fits.length - 1] - _fits[0]).toFixed(2) + 'm)'; }
+        else { off = zLo - lo; _offSrc = 'FALLBACK lowest element (no storey has a planar slab) ⚠'; }
+        st.levels.forEach(function (L) { L.z += off; });
+      }
       console.log('§FLYTHRU_DATUM_ZDATUM levels=' + lo.toFixed(2) + '..' + hi.toFixed(2) +
         ' elements=' + zLo.toFixed(2) + '..' + zHi.toFixed(2) + ' offset=' + off.toFixed(2) + 'm' +
-        (off ? ' (levels were in a LOCAL datum)' : ' (already in the element datum)'));
+        (off ? ' (levels were in a LOCAL datum; anchored to ' + _offSrc + ')' : ' (already in the element datum)'));
     }
     // ⚠ DEGRADE, never invent: no columns -> no ground grid, and say so rather than draw a made-up module.
     if (gx.length < 2 || gy.length < 2) console.log('§FLYTHRU_DATUM_GRID VACUOUS — columns=' + cols.length + ' gave ' + gx.length + 'x' + gy.length + ' lines; ground grid omitted');
@@ -712,7 +730,8 @@ function setupCpeFlythruDatum(A) {
     if (_lines.gx.length > 1) ov.push(_lines.gx[_lines.gx.length - 1] - _lines.gx[0]);
     if (_lines.gy.length > 1) ov.push(_lines.gy[_lines.gy.length - 1] - _lines.gy[0]);
     if (lv.length > 1) ov.push(lv[lv.length - 1] - lv[0]);
-    return { storeys: storeys, bays: bays, overalls: ov, levels: lv };
+    var named = (_lines.levels || []).slice().sort(function (a, b) { return a.z - b.z; });
+    return { storeys: storeys, bays: bays, overalls: ov, levels: lv, levelNames: named.map(function (L) { return String(L.name || ''); }) };
   };
   A.flythruDatumDispose = function () {
     if (_grp && A.scene) { A.scene.remove(_grp); _grp.children.forEach(function (o) { if (o.geometry) o.geometry.dispose(); if (o.material) o.material.dispose(); }); }

--- a/viewer/cpe_indoor_beats.js
+++ b/viewer/cpe_indoor_beats.js
@@ -1,0 +1,294 @@
+/**
+ * BIM OOTB — Frictionless BIM. Two DBs. One browser. Zero install.
+ * Copyright (c) 2025-2026 Redhuan D. Oon <red1org@gmail.com>
+ * SPDX-License-Identifier: MIT
+ *
+ * cpe_indoor_beats.js — §INDOOR_BEATS: the hall, the stair, the opening, the clear height.
+ * Implementing bim-compiler prompts/MEP_CLASH_REVEAL_MOVIE.md §29 (+ §29.8 decisions). Witness: W-INDOOR-BEATS
+ * (viewer/tests/witness_indoor_beats.js). Rides the Alt-C Measure checkbox.
+ *
+ * USER (2026-09-08): "Once indoors i reckoned we pursue the hall area which most bakes will land first … So it label
+ * 'Hall-Corridor, Walkable area: #m²'. The tint remains until frame out. … Along the way we can catch the stairs as
+ * the next prize. … Otherwise catch a door or window gives its XY and area dims. A tallest point height in middle of
+ * hallway will be also a killer."
+ *
+ * FOUR SLOTS, FOUR CAPABILITIES (§29.1) — hall walkable area · stair going · door type · clear height. No fifth.
+ * Every number is read: the hall from storey_walkable_raster bounded at IfcDoor footprints (§29.2a), the stair and
+ * door from element_transforms, the clear height from a DB column cast (§29.8.6). Nothing is composed.
+ *
+ * CAN SAY NO (PRIMAL LAW §4): INCONCLUSIVE (no plan / no datum / no raster for the camera's storey), VACUOUS <class>,
+ * NOTHING <beat> with the rule that rejected it, §INDOOR_BEAT_CAMERA_BELOW_FLOOR for the HHS path (§29.7 item 3).
+ */
+function setupCpeIndoorBeats(A) {
+  if (!A) return;
+  var ENV = { fadeIn: 0.6, hold: 1.0, fadeOut: 0.6 }, ENV_SPAN = 2.2, GAP = 0.5, SLOT = ENV_SPAN + GAP;  // §14
+  var STEP = 0.25, MIN_PX = 24, DATUM_TOL = 0.02, INK = '#ffd600', HALL_TINT = 0x3fa9f5;
+  var _built = false, _report = null, _beats = [], _hall = null, _grp = null, _lastLog = {};
+  function log(s) { console.log(s); }
+  function fmt(n, dp) { var s = (+n).toFixed(dp == null ? 0 : dp), p = s.split('.'); p[0] = p[0].replace(/\B(?=(\d{3})+(?!\d))/g, ','); return p.join('.'); }
+  function fmtMM(m) { return fmt(Math.round(m * 1000)); }
+  function envAt(dt) { if (dt < 0) return 0; if (dt < ENV.fadeIn) return dt / ENV.fadeIn; if (dt < ENV.fadeIn + ENV.hold) return 1; if (dt < ENV_SPAN) return 1 - (dt - ENV.fadeIn - ENV.hold) / ENV.fadeOut; return 0; }
+  function semanticName(raw) { if (!raw) return null; var p = String(raw).split(':'); return (p.length >= 3 ? p.slice(1, p.length - 1).join(':') : String(raw)).trim(); }
+
+  A.indoorBeatsBuild = function (plan, filmSecFull, bkState) {
+    if (_built) return _report;
+    _built = true; _beats = []; _hall = null;
+    _report = { state: 'INCONCLUSIVE', why: null, beats: [], window: null, belowFloor: 0, samples: 0, rejected: {} };
+    var T = window.THREE, SR = window.StoreyRaster;
+    function fail(state, why) { _report.state = state; _report.why = why; log('§INDOOR_BEAT ' + state + ' — ' + why); return _report; }
+    if (!T || !SR || typeof A.ifc2three !== 'function' || typeof A.three2ifc !== 'function' || typeof A.dbQuery !== 'function') return fail('INCONCLUSIVE', 'no THREE / StoreyRaster / ifc2three / three2ifc / dbQuery');
+    if (!plan || typeof plan.poseAt !== 'function' || !(plan.beats && plan.beats.dive > 0 && plan.beats.out > plan.beats.dive)) return fail('INCONCLUSIVE', 'no plan.poseAt or no dive→out window on the plan');
+    var figs = (typeof A.flythruDatumFigures === 'function') ? A.flythruDatumFigures() : null;
+    if (!figs || !figs.levels || figs.levels.length < 1) return fail('INCONCLUSIVE', 'no datum levels — the datum must be built first (Measure on)');
+    var t0 = plan.beats.dive * filmSecFull, t1 = plan.beats.out * filmSecFull;
+    _report.window = { from: +t0.toFixed(2), to: +t1.toFixed(2) };
+    var W = (A.renderer && A.renderer.domElement && A.renderer.domElement.width) || 1280, H = (A.renderer && A.renderer.domElement && A.renderer.domElement.height) || 720, k = H / 720;
+
+    // ── taken windows from every other layer (§14 across layers)
+    var taken = [];
+    if (typeof A.flythruCuesWindows === 'function') A.flythruCuesWindows().forEach(function (w) { taken.push({ from: w.from, to: w.to, who: 'cue:' + w.key }); });
+    var sb = (typeof A.slabBeatReport === 'function') ? A.slabBeatReport() : null; if (sb && sb.state === 'BEAT' && sb.beat) taken.push({ from: sb.beat.sec, to: sb.beat.sec + SLOT, who: 'plate' });
+    var lb = (typeof A.linearBeatReport === 'function') ? A.linearBeatReport() : null; if (lb && lb.picks) lb.picks.forEach(function (p) { taken.push({ from: p.sec, to: p.sec + SLOT, who: p.cls }); });
+    function free(t) { return taken.every(function (w) { return t + SLOT <= w.from || t >= w.to; }); }
+
+    // ── the samples: camera pose, storey, floor, forward heading
+    var lv = figs.levels, names = figs.levelNames || [];
+    function storeyAt(iz) { var idx = -1; for (var i = 0; i < lv.length; i++) if (lv[i] <= iz + 0.3) idx = i; return idx; }
+    var samples = [], below = 0;
+    for (var t = t0; t <= t1 + 1e-9; t += STEP) {
+      var p = plan.poseAt(t / filmSecFull), c = A.three2ifc(p.x, p.y, p.z), tg = A.three2ifc(p.tx, p.ty, p.tz);
+      var si = storeyAt(c.iz), floorZ = si >= 0 ? lv[si] : null;
+      var s = { t: +t.toFixed(3), pose: p, ifc: c, si: si, storey: si >= 0 ? names[si] : null, floorZ: floorZ, camAbove: floorZ == null ? null : c.iz - floorZ,
+                fwd: { x: tg.ix - c.ix, y: tg.iy - c.iy } };
+      var L = Math.hypot(s.fwd.x, s.fwd.y) || 1; s.fwd.x /= L; s.fwd.y /= L;
+      if (floorZ != null && c.iz < floorZ - 1.0) { s.below = true; below++; }
+      samples.push(s);
+    }
+    _report.samples = samples.length; _report.belowFloor = below;
+    log('§INDOOR_BEAT_WINDOW from=' + t0.toFixed(2) + 's to=' + t1.toFixed(2) + 's (beats dive→out) samples=' + samples.length + ' @' + STEP + 's storeys=' + names.join('|') +
+        (below ? ' ⚠ §INDOOR_BEAT_CAMERA_BELOW_FLOOR samples=' + below + ' (' + samples.filter(function (s) { return s.below; })[0].t + 's…) — the PATH is under its floor there (§29.7 item 3)' : ''));
+
+    function camFor(s) { var cam = A.camera.clone(); cam.position.set(s.pose.x, s.pose.y, s.pose.z); cam.lookAt(s.pose.tx, s.pose.ty, s.pose.tz); cam.updateMatrixWorld(true); cam.updateProjectionMatrix(); return cam; }
+    function camAtSec(t) { var p = plan.poseAt(Math.min(1, t / filmSecFull)); return camFor({ pose: p }); }
+    // INDOORS THE CAMERA WALKS PAST THINGS. A cue is legible only if it stays in frame for its whole envelope, so the
+    // score is the MINIMUM projected size over (t, t+1.1, t+2.1) with all three in frame — MEASURED before this rule:
+    // the max-at-one-instant pick put HHS's stair and Hospital's height cast behind the camera within a second.
+    var ENV_SAMPLES = [0, 1.1, 2.1];
+    function heldPx(a3, b3, t) { var mn = Infinity; for (var i = 0; i < ENV_SAMPLES.length; i++) { var m = pxOf(a3, b3, camAtSec(t + ENV_SAMPLES[i])); if (!m.inF) return { px: 0, inF: false }; if (m.px < mn) mn = m.px; } return { px: mn, inF: true }; }
+    function P3(ix, iy, iz) { var v = A.ifc2three(ix, iy, iz); return new T.Vector3(v.x, v.y, v.z); }
+    function proj(v, cam) { var q = v.clone().project(cam); return { x: (q.x + 1) / 2 * W, y: (1 - q.y) / 2 * H, z: q.z, inF: Math.abs(q.x) <= 1 && Math.abs(q.y) <= 1 && q.z < 1 }; }
+    function pxOf(a3, b3, cam) { var qa = proj(a3, cam), qb = proj(b3, cam); return { px: (qa.inF && qb.inF) ? Math.hypot(qa.x - qb.x, qa.y - qb.y) : 0, inF: qa.inF && qb.inF }; }
+
+    // ── 1. THE HALL — walkable raster bounded at door thresholds, flooded from the camera cell
+    var rasters = {}, doorsByStorey = {};
+    function rasterFor(storey) {
+      if (storey in rasters) return rasters[storey];
+      var r = null; try { var wr = A.dbQuery('SELECT storey,res,x0,y0,cols,rows,bits FROM storey_walkable_raster WHERE storey=?', [storey]) || []; if (wr.length) r = SR.fromRow(wr[0]); } catch (e) {}
+      rasters[storey] = r; return r;
+    }
+    var doorRows = []; try { doorRows = A.dbQuery("SELECT m.guid, m.element_name, m.storey, t.center_x, t.center_y, t.center_z, t.bbox_x, t.bbox_y, t.bbox_z FROM elements_meta m JOIN element_transforms t ON m.guid=t.guid WHERE m.ifc_class='IfcDoor'") || []; } catch (e) {}
+    var doors = doorRows.map(function (v) { return { guid: v[0], rawName: v[1], storey: String(v[2] == null ? '' : v[2]), cx: +v[3], cy: +v[4], cz: +v[5], bx: +v[6], by: +v[7], bz: +v[8] }; });
+    function blockedRaster(storey, floorZ) {   // a COPY of the storey bitset with door cells cleared
+      var r = rasterFor(storey); if (!r) return null;
+      var bits = new Uint8Array(r.bits.length); bits.set(r.bits);
+      var n = 0;
+      doors.forEach(function (d) {
+        if (Math.abs(d.cz - d.bz / 2 - floorZ) > 1.5) return;      // this storey's doors, by sill height
+        var c0 = Math.floor((d.cx - d.bx / 2 - r.x0) / r.res) - 1, c1 = Math.floor((d.cx + d.bx / 2 - r.x0) / r.res) + 1;
+        var r0 = Math.floor((d.cy - d.by / 2 - r.y0) / r.res) - 1, r1 = Math.floor((d.cy + d.by / 2 - r.y0) / r.res) + 1;
+        for (var rr = Math.max(0, r0); rr <= Math.min(r.rows - 1, r1); rr++) for (var cc = Math.max(0, c0); cc <= Math.min(r.cols - 1, c1); cc++) {
+          var i = rr * r.cols + cc; if (bits[i >> 3] & (1 << (i & 7))) { bits[i >> 3] &= ~(1 << (i & 7)); n++; }
+        }
+      });
+      return { r: r, bits: bits, doorCells: n, get: function (c, rr) { if (c < 0 || rr < 0 || c >= r.cols || rr >= r.rows) return 0; var i = rr * r.cols + c; return (bits[i >> 3] >> (i & 7)) & 1; } };
+    }
+    function flood(B, c0, r0) {
+      var r = B.r, seen = new Uint8Array(r.cols * r.rows), q = [[c0, r0]], head = 0, cells = [], minC = c0, maxC = c0, minR = r0, maxR = r0;
+      seen[r0 * r.cols + c0] = 1;
+      while (head < q.length) {
+        var p = q[head++], c = p[0], rr = p[1]; cells.push(p);
+        if (c < minC) minC = c; if (c > maxC) maxC = c; if (rr < minR) minR = rr; if (rr > maxR) maxR = rr;
+        [[c + 1, rr], [c - 1, rr], [c, rr + 1], [c, rr - 1]].forEach(function (nb) { var i = nb[1] * r.cols + nb[0]; if (nb[0] < 0 || nb[1] < 0 || nb[0] >= r.cols || nb[1] >= r.rows || seen[i] || !B.get(nb[0], nb[1])) return; seen[i] = 1; q.push(nb); });
+      }
+      return { cells: cells, bbox: { minx: r.x0 + minC * r.res, maxx: r.x0 + (maxC + 1) * r.res, miny: r.y0 + minR * r.res, maxy: r.y0 + (maxR + 1) * r.res } };
+    }
+    function nearestWalkable(B, c, rr, reach) { for (var d = 0; d <= reach; d++) for (var dc = -d; dc <= d; dc++) for (var dr = -d; dr <= d; dr++) if (Math.abs(dc) === d || Math.abs(dr) === d) if (B.get(c + dc, rr + dr)) return [c + dc, rr + dr]; return null; }
+
+    var hall = null, hallTried = 0, hallWhy = [];
+    for (var hi = 0; hi < samples.length && !hall; hi++) {
+      var s = samples[hi];
+      if (s.below || s.storey == null) continue;
+      if (!free(s.t)) continue;
+      var B = blockedRaster(s.storey, s.floorZ); if (!B) { hallWhy.push('no raster for "' + s.storey + '"'); continue; }
+      hallTried++;
+      var c = Math.floor((s.ifc.ix - B.r.x0) / B.r.res), rr = Math.floor((s.ifc.iy - B.r.y0) / B.r.res);
+      var start = B.get(c, rr) ? [c, rr] : nearestWalkable(B, c, rr, Math.round(2.0 / B.r.res));
+      if (!start) { hallWhy.push(s.t + 's: camera not on walkable floor (' + s.storey + ')'); continue; }
+      var comp = flood(B, start[0], start[1]);
+      var area = comp.cells.length * B.r.res * B.r.res;
+      var total = 0; for (var q2 = 0; q2 < B.r.cols * B.r.rows; q2++) if ((B.r.bits[q2 >> 3] >> (q2 & 7)) & 1) total++;
+      hall = { t: s.t, storey: s.storey, floorZ: s.floorZ, area: area, cells: comp.cells.length, storeyWalkable: total * B.r.res * B.r.res, doorCellsBlocked: B.doorCells, bbox: comp.bbox, raster: B.r, comp: comp,
+               centroid: { ix: (comp.bbox.minx + comp.bbox.maxx) / 2, iy: (comp.bbox.miny + comp.bbox.maxy) / 2 }, sample: s, startCell: start };
+    }
+    if (hall) {
+      taken.push({ from: hall.t, to: hall.t + SLOT, who: 'hall' });
+      log('§INDOOR_BEAT_HALL sec=' + hall.t.toFixed(2) + ' storey="' + hall.storey + '" walkable=' + fmt(hall.area) + 'm2 (' + hall.cells + ' cells @' + hall.raster.res + 'm; storey walkable ' + fmt(hall.storeyWalkable) +
+          'm2; ' + hall.doorCellsBlocked + ' door cells blocked = the §29.2a bound) bbox=' + (hall.bbox.maxx - hall.bbox.minx).toFixed(1) + 'x' + (hall.bbox.maxy - hall.bbox.miny).toFixed(1) + 'm camAbove=' + hall.sample.camAbove.toFixed(2) + 'm');
+      _beats.push({ key: 'hall', sec: hall.t, persist: true, hall: hall });
+    } else { _report.rejected.hall = hallWhy.slice(0, 4); log('§INDOOR_BEAT_HALL NOTHING — ' + (hallTried ? hallTried + ' standing sample(s) tried; ' : 'no sample stood on a rastered storey; ') + (hallWhy[0] || 'no reason recorded') + (hallWhy.length > 1 ? ' (+' + (hallWhy.length - 1) + ' more)' : '')); }
+
+    // generic picker: over free samples, the (instance, sample) with the largest legible projected size
+    function pickLinear(list, spanOf, who) {
+      var best = null;
+      samples.forEach(function (s) {
+        if (s.below || !free(s.t)) return;
+        var cam = camFor(s);
+        list.forEach(function (it) {
+          var sp = spanOf(it); if (!sp) return;
+          var m0 = pxOf(sp.a, sp.b, cam);
+          if (!m0.inF || m0.px < MIN_PX * k) return;          // cheap first test at the sample itself
+          var m = heldPx(sp.a, sp.b, s.t);                     // then held over the envelope
+          if (!m.inF || m.px < MIN_PX * k) return;
+          if (!best || m.px > best.px) best = { it: it, s: s, px: m.px, span: sp };
+        });
+      });
+      if (best) taken.push({ from: best.s.t, to: best.s.t + SLOT, who: who });
+      return best;
+    }
+
+    // ── 2. THE STAIR — the going, never the rise
+    var stairRows = []; try { stairRows = A.dbQuery("SELECT m.guid, m.ifc_class, m.element_name, m.storey, t.center_x, t.center_y, t.center_z, t.bbox_x, t.bbox_y, t.bbox_z FROM elements_meta m JOIN element_transforms t ON m.guid=t.guid WHERE m.ifc_class IN ('IfcStairFlight','IfcStair')") || []; } catch (e) {}
+    var stairs = stairRows.filter(function (v) { return +v[9] > 1.0; });      // flights AND assemblies with a real rise (Hospital has 1 flight, 61 assemblies)
+    var stairCls = 'IfcStairFlight+IfcStair', stairGuarded = 0;
+    // A GOING IS A FLIGHT'S RUN. The flattest stair any code allows is ~355 mm going on a 150 mm riser (2.4:1); an
+    // assembly's box may add landings, so run/rise ≤ 3.0 is the physical bound — MEASURED before it: Hospital offered a
+    // 99,896 mm "going" on a 6,383 mm rise (a multi-storey stair GROUP's box), which is a corridor's length, not a stair's.
+    var stairNotFlight = 0;
+    var stairList = stairs.map(function (v) { var bx = +v[7], by = +v[8]; return { guid: v[0], cls: v[1], rawName: v[2], name: semanticName(v[2]), storey: String(v[3] || ''), cx: +v[4], cy: +v[5], cz: +v[6], bx: bx, by: by, bz: +v[9], going: Math.max(bx, by), alongX: bx >= by }; })
+      .filter(function (st) { if (st.going > 3.0 * st.bz) { stairNotFlight++; return false; } return true; })
+      .filter(function (st) { var g = st.going, hit = figs.bays.concat(figs.overalls).some(function (f) { return Math.abs(g - f) <= DATUM_TOL * f; }); if (hit) stairGuarded++; return !hit; });
+    log('§INDOOR_BEAT_STAIR_POOL cls=' + stairCls + ' n=' + stairs.length + ' rejectedRunOver3xRise=' + stairNotFlight + ' rejectedAsBayRestatement=' + stairGuarded + ' pool=' + stairList.length + (stairRows.length ? '' : ' VACUOUS'));
+    var stairPick = stairList.length ? pickLinear(stairList, function (st) { var z = st.cz - st.bz / 2 + 0.05; return st.alongX ? { a: P3(st.cx - st.bx / 2, st.cy, z), b: P3(st.cx + st.bx / 2, st.cy, z) } : { a: P3(st.cx, st.cy - st.by / 2, z), b: P3(st.cx, st.cy + st.by / 2, z) }; }, 'stair') : null;
+    if (stairPick) { _beats.push({ key: 'stair', sec: stairPick.s.t, span: stairPick.span, metres: stairPick.it.going, label: 'going ' + fmtMM(stairPick.it.going) + ' mm', title: stairPick.it.cls, sem: stairPick.it.name, px: stairPick.px, it: stairPick.it });
+      log('§INDOOR_BEAT_STAIR sec=' + stairPick.s.t.toFixed(2) + ' going=' + fmtMM(stairPick.it.going) + 'mm rise=' + fmtMM(stairPick.it.bz) + 'mm (not cued) px=' + stairPick.px.toFixed(0) + ' storey="' + stairPick.it.storey + '" "' + stairPick.it.name + '" guid=' + stairPick.it.guid); }
+    else log('§INDOOR_BEAT_STAIR ' + (stairRows.length ? 'NOTHING — no going legible in frame in a free slot' : 'VACUOUS — no stairs in this model'));
+
+    // ── 3. THE OPENING — the modal door leaf, one placed instance of it
+    var buckets = {}; doors.forEach(function (d) { var w = Math.round(Math.max(d.bx, d.by) * 100) * 10, h = Math.round(d.bz * 100) * 10; var kk = w + 'x' + h; (buckets[kk] = buckets[kk] || { w: w, h: h, list: [] }).list.push(d); });
+    var modal = null; Object.keys(buckets).forEach(function (kk) { if (!modal || buckets[kk].list.length > modal.list.length) modal = buckets[kk]; });
+    log('§INDOOR_BEAT_DOOR_POOL n=' + doors.length + (modal ? ' modal=' + modal.w + 'x' + modal.h + 'mm x' + modal.list.length + ' (' + Math.round(100 * modal.list.length / doors.length) + '%)' : ' VACUOUS'));
+    var doorPick = modal ? pickLinear(modal.list, function (d) { var alongX = d.bx >= d.by, w = Math.max(d.bx, d.by); return alongX ? { a: P3(d.cx - w / 2, d.cy, d.cz), b: P3(d.cx + w / 2, d.cy, d.cz), h: { a: P3(d.cx, d.cy, d.cz - d.bz / 2), b: P3(d.cx, d.cy, d.cz + d.bz / 2) } } : { a: P3(d.cx, d.cy - w / 2, d.cz), b: P3(d.cx, d.cy + w / 2, d.cz), h: { a: P3(d.cx, d.cy, d.cz - d.bz / 2), b: P3(d.cx, d.cy, d.cz + d.bz / 2) } }; }, 'door') : null;
+    if (doorPick) { var d0 = doorPick.it; _beats.push({ key: 'door', sec: doorPick.s.t, span: doorPick.span, span2: doorPick.span.h, metres: Math.max(d0.bx, d0.by), metres2: d0.bz, label: fmt(modal.w) + ' × ' + fmt(modal.h) + ' mm', title: 'IfcDoor', sem: modal.list.length + ' of this type', px: doorPick.px, it: d0, modal: { w: modal.w, h: modal.h, n: modal.list.length } });
+      log('§INDOOR_BEAT_DOOR sec=' + doorPick.s.t.toFixed(2) + ' leaf=' + modal.w + 'x' + modal.h + 'mm x' + modal.list.length + ' instance=' + fmtMM(Math.max(d0.bx, d0.by)) + 'x' + fmtMM(d0.bz) + 'mm px=' + doorPick.px.toFixed(0) + ' storey="' + d0.storey + '" guid=' + d0.guid); }
+    else log('§INDOOR_BEAT_DOOR ' + (doors.length ? 'NOTHING — no instance of the modal leaf legible in frame in a free slot' : 'VACUOUS — no IfcDoor'));
+
+    // ── 4. THE CLEAR HEIGHT — a DB column cast ahead of the camera inside the hall
+    var height = null, heightWhy = null;
+    if (hall) {
+      var band = []; try { band = A.dbQuery("SELECT m.ifc_class, t.center_x, t.center_y, t.center_z, t.bbox_x, t.bbox_y, t.bbox_z FROM elements_meta m JOIN element_transforms t ON m.guid=t.guid WHERE t.center_z - t.bbox_z/2 > ? AND t.center_z - t.bbox_z/2 < ?", [hall.floorZ + 0.5, hall.floorZ + 12]) || []; } catch (e) {}
+      var CEIL = { IfcSlab: 1, IfcCovering: 1, IfcRoof: 1, IfcSlabStandardCase: 1 };
+      // §29.8.6 — a DB cast reads AABBs; a railing, stair, ramp, mullion or opening is diagonal or open-frame, so its
+      // box claims air it does not fill. Those cannot be a headroom stop; ducts, pipes, trays, beams, fittings and
+      // ceilings can. MEASURED before this list: Hospital's first cast hit "IfcRailing at 3,848 mm" — the floor above's
+      // balustrade box hanging over the hall it does not touch.
+      var NOT_OVERHEAD = { IfcRailing: 1, IfcStair: 1, IfcStairFlight: 1, IfcRamp: 1, IfcRampFlight: 1, IfcMember: 1, IfcPlate: 1, IfcOpeningElement: 1, IfcSpace: 1, IfcCurtainWall: 1, IfcWall: 1, IfcWallStandardCase: 1, IfcColumn: 1, IfcDoor: 1, IfcWindow: 1, IfcFurnishingElement: 1, IfcFurniture: 1, IfcBuildingElementProxy: 1 };
+      var cands = [];
+      samples.forEach(function (s) {
+        if (s.below || s.storey !== hall.storey || !free(s.t)) return;
+        var cam = camFor(s);
+        for (var dist = 2; dist <= 10; dist += 1) {
+          var px0 = s.ifc.ix + s.fwd.x * dist, py0 = s.ifc.iy + s.fwd.y * dist;
+          if (!hall.raster.contains(px0, py0)) continue;
+          var clear = null, clearCls = null, total = null;
+          band.forEach(function (v) { if (NOT_OVERHEAD[v[0]]) return; var cx = +v[1], cy = +v[2], bot = +v[3] - +v[6] / 2; if (Math.abs(px0 - cx) > +v[4] / 2 || Math.abs(py0 - cy) > +v[5] / 2) return; if (clear == null || bot < clear) { clear = bot; clearCls = v[0]; } if (CEIL[v[0]] && (total == null || bot < total)) total = bot; });
+          if (clear == null) continue;
+          var ch = clear - hall.floorZ, th = total == null ? null : total - hall.floorZ;
+          if (th != null && Math.abs(ch - th) < 0.05) continue;     // nothing hangs here — the cast restates the ceiling
+          if (figs.storeys.some(function (f) { return Math.abs(ch - f) <= DATUM_TOL * f; })) continue;
+          var a3 = P3(px0, py0, hall.floorZ), b3 = P3(px0, py0, clear), m = pxOf(a3, b3, cam);
+          if (!m.inF || m.px < MIN_PX * k) continue;
+          m = heldPx(a3, b3, s.t); if (!m.inF || m.px < MIN_PX * k) continue;
+          cands.push({ s: s, px: m.px, span: { a: a3, b: b3 }, ch: ch, th: th, cls: clearCls, dist: dist });
+        }
+      });
+      cands.sort(function (x, y) { return y.px - x.px; });
+      if (cands.length) { height = cands[0]; taken.push({ from: height.s.t, to: height.s.t + SLOT, who: 'height' });
+        _beats.push({ key: 'height', sec: height.s.t, span: height.span, metres: height.ch, label: 'clear height ' + fmtMM(height.ch) + ' mm', title: 'under ' + height.cls, sem: height.th != null ? 'ceiling ' + fmtMM(height.th) + ' mm (datum, not cued)' : '', px: height.px, cls: height.cls, ch: height.ch, th: height.th });
+        log('§INDOOR_BEAT_HEIGHT sec=' + height.s.t.toFixed(2) + ' clear=' + fmtMM(height.ch) + 'mm under ' + height.cls + ' total=' + (height.th == null ? 'n/a' : fmtMM(height.th) + 'mm') + ' ' + height.dist + 'm ahead px=' + height.px.toFixed(0) + ' candidates=' + cands.length); }
+      else { heightWhy = 'no point 2–10 m ahead inside the hall has something hanging below its ceiling that is legible in a free slot'; log('§INDOOR_BEAT_HEIGHT WITHDRAWN — ' + heightWhy); }
+    } else log('§INDOOR_BEAT_HEIGHT WITHDRAWN — no hall to stand in');
+
+    // ── draw: the hall tint mesh (row-run quads), depth-tested, on the floor
+    if (hall) {
+      _grp = new T.Group(); _grp.name = 'indoorBeats';
+      var r = hall.raster, byRow = {}; hall.comp.cells.forEach(function (p) { (byRow[p[1]] = byRow[p[1]] || []).push(p[0]); });
+      var pos = [], idx = [], vi = 0, z = hall.floorZ + 0.03;
+      Object.keys(byRow).forEach(function (rr) { var cs = byRow[rr].sort(function (a, b) { return a - b; }), i = 0; rr = +rr;
+        while (i < cs.length) { var j = i; while (j + 1 < cs.length && cs[j + 1] === cs[j] + 1) j++;
+          var x0 = r.x0 + cs[i] * r.res, x1 = r.x0 + (cs[j] + 1) * r.res, y0 = r.y0 + rr * r.res, y1 = r.y0 + (rr + 1) * r.res;
+          [[x0, y0], [x1, y0], [x1, y1], [x0, y1]].forEach(function (q) { var v = A.ifc2three(q[0], q[1], z); pos.push(v.x, v.y, v.z); });
+          idx.push(vi, vi + 1, vi + 2, vi, vi + 2, vi + 3, vi, vi + 2, vi + 1, vi, vi + 3, vi + 2); vi += 4; i = j + 1; } });
+      var g = new T.BufferGeometry(); g.setAttribute('position', new T.Float32BufferAttribute(pos, 3)); g.setIndex(idx);
+      var mesh = new T.Mesh(g, new T.MeshBasicMaterial({ color: HALL_TINT, transparent: true, opacity: 0, depthTest: true, depthWrite: false, polygonOffset: true, polygonOffsetFactor: -1 }));
+      mesh.name = 'indoorHallTint'; mesh.visible = false; _grp.add(mesh); if (A.scene) A.scene.add(_grp);
+      hall.mesh = mesh; hall.quads = vi / 4;
+      log('§INDOOR_BEAT_HALL_TINT quads=' + hall.quads + ' depthTest=true (occluded by walls) color=#' + HALL_TINT.toString(16));
+    }
+    _report.taken = taken.map(function (w) { return { from: +w.from.toFixed(3), to: +w.to.toFixed(3), who: w.who }; });
+    _report.beats = _beats.map(function (b) { return { key: b.key, sec: +b.sec.toFixed(3), label: b.label || null, title: b.title || null, sem: b.sem || null, px: b.px == null ? null : +b.px.toFixed(1), metres: b.metres == null ? null : +b.metres.toFixed(4), metres2: b.metres2 == null ? null : +b.metres2.toFixed(4),
+      hall: b.hall ? { storey: b.hall.storey, area: +b.hall.area.toFixed(2), cells: b.hall.cells, storeyWalkable: +b.hall.storeyWalkable.toFixed(2), doorCellsBlocked: b.hall.doorCellsBlocked, quads: b.hall.quads, camAbove: +b.hall.sample.camAbove.toFixed(3), startCell: b.hall.startCell } : null,
+      it: b.it ? { guid: b.it.guid, storey: b.it.storey, going: b.it.going, bx: b.it.bx, by: b.it.by, bz: b.it.bz } : null, modal: b.modal || null, cls: b.cls || null, ch: b.ch == null ? null : +b.ch.toFixed(3), th: b.th == null ? null : +b.th.toFixed(3) }; });
+    _report.state = _beats.length ? 'BEATS' : 'NOTHING'; _report.why = _beats.length ? null : 'no indoor beat placed';
+    log('§INDOOR_BEAT_PLAN beats=' + _beats.length + '/4 [' + _beats.map(function (b) { return b.key + '@' + b.sec.toFixed(2); }).join(' ') + '] taken=' + taken.length + ' windows');
+    return _report;
+  };
+
+  // ── per frame: hall tint opacity + persistence (§29.6); everything else is 2D
+  A.indoorBeatsAt = function (filmSec) {
+    var hb = _beats.filter(function (b) { return b.key === 'hall'; })[0]; if (!hb || !hb.hall.mesh) return null;
+    var h = hb.hall, dt = filmSec - hb.sec, cam = A.camera;
+    if (h.off) { h.mesh.visible = false; return { hall: 'off' }; }
+    if (dt < 0) { h.mesh.visible = false; return { hall: 'pending' }; }
+    var op = Math.min(1, dt / ENV.fadeIn);
+    // frame-out: the hall's bbox corners all off-frame, or the camera left the storey → removed for good
+    var T = window.THREE, cs = [[h.bbox.minx, h.bbox.miny], [h.bbox.maxx, h.bbox.miny], [h.bbox.maxx, h.bbox.maxy], [h.bbox.minx, h.bbox.maxy]], inF = 0;
+    cs.forEach(function (q) { var v = A.ifc2three(q[0], q[1], h.floorZ), p = new T.Vector3(v.x, v.y, v.z).project(cam); if (Math.abs(p.x) <= 1.2 && Math.abs(p.y) <= 1.2 && p.z < 1) inF++; });
+    var c = A.three2ifc(cam.position.x, cam.position.y, cam.position.z), onStorey = c.iz >= h.floorZ - 1.0 && c.iz < h.floorZ + 12;
+    if (dt > ENV.fadeIn && (!inF || !onStorey)) { h.off = true; h.offAt = filmSec; h.mesh.visible = false; console.log('§INDOOR_BEAT_HALL off filmSec=' + filmSec.toFixed(2) + ' reason=' + (!inF ? 'frame-out' : 'left the storey') + ' (§29.6: persisted ' + (filmSec - hb.sec).toFixed(1) + 's)'); return { hall: 'off' }; }
+    h.mesh.visible = true; h.mesh.material.opacity = 0.35 * op;
+    return { hall: 'on', op: op };
+  };
+
+  A.indoorBeatsCompositeOntoCanvas = function (ctx, w, h, filmSec) {
+    if (!_beats.length || !ctx || !A.camera || typeof A.flythruDrawDim !== 'function') return 0;
+    var cam = A.camera, k = h / 720, drawn = 0, T = window.THREE;
+    _beats.forEach(function (b) {
+      if (b.key === 'hall') {
+        var H0 = b.hall; if (H0.off || filmSec < b.sec) return;
+        var op = Math.min(1, (filmSec - b.sec) / ENV.fadeIn);
+        var pts = [[H0.centroid.ix, H0.centroid.iy], [H0.bbox.minx, H0.bbox.miny], [H0.bbox.maxx, H0.bbox.miny], [H0.bbox.maxx, H0.bbox.maxy], [H0.bbox.minx, H0.bbox.maxy]], q = null, best = Infinity;
+        pts.forEach(function (pt) { var v = A.ifc2three(pt[0], pt[1], H0.floorZ), qq = new T.Vector3(v.x, v.y, v.z).project(cam); if (qq.z >= 1) return; var d = Math.hypot(qq.x, qq.y); if (d < best) { best = d; q = qq; } });
+        if (!q) return;   // the whole hall is behind the camera this frame — the 3D tint still shows what is in front
+        ctx.save(); ctx.globalAlpha = op;
+        A.flythruDrawPanel(ctx, { x: Math.max(0, Math.min(w, (q.x + 1) / 2 * w)), y: Math.max(0, Math.min(h, (1 - q.y) / 2 * h)) }, ['Walkable area: ' + fmt(H0.area) + ' m²', H0.storey], 'Hall-Corridor', INK, k, w, h);
+        ctx.restore(); drawn++;
+        var key = 'hall|' + Math.floor(filmSec); if (!_lastLog[key]) { _lastLog[key] = 1; console.log('§INDOOR_BEAT_DRAW key=hall filmSec=' + filmSec.toFixed(2) + ' op=' + op.toFixed(2) + ' area=' + fmt(H0.area) + 'm2'); }
+        return;
+      }
+      var op2 = envAt(filmSec - b.sec); if (op2 <= 0) return;
+      var A2 = A.flythruProj(b.span.a, cam, w, h), B2 = A.flythruProj(b.span.b, cam, w, h);
+      if (A2.z >= 1 || B2.z >= 1) return;
+      ctx.save(); ctx.globalAlpha = op2;
+      var ok = A.flythruDrawDim(ctx, A2, B2, b.metres, INK, k, true);
+      if (b.span2) { var C2 = A.flythruProj(b.span2.a, cam, w, h), D2 = A.flythruProj(b.span2.b, cam, w, h); if (C2.z < 1 && D2.z < 1) A.flythruDrawDim(ctx, C2, D2, b.metres2, INK, k, true); }
+      if (ok) { drawn++; A.flythruDrawPanel(ctx, { x: (A2.x + B2.x) / 2, y: (A2.y + B2.y) / 2 }, [b.label].concat(b.sem ? [b.sem] : []), b.title, INK, k, w, h);
+        var key2 = b.key + '|' + Math.floor(filmSec * 2); if (!_lastLog[key2]) { _lastLog[key2] = 1; console.log('§INDOOR_BEAT_DRAW key=' + b.key + ' filmSec=' + filmSec.toFixed(2) + ' op=' + op2.toFixed(2) + ' ' + b.label); } }
+      ctx.restore();
+    });
+    return drawn;
+  };
+  A.indoorBeatsReport = function () { return _report; };
+  A.indoorBeatsDispose = function () { if (_grp && A.scene) { A.scene.remove(_grp); _grp.traverse(function (o) { if (o.geometry) o.geometry.dispose(); if (o.material) o.material.dispose(); }); } _grp = null; _built = false; _report = null; _beats = []; _hall = null; _lastLog = {}; };
+  log('§INDOOR_BEATS_INIT wired (hall walkable area bounded at doors · stair going · door type · clear height; 4 slots, rides Measure)');
+}
+if (typeof window !== 'undefined') window.setupCpeIndoorBeats = setupCpeIndoorBeats;

--- a/viewer/cpe_storey_reveal.js
+++ b/viewer/cpe_storey_reveal.js
@@ -107,9 +107,20 @@ function setupCpeStoreyReveal(A) {
       "JOIN spatial_structure bs ON bs.guid=sp.parent_guid AND bs.type='IfcBuildingStorey' " +
       "WHERE sp.type='IfcSpace' AND bs.name=?", [name]);
     if (r && r[0] != null) roomCount = +r[0];
-    var out = { doorCount: doorCount, bx: bx, by: by, roomCount: roomCount };
+    // §37.1 (MEP_CLASH_REVEAL_MOVIE.md W6) — the walkable area, from the same storey_walkable_raster §29's hall uses:
+    // mesh-derived, absent from the IFC, the figure a BIM audience leans in at. null when the storey has no raster.
+    var walk = null;
+    try {
+      var FM = window.FlythruMaths, SR = window.StoreyRaster;
+      if (FM && SR && typeof A.dbQuery === 'function') {
+        var wr = A.dbQuery('SELECT storey,res,x0,y0,cols,rows,bits FROM storey_walkable_raster WHERE storey=?', [name]) || [];
+        if (wr.length) walk = FM.ftRasterArea(SR.fromRow(wr[0]));
+      }
+    } catch (eW) { walk = null; }
+    var out = { doorCount: doorCount, bx: bx, by: by, roomCount: roomCount, walk: walk };
     _stats[name] = out;
     console.log('§STOREY_REVEAL_STATS storey="' + name + '" doors=' + doorCount +
+      ' walkable=' + (walk != null ? walk.toFixed(0) + 'm2 (storey_walkable_raster)' : 'n/a (no raster — clause omitted)') +
       ' footprint=' + (bx != null ? bx.toFixed(1) + 'x' + by.toFixed(1) + 'm(estimate,IfcSlab bbox)' : 'n/a') +
       ' rooms=' + roomCount + (roomCount === 0 ? ' (0 — VACUOUS, card omits the room clause)' : ' compiled'));
     return out;
@@ -200,6 +211,7 @@ function setupCpeStoreyReveal(A) {
     if (!vis) return null;
     var st = A.storeyRevealStatsFor(vis.storey);
     var subParts = [];
+    if (st.walk != null && st.walk > 0) subParts.push('walkable ' + Math.round(st.walk).toLocaleString('en-US') + ' m²');   // §37.1 — first, it is the figure the IFC lacks
     if (st.bx != null) subParts.push(st.bx.toFixed(1) + '×' + st.by.toFixed(1) + ' m footprint (estimate)');
     if (st.roomCount > 0) subParts.push(st.roomCount + ' room' + (st.roomCount === 1 ? '' : 's') + ' compiled');
     var card = { big: String(st.doorCount), label: 'doors · ' + vis.storey };

--- a/viewer/main.js
+++ b/viewer/main.js
@@ -13,7 +13,7 @@ async function initViewer() {
   if (typeof setupConfig === 'function') setupConfig(APP);
   if (typeof setupScene === 'function') await setupScene(APP);
   var _mods = [setupHelpers, setupStreaming, setupPanels, setupTools,
-    setupPicking, setupHoverName, setupCpeRoomTitle, setupCpeDayCounter, setupCpePathOverview, setupCpeResourcePanel, setupCpeStoreyReveal, setupCpeFlythruDims, setupCpeFlythruCues, setupCpeFlythruDatum, setupCpeSlabBeat, setupCpeLinearBeat, setupTour, setupMeasure, setupSitecam, setupShare, setupIssues, setupExcel, setupWalk, setupCity];
+    setupPicking, setupHoverName, setupCpeRoomTitle, setupCpeDayCounter, setupCpePathOverview, setupCpeResourcePanel, setupCpeStoreyReveal, setupCpeFlythruDims, setupCpeFlythruCues, setupCpeFlythruDatum, setupCpeSlabBeat, setupCpeLinearBeat, setupCpeIndoorBeats, setupTour, setupMeasure, setupSitecam, setupShare, setupIssues, setupExcel, setupWalk, setupCity];
   _mods.forEach(function(fn) { if (typeof fn === 'function') fn(APP); });
   // BIM_EMBED_WINDOW_SESSION §B2 — chromeless when ?embedded=true (reuses A.EMBEDDED, config.js) +
   // announce readiness to the host (iDempiere) so the embed panel can §-log it (W-BIM-EMBED).

--- a/viewer/sw.js
+++ b/viewer/sw.js
@@ -175,7 +175,8 @@
 // v1165 (2026-09-08) §36 W1/W3 (MEP_CLASH_REVEAL_MOVIE.md): datum sides/plane decided ONCE per life + drop ledger + §20.8 entry
 //   latch (cpe_flythru_datum.js); cue span sets locked per window (cpe_flythru_cues.js); §33 gate rebuilds the datum after Home.
 // v1166 (2026-09-08) §27 §LINEAR_BEAT: new viewer/cpe_linear_beat.js (column + beam dimension cues in the dive, rides Measure).
-const CACHE_VERSION = 'v1166';   // bump on each deploy; per-change detail is the git commit message.
+// v1167 (2026-09-08) §29 §INDOOR_BEATS: new viewer/cpe_indoor_beats.js (hall walkable area, stair going, door type, clear height; rides Measure).
+const CACHE_VERSION = 'v1167';   // bump on each deploy; per-change detail is the git commit message.
 // v1128 (2026-09-02) §SUN_FILL_RATIO: viewer/effects.js — the Alt+S staging HDRI
 // (belfast_sunset_puresky_1k) was being pushed onto EVERY material by _reassertPhotoEnvMap, matte
 // concrete and plaster included. IBL is non-directional and is NOT shadow-map-occluded in three.js,
@@ -626,7 +627,7 @@ const PRECACHE_ASSETS = [
   'hover_name.js',
   'cpe_room_title.js',
   'cpe_day_counter.js','cpe_path_overview.js','cpe_resource_panel.js','cpe_storey_reveal.js','cpe_flythru_dims.js',
-  'cpe_flythru_cues.js','cpe_flythru_datum.js','cpe_slab_beat.js','cpe_linear_beat.js','../common/flythru_maths.js','../common/storey_raster.js',
+  'cpe_flythru_cues.js','cpe_flythru_datum.js','cpe_slab_beat.js','cpe_linear_beat.js','cpe_indoor_beats.js','../common/flythru_maths.js','../common/storey_raster.js',
   'tour.js',
   'clash_matrix.js',
   'clash_narrow.js',

--- a/viewer/sw.js
+++ b/viewer/sw.js
@@ -176,7 +176,8 @@
 //   latch (cpe_flythru_datum.js); cue span sets locked per window (cpe_flythru_cues.js); §33 gate rebuilds the datum after Home.
 // v1166 (2026-09-08) §27 §LINEAR_BEAT: new viewer/cpe_linear_beat.js (column + beam dimension cues in the dive, rides Measure).
 // v1167 (2026-09-08) §29 §INDOOR_BEATS: new viewer/cpe_indoor_beats.js (hall walkable area, stair going, door type, clear height; rides Measure).
-const CACHE_VERSION = 'v1167';   // bump on each deploy; per-change detail is the git commit message.
+// v1168 (2026-09-08) §37 §MEASURE_TO_THE_END: storey-reveal cards carry walkable m² (cpe_storey_reveal.js); the datum's second life on the pull-out (cpe_flythru_datum.js).
+const CACHE_VERSION = 'v1168';   // bump on each deploy; per-change detail is the git commit message.
 // v1128 (2026-09-02) §SUN_FILL_RATIO: viewer/effects.js — the Alt+S staging HDRI
 // (belfast_sunset_puresky_1k) was being pushed onto EVERY material by _reassertPhotoEnvMap, matte
 // concrete and plaster included. IBL is non-directional and is NOT shadow-map-occluded in three.js,

--- a/viewer/tests/witness_datum_stability.js
+++ b/viewer/tests/witness_datum_stability.js
@@ -18,7 +18,7 @@ const puppeteer = require('/home/red1/bim-compiler/node_modules/puppeteer');
 const { Witness } = require('../../witness_kit/contract');
 const arg = (k, d) => { const i = process.argv.indexOf('--' + k); return i > 0 ? process.argv[i + 1] : d; };
 const ROOT = path.resolve(__dirname, '..', '..'), PORT = +arg('port', 8580), DB = arg('db', 'HHS_silent');
-const DUR = +arg('dur', 130.4), TO = +arg('to', 20), FPS = +arg('fps', 24);
+const DUR = +arg('dur', 130.4), TO = +arg('to', 20), FPS = +arg('fps', 24), LIFE2 = process.argv.includes('--life2');
 const MIME = { '.html': 'text/html', '.js': 'text/javascript', '.css': 'text/css', '.json': 'application/json', '.wasm': 'application/wasm', '.db': 'application/octet-stream', '.png': 'image/png', '.svg': 'image/svg+xml', '.hdr': 'application/octet-stream', '.gz': 'application/gzip', '.woff2': 'font/woff2' };
 const server = http.createServer((req, res) => { try { const u = decodeURIComponent(req.url.split('?')[0]); let fp = path.join(ROOT, u.replace(/^\/+/, ''));
   if (fs.existsSync(fp) && fs.statSync(fp).isDirectory()) fp = path.join(fp, 'index.html'); if (!fs.existsSync(fp)) { res.writeHead(404); res.end('404'); return; }
@@ -34,7 +34,7 @@ const server = http.createServer((req, res) => { try { const u = decodeURICompon
   await p.reload({ waitUntil: 'domcontentloaded', timeout: 120000 });
   await p.waitForFunction(() => window.APP && window.APP.cinemaPathPlan && window.APP.flythruDatumBuild && window.APP.flythruCuesBuild, { timeout: 300000 });
   await p.waitForFunction(() => window.APP.db && window.APP.activeBuilding, { timeout: 600000, polling: 1000 });
-  const out = await p.evaluate((dur, to, fps) => {
+  const out = await p.evaluate((dur, to, fps, life2) => {
     const A = window.APP, R = {};
     try {
       // the bake opens from the DB's saved view (main.js §SCENE_STATE_RESTORE); apply it here so the plan is the film's
@@ -48,14 +48,20 @@ const server = http.createServer((req, res) => { try { const u = decodeURICompon
       if (!atLoad.full) { document.body.focus(); document.dispatchEvent(new KeyboardEvent('keydown', { key: 'Home', bubbles: true })); A.flythruDatumDispose(); A.flythruDatumBuild(); R.gate.pressed = true; R.gate.home = judge(); }
       A.flythruDatumDispose(); A.flythruDatumBuild();          // fresh life for the run: first composite decides the sides
       const plan = A.cinemaPathPlan(dur); R.beats = plan.beats;
+      const srw = (plan.storeyReveal && plan.storeyReveal.on && plan.storeyReveal.windowFrac > 0) ? plan.storeyReveal.windowFrac : 0;
+      const l2from = (life2 && life2.from != null) ? life2.from : plan.beats.flyback * dur, l2to = (life2 && life2.to != null) ? life2.to : (plan.beats.rise - srw) * dur;
+      if (A.flythruDatumSetLife2) A.flythruDatumSetLife2(l2from, l2to);
+      R.life2 = { from: +l2from.toFixed(2), to: +l2to.toFixed(2), beatsSec: { out: +(plan.beats.out * dur).toFixed(2), pullout: +(plan.beats.pullout * dur).toFixed(2), flyback: +(plan.beats.flyback * dur).toFixed(2), round2: +(plan.beats.round2 * dur).toFixed(2), reveal: plan.beats.reveal == null ? null : +(plan.beats.reveal * dur).toFixed(2), rise: +(plan.beats.rise * dur).toFixed(2) } };
       let cues = []; try { cues = A.flythruCuesBuild(plan, dur) || []; } catch (e) { R.cuesErr = e.message; }
       R.cues = cues.map(c => ({ key: c.key, at: +c.at.toFixed(2) }));
       R.holdTo = Math.max(6, dur * 0.094) + 2;
       try { const g = A.ifc2three(0, 0, A.groundIfcZ != null ? A.groundIfcZ : 0); R.groundY = g.y; } catch (e) { R.groundY = 0; }
       R.frames = [];
-      const N = Math.round(to * fps);
+      const t0 = life2 ? Math.max(0, R.life2.from - 2) : 0, tEnd = life2 ? R.life2.to + 2 : to;
+      R.outsideSecs = [];   // where the camera is outside the building box, sampled each second (the measurement the window rests on)
+      const N = Math.round((tEnd - t0) * fps);
       for (let i = 0; i <= N; i++) {
-        const sec = i / fps, u = Math.min(1, sec / dur), pz = plan.poseAt(u);
+        const sec = t0 + i / fps, u = Math.min(1, sec / dur), pz = plan.poseAt(u);
         A.camera.position.set(pz.x, pz.y, pz.z); A.camera.lookAt(pz.tx, pz.ty, pz.tz); A.camera.updateMatrixWorld(true);
         const op = A.flythruDatumAt(sec, dur);
         ctx.clearRect(0, 0, 1280, 720);
@@ -63,17 +69,43 @@ const server = http.createServer((req, res) => { try { const u = decodeURICompon
         try { A.flythruCuesApplyVisual(sec); } catch (e) {}
         let cm = 0; try { cm = A.flythruCuesCompositeOntoCanvas(ctx, 1280, 720, sec); } catch (e) {}
         const C = A._flythruCuesLast && Math.abs((A._flythruCuesLast.filmSec || -1) - sec) < 1e-6 ? A._flythruCuesLast : null;
-        R.frames.push({ i, sec: +sec.toFixed(3), drawn: n, dDrawn: L.dDrawn, sidesChanged: !!L.sidesChanged, sidesNow: L.sidesNowKey, sidesKey: L.sidesKey, bubbles: L.bubbles, op: +op.toFixed(3),
+        R.frames.push({ i, sec: +sec.toFixed(3), drawn: n, dDrawn: L.dDrawn, sidesChanged: !!L.sidesChanged, sidesNow: L.sidesNowKey, sidesKey: L.sidesKey, bubbles: L.bubbles, op: +op.toFixed(3), life: L.life || 1,
                         entered: !!(L.enteredAt != null), enteredAt: L.enteredAt == null ? null : +L.enteredAt.toFixed(3),
                         cueLocked: C ? C.lockedAxes.join('') : null, belowGround: A.camera.position.y < (R.groundY != null ? R.groundY : 0),
-                        behind: L.behind ? L.behind.bubbles.join('/') : null, camY: +A.camera.position.y.toFixed(2),
+                        behind: L.behind ? L.behind.bubbles.join('/') : null, behindTot: L.behind ? L.behind.bubbles.reduce((a2, b2) => a2 + b2, 0) + L.behind.figures.reduce((a2, b2) => a2 + b2, 0) : null, camY: +A.camera.position.y.toFixed(2),
                         cueKey: C ? C.key : null, cueAxes: C ? C.axes.join('') : null, cueMarks: cm, cuePanel: C ? C.panelOnly : null });
       }
     } catch (e) { R.err = e.message + ' @ ' + (e.stack || '').split('\n')[1]; }
     return R;
-  }, DUR, TO, FPS);
+  }, DUR, TO, FPS, LIFE2 ? { from: arg('from', null) ? +arg('from') : null, to: arg('to2', null) ? +arg('to2') : null } : null);
   await b.close(); server.close();
   if (out.err) { console.log('§WITNESS_DATUM_STABILITY INCONCLUSIVE — page threw: ' + out.err); process.exit(1); }
+  if (LIFE2) {
+    const F2 = out.frames, L2 = out.life2, span = L2.to - L2.from;
+    console.log('§WITNESS_DATUM_STABILITY_LIFE2 db=' + DB + ' window=' + JSON.stringify(L2) + ' span=' + span.toFixed(2) + 's frames=' + F2.length);
+    const onFrames = F2.filter(f => f.drawn > 0); console.log('§WITNESS_DATUM_STABILITY_LIFE2_ON drawnFrames=' + onFrames.length + (onFrames.length ? ' from ' + onFrames[0].sec + 's to ' + onFrames[onFrames.length - 1].sec + 's' : '') + ' — frames the camera was OUTSIDE the building box and the sheet drew');
+    if (span <= 3.0) { console.log('§WITNESS_DATUM_STABILITY_LIFE2 VACUOUS — the search window is empty on this path; nothing to judge, as the module says'); process.exit(0); }
+    const start = (F2.find(f => f.life === 2 && f.drawn > 0) || {}).sec, hold = Math.max(6, DUR * 0.094), end = start == null ? null : Math.min(L2.to, start + hold + 2.0);
+    if (start == null) { console.log('§WITNESS_DATUM_STABILITY_LIFE2 VACUOUS — the camera is never outside the building inside the search window (' + L2.from + '-' + L2.to + ' s); the module printed no start'); process.exit(0); }
+    const inside = F2.filter(f => start != null && f.sec >= start + 1.0 && f.sec <= end - 2.0), before = F2.filter(f => f.sec < L2.from), after = F2.filter(f => end != null && f.sec > end + 0.1);
+    console.log('§WITNESS_DATUM_STABILITY_LIFE2_PLAN start=' + start + ' hold=' + hold.toFixed(1) + ' end=' + end + ' (search ' + L2.from + '-' + L2.to + ')');
+    for (let s2 = Math.floor(L2.from) - 1; s2 <= Math.ceil(L2.to) + 1; s2 += 3) { const f = F2.find(x => Math.abs(x.sec - s2) < 0.5 / FPS) || F2[0]; console.log(`§WITNESS_DATUM_STABILITY_T sec=${s2} drawn=${f.drawn} life=${f.life} camY=${f.camY} below=${f.belowGround}`); }
+    const unpaid = inside.filter((r, i) => i > 0 && r.dDrawn > 0 && !(inside[i - 1].behindTot != null && (inside[i - 1].behindTot - r.behindTot) >= r.dDrawn - 3));
+    console.log('§WITNESS_DATUM_STABILITY_LIFE2_SUMMARY start=' + start + ' insideFrames=' + inside.length + ' minDrawnInside=' + (inside.length ? Math.min(...inside.map(f => f.drawn)) : 'n/a') + ' rises=' + inside.filter(f => f.dDrawn > 0).length + ' unpaidRises=' + unpaid.length + (unpaid.length ? ' at=[' + unpaid.slice(0, 5).map(f => f.sec + ':+' + f.dDrawn).join(',') + ']' : '') + ' decisions=' + new Set(inside.map(f => f.sidesKey)).size + ' beforeMaxDrawn=' + Math.max(0, ...before.map(f => f.drawn)) + ' afterMaxDrawn=' + Math.max(0, ...after.map(f => f.drawn)));
+    Witness('datum_life2')
+      .population(() => inside)
+      .schema({ type: 'object', required: ['sec', 'drawn', 'life'], properties: { sec: { type: 'number' }, drawn: { type: 'integer', minimum: 0 }, life: { type: 'integer' } } })
+      .invariant('the second life started inside its window and is life=2 on every judged frame', rs => start != null && start >= L2.from - 1e-6 && rs.every(r => r.life === 2))
+      .invariant('drawn > 0 on every frame from ramp-in to fade-out (the sheet is up over the finished building)', rs => rs.every(r => r.drawn > 0))
+      // an ORBITING camera legitimately brings marks back in front of it; what must never happen is a rise the behind-camera
+      // ledger does not pay for (that would be a decision change). Overalls are not in the ledger, hence the slack of 3.
+      .invariant('every rise in drawn is paid for by a fall in the behind-camera ledger (re-entry, not re-decision)', rs => rs.every((r, i) => i === 0 || r.dDrawn == null || r.dDrawn <= 0 || (rs[i - 1].behindTot != null && r.behindTot != null && (rs[i - 1].behindTot - r.behindTot) >= r.dDrawn - 3)))
+      .invariant('one side decision for the whole second life', rs => new Set(rs.map(r => r.sidesKey)).size === 1)
+      .invariant('nothing drawn before the window opens or after it closes', () => before.every(f => f.drawn === 0) && after.every(f => f.drawn === 0))
+      .redControl(rs => { const c = rs.map(r => Object.assign({}, r)); if (c[3]) c[3].drawn = 0; return c; })
+      .run();
+    process.exit(0);
+  }
   // judged = inside the hold, before the camera enters the envelope (§20.8 — the drawing fades on entry and is not judged after)
   const F = out.frames, entryAt = (F.find(f => f.entered) || {}).enteredAt, holdEnd = out.holdTo - 1.5 / FPS;
   const aliveAll = F.filter(f => f.sec < holdEnd), under = aliveAll.filter(f => f.belowGround), alive = aliveAll.filter(f => !f.belowGround && (entryAt == null || f.sec < entryAt));

--- a/viewer/tests/witness_indoor_beats.js
+++ b/viewer/tests/witness_indoor_beats.js
@@ -1,0 +1,82 @@
+#!/usr/bin/env node
+// WITNESS — indoor_beats: §29 §INDOOR_BEATS in the real page on the real stored path (datum, cues, slab and linear beats
+// built first, as the bake does), Time Machine primed the bake's way.
+// Spec: bim-compiler prompts/MEP_CLASH_REVEAL_MOVIE.md §29 + §29.8.
+//
+// ISSUE THIS PROVES OR DISPROVES: inside the dive→out window the module places at most FOUR beats (§29.1), each in a slot
+// free of every other layer (§14 across layers); the hall's area is the door-bounded component the camera stands in
+// (0 < area <= the storey's walkable area, door cells blocked > 0, the start cell is walkable and within 2 m of the
+// camera); the stair cue is the GOING of the placed instance and never a bay restatement; the door cue is the modal leaf
+// and the placed instance belongs to it; the clear height is below the ceiling and restates no storey height; every
+// 2D beat composites inside its envelope and not outside; the hall persists (§29.6) then switches off with a reason;
+// samples with the camera below its floor are counted (§29.7 item 3). It can say NO: INCONCLUSIVE / VACUOUS / NOTHING.
+// Command: node viewer/tests/witness_indoor_beats.js --db Hospital_silent_local --dur 195.79 [--port 8600]
+'use strict';
+const path = require('path'), fs = require('fs'), http = require('http');
+const puppeteer = require('/home/red1/bim-compiler/node_modules/puppeteer');
+const { Witness } = require('../../witness_kit/contract');
+const arg = (k, d) => { const i = process.argv.indexOf('--' + k); return i > 0 ? process.argv[i + 1] : d; };
+const ROOT = path.resolve(__dirname, '..', '..'), PORT = +arg('port', 8600), DB = arg('db', 'Hospital_silent_local'), DUR = +arg('dur', 195.79);
+const MIME = { '.html': 'text/html', '.js': 'text/javascript', '.css': 'text/css', '.json': 'application/json', '.wasm': 'application/wasm', '.db': 'application/octet-stream', '.png': 'image/png', '.svg': 'image/svg+xml', '.hdr': 'application/octet-stream', '.gz': 'application/gzip', '.woff2': 'font/woff2' };
+const server = http.createServer((req, res) => { try { const u = decodeURIComponent(req.url.split('?')[0]); let fp = path.join(ROOT, u.replace(/^\/+/, ''));
+  if (fs.existsSync(fp) && fs.statSync(fp).isDirectory()) fp = path.join(fp, 'index.html'); if (!fs.existsSync(fp)) { res.writeHead(404); res.end('404'); return; }
+  res.writeHead(200, { 'Content-Type': MIME[path.extname(fp).toLowerCase()] || 'application/octet-stream', 'Cache-Control': 'no-store' }); fs.createReadStream(fp).pipe(res); } catch (e) { res.writeHead(500); res.end(String(e)); } });
+(async () => {
+  await new Promise(r => server.listen(PORT, '127.0.0.1', r));
+  const b = await puppeteer.launch({ headless: 'new', protocolTimeout: 1800000, args: ['--no-sandbox', '--enable-unsafe-swiftshader', '--use-gl=angle', '--use-angle=swiftshader', '--disable-dev-shm-usage', '--js-flags=--max-old-space-size=3072'] });
+  const p = await b.newPage(); await p.setViewport({ width: 1280, height: 720 });
+  p.on('console', m => { const t = m.text(); if (/§INDOOR_BEAT|PAGEERROR|§LOAD_FAIL/.test(t)) console.log('  ' + t.slice(0, 280)); });
+  p.on('pageerror', e => console.log('  PAGEERROR ' + e.message));
+  await p.goto(`http://127.0.0.1:${PORT}/viewer/viewer.html?db=/buildings/${DB}.db`, { waitUntil: 'domcontentloaded', timeout: 120000 });
+  await p.evaluate(async () => { try { if (navigator.serviceWorker) for (const r of await navigator.serviceWorker.getRegistrations()) await r.unregister(); if (window.caches) for (const k of await caches.keys()) await caches.delete(k); } catch (e) {} });
+  await p.reload({ waitUntil: 'domcontentloaded', timeout: 120000 });
+  await p.waitForFunction(() => window.APP && window.APP.cinemaPathPlan && window.APP.indoorBeatsBuild, { timeout: 300000 });
+  await p.waitForFunction(() => window.APP.db && window.APP.activeBuilding, { timeout: 600000, polling: 1000 });
+  const prime = await p.evaluate(async () => { if (typeof window.tmActivateForBake !== 'function') return 'no-hook'; let ok = await window.tmActivateForBake(); if (!ok) ok = await window.tmActivateForBake(); return ok ? 'ok' : 'FAILED'; });
+  console.log('§WITNESS_INDOOR_BEATS_TM_PRIME ' + prime);
+  const out = await p.evaluate((dur) => {
+    const A = window.APP, R = {};
+    try {
+      try { const ss = A.dbQuery('SELECT cam_ifc_x,cam_ifc_y,cam_ifc_z,tgt_ifc_x,tgt_ifc_y,tgt_ifc_z FROM scene_state LIMIT 1'); if (ss && ss.length && ss[0][0] != null) { const c = A.ifc2three(ss[0][0], ss[0][1], ss[0][2]), t = A.ifc2three(ss[0][3], ss[0][4], ss[0][5]); A.camera.position.set(c.x, c.y, c.z); if (A.controls) { A.controls.target.set(t.x, t.y, t.z); A.controls.update(); } A.camera.lookAt(t.x, t.y, t.z); } } catch (e) {}
+      const cv = document.createElement('canvas'); cv.width = 1280; cv.height = 720; const ctx = cv.getContext('2d');
+      A.flythruDatumBuild();
+      const judge = () => { A.camera.updateMatrixWorld(true); A.camera.updateProjectionMatrix(); A.flythruDatumCompositeOntoCanvas(ctx, 1280, 720, 0, dur); const L = A._flythruDatumLast || {}; return L.bubbles === L.bubblesTotal && L.overalls === 3; };
+      if (!judge()) { document.body.focus(); document.dispatchEvent(new KeyboardEvent('keydown', { key: 'Home', bubbles: true })); A.flythruDatumDispose(); A.flythruDatumBuild(); R.homed = true; }
+      const bk = window.tmFollowTimeline(); const plan = A.cinemaPathPlan(dur);
+      try { A.flythruCuesBuild(plan, dur); } catch (e) {}
+      A.slabBeatBuild(plan, dur, bk, dur); A.linearBeatBuild(plan, dur, bk, dur);
+      R.rep = A.indoorBeatsBuild(plan, dur, bk);
+      R.frames = [];
+      const drive = (sec) => { const pz = plan.poseAt(Math.min(1, sec / dur)); A.camera.position.set(pz.x, pz.y, pz.z); A.camera.lookAt(pz.tx, pz.ty, pz.tz); A.camera.updateMatrixWorld(true); A.camera.updateProjectionMatrix(); };
+      const frame = (bt, dt) => { const sec = bt.sec + dt; drive(sec); const st = A.indoorBeatsAt(sec); ctx.clearRect(0, 0, 1280, 720); const n = A.indoorBeatsCompositeOntoCanvas(ctx, 1280, 720, sec); R.frames.push({ key: bt.key, dt, sec: +sec.toFixed(3), marks: n, hall: st && st.hall }); };
+      // 1. the hall's own frames (camera on the hall path, nothing latches it off), 2. its persistence to window end
+      //    at 1 s steps (when/why it switches off, §29.6), 3. the other beats' frames (they may legitimately frame the hall out)
+      const hb0 = (R.rep.beats || []).find(x => x.key === 'hall');
+      if (hb0) { [-0.1, 0.3, 1.0].forEach(dt => frame(hb0, dt));
+        for (let sec = hb0.sec; sec <= R.rep.window.to + 1; sec += 1) { drive(sec); const st = A.indoorBeatsAt(sec); if (st && st.hall === 'off') { R.hallOffAt = +sec.toFixed(2); break; } } }
+      (R.rep.beats || []).filter(x => x.key !== 'hall').forEach(bt => { [-0.1, 0.3, 1.0, 2.1, 2.6].forEach(dt => frame(bt, dt)); });
+    } catch (e) { R.err = e.message + ' @ ' + (e.stack || '').split('\n')[1]; }
+    return R;
+  }, DUR);
+  await b.close(); server.close();
+  if (out.err) { console.log('§WITNESS_INDOOR_BEATS INCONCLUSIVE — page threw: ' + out.err); process.exit(1); }
+  const rep = out.rep || {}; const beats = rep.beats || []; const F = out.frames || [];
+  console.log('§WITNESS_INDOOR_BEATS_RUN db=' + DB + ' dur=' + DUR + ' homed=' + !!out.homed + ' state=' + rep.state + ' window=' + JSON.stringify(rep.window) + ' samples=' + rep.samples + ' belowFloor=' + rep.belowFloor + ' beats=' + JSON.stringify(beats.map(x => x.key + '@' + x.sec + (x.label ? ' ' + x.label : ''))) + ' hallOffAt=' + (out.hallOffAt == null ? 'never (to window end)' : out.hallOffAt + 's'));
+  F.forEach(f => console.log('§WITNESS_INDOOR_BEATS_FRAME key=' + f.key + ' dt=' + f.dt + ' sec=' + f.sec + ' marks=' + f.marks + (f.hall ? ' hall=' + f.hall : '')));
+  if (rep.state === 'INCONCLUSIVE') { console.log('§WITNESS_INDOOR_BEATS INCONCLUSIVE — ' + rep.why); process.exit(1); }
+  if (!beats.length) { console.log('§WITNESS_INDOOR_BEATS NOTHING — ' + JSON.stringify(rep.rejected)); process.exit(0); }
+  const own = (rep.taken || []).filter(w => ['hall', 'stair', 'door', 'height'].includes(w.who));
+  Witness('indoor_beats')
+    .population(() => beats.map(b0 => Object.assign({}, b0)))
+    .schema({ type: 'object', required: ['key', 'sec'], properties: { key: { enum: ['hall', 'stair', 'door', 'height'] }, sec: { type: 'number', minimum: 0 } } })
+    .invariant('at most four beats, one per capability (§29.1)', rs => rs.length <= 4 && new Set(rs.map(r => r.key)).size === rs.length)
+    .invariant('every beat inside the dive→out window', rs => rs.every(r => r.sec >= rep.window.from - 0.02 && r.sec <= rep.window.to + 0.02))
+    .invariant('no beat slot overlaps any other layer\'s window (§14 across layers)', () => own.every(a => (rep.taken || []).every(b2 => a === b2 || a.to <= b2.from + 1e-9 || a.from >= b2.to - 1e-9)))
+    .invariant('hall: 0 < area <= storey walkable, door cells blocked > 0, start cell within 2 m, camera above its floor', rs => rs.filter(r => r.key === 'hall').every(r => r.hall.area > 0 && r.hall.area <= r.hall.storeyWalkable + 1e-6 && r.hall.doorCellsBlocked > 0 && r.hall.camAbove > -1.0 && r.hall.quads > 0))
+    .invariant('stair: label = going of the placed instance (long horizontal bbox side), never the rise', rs => rs.filter(r => r.key === 'stair').every(r => r.label === 'going ' + Math.round(Math.max(r.it.bx, r.it.by) * 1000).toLocaleString('en-US') + ' mm' && Math.abs(r.metres - Math.max(r.it.bx, r.it.by)) < 1e-3))
+    .invariant('door: label = the modal leaf and the placed instance belongs to it (10 mm buckets)', rs => rs.filter(r => r.key === 'door').every(r => r.label === r.modal.w.toLocaleString('en-US') + ' × ' + r.modal.h.toLocaleString('en-US') + ' mm' && Math.round(Math.max(r.it.bx, r.it.by) * 100) * 10 === r.modal.w && Math.round(r.it.bz * 100) * 10 === r.modal.h))
+    .invariant('clear height: below the ceiling (or no ceiling found) and never within 2 % of a storey height', rs => rs.filter(r => r.key === 'height').every(r => (r.th == null || r.ch < r.th - 0.05) && r.ch > 1.0))
+    .invariant('2D beats composite inside their envelope and not outside; the hall composites from its second on', () => beats.every(bt => { const f = {}; F.filter(x => x.key === bt.key).forEach(x => f[x.dt] = x.marks); return bt.key === 'hall' ? (f[-0.1] === 0 && f[0.3] > 0) : (f[-0.1] === 0 && f[0.3] > 0 && f[1.0] > 0 && f[2.1] > 0 && f[2.6] === 0); }))
+    .redControl(rs => { const c = rs.map(r => Object.assign({}, r)); const h = c.find(r => r.key === 'hall'); if (h) h.hall = Object.assign({}, h.hall, { area: h.hall.storeyWalkable + 100 }); else if (c[0]) c[0].sec = -1; return c; })
+    .run();
+})().catch(e => { console.error('WITNESS FAILED ' + e.message); try { server.close(); } catch (e2) {} process.exit(1); });

--- a/viewer/tests/witness_storey_walkable_card.js
+++ b/viewer/tests/witness_storey_walkable_card.js
@@ -1,0 +1,58 @@
+#!/usr/bin/env node
+// WITNESS — storey_walkable_card: §37.1 — every storey-reveal card carries the storey's WALKABLE area and the figure is the
+// raster's own. Spec: bim-compiler prompts/MEP_CLASH_REVEAL_MOVIE.md §37.1.
+// ISSUE THIS PROVES OR DISPROVES: A.storeyRevealStatsFor(storey).walk === ftRasterArea(storey_walkable_raster row) for every
+// rastered storey; a storey without a raster reports null and the card omits the clause (never 0); the card text produced by
+// A.storeyRevealStatCardAt inside the reveal window contains "walkable N m²". Red control: a walk value shifted.
+// Command: node viewer/tests/witness_storey_walkable_card.js --db Hospital_silent_local --dur 195.79 [--port 8610]
+'use strict';
+const path = require('path'), fs = require('fs'), http = require('http');
+const puppeteer = require('/home/red1/bim-compiler/node_modules/puppeteer');
+const { Witness } = require('../../witness_kit/contract');
+const arg = (k, d) => { const i = process.argv.indexOf('--' + k); return i > 0 ? process.argv[i + 1] : d; };
+const ROOT = path.resolve(__dirname, '..', '..'), PORT = +arg('port', 8610), DB = arg('db', 'Hospital_silent_local'), DUR = +arg('dur', 195.79);
+const MIME = { '.html': 'text/html', '.js': 'text/javascript', '.css': 'text/css', '.json': 'application/json', '.wasm': 'application/wasm', '.db': 'application/octet-stream', '.png': 'image/png', '.svg': 'image/svg+xml', '.hdr': 'application/octet-stream', '.gz': 'application/gzip', '.woff2': 'font/woff2' };
+const server = http.createServer((req, res) => { try { const u = decodeURIComponent(req.url.split('?')[0]); let fp = path.join(ROOT, u.replace(/^\/+/, ''));
+  if (fs.existsSync(fp) && fs.statSync(fp).isDirectory()) fp = path.join(fp, 'index.html'); if (!fs.existsSync(fp)) { res.writeHead(404); res.end('404'); return; }
+  res.writeHead(200, { 'Content-Type': MIME[path.extname(fp).toLowerCase()] || 'application/octet-stream', 'Cache-Control': 'no-store' }); fs.createReadStream(fp).pipe(res); } catch (e) { res.writeHead(500); res.end(String(e)); } });
+(async () => {
+  await new Promise(r => server.listen(PORT, '127.0.0.1', r));
+  const b = await puppeteer.launch({ headless: 'new', protocolTimeout: 1800000, args: ['--no-sandbox', '--enable-unsafe-swiftshader', '--use-gl=angle', '--use-angle=swiftshader', '--disable-dev-shm-usage'] });
+  const p = await b.newPage(); await p.setViewport({ width: 1280, height: 720 });
+  p.on('console', m => { const t = m.text(); if (/§STOREY_REVEAL_STATS|PAGEERROR|§LOAD_FAIL/.test(t)) console.log('  ' + t.slice(0, 220)); });
+  p.on('pageerror', e => console.log('  PAGEERROR ' + e.message));
+  await p.goto(`http://127.0.0.1:${PORT}/viewer/viewer.html?db=/buildings/${DB}.db`, { waitUntil: 'domcontentloaded', timeout: 120000 });
+  await p.evaluate(async () => { try { if (navigator.serviceWorker) for (const r of await navigator.serviceWorker.getRegistrations()) await r.unregister(); if (window.caches) for (const k of await caches.keys()) await caches.delete(k); } catch (e) {} });
+  await p.reload({ waitUntil: 'domcontentloaded', timeout: 120000 });
+  await p.waitForFunction(() => window.APP && window.APP.cinemaPathPlan && window.APP.storeyRevealStatsFor, { timeout: 300000 });
+  await p.waitForFunction(() => window.APP.db && window.APP.activeBuilding, { timeout: 600000, polling: 1000 });
+  const out = await p.evaluate((dur) => {
+    const A = window.APP, R = { rows: [] };
+    try {
+      const FM = window.FlythruMaths, SR = window.StoreyRaster;
+      const wr = A.dbQuery('SELECT storey,res,x0,y0,cols,rows,bits FROM storey_walkable_raster') || [];
+      wr.forEach(r => { const area = FM.ftRasterArea(SR.fromRow(r)); const st = A.storeyRevealStatsFor(r[0]); R.rows.push({ storey: r[0], rasterArea: +area.toFixed(2), walk: st.walk == null ? null : +st.walk.toFixed(2) }); });
+      const lv = A.dbQuery("SELECT DISTINCT name FROM spatial_structure WHERE type='IfcBuildingStorey'") || [];
+      lv.forEach(v => { if (!R.rows.find(x => x.storey === v[0])) { const st = A.storeyRevealStatsFor(v[0]); R.rows.push({ storey: v[0], rasterArea: null, walk: st.walk == null ? null : +st.walk.toFixed(2) }); } });
+      // the bake plans with the STORED override (flags included); the storey reveal is gated on plan.storeyReveal.on
+      try { A.cinemaPathPlan(60); } catch (e) {}
+      const ov0 = (A._getCinemaPathEdit && A._getCinemaPathEdit()) || null;
+      const plan = A.cinemaPathPlan(dur, ov0 ? Object.assign({}, ov0, { storeyReveal: true }) : undefined); R.cards = []; R.planHasReveal = !!(plan && plan.storeyReveal && plan.storeyReveal.on);
+      if (A.storeyRevealStatCardAt && plan && plan.beats) { for (let u = plan.beats.rise - 0.026; u < plan.beats.rise; u += 0.003) { const c = A.storeyRevealStatCardAt(plan, u); if (c && c.card) R.cards.push({ u: +u.toFixed(4), label: c.card.label, sub: c.card.sub || '' }); } }
+    } catch (e) { R.err = e.message + ' @ ' + (e.stack || '').split('\n')[1]; }
+    return R;
+  }, DUR);
+  await b.close(); server.close();
+  if (out.err) { console.log('§WITNESS_STOREY_WALKABLE_CARD INCONCLUSIVE — ' + out.err); process.exit(1); }
+  console.log('§WITNESS_STOREY_WALKABLE_CARD db=' + DB + ' planHasReveal=' + out.planHasReveal + ' cards=' + (out.cards || []).length + ' rows=' + JSON.stringify(out.rows) );
+  (out.cards || []).forEach(c => console.log('§WITNESS_STOREY_WALKABLE_CARD_TEXT u=' + c.u + ' ' + c.label + ' | ' + c.sub));
+  const cardsFor = {}; (out.cards || []).forEach(c => { const st = c.label.replace(/^doors · /, ''); cardsFor[st] = c.sub; });
+  Witness('storey_walkable_card')
+    .population(() => out.rows)
+    .schema({ type: 'object', required: ['storey'], properties: { storey: { type: 'string' }, rasterArea: { type: ['number', 'null'] }, walk: { type: ['number', 'null'] } } })
+    .invariant('walk equals the raster\'s own area for every rastered storey', rs => rs.filter(r => r.rasterArea != null).every(r => r.walk != null && Math.abs(r.walk - r.rasterArea) < 0.01))
+    .invariant('a storey without a raster reports null, never 0', rs => rs.filter(r => r.rasterArea == null).every(r => r.walk == null))
+    .invariant('every card shown in the reveal window carries "walkable N m²" for a rastered storey', () => Object.keys(cardsFor).length > 0 && Object.keys(cardsFor).every(st => { const row = out.rows.find(r => r.storey === st); return !row || row.rasterArea == null ? !/walkable/.test(cardsFor[st]) : new RegExp('walkable ' + Math.round(row.rasterArea).toLocaleString('en-US') + ' m²').test(cardsFor[st]); }))
+    .redControl(rs => { const c = rs.map(r => Object.assign({}, r)); const q = c.find(r => r.rasterArea != null); if (q) q.walk = q.walk + 1; return c; })
+    .run();
+})().catch(e => { console.error('WITNESS FAILED ' + e.message); try { server.close(); } catch (e2) {} process.exit(1); });

--- a/viewer/viewer.html
+++ b/viewer/viewer.html
@@ -874,6 +874,7 @@ html.bim-embedded, html.bim-embedded body { background: #0b0b0b; }
 <script src="cpe_flythru_datum.js?v=1" onerror="console.warn('§LOAD_FAIL cpe_flythru_datum.js — opening datum grid disabled')"></script>
 <script src="cpe_slab_beat.js?v=1" onerror="console.warn('§LOAD_FAIL cpe_slab_beat.js — slab beat (floor plate marked as laid) disabled')"></script>
 <script src="cpe_linear_beat.js?v=1" onerror="console.warn('§LOAD_FAIL cpe_linear_beat.js — linear beat (column/beam cues) disabled')"></script>
+<script src="cpe_indoor_beats.js?v=1" onerror="console.warn('§LOAD_FAIL cpe_indoor_beats.js — indoor beats (hall/stair/door/clear height) disabled')"></script>
 <script src="tour.js?v=17" onerror="console.warn('§LOAD_FAIL tour.js')"></script>
 <script src="clash_report.js?v=1" onerror="console.warn('§LOAD_FAIL clash_report.js')"></script>
 <script src="clash_snag.js?v=1" onerror="console.warn('§LOAD_FAIL clash_snag.js')"></script>


### PR DESCRIPTION
Continues #1697 (bim-compiler `prompts/MEP_CLASH_REVEAL_MOVIE.md` §36 W5–W6).

- **§29 indoor beats** (`cpe_indoor_beats.js`): hall walkable area bounded at door thresholds (flood fill on `storey_walkable_raster` with IfcDoor cells blocked), stair going (run ≤ 3× rise, never the rise), modal door leaf with one placed instance, clear height from a DB column cast over overhead classes — four slots, §14 across every layer, scored by legibility held over the envelope.
- **§37** storey-reveal cards carry `walkable N m²`; the datum gets a second life over the finished building at the first exterior frame after flyback (Hospital 148.6–169.0 s, HHS 89.7–100.1 s).
- **Datum fix:** local storey elevations are now anchored to each storey's own slab (Hospital 165.81 m), not the lowest element (a footing, 156.61 m) — the storey rules were 9.2 m low. One building box (column-grid plan below the top storey rule) for the §20.8 entry latch and the second life.
- sw.js v1166 → v1168.

**Witnesses (all green, both buildings):** `witness_indoor_beats.js` 11/11, `witness_storey_walkable_card.js` 6/6, `witness_datum_stability.js` 8/8 (opening) and 8/8 (`--life2`), `witness_linear_beat.js` 12/12, `witness_slab_beat.js` 17/17. Bakes remain user-gated (W7).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013wim7eALoRtdHijYAfXJhn