### PR TITLE
REST bridge to external legacy ERP (iDempiere first) — critical POC

### DIFF
--- a/tests/mock_adinterface_server.js
+++ b/tests/mock_adinterface_server.js
@@ -1,0 +1,141 @@
+/**
+ * BIM OOTB — Frictionless BIM. Two DBs. One browser. Zero install.
+ * Copyright (c) 2025-2026 Redhuan D. Oon <red1org@gmail.com>
+ * SPDX-License-Identifier: MIT
+ */
+// mock_adinterface_server.js — a faithful stand-in for iDempiere's ADInterface REST webservices,
+// used ONLY because no real iDempiere is reachable from this dev machine (private-LAN target,
+// prompts/BIM_OOTB_LEGACY_IDEMPIERE_INTEGRATION.md §3 "Testing without a reachable real server").
+// Implements exactly the contract read from real source (org.idempiere.webservices,
+// ModelADServiceImpl.java + idempiere-schema.xsd) — including the field-whitelist rejection
+// (scanFields "input column X not allowed") so that failure path is exercised too, not just the
+// happy path. This is NOT a real iDempiere — it proves the CLIENT's request/response handling and
+// sequencing, not that a real server will accept it.
+'use strict';
+var http = require('http');
+
+// Per-table column whitelist — stands in for a real WS_WebServiceType + WS_WebServiceFieldInput
+// registration (§5 cheatsheet #2). Mirrors exactly the columns erp_rest_push.js writes.
+var WHITELIST = {
+  C_Project: ['Value', 'Name'],
+  C_ProjectPhase: ['C_Project_ID', 'Name', 'SeqNo', 'StartDate', 'EndDate'],
+  C_ProjectTask: ['C_ProjectPhase_ID', 'Name'],
+  M_Product_Category: ['Name'],
+  M_Product: ['Value', 'Name', 'M_Product_Category_ID'],
+  C_ProjectLine: ['C_ProjectPhase_ID', 'C_Project_ID', 'M_Product_ID', 'PlannedQty', 'PlannedPrice', 'PlannedAmt']
+};
+
+function createMockServer(opts) {
+  opts = opts || {};
+  var db = {}; // tableName -> array of row objects
+  var nextId = {};
+  var log = []; // every call, for the POC's own assertions
+
+  function table(name) { return db[name] || (db[name] = []); }
+  function allocId(name) { nextId[name] = (nextId[name] || 1000) + 1; return nextId[name]; }
+
+  function readBody(req, cb) {
+    var chunks = [];
+    req.on('data', function (c) { chunks.push(c); });
+    req.on('end', function () { cb(Buffer.concat(chunks).toString('utf8')); });
+  }
+  function tagAll(xml, name) {
+    var re = new RegExp('<' + name + '\\b([^>]*)>([\\s\\S]*?)</' + name + '>', 'g');
+    var out = [], m;
+    while ((m = re.exec(xml))) out.push({ attrs: m[1], body: m[2] });
+    return out;
+  }
+  function tag(xml, name) {
+    var m = xml.match(new RegExp('<' + name + '[^>]*>([\\s\\S]*?)</' + name + '>'));
+    return m ? m[1] : null;
+  }
+  function parseFields(dataRowXml) {
+    if (!dataRowXml) return [];
+    return tagAll(dataRowXml, 'field').map(function (f) {
+      var col = (f.attrs.match(/column="([^"]*)"/) || [])[1];
+      var val = tag(f.body, 'val');
+      return { column: col, val: val };
+    });
+  }
+  // Only what erp_rest_push.js actually sends: single/AND-ed "Col='val'" or "Col=NNN" clauses.
+  function matchFilter(row, filter) {
+    if (!filter) return true;
+    return filter.split(/\s+AND\s+/i).every(function (clause) {
+      var m = clause.match(/^\s*([\w_]+)\s*=\s*'?([^']*)'?\s*$/);
+      if (!m) return false;
+      return String(row[m[1]]) === String(m[2]);
+    });
+  }
+
+  function xmlResponse(res, status, body) {
+    res.writeHead(status, { 'Content-Type': 'application/xml' });
+    res.end(body);
+  }
+  function standardResponse(res, isError, recordId, error) {
+    xmlResponse(res, 200,
+      '<StandardResponseDocument><StandardResponse IsError="' + (isError ? 'true' : 'false') + '"' +
+      (recordId != null ? ' RecordID="' + recordId + '"' : '') + '>' +
+      (error ? '<Error>' + error + '</Error>' : '') +
+      '</StandardResponse></StandardResponseDocument>');
+  }
+  function windowTabData(res, rows, error) {
+    var dataRows = rows.map(function (r) {
+      return '<DataRow>' + Object.keys(r).map(function (k) {
+        return '<field column="' + k + '"><val>' + r[k] + '</val></field>';
+      }).join('') + '</DataRow>';
+    }).join('');
+    xmlResponse(res, 200,
+      '<WindowTabDataDocument><WindowTabData>' +
+      (error ? ('<Error>' + error + '</Error>') : ('<DataSet>' + dataRows + '</DataSet>' +
+        '<RowCount>' + rows.length + '</RowCount><Success>true</Success>')) +
+      '</WindowTabData></WindowTabDataDocument>');
+  }
+
+  var server = http.createServer(function (req, res) {
+    if (req.method !== 'POST') { res.writeHead(404); return res.end(); }
+    readBody(req, function (body) {
+      var m = req.url.match(/\/model_adservice\/(\w+)/);
+      var op = m ? m[1] : null;
+      var tableName = tag(body, 'TableName');
+      var filter = tag(body, 'Filter');
+      var action = tag(body, 'Action');
+      var loginOk = /<ADLoginRequest>/.test(body) && tag(body, 'user');
+      log.push({ op: op, tableName: tableName, filter: filter, action: action });
+      console.log('§MOCK_ADINTERFACE op=' + op + ' table=' + tableName + ' action=' + action + (filter ? ' filter=' + filter : ''));
+
+      if (!loginOk) return standardResponse(res, true, null, 'No login credentials');
+
+      if (op === 'query_data') {
+        var rows = table(tableName).filter(function (r) { return matchFilter(r, filter); });
+        return windowTabData(res, rows);
+      }
+      if (op === 'create_data') {
+        var fields = parseFields(tag(body, 'DataRow'));
+        var allowed = WHITELIST[tableName] || [];
+        for (var i = 0; i < fields.length; i++) {
+          if (allowed.indexOf(fields[i].column) === -1) {
+            console.log('§MOCK_ADINTERFACE_REJECT table=' + tableName + ' column=' + fields[i].column);
+            return standardResponse(res, true, null,
+              'Web service type BIMOOTB: input column ' + fields[i].column + ' not allowed');
+          }
+        }
+        var row = {}; fields.forEach(function (f) { row[f.column] = f.val; });
+        var id = allocId(tableName);
+        row[tableName + '_ID'] = id;
+        table(tableName).push(row);
+        return standardResponse(res, false, id, null);
+      }
+      return standardResponse(res, true, null, 'Unknown op ' + op);
+    });
+  });
+
+  return {
+    listen: function (port, cb) { server.listen(port, cb); },
+    close: function (cb) { server.close(cb); },
+    address: function () { return server.address(); },
+    db: db,
+    callLog: log
+  };
+}
+
+module.exports = { createMockServer: createMockServer };

--- a/tests/poc_erp_rest_push.js
+++ b/tests/poc_erp_rest_push.js
@@ -1,0 +1,104 @@
+/**
+ * BIM OOTB — Frictionless BIM. Two DBs. One browser. Zero install.
+ * Copyright (c) 2025-2026 Redhuan D. Oon <red1org@gmail.com>
+ * SPDX-License-Identifier: MIT
+ */
+// poc_erp_rest_push.js — the critical POC for prompts/BIM_OOTB_LEGACY_IDEMPIERE_INTEGRATION.md §3.
+// PROVES: the REST client (viewer/erp_rest_push.js) issues the right sequence of calls, the right
+// XML shapes, and is idempotent on a 2nd push — against a mock server that speaks the SAME wire
+// contract real iDempiere does (verified from source, see mock_adinterface_server.js header).
+// DOES NOT prove a real iDempiere accepts it — no real instance is reachable from this machine.
+// Read the log after this run — §-tagged lines are the evidence, exit code alone is not.
+'use strict';
+var ErpRestPush = require('../viewer/erp_rest_push.js');
+var Mock = require('./mock_adinterface_server.js');
+
+var PLAN = {
+  building: 'Hospital_Demo',
+  phases: [
+    {
+      name: 'Substructure', seqno: 1, startDate: '2026-01-01', endDate: '2026-01-15',
+      tasks: [{ name: 'Concrete Crew' }],
+      lines: [
+        { productValue: 'IFCWALL-CONC', productName: 'Concrete Wall', categoryName: 'Structure', qty: 40, price: 120, plannedAmt: 4800 },
+        { productValue: 'IFCSLAB-CONC', productName: 'Concrete Slab', categoryName: 'Structure', qty: 10, price: 300, plannedAmt: 3000 }
+      ]
+    },
+    {
+      name: 'Superstructure', seqno: 2, startDate: '2026-01-16', endDate: '2026-02-10',
+      tasks: [{ name: 'Framing Crew' }],
+      lines: [
+        { productValue: 'IFCCOLUMN-STEEL', productName: 'Steel Column', categoryName: 'Structure', qty: 20, price: 500, plannedAmt: 10000 }
+      ]
+    }
+  ]
+};
+
+function countCalls(log, op) { return log.filter(function (l) { return l.op === op; }).length; }
+function countCreates(created) { return created.categories + created.products + created.projects + created.phases + created.tasks + created.lines; }
+
+var mock = Mock.createMockServer();
+mock.listen(0, function () {
+  var port = mock.address().port;
+  var cfg = { baseUrl: 'http://127.0.0.1:' + port, login: { user: 'SuperUser', pass: 'System', clientId: 11, roleId: 102, orgId: 11, warehouseId: 0 } };
+  var failures = [];
+
+  console.log('§POC_ERP_REST_PUSH_START port=' + port);
+
+  ErpRestPush.pushProjectOrder(cfg, PLAN)
+    .then(function (run1) {
+      // ── Assertion 1: 1st run creates exactly the expected rows ──
+      // 1 project + 2 phases + 2 tasks + 1 category (Structure, shared) + 3 products + 3 lines = 12
+      var expected1 = { projects: 1, phases: 2, tasks: 2, categories: 1, products: 3, lines: 3 };
+      Object.keys(expected1).forEach(function (k) {
+        if (run1.created[k] !== expected1[k])
+          failures.push('run1.created.' + k + '=' + run1.created[k] + ' expected ' + expected1[k]);
+      });
+      console.log('§POC_RUN1 created=' + JSON.stringify(run1.created) + ' expected=' + JSON.stringify(expected1) +
+        (failures.length ? ' MISMATCH' : ' OK'));
+
+      var callsAfterRun1 = mock.callLog.length;
+
+      return ErpRestPush.pushProjectOrder(cfg, PLAN).then(function (run2) {
+        // ── Assertion 2: idempotent — 2nd run creates +0 new rows, but still queries every row ──
+        var total2 = countCreates(run2.created);
+        if (total2 !== 0) failures.push('run2 created ' + total2 + ' rows, expected 0 (idempotency broken)');
+        console.log('§POC_RUN2 created=' + JSON.stringify(run2.created) + (total2 === 0 ? ' OK (+0, idempotent)' : ' MISMATCH'));
+
+        var queryCalls2 = mock.callLog.slice(callsAfterRun1).filter(function (l) { return l.op === 'query_data'; }).length;
+        var createCalls2 = mock.callLog.slice(callsAfterRun1).filter(function (l) { return l.op === 'create_data'; }).length;
+        if (createCalls2 !== 0) failures.push('run2 issued ' + createCalls2 + ' create_data calls, expected 0');
+        console.log('§POC_RUN2_CALLS query=' + queryCalls2 + ' create=' + createCalls2 + (createCalls2 === 0 ? ' OK' : ' MISMATCH'));
+
+        // ── Assertion 3: the field-whitelist rejection path is real (§5 finding) ──
+        return ErpRestPush.pushProjectOrder(cfg, {
+          building: 'Hospital_Demo',
+          phases: [{ name: 'Substructure', seqno: 1, startDate: '2026-01-01', endDate: '2026-01-15', tasks: [], lines: [] }]
+        }).then(function () {
+          // that call is all-whitelisted fields, won't trigger rejection — test rejection directly:
+          var badXml = ErpRestPush.buildCrudXml(cfg.login, {
+            serviceType: 'BIMOOTB_Project', tableName: 'C_Project', action: 'Create',
+            fields: [{ column: 'Value', val: 'X' }, { column: 'NotOnWhitelist', val: 'Y' }]
+          });
+          return fetch(cfg.baseUrl + '/ADInterface/services/rest/model_adservice/create_data', {
+            method: 'POST', headers: { 'Content-Type': 'application/xml' }, body: badXml
+          }).then(function (res) { return res.text(); }).then(function (text) {
+            var resp = ErpRestPush.parseStandardResponse(text);
+            var rejected = resp.isError && /not allowed/.test(resp.error || '');
+            if (!rejected) failures.push('field-whitelist rejection NOT triggered as expected: ' + JSON.stringify(resp));
+            console.log('§POC_WHITELIST_REJECT isError=' + resp.isError + ' error="' + resp.error + '"' + (rejected ? ' OK' : ' MISMATCH'));
+          });
+        });
+      });
+    })
+    .then(function () {
+      mock.close(function () {
+        console.log('§POC_ERP_REST_PUSH_VERDICT ' + (failures.length ? ('FAIL (' + failures.length + '): ' + failures.join(' | ')) : 'PASS'));
+        process.exit(failures.length ? 1 : 0);
+      });
+    })
+    .catch(function (e) {
+      console.log('§POC_ERP_REST_PUSH_ERROR ' + (e && e.stack || e));
+      mock.close(function () { process.exit(1); });
+    });
+});

--- a/viewer/erp_rest_push.js
+++ b/viewer/erp_rest_push.js
@@ -1,0 +1,204 @@
+/**
+ * BIM OOTB — Frictionless BIM. Two DBs. One browser. Zero install.
+ * Copyright (c) 2025-2026 Redhuan D. Oon <red1org@gmail.com>
+ * SPDX-License-Identifier: MIT
+ */
+// erp_rest_push.js — push a Project Order into a REAL, EXTERNAL legacy iDempiere over its stock
+// ADInterface REST webservices (org.idempiere.webservices — no plugin needed on the target server).
+// prompts/BIM_OOTB_LEGACY_IDEMPIERE_INTEGRATION.md §3 — the locked write footprint:
+//   creates  M_Product / M_Product_Category (find-or-create) → C_Project → C_ProjectPhase →
+//            C_ProjectTask → C_ProjectLine.
+//   NEVER creates C_BPartner, C_Order/PO, or any GL/Fact_Acct row.
+// Wire contract verified against real source (~/idempiere-dev-setup, org.idempiere.webservices):
+//   ModelADService.java (JAX-RS paths) + WEB-INF/xsd/idempiere-schema.xsd (ModelCRUDRequest/
+//   ADLoginRequest/DataRow/StandardResponse/WindowTabData shapes) — nothing here is guessed.
+// Auth is STATELESS per call: ADLoginRequest{user,pass,lang,ClientID,RoleID,OrgID,WarehouseID,stage}
+// rides inside every request body; there is no separate login/session step at this layer.
+// Every column written must be pre-registered in a WS_WebServiceType field whitelist on the target
+// instance (§5 cheatsheet) — ModelADServiceImpl.scanFields throws "input column X not allowed"
+// otherwise. This module does not (cannot) fix that — it is a target-instance config step.
+// Uses XML request/response bodies, not JSON — the endpoint accepts both, but the JSON form is an
+// unverified XMLBeans auto-conversion; XML is unambiguous straight from the XSD.
+// Dual export: node (require → tests/poc_erp_rest_push.js) + browser (window.ErpRestPush).
+
+(function (global) {
+  'use strict';
+
+  var _fetch = (typeof fetch !== 'undefined') ? fetch : null;
+
+  function esc(s) {
+    return String(s == null ? '' : s)
+      .replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;')
+      .replace(/"/g, '&quot;');
+  }
+
+  // ── §XML — build one ModelCRUDRequest body, per idempiere-schema.xsd ──────────────────────────
+  function buildCrudXml(login, crud) {
+    var fields = (crud.fields || []).map(function (f) {
+      return '<field column="' + esc(f.column) + '"><val>' + esc(f.val) + '</val></field>';
+    }).join('');
+    var dataRow = fields ? ('<DataRow>' + fields + '</DataRow>') : '';
+    return '<?xml version="1.0" encoding="UTF-8"?>' +
+      '<ModelCRUDRequest xmlns="http://idempiere.org/ADInterface/1_0">' +
+      '<ModelCRUD>' +
+      '<serviceType>' + esc(crud.serviceType) + '</serviceType>' +
+      '<TableName>' + esc(crud.tableName) + '</TableName>' +
+      '<RecordID>' + (crud.recordId || 0) + '</RecordID>' +
+      (crud.filter ? ('<Filter>' + esc(crud.filter) + '</Filter>') : '') +
+      '<Action>' + esc(crud.action) + '</Action>' +
+      dataRow +
+      '</ModelCRUD>' +
+      '<ADLoginRequest>' +
+      '<user>' + esc(login.user) + '</user>' +
+      '<pass>' + esc(login.pass) + '</pass>' +
+      '<lang>' + esc(login.lang || 'en_US') + '</lang>' +
+      '<ClientID>' + (login.clientId || 0) + '</ClientID>' +
+      '<RoleID>' + (login.roleId || 0) + '</RoleID>' +
+      '<OrgID>' + (login.orgId || 0) + '</OrgID>' +
+      '<WarehouseID>' + (login.warehouseId || 0) + '</WarehouseID>' +
+      '<stage>' + (login.stage || 0) + '</stage>' +
+      '</ADLoginRequest>' +
+      '</ModelCRUDRequest>';
+  }
+
+  // ── §XML-PARSE — minimal, tolerant extraction (no external XML lib assumed) ───────────────────
+  function tag(xml, name) {
+    var m = xml.match(new RegExp('<' + name + '[^>]*>([\\s\\S]*?)</' + name + '>'));
+    return m ? m[1] : null;
+  }
+  function attr(xml, tagName, attrName) {
+    var m = xml.match(new RegExp('<' + tagName + '\\b[^>]*\\b' + attrName + '="([^"]*)"'));
+    return m ? m[1] : null;
+  }
+  function parseStandardResponse(xml) {
+    var isErrorAttr = attr(xml, 'StandardResponse', 'IsError');
+    var recordIdAttr = attr(xml, 'StandardResponse', 'RecordID');
+    return {
+      isError: isErrorAttr === 'true',
+      recordId: recordIdAttr != null ? parseInt(recordIdAttr, 10) : null,
+      error: tag(xml, 'Error')
+    };
+  }
+  function parseWindowTabData(xml) {
+    var rows = [];
+    var rowRe = /<DataRow>([\s\S]*?)<\/DataRow>/g, rm;
+    while ((rm = rowRe.exec(xml))) {
+      var row = {};
+      var fieldRe = /<field\b([^>]*)>([\s\S]*?)<\/field>/g, fm;
+      while ((fm = fieldRe.exec(rm[1]))) {
+        var col = (fm[1].match(/column="([^"]*)"/) || [])[1];
+        var val = tag(fm[2], 'val');
+        if (col != null) row[col] = val;
+      }
+      rows.push(row);
+    }
+    return { rows: rows, rowCount: parseInt(tag(xml, 'RowCount') || '0', 10), success: tag(xml, 'Success') === 'true', error: tag(xml, 'Error') };
+  }
+
+  // ── §CALL — one HTTP round-trip; logs §ERP_REST every call (Log Mandate) ──────────────────────
+  function call(baseUrl, path, login, crud) {
+    if (!_fetch) return Promise.reject(new Error('no fetch available'));
+    var url = baseUrl.replace(/\/$/, '') + '/ADInterface/services/rest/model_adservice/' + path;
+    var body = buildCrudXml(login, crud);
+    console.log('§ERP_REST_CALL path=' + path + ' table=' + crud.tableName + ' action=' + crud.action + (crud.filter ? ' filter=' + crud.filter : ''));
+    return _fetch(url, { method: 'POST', headers: { 'Content-Type': 'application/xml', 'Accept': 'application/xml' }, body: body })
+      .then(function (res) { return res.text().then(function (text) { return { status: res.status, text: text }; }); })
+      .then(function (r) {
+        console.log('§ERP_REST_RESP path=' + path + ' status=' + r.status + ' len=' + r.text.length);
+        return r;
+      });
+  }
+
+  // ── §FIND-OR-CREATE — query_data by natural-key Filter, create_data if RowCount=0 ──────────────
+  function findOrCreate(baseUrl, login, serviceType, tableName, filter, fields) {
+    return call(baseUrl, 'query_data', login, { serviceType: serviceType, tableName: tableName, action: 'Read', filter: filter })
+      .then(function (r) {
+        var parsed = parseWindowTabData(r.text);
+        if (parsed.error) throw new Error('§ERP_REST_QUERY_ERR ' + tableName + ': ' + parsed.error);
+        var idCol = tableName + '_ID';
+        if (parsed.rowCount > 0 && parsed.rows[0][idCol]) {
+          console.log('§ERP_REST_FOUND table=' + tableName + ' id=' + parsed.rows[0][idCol] + ' (+0)');
+          return { id: parseInt(parsed.rows[0][idCol], 10), created: false };
+        }
+        return call(baseUrl, 'create_data', login, { serviceType: serviceType, tableName: tableName, action: 'Create', fields: fields })
+          .then(function (r2) {
+            var resp = parseStandardResponse(r2.text);
+            if (resp.isError) throw new Error('§ERP_REST_CREATE_ERR ' + tableName + ': ' + resp.error);
+            console.log('§ERP_REST_CREATED table=' + tableName + ' id=' + resp.recordId);
+            return { id: resp.recordId, created: true };
+          });
+      });
+  }
+
+  // ── §PUSH — the locked write footprint, in order ──────────────────────────────────────────────
+  // plan = { building, phases: [ { name, seqno, startDate, endDate, plannedAmt,
+  //            tasks: [ { name } ],
+  //            lines: [ { productValue, productName, categoryName, qty, price, plannedAmt } ] } ] }
+  function pushProjectOrder(cfg, plan) {
+    var baseUrl = cfg.baseUrl, login = cfg.login;
+    var svc = cfg.serviceTypes || {}; // per-table WS_WebServiceType.Value (§5 #2 registration)
+    var created = { categories: 0, products: 0, projects: 0, phases: 0, tasks: 0, lines: 0 };
+
+    return findOrCreate(baseUrl, login, svc.C_Project || 'BIMOOTB_Project', 'C_Project',
+      "Value='" + plan.building + "'",
+      [{ column: 'Value', val: plan.building }, { column: 'Name', val: 'BIM: ' + plan.building }])
+      .then(function (proj) {
+        if (proj.created) created.projects++;
+        var phaseChain = Promise.resolve();
+        (plan.phases || []).forEach(function (ph) {
+          phaseChain = phaseChain.then(function () {
+            return findOrCreate(baseUrl, login, svc.C_ProjectPhase || 'BIMOOTB_ProjectPhase', 'C_ProjectPhase',
+              "C_Project_ID=" + proj.id + " AND Name='" + ph.name + "'",
+              [{ column: 'C_Project_ID', val: proj.id }, { column: 'Name', val: ph.name },
+               { column: 'SeqNo', val: ph.seqno }, { column: 'StartDate', val: ph.startDate }, { column: 'EndDate', val: ph.endDate }])
+              .then(function (phase) {
+                if (phase.created) created.phases++;
+                var taskChain = Promise.resolve();
+                (ph.tasks || []).forEach(function (t) {
+                  taskChain = taskChain.then(function () {
+                    return findOrCreate(baseUrl, login, svc.C_ProjectTask || 'BIMOOTB_ProjectTask', 'C_ProjectTask',
+                      "C_ProjectPhase_ID=" + phase.id + " AND Name='" + t.name + "'",
+                      [{ column: 'C_ProjectPhase_ID', val: phase.id }, { column: 'Name', val: t.name }])
+                      .then(function (task) { if (task.created) created.tasks++; });
+                  });
+                });
+                var lineChain = taskChain;
+                (ph.lines || []).forEach(function (ln) {
+                  lineChain = lineChain.then(function () {
+                    return findOrCreate(baseUrl, login, svc.M_Product_Category || 'BIMOOTB_ProductCategory', 'M_Product_Category',
+                      "Name='" + ln.categoryName + "'",
+                      [{ column: 'Name', val: ln.categoryName }])
+                      .then(function (cat) {
+                        if (cat.created) created.categories++;
+                        return findOrCreate(baseUrl, login, svc.M_Product || 'BIMOOTB_Product', 'M_Product',
+                          "Value='" + ln.productValue + "'",
+                          [{ column: 'Value', val: ln.productValue }, { column: 'Name', val: ln.productName },
+                           { column: 'M_Product_Category_ID', val: cat.id }]);
+                      })
+                      .then(function (prod) {
+                        if (prod.created) created.products++;
+                        return findOrCreate(baseUrl, login, svc.C_ProjectLine || 'BIMOOTB_ProjectLine', 'C_ProjectLine',
+                          "C_ProjectPhase_ID=" + phase.id + " AND M_Product_ID=" + prod.id,
+                          [{ column: 'C_ProjectPhase_ID', val: phase.id }, { column: 'C_Project_ID', val: proj.id },
+                           { column: 'M_Product_ID', val: prod.id }, { column: 'PlannedQty', val: ln.qty },
+                           { column: 'PlannedPrice', val: ln.price }, { column: 'PlannedAmt', val: ln.plannedAmt }]);
+                      })
+                      .then(function (line) { if (line.created) created.lines++; });
+                  });
+                });
+                return lineChain;
+              });
+          });
+        });
+        return phaseChain.then(function () {
+          console.log('§ERP_REST_PUSH_DONE building="' + plan.building + '" projectId=' + proj.id +
+            ' created=' + JSON.stringify(created));
+          return { projectId: proj.id, created: created };
+        });
+      });
+  }
+
+  var API = { pushProjectOrder: pushProjectOrder, buildCrudXml: buildCrudXml, parseStandardResponse: parseStandardResponse, parseWindowTabData: parseWindowTabData };
+  if (typeof module !== 'undefined' && module.exports) module.exports = API;
+  else global.ErpRestPush = API;
+})(typeof self !== 'undefined' ? self : this);


### PR DESCRIPTION
## Summary
- Adds `viewer/erp_rest_push.js` — a REST client that pushes a Project Order (Product/Category find-or-create → Project → Phase → Task → Line) into a REAL, EXTERNAL, legacy classic iDempiere over its stock `ADInterface` webservices. No plugin install needed on the target server; wire contract (endpoints, XML shapes, stateless per-call auth) verified against real `org.idempiere.webservices` source, not guessed.
- Write footprint is intentionally locked (see `prompts/BIM_OOTB_LEGACY_IDEMPIERE_INTEGRATION.md` §3): never creates a BPartner, Order/PO, or GL posting.
- Intended as the first slice of a general external-ERP adapter — iDempiere is the first target since its REST contract ships out of the box; the same shape (find-or-create + Project/Phase/Task/Line plan → HTTP push) should generalize to other ERPs later.
- Adds `tests/mock_adinterface_server.js` + `tests/poc_erp_rest_push.js` — a mock server matching the same wire contract, since no real iDempiere is reachable from dev. POC asserts: correct create sequence, idempotent 2nd run (+0 rows), and the field-whitelist rejection path (`WS_WebServiceType` — an unregistered column throws `"input column X not allowed"`, confirmed from real `ModelADServiceImpl.scanFields` source) fires correctly.

## Test plan
- [x] `node tests/poc_erp_rest_push.js` — PASS (log: correct 1 Project/2 Phase/2 Task/1 Category/3 Product/3 Line create sequence, 2nd run 0 creates, whitelist-rejection error text matches real iDempiere's)
- [ ] Not yet run against a real iDempiere instance (none reachable from this dev environment) — the mock proves the client, not server acceptance
- [ ] Target instance still needs: `WS_WebServiceType` + field whitelist registered per table (see `prompts/BIM_OOTB_LEGACY_IDEMPIERE_INTEGRATION.md` §5), and the auth credential/base-URL wiring on the Settings side (not yet built)

🤖 Generated with [Claude Code](https://claude.com/claude-code)