### PR TITLE
feat(modeller): §DAGEVU relationship-edge engine — openings anchor by default under grid stretch, ride is opt-in

### DIFF
--- a/modeller/bonsai_gridmove.js
+++ b/modeller/bonsai_gridmove.js
@@ -30,9 +30,38 @@
     // OUT of the current drag (green). Seeded empty every session (modeller.html enterGridMove/exitGridMove
     // call resetOverrides()) — NOT persisted, NOT a per-user config (that's explicitly deferred).
     _overrides: new Set(),
-    resetOverrides() { this._overrides = new Set(); console.log(TAG + ' §GREEN-EXCLUDE reset (new drag session, all orange)'); },
+    // §DAGEVU (prompts/SPEC_DAGEVU_ENGINE.md §4): per-session RIDE opt-in set for hosted openings. ANCHOR (the
+    // opening keeps its world position while its host's length changes) is the DEFAULT; a filling in this set
+    // rides proportionally instead (the pre-§DAGEVU behaviour). Same lifecycle as _overrides (reset per session).
+    _rideFids: new Set(), _dagevuCache: null,
+    resetOverrides() { this._overrides = new Set(); this._rideFids = new Set(); this._dagevuCache = null; console.log(TAG + ' §GREEN-EXCLUDE reset (new drag session, all orange) §DAGEVU all openings anchor'); },
+    // The DAGeVu relationship-edge engine over the REAL rel_fills_host + abuts rows through the §ARC-1 bridge.
+    // Cached per drag session (§SCALE_CHECK_FIX invariant — never rebuilt per pointermove frame); invalidated on
+    // a ride toggle; build-and-discard outside a session. null when the engine or the bridge is not loaded — the
+    // caller then falls back to the pre-§DAGEVU stretchRide path byte-identically.
+    _dagevu() {
+      if (this._dagevuCache) return this._dagevuCache;
+      const DE = window.DagevuEngine && window.DagevuEngine.DagevuEngine;
+      if (!DE || !window.SdgCascade || !window.__arcGuidByFid || !window.__arcFidByGuid || !window.swXEdges || !window.swXEdges.fills) return null;
+      const eng = new DE({ guidByFid: window.__arcGuidByFid, fidByGuid: window.__arcFidByGuid, fills: window.swXEdges.fills,
+        abuts: window.swXEdges.abuts || [], cascade: window.SdgCascade, gate: window.SdgGate, rideFids: Array.from(this._rideFids) });
+      if (this._engine) this._dagevuCache = eng;              // inside a drag session → cache alongside the attach-map engine
+      return eng;
+    },
+    isFilling(fid) { const e = this._dagevu(); return !!(e && e.isFilling(fid)); },
+    rideList() { return Array.from(this._rideFids); },
     // toggleOverride(fid) → true if now EXCLUDED (green), false if now back to included (orange). Bidirectional.
+    // §DAGEVU: a hosted OPENING (a real rel_fills_host filling) is never directly governed — for it the SAME
+    // ctrl+click toggles anchor(held, green) ↔ ride(moves, blue) instead: returns true when now HELD (anchor),
+    // false when now RIDING. One interaction, two meanings, decided by what was clicked (spec §1 reuse row 5).
     toggleOverride(fid) {
+      if (this.isFilling(fid)) {
+        const wasRide = this._rideFids.has(fid);
+        if (wasRide) this._rideFids.delete(fid); else this._rideFids.add(fid);
+        this._dagevuCache = null;
+        console.log(TAG + ' §DAGEVU toggle opening fid=' + fid + ' -> ' + (wasRide ? 'anchor(held)' : 'ride(opt-in)'));
+        return wasRide;
+      }
       const wasExcluded = this._overrides.has(fid);
       if (wasExcluded) this._overrides.delete(fid); else this._overrides.add(fid);
       console.log(TAG + ' §GREEN-EXCLUDE toggle fid=' + fid + ' -> ' + (wasExcluded ? 'orange(included)' : 'green(excluded)'));
@@ -189,7 +218,7 @@
     // scene, so a scene edit between drags is never served a stale attach map.
     endDragSession() {
       if (this._engine) console.log(TAG + ' §SCALE_CHECK_FIX drag-session end — caches cleared');
-      this._engine = null; this._meshCache = null; this._boxCache = null; this._insertMapsCache = null;
+      this._engine = null; this._meshCache = null; this._boxCache = null; this._insertMapsCache = null; this._dagevuCache = null;
       this._dragAxis = null; this._dragOrthoAt = null;
     },
     // PURE recompose: use the cached attached engine if a drag session is active, else build-and-discard
@@ -238,8 +267,21 @@
     // commit can never disagree.
     previewCommands(gridId, delta) {
       let commands = this.computeCommands(gridId, delta);
-      let riders = [];
-      // §STRETCH-RIDE: a hosted opening must NOT divorce or scale when its host wall is grid-stretched — the
+      let riders = [], held = [], refusals = [], proposals = [], dimLabel = '';
+      // §DAGEVU (SPEC_DAGEVU_ENGINE.md §4): the relationship-edge engine replaces the direct stretchRide call.
+      // ANCHOR default — a hosted opening keeps its world position while its host's LENGTH changes (SCALE ⇒ zero
+      // induced delta; TRANSLATE still carries it rigidly); RIDE is the per-opening ctrl+click opt-in; an
+      // opening the dictated end would cross is REFUSED (reported here, blocks commit() below). The ride math
+      // itself is still sdg_cascade.stretchRide, called by the engine — one implementation.
+      const dagevu = this._dagevu();
+      if (dagevu) {
+        const out = dagevu.propagateCommands(commands, this._boxByFid());
+        commands = out.commands; riders = out.riders; held = out.held; refusals = out.refusals; proposals = out.proposals; dimLabel = out.dimLabel;
+        const applied = this.applyOverrides(commands, riders);
+        return { commands: applied.commands, riders: applied.riders, excluded: applied.excluded, held, refusals, proposals, dimLabel };
+      }
+      // §STRETCH-RIDE (pre-§DAGEVU path, kept byte-identical for a LOAD_FAIL of dagevu_engine.js or an absent bridge):
+      // a hosted opening must NOT divorce or scale when its host wall is grid-stretched — the
       // engine classifies EVERY authored mesh independently (doors/windows included), so strip any rider's OWN
       // command and induce ONE rigid move instead, resolved ONLY over the REAL rel_fills_host edges through the
       // §ARC-1 bridge (non-invent — never a proximity heuristic). Absent the bridge (no fills data for this
@@ -252,7 +294,7 @@
         commands = ride.commands; riders = ride.riders;
       }
       const applied = this.applyOverrides(commands, riders);
-      return { commands: applied.commands, riders: applied.riders, excluded: applied.excluded };
+      return { commands: applied.commands, riders: applied.riders, excluded: applied.excluded, held, refusals, proposals, dimLabel };
     },
 
     // Commit ONE signed GEOM_GRID_MOVE per drag-release; the worker folds the recompose deterministically.
@@ -260,6 +302,19 @@
     async commit(gridId, delta) {
       const preview = this.previewCommands(gridId, delta);
       let commands = preview.commands, riders = preview.riders;
+      // §DAGEVU: an honest refusal is a hard stop, never a fabricated resolution — nothing is committed. The thrown
+      // message lands in modeller.html's existing catch → status 'FAIL …' with the drag still armed, so the user
+      // can shorten the drag or ctrl+click the opening to let it ride.
+      if (preview.refusals && preview.refusals.length) {
+        const r = preview.refusals[0];
+        const msg = '§DAGEVU refused: opening #' + r.fillingFid + ' would leave wall #' + r.hostFid + ' on ' + r.axis +
+          ' (wall ' + r.hostAfter[0].toFixed(2) + '..' + r.hostAfter[1].toFixed(2) + ' vs opening ' + r.filling[0].toFixed(2) + '..' + r.filling[1].toFixed(2) +
+          ') — drag less, or ctrl+click the opening to let it ride' + (preview.refusals.length > 1 ? ' [+' + (preview.refusals.length - 1) + ' more]' : '');
+        console.warn(TAG + ' ' + msg);
+        throw new Error(msg);
+      }
+      if (preview.held && preview.held.length) console.log(TAG + ' §DAGEVU anchor held=' + preview.held.length + ' opening(s) in place: ' + preview.held.join(','));
+      if (preview.proposals && preview.proposals.length) console.log(TAG + ' §DAGEVU abuts-realign proposed (report-only, not applied): ' + JSON.stringify(preview.proposals));
       if (preview.excluded.length) console.log(TAG + ' §GREEN-EXCLUDE commit skipped=' + preview.excluded.length + ' fid(s) (green, did not move): ' + preview.excluded.join(','));
       if (riders.length) console.log(TAG + ' §STRETCH-RIDE stripped=' + riders.length + ' rider cmd(s) → induced move instead: ' + riders.map(r => r.featureId).join(','));
       // §P8 (RESUME_MODELLER_POLISH_BATCH.md — Witness: W-GESTURE-UNDO): with riders, the stretch + its

--- a/modeller/dagevu_engine.js
+++ b/modeller/dagevu_engine.js
@@ -1,0 +1,190 @@
+// dagevu_engine.js — §DAGEVU (prompts/SPEC_DAGEVU_ENGINE.md — Witness: W-DAGEVU-ENGINE): the DAGeVu relationship-
+// edge engine. ES6 class-based (the one deliberate departure from this codebase's closure style — the contract is
+// meant to be subclassed). A RelationEdge is one REAL, recovered dependency between two elements; propagate() turns
+// the driving element's edit into the dependent's induced edit, or refuses honestly (null) when no honest answer
+// exists. Everything numeric comes from measured AABBs and the recovered edge rows; nothing is guessed.
+//
+// REUSES, never re-implements (SPEC §1): sdg_cascade.js stretchRide (the ride math), sdg_gate.js evaluate (the
+// abuts-realign proposal + the door-crush fit rule the anchor refusal mirrors), bonsai_library.js foldInsert's
+// grid-command mapping (foldBox below is its AABB image: TRANSLATE x+=d; SCALE about the world min edge
+// x' = f·x + min·(1−f) + t).
+//
+// HostFillEdge mode 'anchor' (DEFAULT, SPEC §3): the opening's world position is invariant under a host LENGTH
+// change — SCALE induces zero filling delta; TRANSLATE still carries it rigidly (a whole-body wall move cannot
+// leave its door in the air). The grid dictates which end grows; the edge VERIFIES that end is free of the opening
+// with the gate's own fit rule (fitBefore && !fitAfter, tol 0.05 on the changed axis) and REFUSES otherwise.
+// mode 'ride' = today's proportional ride, now an explicit per-element opt-in.
+// AbutsEdge: reports the gate's proposedDelta for a neighbour pulled away — REPORTS ONLY (accept-gated apply is a
+// future op per SDG_BACKPROP_ABUTS_REALIGN.md). AngleEdge: ⛔ PAUSED, not built (no measured roof-slope data).
+//
+// Dual-export (window + node) like sdg_cascade.js / sdg_gate.js so the value witness runs pure-node.
+(function (root, factory) {
+  if (typeof module !== 'undefined' && module.exports) module.exports = factory();
+  else root.DagevuEngine = factory();
+})(typeof window !== 'undefined' ? window : this, function () {
+  'use strict';
+  const AX = { x: 0, y: 1, z: 2 };
+  const FIT_TOL = 0.05;                     // m — sdg_gate.js door-crush / withinXY tolerance (non-invent reuse)
+  const MODES = ['anchor', 'ride'];
+
+  class RelationEdge {
+    constructor(kind, a, b) { this.kind = kind; this.a = a; this.b = b; this.refusal = null; }
+    // propagate(drivingDelta, realGeometry) → { dependentDeltas:[{featureId,dx,dy,dz}], dimLabel } | null (refused)
+    propagate() { throw new Error('RelationEdge.propagate is abstract — subclass it (' + this.kind + ')'); }
+    // foldBox(aabb, commands) → aabb' — the AABB image of the fold's own grid-command mapping (bonsai_library.js
+    // foldInsert gridCmds branch): TRANSLATE shifts; SCALE maps about the CURRENT world min on the command axis.
+    // aabb layout = [minx,maxx,miny,maxy,minz,maxz] (the _gateBoxes shape). Pure; input untouched.
+    static foldBox(box, commands) {
+      const b = box.slice();
+      for (const cmd of commands || []) {
+        const k = AX[cmd.axis]; if (k == null) continue;                  // axis-less command (ROOF_LIFT) → no plan-axis image
+        if (cmd.action === 'TRANSLATE') { const d = cmd.delta || 0; b[2 * k] += d; b[2 * k + 1] += d; }
+        else {
+          const f = cmd.newScale != null ? cmd.newScale : 1, tx = b[2 * k] * (1 - f) + (cmd.translateDelta || 0);
+          const lo = f * b[2 * k] + tx, hi = f * b[2 * k + 1] + tx;
+          b[2 * k] = Math.min(lo, hi); b[2 * k + 1] = Math.max(lo, hi);
+        }
+      }
+      return b;
+    }
+    static fitsOnAxis(inner, outer, k, tol) {
+      tol = tol == null ? FIT_TOL : tol;
+      return inner[2 * k] >= outer[2 * k] - tol && inner[2 * k + 1] <= outer[2 * k + 1] + tol;
+    }
+  }
+
+  class HostFillEdge extends RelationEdge {
+    // row = one REAL rel_fills_host row {host_guid, filling_guid, provenance}; fids resolved through the §ARC-1 bridge
+    constructor({ hostFid, fillingFid, hostGuid, fillingGuid, provenance, mode, cascade }) {
+      super('fills', hostFid, fillingFid);
+      this.hostFid = hostFid; this.fillingFid = fillingFid; this.hostGuid = hostGuid; this.fillingGuid = fillingGuid;
+      this.provenance = provenance; this.cascade = cascade; this.setMode(mode || 'anchor');
+    }
+    setMode(mode) { if (MODES.indexOf(mode) < 0) throw new Error('HostFillEdge mode must be anchor|ride, got ' + mode); this.mode = mode; return this; }
+    row() { return { host_guid: this.hostGuid, filling_guid: this.fillingGuid, provenance: this.provenance }; }
+    // ride math lives in ONE place: sdg_cascade.stretchRide, fed this single row so it rides only this filling.
+    _ride(cmds, geo) {
+      const out = this.cascade.stretchRide(cmds, geo.guidByFid, geo.fidByGuid, [this.row()], geo.boxByFid);
+      const r = out.riders.find(x => x.featureId === this.fillingFid);
+      return r ? [r.dx, r.dy, r.dz] : [0, 0, 0];
+    }
+    // propagate(hostCommands, { boxByFid, guidByFid, fidByGuid }) — hostCommands = this host's commands IN ORDER.
+    propagate(hostCommands, geo) {
+      this.refusal = null;
+      const hb = geo.boxByFid[this.hostFid], fb = geo.boxByFid[this.fillingFid];
+      if (!hb || !fb || !Array.isArray(hostCommands) || !hostCommands.length) return null;   // no honest pre-state → no claim
+      const hostAfter = RelationEdge.foldBox(hb, hostCommands);
+      const scaleAxes = []; hostCommands.forEach(c => { if (c.action !== 'TRANSLATE' && AX[c.axis] != null && scaleAxes.indexOf(AX[c.axis]) < 0) scaleAxes.push(AX[c.axis]); });
+      let d;
+      if (this.mode === 'ride') d = this._ride(hostCommands, geo);
+      else {
+        d = this._ride(hostCommands.filter(c => c.action === 'TRANSLATE'), geo);   // anchor: only the rigid part carries
+        const fAfter = [fb[0] + d[0], fb[1] + d[0], fb[2] + d[1], fb[3] + d[1], fb[4] + d[2], fb[5] + d[2]];
+        for (const k of scaleAxes) {                                              // free-end check = the gate's door-crush rule
+          if (RelationEdge.fitsOnAxis(fb, hb, k) && !RelationEdge.fitsOnAxis(fAfter, hostAfter, k)) {
+            this.refusal = { kind: 'anchor-no-free-end', hostFid: this.hostFid, fillingFid: this.fillingFid, axis: 'xyz'[k],
+              hostAfter: [hostAfter[2 * k], hostAfter[2 * k + 1]], filling: [fAfter[2 * k], fAfter[2 * k + 1]] };
+            return null;
+          }
+        }
+      }
+      const k0 = scaleAxes.length ? scaleAxes[0] : null;
+      const dimLabel = k0 != null
+        ? '#' + this.hostFid + ' ' + (hb[2 * k0 + 1] - hb[2 * k0]).toFixed(2) + '→' + (hostAfter[2 * k0 + 1] - hostAfter[2 * k0]).toFixed(2) + 'm · #' + this.fillingFid + ' ' + (this.mode === 'ride' ? 'rides' : 'held')
+        : '#' + this.fillingFid + ' rides #' + this.hostFid;
+      return { dependentDeltas: [{ featureId: this.fillingFid, dx: d[0], dy: d[1], dz: d[2] }], dimLabel, hostAfter };
+    }
+  }
+
+  class AbutsEdge extends RelationEdge {
+    constructor({ a, b, gate }) { super('abuts', a, b); this.gate = gate; }
+    // propagate({ before, after, moved }) — wraps sdg_gate.evaluate's abuts-realign for THIS pair only. Report-only.
+    propagate(state) {
+      this.refusal = null;
+      if (!state || !state.before || !state.after || !Array.isArray(state.moved)) return null;
+      const g = this.gate.evaluate(state.before, state.after, state.moved, { related: () => false, hostOf: {}, abuts: [{ a: this.a, b: this.b }] }, {});
+      const hit = g.orange.find(o => o.kind === 'abuts-realign');
+      if (!hit) return null;
+      const p = hit.proposedDelta;
+      return { dependentDeltas: [{ featureId: hit.a, dx: p[0], dy: p[1], dz: p[2], proposed: true, gap: hit.gap, axis: hit.axis }],
+        dimLabel: '#' + hit.a + ' gap ' + hit.gap.toFixed(3) + 'm (' + hit.axis + ')' };
+    }
+  }
+
+  class DagevuEngine {
+    // fills/abuts = the REAL recovered rows (window.swXEdges); guidByFid/fidByGuid = the §ARC-1 bridge;
+    // cascade = SdgCascade, gate = SdgGate (injected so node witnesses pass the required modules explicitly).
+    constructor({ guidByFid, fidByGuid, fills, abuts, cascade, gate, rideFids }) {
+      this.guidByFid = guidByFid || {}; this.fidByGuid = fidByGuid || {};
+      this.cascade = cascade; this.gate = gate;
+      this.edges = []; this.byFilling = {}; this.byHost = {};
+      const ride = new Set(rideFids || []);
+      for (const e of fills || []) {
+        const h = this.fidByGuid[e.host_guid], f = this.fidByGuid[e.filling_guid];
+        if (h == null || f == null || !cascade) continue;                 // unresolvable row → no edge (non-invent)
+        const edge = new HostFillEdge({ hostFid: h, fillingFid: f, hostGuid: e.host_guid, fillingGuid: e.filling_guid,
+          provenance: e.provenance, mode: ride.has(f) ? 'ride' : 'anchor', cascade });
+        this.edges.push(edge); (this.byFilling[f] = this.byFilling[f] || []).push(edge); (this.byHost[h] = this.byHost[h] || []).push(edge);
+      }
+      for (const e of abuts || []) {
+        const a = this.fidByGuid[e.a], b = this.fidByGuid[e.b];
+        if (a == null || b == null || !gate) continue;
+        this.edges.push(new AbutsEdge({ a, b, gate }));
+      }
+    }
+    isFilling(fid) { return !!this.byFilling[fid]; }
+    modeOf(fid) { const es = this.byFilling[fid]; return es ? es[0].mode : null; }
+    setMode(fid, mode) { (this.byFilling[fid] || []).forEach(e => e.setMode(mode)); return this.modeOf(fid); }
+    toggleMode(fid) { return this.setMode(fid, this.modeOf(fid) === 'ride' ? 'anchor' : 'ride'); }
+    reset() { this.edges.forEach(e => { if (e instanceof HostFillEdge) e.setMode('anchor'); e.refusal = null; }); }
+
+    // propagateCommands(commands, boxByFid) → { commands, riders, held, refusals, proposals, dimLabel }
+    // The grid engine's per-feature commands (bonsai_gridmove.computeCommands) IN; the rider-stripped list plus the
+    // induced rider moves OUT — the same {commands, riders} shape stretchRide returns, so gridmove's commit path
+    // (gesture group of GEOM_GRID_MOVE + induced GEOM_MOVEs) is unchanged. A refused edge leaves its host's
+    // commands AND its filling's commands untouched and is reported; the caller must not commit a refusal.
+    propagateCommands(commands, boxByFid, opts) {
+      opts = opts || {};
+      const out = { commands, riders: [], held: [], refusals: [], proposals: [], dimLabel: '' };
+      if (!Array.isArray(commands) || !commands.length) return out;
+      const byFid = {};
+      commands.forEach(c => { if (c && c.featureId != null) (byFid[c.featureId] = byFid[c.featureId] || []).push(c); });
+      const geo = { boxByFid: boxByFid || {}, guidByFid: this.guidByFid, fidByGuid: this.fidByGuid };
+      const strip = {}, labels = [], ridden = {};
+      let firstScaleLabel = null;
+      for (const edge of this.edges) {
+        if (!(edge instanceof HostFillEdge) || !byFid[edge.hostFid] || ridden[edge.fillingFid]) continue;   // one ride per filling (first host wins)
+        const hb = geo.boxByFid[edge.hostFid], fb = geo.boxByFid[edge.fillingFid];
+        if (!hb || !fb) continue;                                        // no honest pre-state → leave the engine's view alone
+        const r = edge.propagate(byFid[edge.hostFid], geo);
+        if (r === null) { if (edge.refusal) out.refusals.push(edge.refusal); continue; }
+        ridden[edge.fillingFid] = 1; strip[edge.fillingFid] = 1;
+        const d = r.dependentDeltas[0];
+        if (Math.abs(d.dx) > 1e-12 || Math.abs(d.dy) > 1e-12 || Math.abs(d.dz) > 1e-12) out.riders.push(d);
+        else out.held.push(edge.fillingFid);
+        if (!firstScaleLabel && /→/.test(r.dimLabel)) firstScaleLabel = r.dimLabel.split(' · ')[0];
+      }
+      if (Object.keys(strip).length) out.commands = commands.filter(c => !(c && c.featureId != null && strip[c.featureId]));
+      // abuts proposals: image every commanded box + rider through the fold, ask each AbutsEdge (report-only)
+      if (this.edges.some(e => e instanceof AbutsEdge)) {
+        const after = Object.assign({}, geo.boxByFid), moved = [];
+        Object.keys(byFid).forEach(f => { if (geo.boxByFid[f] && !strip[f]) { after[f] = RelationEdge.foldBox(geo.boxByFid[f], byFid[f]); moved.push(+f); } });
+        out.riders.forEach(r => { const b = geo.boxByFid[r.featureId]; if (b) { after[r.featureId] = RelationEdge.foldBox(b, [{ action: 'TRANSLATE', axis: 'x', delta: r.dx }, { action: 'TRANSLATE', axis: 'y', delta: r.dy }, { action: 'TRANSLATE', axis: 'z', delta: r.dz }]); moved.push(r.featureId); } });
+        for (const edge of this.edges) {
+          if (!(edge instanceof AbutsEdge)) continue;
+          const p = edge.propagate({ before: geo.boxByFid, after, moved });
+          if (p) out.proposals.push(p.dependentDeltas[0]);
+        }
+      }
+      if (firstScaleLabel) labels.push(firstScaleLabel);
+      if (out.held.length) labels.push(out.held.length + ' held');
+      if (out.riders.length) labels.push(out.riders.length + ' ride');
+      if (out.refusals.length) labels.push('REFUSED #' + out.refusals.map(r => r.fillingFid).join(',#'));
+      if (out.proposals.length) labels.push(out.proposals.length + ' abuts gap');
+      out.dimLabel = labels.join(' · ');
+      return out;
+    }
+  }
+
+  return { RelationEdge, HostFillEdge, AbutsEdge, DagevuEngine, MODES, FIT_TOL };
+});

--- a/modeller/modeller.html
+++ b/modeller/modeller.html
@@ -254,6 +254,8 @@ if (window.WholeHistory && WholeHistory.mount) WholeHistory.mount({ page: 'model
 <script src="arc_editable.js?v=5" onerror="console.warn('§ARC LOAD_FAIL arc_editable.js')"></script>
 <script src="sdg_cascade.js?v=1" onerror="console.warn('§SDG LOAD_FAIL sdg_cascade.js')"></script>
 <script src="sdg_gate.js?v=1" onerror="console.warn('§GATE LOAD_FAIL sdg_gate.js')"></script>
+<!-- §DAGEVU: relationship-edge engine (anchor-default hosted openings) — wraps sdg_cascade + sdg_gate above. -->
+<script src="dagevu_engine.js?v=1" onerror="console.warn('§DAGEVU LOAD_FAIL dagevu_engine.js')"></script>
 <!-- §SAVE-1/2 (MODELLER_SAVE_COMPLETEIT.md): Save = validated snapshot promotion. sdg_save.js = pure
      classify/plan-op core (auto-heal planning); save_catalog.js = the shared landing-page IndexedDB
      versions[]/latestVersion catalog writer (same store import_own.js reads/writes). -->
@@ -1878,12 +1880,13 @@ function gmPreviewLine(axis, coord) {
 // host (§STRETCH-RIDE induced move, fixed here to tint correctly instead of showing their own raw — possibly
 // WRONG — command); excludedFids = green, always wins over blue/orange.
 const GM_GREEN = 0x1ea83c;
+const GM_RED = 0xc81e1e;        // §DAGEVU: a refused host/opening pair (the drag would push the held opening out of its wall)
 function gmClearTints() {
   const g = window.Bonsai.group && window.Bonsai.group(); if (!g) return;
   g.children.forEach(m => { if (m.isMesh && m.material && m.material.emissive) m.material.emissive.setHex(0x000000); });
 }
-function gmTint(commands, riders, excludedFids) {
-  const g = window.Bonsai.group && window.Bonsai.group(); if (!g) return { t: 0, s: 0, x: 0 };
+function gmTint(commands, riders, excludedFids, dagevu) {
+  const g = window.Bonsai.group && window.Bonsai.group(); if (!g) return { t: 0, s: 0, x: 0, h: 0, r: 0 };
   // §SCALE_CHECK_FIX (Finding 1): g.children.find() per command was an O(n) lookup per command per frame — at
   // Terminal scale (35,818 elements) this compounded on top of the engine rebuild. bonsai_gridmove.js now caches
   // a fid->mesh map ONCE per drag session (built alongside the attach-map engine on gridline-grab); reuse it here
@@ -1912,8 +1915,14 @@ function gmTint(commands, riders, excludedFids) {
     if (!m || !m.material || !m.material.emissive) return;
     _emis(m, GM_GREEN); x++;
   });
+  // §DAGEVU (SPEC_DAGEVU_ENGINE.md §4): a HELD opening (anchor default — stays put while its wall's length changes)
+  // reads green like any non-mover; a REFUSED pair (the dictated end would cross the opening) reads red on BOTH the
+  // wall and the opening — the commit will refuse, so the preview must say so before release.
+  let h = 0, r = 0;
+  ((dagevu && dagevu.held) || []).forEach(fid => { const m = meshFor(fid); if (m && m.material && m.material.emissive) { _emis(m, GM_GREEN); h++; } });
+  ((dagevu && dagevu.refusals) || []).forEach(rf => { [rf.hostFid, rf.fillingFid].forEach(fid => { const m = meshFor(fid); if (m && m.material && m.material.emissive) _emis(m, GM_RED); }); r++; });
   if (window.A && A.requestRender) A.requestRender();
-  return { t, s, x };
+  return { t, s, x, h, r };
 }
 function enterGridMove() {
   if (!window.Bonsai.grid.active) { window.Bonsai.grid.show(true); bGrid.classList.add('on'); }
@@ -1921,7 +1930,7 @@ function enterGridMove() {
   // §GREEN-EXCLUDE: fresh empty opt-out set every session — seeded empty, scoped to THIS drag session only (not
   // persisted, not a per-user default — GRID_PREDRAG_GREENORANGE_PREVIEW.md explicitly defers that).
   if (window.Bonsai.gridmove && window.Bonsai.gridmove.resetOverrides) window.Bonsai.gridmove.resetOverrides();
-  setStat('move grid: hover a gridline, drag it — affected walls preview (blue=move, orange=stretch, ctrl+click=opt-out green)');
+  setStat('move grid: hover a gridline, drag it — affected walls preview (blue=move, orange=stretch, ctrl+click wall=opt-out green, ctrl+click opening=anchor↔ride)');
 }
 function exitGridMove() {
   gridMoving = false; _dragGrid = null; bGridMove.innerHTML = GM_MOVE; controls.enabled = true; applyModeCursor();
@@ -1949,14 +1958,15 @@ canvas.addEventListener('pointerdown', (e) => {
         // reflected exactly as commit() would see it (riders + overrides), not just this one mesh.
         try {
           const preview = window.Bonsai.gridmove.previewCommands(_dragGrid.id, _dragGrid.delta);
-          const r2 = gmTint(preview.commands, preview.riders, preview.excluded);
-          setStat('grid ' + _dragGrid.id + ' Δ' + _dragGrid.delta.toFixed(2) + ' — ' + r2.t + ' move, ' + r2.s + ' stretch, ' + r2.x + ' excluded(green)');
+          const r2 = gmTint(preview.commands, preview.riders, preview.excluded, preview);
+          setStat(gmStatText(_dragGrid, r2, preview));
         } catch (err) { }
       } else {
         // no gridline grabbed yet — nothing to recompute against; give immediate feedback on this one mesh.
         _emis(hit.object, nowExcluded ? GM_GREEN : 0x000000);
         if (window.A && A.requestRender) A.requestRender();
-        setStat((nowExcluded ? 'excluded (green) ' : 're-included (orange) ') + '#' + fid + ' for this grid-move — now hover/drag a gridline');
+        const isOpening = window.Bonsai.gridmove.isFilling && window.Bonsai.gridmove.isFilling(fid);   // §DAGEVU: opening ⇒ anchor/ride, wall ⇒ exclude/include
+        setStat((isOpening ? (nowExcluded ? 'opening held (anchor) ' : 'opening rides (opt-in) ') : (nowExcluded ? 'excluded (green) ' : 're-included (orange) ')) + '#' + fid + ' for this grid-move — now hover/drag a gridline');
       }
     }
     return;   // ctrl+click never grabs a gridline
@@ -1997,12 +2007,21 @@ canvas.addEventListener('pointermove', (e) => {
   // PREVIEW which walls move/stretch — previewCommands() applies §STRETCH-RIDE (openings ride, never their own
   // raw command) AND §GREEN-EXCLUDE (opt-out) BEFORE tinting, so this can never disagree with commit() below
   // (both call the SAME bonsai_gridmove.js pipeline).
+  let lbl = _dragGrid.id + ' Δ' + (_dragGrid.delta >= 0 ? '+' : '') + _dragGrid.delta.toFixed(2) + 'm';
   try { const preview = window.Bonsai.gridmove.previewCommands(_dragGrid.id, _dragGrid.delta);
-    const r2 = gmTint(preview.commands, preview.riders, preview.excluded);
-    setStat('grid ' + _dragGrid.id + ' Δ' + _dragGrid.delta.toFixed(2) + ' — ' + r2.t + ' move, ' + r2.s + ' stretch' +
-      (r2.x ? ', ' + r2.x + ' excluded(green)' : '')); } catch (err) { }
-  if (typeof dimLabelShow === 'function') dimLabelShow(_dragGrid.id + ' Δ' + (_dragGrid.delta >= 0 ? '+' : '') + _dragGrid.delta.toFixed(2) + 'm', hit);   // §V7
+    const r2 = gmTint(preview.commands, preview.riders, preview.excluded, preview);
+    setStat(gmStatText(_dragGrid, r2, preview));
+    if (preview.dimLabel) lbl += ' · ' + preview.dimLabel;   // §DAGEVU: the engine's measured readout (wall w→w', held/ride/REFUSED) — the SAME string the status line carries
+  } catch (err) { }
+  if (typeof dimLabelShow === 'function') dimLabelShow(lbl, hit);   // §V7
 });
+// §DAGEVU: ONE status-line composer for the pointermove frame AND the mid-drag ctrl+click recompute (both print
+// the engine's dimLabel verbatim — never a second math path, per §V7's own rule).
+function gmStatText(dg, r2, preview) {
+  return 'grid ' + dg.id + ' Δ' + dg.delta.toFixed(2) + ' — ' + r2.t + ' move, ' + r2.s + ' stretch' +
+    (r2.x ? ', ' + r2.x + ' excluded(green)' : '') + (r2.h ? ', ' + r2.h + ' held' : '') +
+    (r2.r ? ', ' + r2.r + ' REFUSED(red)' : '') + (preview.dimLabel ? ' · ' + preview.dimLabel : '');
+}
 async function commitGridMove() {
   if (typeof dimLabelHide === 'function') dimLabelHide();       // §V7 (also covers the FAIL path below)
   if (!_dragGrid || Math.abs(_dragGrid.delta || 0) < 0.05) { exitGridMove(); return; }

--- a/modeller/tests/witness_dagevu_engine.js
+++ b/modeller/tests/witness_dagevu_engine.js
@@ -1,0 +1,189 @@
+#!/usr/bin/env node
+/**
+ * # ⚠ DO NOT REMOVE — W-DAGEVU-ENGINE: §DAGEVU value witness (PURE NODE, REAL SampleHouse substrate).
+ * Implementing prompts/SPEC_DAGEVU_ENGINE.md §5. Read the log after every run — exit code alone is not evidence.
+ *
+ * Issue under test: grid-stretching a wall used to ALWAYS ride its hosted opening proportionally (a door at 1/3 of
+ * a wall stays at 1/3 — "distortion" of the opening's real position). The engine makes ANCHOR (opening keeps its
+ * world position, the wall's free end absorbs the delta) the default, RIDE an explicit opt-in, and refuses honestly
+ * when the dictated end is NOT free. Every number below is measured off the production fold's real AABBs and the
+ * recovered rel_fills_host rows — the same substrate witness_stretch_ride.js proves.
+ *
+ *   D1 CONTRACT         — base propagate throws; subclasses instanceof RelationEdge; #edges == resolvable real rows
+ *   D2 RIDE-WRAP        — mode ride ≡ SdgCascade.stretchRide output (riders exact, same strip) — a wrap, not a fork
+ *   D3 ANCHOR-GROW      — default: host SCALE grow ⇒ filling delta 0, own cmd stripped, held, no refusal, label w→f·w
+ *   D4 ANCHOR-TRANSLATE — host TRANSLATE d ⇒ anchored filling still rides by EXACTLY d (anchor = length change only)
+ *   D5 ANCHOR-REFUSE    — shrink crossing the filling ⇒ null + refusal{fids,axis}, commands untouched, and the gate's
+ *                         own door-crush fires on the same before/after boxes (preview oracle == commit oracle)
+ *   D6 MULTI            — the real 2-filling host: each filling refused iff the gate's rule says so, independently
+ *   D7 TOGGLE           — default anchor; toggle→ride→anchor; reset restores anchor
+ *   D8 ABUTS-WRAP       — real wall + constructed flush neighbour (A8 precedent): proposal == gate proposedDelta;
+ *                         the commands list is NOT changed by it (report-only)
+ *   D9 ROSETTA          — anchor: stretch then exact inverse ⇒ host extent restored ≤1e-9, filling delta 0 both ways
+ */
+'use strict';
+var fs = require('fs'), path = require('path');
+global.window = global.window || {};
+global.fetch = undefined;
+global.location = { href: 'http://localhost/' };
+if (typeof global.crypto === 'undefined') global.crypto = require('crypto').webcrypto;
+
+var ROOT = path.join(__dirname, '..');
+var ArcEditable = require(path.join(ROOT, 'arc_editable.js'));
+var SdgCascade = require(path.join(ROOT, 'sdg_cascade.js'));
+var SdgGate = require(path.join(ROOT, 'sdg_gate.js'));
+var CrossEdges = require(path.join(ROOT, 'cross_edges.js'));
+var D = require(path.join(ROOT, 'dagevu_engine.js'));
+require(path.join(ROOT, 'kernel_ops.js'));
+require(path.join(ROOT, 'bonsai_library.js'));
+var KernelOps = global.window.KernelOps, Library = global.window.Bonsai.library;
+var initSqlJs = require(path.join(ROOT, 'lib', 'sql-wasm.js'));
+var wasmBinary = fs.readFileSync(path.join(ROOT, 'lib', 'sql-wasm.wasm'));
+var DBPATH = path.join(ROOT, 'SampleHouse_extracted.db');
+
+var pass = 0, fail = 0;
+function chk(n, c, e) { if (c) { pass++; console.log('  ✅ ' + n + (e ? '  ' + e : '')); } else { fail++; console.log('  ❌ ' + n + (e ? '  ' + e : '')); } }
+function bboxOf(positions) {
+  var mn = [1e9, 1e9, 1e9], mx = [-1e9, -1e9, -1e9];
+  for (var i = 0; i < positions.length; i += 3) for (var k = 0; k < 3; k++) { if (positions[i + k] < mn[k]) mn[k] = positions[i + k]; if (positions[i + k] > mx[k]) mx[k] = positions[i + k]; }
+  return [mn[0], mx[0], mn[1], mx[1], mn[2], mx[2]];
+}
+function centreOf(b) { return [(b[0] + b[1]) / 2, (b[2] + b[3]) / 2, (b[4] + b[5]) / 2]; }
+function withinXY(box, pt, tol) { return pt[0] >= box[0] - tol && pt[0] <= box[1] + tol && pt[1] >= box[2] - tol && pt[1] <= box[3] + tol; }
+function fits(inner, outer, k) { return inner[2 * k] >= outer[2 * k] - 0.05 && inner[2 * k + 1] <= outer[2 * k + 1] + 0.05; }
+function j(x) { return JSON.stringify(x); }
+
+initSqlJs({ wasmBinary: wasmBinary }).then(async function (SQL) {
+  console.log('═══ W-DAGEVU-ENGINE — anchor-default relationship edges (node, REAL SampleHouse) ═══');
+  var bdb = new SQL.Database(fs.readFileSync(DBPATH));
+  var oplog = new SQL.Database();
+  var seed = await ArcEditable.seedArc(bdb, {
+    commitGroup: function (ops, gid) { return KernelOps.commitGroup(oplog, ops, { gid: gid, baseTs: 1700000000000 }); },
+    building: 'SampleHouse'
+  });
+  var fbg = seed.bridge.fidByGuid, gbf = seed.bridge.guidByFid;
+  var opByFid = {}; seed.ops.forEach(function (o) { opByFid[fbg[o.outputGuid]] = o; });
+  var X = CrossEdges.deriveAll(bdb), fills = X.fills;
+  var boxByFid = {};
+  Object.keys(opByFid).forEach(function (fid) { boxByFid[fid] = bboxOf(Library.foldInsert({ id: +fid, op_type: 'GEOM_INSERT', parameters: opByFid[fid].params }, null).positions); });
+  var edgeRow = fills.find(function (e) {
+    var hf = fbg[e.host_guid], rf = fbg[e.filling_guid];
+    return hf != null && rf != null && boxByFid[hf] && boxByFid[rf] && withinXY(boxByFid[hf], centreOf(boxByFid[rf]), 0.05);
+  });
+  var hostFid = fbg[edgeRow.host_guid], doorFid = fbg[edgeRow.filling_guid];
+  var hb = boxByFid[hostFid], fb = boxByFid[doorFid];
+  var ext3 = [hb[1] - hb[0], hb[3] - hb[2]], K = ext3[0] >= ext3[1] ? 0 : 1, ax = 'xy'[K];   // the wall's long (run) axis
+  var ext = hb[2 * K + 1] - hb[2 * K];
+  var resolvable = fills.filter(function (e) { return fbg[e.host_guid] != null && fbg[e.filling_guid] != null; }).length;
+  chk('D0 substrate: seeded bridge + real fills + hosted pair on the wall\'s run axis', seed.committed > 0 && fills.length > 0 && fits(fb, hb, K),
+    'host=' + hostFid + ' door=' + doorFid + ' axis=' + ax + ' ext=' + ext.toFixed(3) + ' resolvable=' + resolvable + '/' + fills.length);
+
+  function mk(opts) { return new D.DagevuEngine(Object.assign({ guidByFid: gbf, fidByGuid: fbg, fills: fills, abuts: [], cascade: SdgCascade, gate: SdgGate }, opts || {})); }
+
+  // D1 CONTRACT
+  var threw = false; try { new D.RelationEdge('x', 1, 2).propagate(); } catch (e) { threw = /abstract/.test(e.message); }
+  var eng = mk();
+  var hostFillCount = eng.edges.filter(function (e) { return e instanceof D.HostFillEdge; }).length;
+  var badRow = mk({ fills: fills.concat([{ host_guid: 'NOT-A-GUID', filling_guid: edgeRow.filling_guid, provenance: 'ifc:recovered' }]) });
+  chk('D1 CONTRACT: abstract propagate throws; HostFillEdge/AbutsEdge instanceof RelationEdge; #edges == resolvable real rows; unresolvable row ⇒ no edge',
+    threw && eng.edges[0] instanceof D.RelationEdge && new D.AbutsEdge({ a: 1, b: 2, gate: SdgGate }) instanceof D.RelationEdge &&
+    hostFillCount === resolvable && badRow.edges.length === eng.edges.length,
+    'edges=' + hostFillCount + ' resolvable=' + resolvable);
+
+  // D2 RIDE-WRAP — opt every filling of this host into ride, compare with stretchRide over the same rows
+  var f = 1.4;
+  var scaleCmd = { featureId: hostFid, action: 'SCALE', axis: ax, newScale: f, translateDelta: 0, edge: 'far' };
+  var engineDoorCmd = { featureId: doorFid, action: 'SCALE', axis: ax, newScale: 1.2, translateDelta: 0, edge: 'far' };
+  var hostRows = fills.filter(function (e) { return e.host_guid === edgeRow.host_guid && fbg[e.filling_guid] != null; });
+  var rideEng = mk({ rideFids: hostRows.map(function (e) { return fbg[e.filling_guid]; }) });
+  var r2 = rideEng.propagateCommands([scaleCmd, engineDoorCmd], boxByFid);
+  var ref2 = SdgCascade.stretchRide([scaleCmd, engineDoorCmd], gbf, fbg, hostRows, boxByFid);
+  var sameRiders = r2.riders.length === ref2.riders.length && ref2.riders.every(function (rr) { var m = r2.riders.find(function (q) { return q.featureId === rr.featureId; }); return m && m.dx === rr.dx && m.dy === rr.dy && m.dz === rr.dz; });
+  var sameCmds = j(r2.commands) === j(ref2.commands);
+  chk('D2 RIDE-WRAP: mode ride ≡ stretchRide (riders exact to the bit, identical strip)', sameRiders && sameCmds && r2.refusals.length === 0,
+    'riders=' + j(r2.riders.map(function (r) { return [r.featureId, +r.dx.toFixed(4), +r.dy.toFixed(4)]; })));
+
+  // D3 ANCHOR-GROW (default)
+  var r3 = eng.propagateCommands([scaleCmd, engineDoorCmd], boxByFid);
+  var doorRides3 = r3.riders.some(function (r) { return r.featureId === doorFid; });
+  var stripped3 = !r3.commands.some(function (c) { return c.featureId === doorFid; }) && r3.commands.some(function (c) { return c.featureId === hostFid; });
+  var wantLbl = ext.toFixed(2) + '→' + (f * ext).toFixed(2) + 'm';
+  chk('D3 ANCHOR-GROW: default holds the filling (delta 0, own cmd stripped, host cmd kept, no refusal); label carries measured w→f·w',
+    !doorRides3 && r3.held.indexOf(doorFid) >= 0 && stripped3 && r3.refusals.length === 0 && r3.dimLabel.indexOf(wantLbl) >= 0,
+    'held=' + j(r3.held) + ' label="' + r3.dimLabel + '"');
+
+  // D4 ANCHOR-TRANSLATE
+  var dT = 1.25;
+  var r4 = eng.propagateCommands([{ featureId: hostFid, action: 'TRANSLATE', axis: ax, delta: dT }], boxByFid);
+  var rid4 = r4.riders.find(function (r) { return r.featureId === doorFid; });
+  chk('D4 ANCHOR-TRANSLATE: a translated host still carries its anchored filling by EXACTLY d (anchor = length change only)',
+    rid4 && (ax === 'x' ? rid4.dx === dT && rid4.dy === 0 : rid4.dy === dT && rid4.dx === 0) && rid4.dz === 0 && r4.held.length === 0,
+    'rider=' + j(rid4));
+
+  // D5 ANCHOR-REFUSE — shrink from the max end until the host's max crosses INTO the door's span
+  var fShrink = ((fb[2 * K] - hb[2 * K]) / ext) * 0.5;               // host' max lands halfway between host min and the door's min
+  var shrinkCmd = { featureId: hostFid, action: 'SCALE', axis: ax, newScale: fShrink, translateDelta: 0, edge: 'far' };
+  var r5 = eng.propagateCommands([shrinkCmd], boxByFid);
+  var ref5 = r5.refusals.find(function (r) { return r.fillingFid === doorFid && r.hostFid === hostFid; });
+  var edge5 = eng.byFilling[doorFid][0];
+  var direct5 = edge5.propagate([shrinkCmd], { boxByFid: boxByFid, guidByFid: gbf, fidByGuid: fbg });
+  var after5 = {}; after5[hostFid] = D.RelationEdge.foldBox(hb, [shrinkCmd]); after5[doorFid] = fb;
+  var before5 = {}; before5[hostFid] = hb; before5[doorFid] = fb;
+  var hostOf5 = {}; hostOf5[doorFid] = hostFid;
+  var gate5 = SdgGate.evaluate(before5, after5, [hostFid], { related: function () { return true; }, hostOf: hostOf5, abuts: [] }, {});
+  var crush5 = gate5.red.find(function (x) { return x.kind === 'door-crush' && x.a === doorFid && x.b === hostFid; });
+  chk('D5 ANCHOR-REFUSE: shrink crossing the held filling ⇒ propagate null + refusal{host,filling,axis}; commands untouched; the gate\'s door-crush agrees on the same boxes',
+    direct5 === null && ref5 && ref5.axis === ax && ref5.kind === 'anchor-no-free-end' && j(r5.commands) === j([shrinkCmd]) && r5.riders.length === 0 && !!crush5 && crush5.axis === ax,
+    'f=' + fShrink.toFixed(3) + ' refusal=' + j(ref5) + ' gate=' + j(crush5));
+
+  // D6 MULTI — the real host with the most rows: each filling refused iff the gate's rule says so
+  var byHostGuid = {}; hostRows.length; fills.forEach(function (e) { if (fbg[e.host_guid] != null && fbg[e.filling_guid] != null) (byHostGuid[e.host_guid] = byHostGuid[e.host_guid] || []).push(fbg[e.filling_guid]); });
+  var multiGuid = Object.keys(byHostGuid).sort(function (a, b) { return byHostGuid[b].length - byHostGuid[a].length; })[0];
+  var mHost = fbg[multiGuid], mFills = byHostGuid[multiGuid], mb = boxByFid[mHost];
+  var mK = (mb[1] - mb[0]) >= (mb[3] - mb[2]) ? 0 : 1, mAx = 'xy'[mK], mExt = mb[2 * mK + 1] - mb[2 * mK];
+  var mHostAfter = D.RelationEdge.foldBox(mb, [{ action: 'SCALE', axis: mAx, newScale: 0.55, translateDelta: 0 }]);
+  var r6 = eng.propagateCommands([{ featureId: mHost, action: 'SCALE', axis: mAx, newScale: 0.55, translateDelta: 0, edge: 'far' }], boxByFid);
+  var agree6 = mFills.every(function (fid) {
+    var b = boxByFid[fid]; if (!b) return true;
+    var expectRefuse = fits(b, mb, mK) && !fits(b, mHostAfter, mK);
+    var refused = r6.refusals.some(function (r) { return r.fillingFid === fid; });
+    var held = r6.held.indexOf(fid) >= 0;
+    return expectRefuse ? (refused && !held) : (!refused && held);
+  });
+  chk('D6 MULTI: ' + mFills.length + ' real fillings on host #' + mHost + ' — each independently refused iff the gate\'s fit rule says so (delta-honest on a never-fit filling)',
+    mFills.length >= 2 && agree6, 'refused=' + j(r6.refusals.map(function (r) { return r.fillingFid; })) + ' held=' + j(r6.held));
+
+  // D7 TOGGLE
+  var e7 = mk();
+  var m0 = e7.modeOf(doorFid), m1 = e7.toggleMode(doorFid), m2 = e7.toggleMode(doorFid); e7.setMode(doorFid, 'ride'); e7.reset();
+  chk('D7 TOGGLE: default anchor; toggle→ride→anchor; reset restores anchor; non-filling has no mode',
+    m0 === 'anchor' && m1 === 'ride' && m2 === 'anchor' && e7.modeOf(doorFid) === 'anchor' && e7.modeOf(hostFid) === null && e7.isFilling(doorFid) && !e7.isFilling(hostFid));
+
+  // D8 ABUTS-WRAP — real wall + constructed flush neighbour on its thinnest (face-normal) axis (witness_sdg_gate A8)
+  var ext8 = [hb[1] - hb[0], hb[3] - hb[2], hb[5] - hb[4]], k8 = ext8.indexOf(Math.min.apply(null, ext8));
+  var nb = hb.slice(); nb[2 * k8] = hb[2 * k8 + 1]; nb[2 * k8 + 1] = hb[2 * k8 + 1] + 0.1;
+  var NB = 9002, gbf8 = Object.assign({}, gbf), fbg8 = Object.assign({}, fbg); gbf8[NB] = 'g-nb'; fbg8['g-nb'] = NB;
+  var box8 = Object.assign({}, boxByFid); box8[NB] = nb;
+  var e8 = mk({ guidByFid: gbf8, fidByGuid: fbg8, abuts: [{ a: edgeRow.host_guid, b: 'g-nb' }] });
+  var mv8 = { featureId: hostFid, action: 'TRANSLATE', axis: 'xyz'[k8], delta: ext8[k8] + 0.5 };
+  var r8 = e8.propagateCommands([mv8], box8);
+  var b8 = {}; b8[hostFid] = hb; b8[NB] = nb; var a8 = {}; a8[hostFid] = D.RelationEdge.foldBox(hb, [mv8]); a8[NB] = nb;
+  var g8 = SdgGate.evaluate(b8, a8, [hostFid], { related: function () { return false; }, hostOf: {}, abuts: [{ a: hostFid, b: NB }] }, {}).orange.find(function (o) { return o.kind === 'abuts-realign'; });
+  var p8 = r8.proposals[0];
+  chk('D8 ABUTS-WRAP: AbutsEdge proposal == the gate\'s own abuts-realign proposedDelta (neighbour, gap, axis); commands untouched (report-only)',
+    e8.edges.some(function (e) { return e instanceof D.AbutsEdge; }) && p8 && g8 && p8.featureId === g8.a && p8.proposed === true &&
+    p8.dx === g8.proposedDelta[0] && p8.dy === g8.proposedDelta[1] && p8.dz === g8.proposedDelta[2] && j(r8.commands) === j([mv8]),
+    'proposal=' + j(p8) + ' gate=' + j(g8 && g8.proposedDelta));
+
+  // D9 ROSETTA — anchor: SCALE f then SCALE 1/f about the (unchanged) min ⇒ extent restored; filling delta 0 both ways
+  var box9 = Object.assign({}, boxByFid); box9[hostFid] = D.RelationEdge.foldBox(hb, [scaleCmd]);
+  var r9 = eng.propagateCommands([{ featureId: hostFid, action: 'SCALE', axis: ax, newScale: 1 / f, translateDelta: 0, edge: 'far' }], box9);
+  var back9 = D.RelationEdge.foldBox(box9[hostFid], [{ action: 'SCALE', axis: ax, newScale: 1 / f, translateDelta: 0 }]);
+  var extErr = Math.abs((back9[2 * K + 1] - back9[2 * K]) - ext), minErr = Math.abs(back9[2 * K] - hb[2 * K]);
+  chk('D9 ROSETTA: stretch then exact inverse ⇒ host extent + min restored ≤1e-9; the held filling never moved (0 both ways)',
+    extErr <= 1e-9 && minErr <= 1e-9 && r3.held.indexOf(doorFid) >= 0 && r9.held.indexOf(doorFid) >= 0 && !r9.riders.some(function (r) { return r.featureId === doorFid; }),
+    'extErr=' + extErr.toExponential(2) + ' minErr=' + minErr.toExponential(2));
+
+  console.log('W-DAGEVU-ENGINE: ' + pass + ' PASS / ' + fail + ' FAIL');
+  process.exit(fail ? 1 : 0);
+}).catch(function (e) { console.error('WITNESS ERROR', e && e.stack || e); process.exit(1); });

--- a/modeller/tests/witness_e2e_grid_greenorange.js
+++ b/modeller/tests/witness_e2e_grid_greenorange.js
@@ -190,9 +190,11 @@ runE2E('W-E2E-GRID-GREENORANGE', async (t) => {
   await t.pg.mouse.down(); await t.sleep(40);
   await t.pg.mouse.move(midB[0], midB[1], { steps: 6 }); await t.sleep(150);
   const midHost = await emisOf(t, idsB.host), midDoor = await emisOf(t, idsB.door);
-  console.log('  §GREENORANGE H1 mid-drag host=0x' + (midHost || 0).toString(16) + ' door=0x' + (midDoor || 0).toString(16) + ' (door must be BLUE=rides, NOT orange=its own raw SCALE)');
-  t.assert('H1 mid-drag (before release): hosted door tints BLUE (rides host via §STRETCH-RIDE), NOT orange (its own raw SCALE — the item-1 bug)',
-    midHost === ORANGE && midDoor === BLUE, 'host=0x' + (midHost || 0).toString(16) + ' door=0x' + (midDoor || 0).toString(16));
+  console.log('  §GREENORANGE H1 mid-drag host=0x' + (midHost || 0).toString(16) + ' door=0x' + (midDoor || 0).toString(16) + ' (§DAGEVU: door must be GREEN=held/anchor, NOT orange=its own raw SCALE, NOT blue=ride)');
+  // §DAGEVU (SPEC_DAGEVU_ENGINE.md §5): the old H1 expected BLUE (always-ride) — STALE. The anchor default holds
+  // the opening in place while the host stretches: it tints GREEN (non-mover), never its own raw orange SCALE.
+  t.assert('H1 mid-drag (before release): hosted door tints GREEN (held — §DAGEVU anchor default), NOT orange (its own raw SCALE — the item-1 bug), NOT blue (ride is opt-in now)',
+    midHost === ORANGE && midDoor === GREEN, 'host=0x' + (midHost || 0).toString(16) + ' door=0x' + (midDoor || 0).toString(16));
   await t.shot('06-scenarioB-middrag');
 
   await t.pg.mouse.move(finalB[0], finalB[1], { steps: 6 }); await t.sleep(60);
@@ -210,9 +212,40 @@ runE2E('W-E2E-GRID-GREENORANGE', async (t) => {
       doorInCommands: gridMove ? gridMove.parameters.commands.some(c => c.featureId === doorFid) : null, inducedCount: induced.length };
   }, beforeB.len, idsB.door);
   console.log('  §GREENORANGE H2 ' + JSON.stringify(opCheckB));
-  t.assert('H2 commit: door\'s own command is STRIPPED from the committed GEOM_GRID_MOVE + exactly ONE induced hosted-by GEOM_MOVE for it (preview and commit AGREE)',
-    afterB.len === beforeB.len + 2 && opCheckB.doorInCommands === false && opCheckB.inducedCount === 1, JSON.stringify(opCheckB));
+  t.assert('H2 commit: door\'s own command is STRIPPED from the committed GEOM_GRID_MOVE + ZERO induced GEOM_MOVE for it (held — preview and commit AGREE)',
+    afterB.len === beforeB.len + 1 && opCheckB.doorInCommands === false && opCheckB.inducedCount === 0, JSON.stringify(opCheckB));
   await t.shot('07-scenarioB-committed');
+
+  // ── H3 (§DAGEVU): RIDE OPT-IN through the SAME real ctrl+click — on an OPENING the toggle means anchor↔ride,
+  // not exclude. Undo, ctrl+click the door, re-drag the same gridline → door tints BLUE mid-drag and the commit
+  // carries exactly ONE induced hosted-by GEOM_MOVE (the pre-§DAGEVU behaviour, now explicit).
+  await t.undoToCursor(beforeB.cur);
+  await t.clickSel('#b-gridmove'); await t.sleep(300);                            // re-arm (H2's commit already exited grid-move)
+  // The fixture door (x 3.7..4.0, y 0.05..0.15, z 0..1) is FULLY ENCLOSED by the host box (0..4, 0..0.2, 0..3), so a
+  // raycast pick from any camera hits the wall first — a real ctrl+click cannot reach it in this fixture (real
+  // SampleHouse doors sit in cut voids / protrude and are pickable; the pick itself is already proven by G1-G3).
+  // So call the SAME production function the ctrl+click handler calls one level below the pick.
+  const tog = await t.pg.evaluate((fid) => ({ isFilling: window.Bonsai.gridmove.isFilling(fid), held: window.Bonsai.gridmove.toggleOverride(fid) }), idsB.door);
+  const rideSet = await t.pg.evaluate(() => window.Bonsai.gridmove.rideList());
+  const doorEmisPre = await emisOf(t, idsB.door);
+  await t.pg.mouse.move(downB[0], downB[1]); await t.sleep(40);
+  await t.pg.mouse.down(); await t.sleep(40);
+  await t.pg.mouse.move(midB[0], midB[1], { steps: 6 }); await t.sleep(150);
+  const midDoor3 = await emisOf(t, idsB.door);
+  await t.pg.mouse.move(finalB[0], finalB[1], { steps: 6 }); await t.sleep(60);
+  await t.pg.mouse.up(); await t.sleep(900);
+  const after3 = await t.oplog();
+  // undone rows stay in _geomOps (undone=1 flag) — count only ops appended AFTER H2's commit (afterB.len).
+  const op3 = await t.pg.evaluate((fromLen, doorFid) => {
+    const added = window.Bonsai.oplog._geomOps().slice(fromLen);
+    return { addedTypes: added.map(o => o.op_type), inducedCount: added.filter(o => o.op_type === 'GEOM_MOVE' && o.parameters && o.parameters.induced === 'hosted-by' && o.parameters.parent === doorFid).length };
+  }, afterB.len, idsB.door);
+  console.log('  §DAGEVU H3 toggle=' + JSON.stringify(tog) + ' rideSet=' + JSON.stringify(rideSet) + ' doorEmisPreDrag=0x' + (doorEmisPre || 0).toString(16) + ' midDoor=0x' + (midDoor3 || 0).toString(16) + ' ops=' + JSON.stringify(op3) + ' len ' + afterB.len + '→' + after3.len);
+  t.slog.filter(l => /§DAGEVU/.test(l)).forEach(l => console.log('    ' + l.slice(0, 300)));
+  await t.shot('08-scenarioB-ride-optin');
+  t.assert('H3 ride opt-in: toggleOverride(OPENING) means anchor→ride (isFilling true, rideList has it), door tints BLUE mid-drag, commit = GEOM_GRID_MOVE + exactly ONE induced hosted-by GEOM_MOVE',
+    tog.isFilling === true && tog.held === false && rideSet.includes(idsB.door) && midDoor3 === BLUE && after3.len === afterB.len + 2 && op3.inducedCount === 1,
+    'toggle=' + JSON.stringify(tog) + ' mid=0x' + (midDoor3 || 0).toString(16) + ' ' + JSON.stringify(op3));
 
   // Surface the REAL production §GRIDMOVE log lines captured off the app's own console (t.slog) — the app code
   // itself (bonsai_gridmove.js) is what logs §GREEN-EXCLUDE toggle/reset/commit-skip, not just this witness's

--- a/modeller/tests/witness_e2e_gridmove_real.js
+++ b/modeller/tests/witness_e2e_gridmove_real.js
@@ -182,8 +182,12 @@ runE2E('W-E2E-GRIDMOVE-REAL', async (t) => {
   const riderCmd = gestureOps.find(o => o.op_type === 'GEOM_MOVE' && o.parameters && o.parameters.parent === doorFid && o.parameters.induced === 'hosted-by');
   const totalRiders = gestureOps.filter(o => o.op_type === 'GEOM_MOVE' && o.parameters && o.parameters.induced === 'hosted-by').length;
   console.log('  §GESTURE-RIDERS n=' + totalRiders + ' tail=' + JSON.stringify(gestureOps.map(o => o.op_type + (o.parameters && o.parameters.parent != null ? ':' + o.parameters.parent : ''))));
-  t.assert('G7 RIDE (host wall106\'s real hosted door rode via §STRETCH-RIDE, not left behind)',
-    doorFid != null && riderCmd && riderCmd.parameters && riderCmd.parameters.parent === doorFid && doorC0 && doorC1 && Math.abs((doorC1[1] - doorC0[1]) - riderCmd.parameters.dy) < 0.01,
+  // §DAGEVU (SPEC_DAGEVU_ENGINE.md §5): the old G7 expected the door to RIDE (always-ride default) — STALE. The
+  // anchor default HOLDS the real hosted door in place while wall106 grows (+DY at the gridline end): no induced
+  // rider row for it, centre unchanged. (ride is now the explicit ctrl+click opt-in — proven in
+  // witness_e2e_stretch_ride E5 / witness_e2e_grid_greenorange H3.)
+  t.assert('G7 ANCHOR (host wall106\'s real hosted door HELD in place — no induced rider row, centre unchanged; §DAGEVU default)',
+    doorFid != null && !riderCmd && doorC0 && doorC1 && Math.abs(doorC1[1] - doorC0[1]) < 1e-3 && Math.abs(doorC1[0] - doorC0[0]) < 1e-3,
     'doorFid=' + doorFid + ' door y ' + (doorC0 && doorC0[1].toFixed(3)) + '→' + (doorC1 && doorC1[1].toFixed(3)) + ' riderDy=' + (riderCmd && riderCmd.parameters && riderCmd.parameters.dy && riderCmd.parameters.dy.toFixed(3)) + ' induced=' + (riderCmd && riderCmd.parameters && riderCmd.parameters.induced));
 
   t.assert('G8 CHAIN-OK (verifyChain)', chain === true, 'verifyChain=' + chain);

--- a/modeller/tests/witness_e2e_stretch_ride.js
+++ b/modeller/tests/witness_e2e_stretch_ride.js
@@ -4,6 +4,13 @@
  * NOT divorce or scale its hosted door/window). Implementing RESUME_CASCADE_INTO_STRETCH.md §STRETCH-RIDE —
  * Witness: W-STRETCH-RIDE. Read the log after every run.
  *
+ * §DAGEVU UPDATE (2026-09-10, prompts/SPEC_DAGEVU_ENGINE.md §5): the DEFAULT for a hosted opening under a host
+ * LENGTH change is now ANCHOR (the opening keeps its world position; the wall's free end absorbs the delta) —
+ * the proportional RIDE is an explicit per-opening opt-in (ctrl+click / gridmove.toggleOverride). E2b/E3a below
+ * were STALE expectations of the old always-ride default and now assert the anchor default; E5 proves the opt-in
+ * still yields the old ride exactly. E1 additionally requires a pair the engine does not REFUSE (a shrink that
+ * would push the held opening out of its wall is refused honestly, never committed).
+ *
  * Real production path (real toolbar + real drag hook), REAL SampleHouse (7 rel_fills_host rows, §ARC-1 substrate
  * auto-seeded on Open — see str_walker_outliner.js _seedArcEditable). No hardcoded featureIds: the host/gridline/
  * delta/rider are DISCOVERED live from the app's own engine (window.Bonsai.gridmove.computeCommands) cross-checked
@@ -45,7 +52,7 @@ runE2E('W-E2E-STRETCH-RIDE', async (t) => {
     function centreOf(b) { return [(b[0] + b[1]) / 2, (b[2] + b[3]) / 2, (b[4] + b[5]) / 2]; }
     const fbg = window.__arcFidByGuid, gbf = window.__arcGuidByFid, fills = window.swXEdges.fills;
     const lines = window.Bonsai.gridmove.gridLines();      // REAL authoring grid, current state
-    const deltas = [1, -1, 2, -2, 0.5, -0.5, 1.5, -1.5, 3, -3, 4, -4];
+    const deltas = [1, 2, 0.5, 1.5, 3, 4, -0.5, -1, -1.5, -2, -3, -4];   // §DAGEVU: grows first (never refused); shrinks may be refused
     for (const line of lines) {
       for (const d of deltas) {
         let cmds; try { cmds = window.Bonsai.gridmove.computeCommands(line.id, d); } catch (e) { continue; }
@@ -61,7 +68,10 @@ runE2E('W-E2E-STRETCH-RIDE', async (t) => {
             const doorFid = fbg[edge.filling_guid];
             const rb = boxOf(doorFid); if (!rb) continue;
             if (!withinXY(hb, centreOf(rb), 0.05)) continue;    // the SAME honest pre-check the production gate uses
-            return { gridId: line.id, delta: d, hostFid: c.featureId, doorFid: doorFid, hostGuid, doorGuid: edge.filling_guid };
+            // §DAGEVU: the production preview must HOLD this door (anchor default) and refuse nothing for this drag
+            let pv; try { pv = window.Bonsai.gridmove.previewCommands(line.id, d); } catch (e) { continue; }
+            if (!pv || (pv.refusals && pv.refusals.length) || !(pv.held || []).includes(doorFid)) continue;
+            return { gridId: line.id, delta: d, hostFid: c.featureId, doorFid: doorFid, hostGuid, doorGuid: edge.filling_guid, dimLabel: pv.dimLabel };
           }
         }
       }
@@ -101,11 +111,15 @@ runE2E('W-E2E-STRETCH-RIDE', async (t) => {
   console.log('  §STRETCH-RIDE E2 pre.dims=' + JSON.stringify(pre && pre.dims) + ' post.dims=' + JSON.stringify(post && post.dims) + ' dimDelta=' + dimDelta.toExponential(2));
   console.log('  §STRETCH-RIDE E2 pre.centre=' + JSON.stringify(pre && pre.centre) + ' post.centre=' + JSON.stringify(post && post.centre) + ' centreShift=' + centreShift.toFixed(4) + 'm');
   console.log('  §STRETCH-RIDE E2 lastGate="' + lastGate + '" oplog ' + before.len + '→' + after.len);
+  // Log Mandate: surface the app's OWN §GATE / §DAGEVU / §GRIDMOVE lines (captured off the page console) so the
+  // gate's actual RED/ORANGE kinds are in this log, not just the status-bar summary string.
+  t.slog.filter(l => /§GATE|§DAGEVU|§STRETCH-RIDE|§GREEN-EXCLUDE/.test(l)).forEach(l => console.log('    ' + l.slice(0, 400)));
   await t.shot('03-post-ride');
 
-  t.assert('E2a RIDE — rider mesh extent UNCHANGED (no scale reached it, tol 1e-4)', dimDelta < 1e-4, 'dimDelta=' + dimDelta.toExponential(2));
-  t.assert('E2b RIDE — rider mesh centre MOVED (the ride fired)', centreShift > 0.01, 'centreShift=' + centreShift.toFixed(4) + 'm');
-  t.assert('E2c RIDE — gate shows no door-out RED (legitimate stretch)', !/RED/.test(lastGate) || !/door-out/.test(lastGate), 'lastGate="' + lastGate + '"');
+  t.assert('E2a ANCHOR — opening mesh extent UNCHANGED (no scale reached it, tol 1e-4)', dimDelta < 1e-4, 'dimDelta=' + dimDelta.toExponential(2));
+  t.assert('E2b ANCHOR — opening mesh centre UNCHANGED (§DAGEVU default: the wall\'s free end absorbed the delta, the opening stayed put)', centreShift < 1e-3, 'centreShift=' + centreShift.toFixed(4) + 'm');
+  t.assert('E2c ANCHOR — gate shows no door-out/door-crush RED (the held opening is still inside its wall)', !/RED/.test(lastGate) || !/door-(out|crush)/.test(lastGate), 'lastGate="' + lastGate + '"');
+  t.assert('E2d READOUT — the engine\'s dimLabel carried the measured wall length change (w→w\') + "held"', typeof disc.dimLabel === 'string' && /→/.test(disc.dimLabel) && /held/.test(disc.dimLabel), 'dimLabel="' + disc.dimLabel + '"');
 
   // E3 — real op-log: exactly one induced GEOM_MOVE {induced:'hosted-by', parent:doorFid} for the rider, and the
   // committed GEOM_GRID_MOVE's own parameters.commands has NO entry for the rider (stripped, not just overridden).
@@ -118,8 +132,8 @@ runE2E('W-E2E-STRETCH-RIDE', async (t) => {
     return { addedTypes: added.map(o => o.op_type), inducedCount: inducedMoves.length, strippedOk, gridMoveCmds: gridMove ? gridMove.parameters.commands.length : null };
   }, disc.doorFid, before.len);
   console.log('  §STRETCH-RIDE E3 ' + JSON.stringify(opCheck));
-  t.assert('E3a OP-LOG — exactly ONE induced GEOM_MOVE {induced:hosted-by, parent:rider} for the rider', opCheck.inducedCount === 1, JSON.stringify(opCheck));
-  t.assert('E3b OP-LOG — the committed GEOM_GRID_MOVE carries NO entry for the rider (stripped)', opCheck.strippedOk, JSON.stringify(opCheck));
+  t.assert('E3a OP-LOG — ZERO induced GEOM_MOVE for the held opening (anchor default: nothing to induce)', opCheck.inducedCount === 0, JSON.stringify(opCheck));
+  t.assert('E3b OP-LOG — the committed GEOM_GRID_MOVE carries NO entry for the opening (stripped, never scaled)', opCheck.strippedOk, JSON.stringify(opCheck));
 
   // E4 — pixel-readback visibility (open rigor item): project the rider's post-ride world bbox centre to screen
   // space and readPixels a small rect around it; assert non-background colour + visible + opaque + in-frustum.
@@ -162,4 +176,28 @@ runE2E('W-E2E-STRETCH-RIDE', async (t) => {
   await t.shotClip('04-rider-visible', disc.doorFid, 60);
   t.assert('E4a VISIBLE — rider is in-frustum, mesh.visible, opacity>0', vis.ok && vis.inFrustum && vis.visible === true && (vis.opacity == null || vis.opacity > 0), JSON.stringify(vis));
   t.assert('E4b VISIBLE — readPixels around the rider finds non-background pixels (rasterized, not just data-visible)', vis.ok && vis.total > 0 && vis.nonBg > 0, 'nonBg=' + vis.nonBg + '/' + vis.total);
+
+  // E5 — RIDE OPT-IN: undo the anchored stretch, opt the opening into RIDE (the production toggle the ctrl+click
+  // handler calls), re-run the SAME stretch → the pre-§DAGEVU behaviour exactly: centre moved, one induced move.
+  await t.undoToCursor(before.cur);
+  const undone = await t.oplog();
+  const optIn = await t.pg.evaluate((fid) => { const held = window.Bonsai.gridmove.toggleOverride(fid); return { held, ride: window.Bonsai.gridmove.rideList() }; }, disc.doorFid);
+  await t.pg.evaluate((id, d) => window.__gridStretch(id, d), disc.gridId, disc.delta);
+  await t.sleep(900);
+  const post5 = await t.pg.evaluate((fid) => {
+    const g = window.Bonsai.group(); const m = g.children.find(o => o.isMesh && o.userData.featureId === fid);
+    if (!m) return null; m.geometry.computeBoundingBox(); const b = m.geometry.boundingBox;
+    return { dims: [b.max.x - b.min.x, b.max.y - b.min.y, b.max.z - b.min.z], centre: [(b.min.x + b.max.x) / 2, (b.min.y + b.max.y) / 2, (b.min.z + b.max.z) / 2] };
+  }, disc.doorFid);
+  const op5 = await t.pg.evaluate((doorFid, beforeLen) => {
+    const added = window.Bonsai.oplog._geomOps().slice(beforeLen);
+    return { addedTypes: added.map(o => o.op_type), inducedCount: added.filter(o => o.op_type === 'GEOM_MOVE' && o.parameters && o.parameters.induced === 'hosted-by' && o.parameters.parent === doorFid).length };
+  }, disc.doorFid, before.len);
+  const shift5 = pre && post5 ? Math.hypot(...pre.centre.map((v, i) => v - post5.centre[i])) : 0;
+  const dim5 = pre && post5 ? Math.max(...pre.dims.map((v, i) => Math.abs(v - post5.dims[i]))) : Infinity;
+  console.log('  §DAGEVU E5 undone.cur=' + undone.cur + ' optIn=' + JSON.stringify(optIn) + ' centreShift=' + shift5.toFixed(4) + 'm ops=' + JSON.stringify(op5));
+  await t.shot('05-ride-optin');
+  t.assert('E5 RIDE OPT-IN — after undo + toggleOverride(opening) the SAME stretch rides it: centre MOVED, extent unchanged, exactly ONE induced hosted-by GEOM_MOVE',
+    undone.cur === before.cur && optIn.held === false && optIn.ride.includes(disc.doorFid) && shift5 > 0.01 && dim5 < 1e-4 && op5.inducedCount === 1,
+    'shift=' + shift5.toFixed(4) + ' dim=' + dim5.toExponential(2) + ' ' + JSON.stringify(op5));
 }, { width: 1280, height: 860, dpr: 2 });

--- a/prompts/RESUME_MODELLER_DAGEVU_ENGINE.md
+++ b/prompts/RESUME_MODELLER_DAGEVU_ENGINE.md
@@ -115,6 +115,43 @@ expectation, update it" from "real regression, don't paper over it" for each, an
   PAUSED note above) — don't redispatch with the original roof-inclusive brief, use the narrowed one
   in "Full original engine brief" above (AngleEdge already marked ⛔ there).
 
+## Separate backlog item (2026-09-10, not part of the engine work) — repo-root script clutter
+
+`bim-ootb` repo root has ~202 loose scripts that should be nested into their proper folders:
+- **163 `witness_*.js`** directly at root (not in any `tests/` dir). By naming (`witness_cinema_*`,
+  `witness_gantt_*`, `witness_tour_*`, `witness_room_*`, `witness_cpe_*`, `witness_maxq_*`,
+  `witness_photo_*`, etc.) these clearly belong in `viewer/tests/` alongside the 133 already there —
+  confirmed ZERO filename collisions against every existing nested tests dir (viewer/modeller/
+  hr_bim_asset/erp/geomapping/teams/common/tests).
+- **39 other loose scripts** (`probe_*`, `sandbox_*`, `cli_*`, `poc_*`, `smoke_*`, `drag_test.js`,
+  `optics_*`, `cdp.js`, `import_own.js`) plus **1 `.py`** (`score_frame_budget.py`) — same clutter
+  pattern. `eslint.config.js` is legitimate, leave it at root.
+
+**NOT a safe blind `git mv`.** At least 66 of the 163 witness files build filesystem paths off
+`__dirname` ASSUMING `__dirname` is the repo root — e.g. `path.join(__dirname, 'viewer', 'scene.js')`,
+`path.join(__dirname, 'common', 'room_graph.js')`, `path.join(__dirname, 'buildings', ...)`,
+`path.join(__dirname, 'modeller', 'lib', 'sql-wasm.wasm')`. Moving any of them one directory deeper
+breaks that resolution silently. (One exception found: `execSync('git show origin/main:common/...',
+{cwd:__dirname})` is SAFE regardless of depth — git resolves `rev:path` against the repo root, not
+cwd, as long as cwd is anywhere inside the repo.)
+
+**The fix is mechanically uniform IF the move is exactly one level deep** (e.g. everything into
+`viewer/tests/`, which is one level deeper than root): every repo-root-relative `path.join(__dirname,
+X, ...)` / `__dirname + '/X/...'` needs exactly one `'..'` inserted right after `__dirname`. But
+"uniform mechanical fix" still means: apply it, then actually RUN a representative sample of the
+moved witness files to confirm nothing broke — don't trust the pattern-match alone. That's real token
+cost (a meaningful fraction of 163 test runs, several needing headless Chrome), which is why this was
+deferred rather than done same-session (user, 2026-09-10: "be careful on the tokens burning fast").
+
+**Not investigated at all yet:** which folder each of the 39 non-witness scripts actually belongs in
+(probably `scripts/` or a new `sandbox/`/`probes/` dir — didn't check for an existing home), and
+whether THEY have the same `__dirname`-as-root coupling (likely, given the shared authoring pattern,
+but unconfirmed).
+
+**Suggested approach next session:** pick ONE destination folder, move+fix+verify in a small batch
+(e.g. 10-15 files), confirm the pattern holds, then batch the rest — don't attempt all ~200 in one
+pass untested.
+
 ## How to resume next session
 
 1. Try `SendMessage` to agent id `a9dfff070e94bb7ce` (the engine) first — cheapest path if it resolves.

--- a/prompts/RESUME_MODELLER_DAGEVU_ENGINE.md
+++ b/prompts/RESUME_MODELLER_DAGEVU_ENGINE.md
@@ -1,0 +1,125 @@
+# RESUME — DAGeVu Engine (foundational constraint-graph) + related in-flight tasks
+
+```
+# ⚠ DO NOT REMOVE
+SCOPE: build modeller/dagevu_engine.js — a small, reusable, OOP (ES6 class-based, not the closure
+style used elsewhere in this codebase) "relationship edge" engine that generalizes the existing
+proven rel_fills_host stretch-ride pattern into a named, reusable contract. This is the FOUNDATIONAL
+piece three concrete asks build on: (1) grid-stretch default flips from "opening rides" to "opening
+stays put, host absorbs the delta at its free end", with ride demoted to an explicit per-element
+opt-in; (2) a generic live-dimension-readout hook for any constrained drag; (3) future roof
+angle/apex editing — EXPLICITLY PAUSED, see below, do not resume without asking first.
+Honour this scope until every numbered item below is ✅ or ⛔. Read the log after every witness run —
+exit code alone is not evidence.
+```
+
+## Why this exists (session 2026-09-10)
+
+User wants DAGeVu's core differentiator — dragging a grid line and dependent geometry (walls,
+openings) intuitively adjusting without distortion — extended two ways: (a) an anchored-opening mode
+where the opening does NOT ride, the wall grows/shrinks around it instead; (b) a live dimension
+readout while dragging, matching what move/rotate/scale already show (grid-move currently shows
+NONE — confirmed by grep, zero hits for `dimLabelShow`/`setStat`/`§V7` in `bonsai_gridmove.js`).
+Rather than patch these in ad hoc, user asked for a foundational, reusable engine first, explicitly
+in clean OOP (their words: "reusable Java like OOP... which we can then claim as our DAGeVu engine").
+
+Roof angle/apex was raised as a third use case but is **PAUSED, not in scope right now** — a live
+check found ZERO real measured roof-slope/pitch/apex data anywhere in the codebase (every "roof" hit
+is just an `IfcRoof` class/color label). Building it would mean inventing a slope number, which
+violates this codebase's NON-INVENT rule. User's own words, 2026-09-10: "pause the roof slope task
+as it is not foundational." Do not build `AngleEdge` or research roof data further without the user
+raising it again.
+
+## What already exists and must be REUSED, not reinvented
+
+- `modeller/sdg_cascade.js` `stretchRide()`/`ridersFor()` — the proven host→filling ride math, sourced
+  strictly from real extracted `rel_fills_host` edges (`cross_edges.js` ~line 246-251, never proximity
+  guessing). Green: `witness_sdg_cascade.js` 7/7, `witness_e2e_stretch_ride.js` 9/9.
+- `modeller/sdg_gate.js` "abuts-realign" ORANGE check — real wall-adjacency gap math with a
+  `proposedDelta` that re-closes a gap. Green: `witness_sdg_gate.js` A8/A8b/A8c.
+- `witness_e2e_grid_greenorange.js` (12/12) — the existing per-element opt-out UX during a grid drag
+  (ctrl+click a wall to toggle green/excluded vs orange/included, live tinting, stripped from the
+  committed `GEOM_GRID_MOVE` command list). The anchor/ride mode toggle should REUSE this exact
+  interaction, not invent a new one.
+- `bonsai_itemdrag.js`'s `resolveHost()`/`HOST_TOL`/wall-branch — the host-axis/plane math for "which
+  wall, which face" — reuse for anchor mode's "which end of the wall is free of openings" derivation.
+- `modeller.html` `dimLabelShow()`/`setStat()` (search "§V7") — the existing live-readout UI primitives
+  move/rotate/scale already use. Grid-move must call these, not build new UI.
+
+## Full original engine brief (unabridged — the dispatched agent had this; re-read before continuing)
+
+Build `modeller/dagevu_engine.js`:
+- Abstract base `RelationEdge` — one contract method `propagate(drivingDelta, realGeometry) →
+  { dependentDeltas, dimLabel }`.
+- `HostFillEdge extends RelationEdge` — `mode:'ride'` delegates to existing `stretchRide()` (wrap,
+  don't duplicate). `mode:'anchor'` (NEW): filling's world position stays fixed; host absorbs the
+  whole delta at the END AWAY FROM the opening (derive via real measured position along the wall's
+  local axis). Multiple openings on one wall: keep ALL fixed, grow from whichever end is free; if
+  openings exist on BOTH ends (no free end), REFUSE honestly (return null/error), never fabricate a
+  resolution.
+- `AbutsEdge extends RelationEdge` — wraps `sdg_gate.js`'s abuts-realign `proposedDelta` (don't
+  reimplement) — closes the gap anchor mode's freed-end growth creates against a real neighbor.
+- `AngleEdge` — ⛔ PAUSED, do not build (see above).
+
+Wire into `bonsai_gridmove.js`: anchor becomes the default; ride is the explicit per-element
+override via the green/orange toggle (repurpose the existing interaction, don't rebuild it). Wire the
+live dimension readout into the same file's pointermove, feeding `dimLabelShow()`/`setStat()`.
+
+**Explicit behavior-change warning carried into the original brief:** this changes a TESTED default
+(grid-stretch used to always ride). `witness_e2e_gridstretch.js`, `witness_e2e_stretch_ride.js`,
+`witness_sdg_cascade.js` (if it has a grid-driven E2E path), `witness_e2e_grid_greenorange.js` will
+need assertions UPDATED to match the new intended default — exactly like `witness_e2e_delete.js` D4
+needed updating in the sibling DELETE/REDO fix (below) for an analogous reason. Distinguish "stale
+expectation, update it" from "real regression, don't paper over it" for each, and say which.
+
+## Status of the three dispatched tasks (2026-09-10, session paused for a reset)
+
+### 1. ✅ DONE — DELETE/REDO history-tree fix (unrelated bug, not part of the engine, already shipped)
+- Root cause: `deleteFeature()` flagged rows `undone=1` but was never wired into `ModellerHistory`'s
+  tree — Ctrl+Z after a delete undid the wrong thing, Ctrl+Y only "worked" by op-log accident.
+- Fix: `bonsai_oplog.js#setUndone(ids,val)` (id-targeted flip) + `modeller_history.js` wraps
+  `deleteFeature()` to push a tree node carrying its row ids; ordinary commits stay on the old path.
+- **PR open, unmerged: https://github.com/red1oon/bim-ootb/pull/1704** (branch
+  `fix/delete-redo-history-sync`, worktree `/tmp/wt-scale-cut-fix` — still on disk).
+- Docs correction for the same fix, also open unmerged: **BIMCompiler PR #100**
+  (branch `docs/delete-redo-fix`, worktree `/tmp/wt-bimcompiler-docs`, corrects `docs/ModellerGuide.md`
+  §Delete). Live docs site NOT redeployed yet (deliberately — `scripts/safe_gh_deploy.sh` publishes
+  publicly, held for explicit go-ahead).
+- **Next session: just merge both PRs if the diffs still look right — no further coding needed here.**
+
+### 2. 🔶 IN PROGRESS, KILLED MID-TASK — along-host opening-slide drag (separate feature, not the engine)
+- Scope was: let `bonsai_itemdrag.js`'s free single-item drag constrain a hosted filling to slide
+  along its OWN host wall's plane/bounds (not free 3D), and either keep a real carved cut void in sync
+  or honestly refuse — the gap that file's own header flags at line ~88 ("no separate along-host
+  slide constraint in v1, spec §3.1 defers to Q5").
+- **Real, substantial, UNVERIFIED progress exists on disk**: 256 lines changed in `bonsai_itemdrag.js`,
+  6 lines in `modeller.html`, uncommitted, in worktree
+  `/home/red1/bim-ootb/.claude/worktrees/agent-a8b5dc9ca46ba4e72` (branch
+  `worktree-agent-a8b5dc9ca46ba4e72`). Never ran its witness test, never confirmed it works —
+  treat as a rough draft, not working code, until reviewed and tested.
+- **Resumable**: this was a background agent (killed via TaskStop, not completed) — per this
+  session's own tooling, sending it another message resumes it from its saved transcript. Its
+  agent id: `a8b5dc9ca46ba4e72`. If that id/name no longer resolves next session (agent ids don't
+  always survive a hard reset), fall back to: read the diff in that worktree directly, read
+  `bonsai_itemdrag.js`'s own header + the original dispatch brief in this session's transcript
+  (not reproduced here — this doc is the pointer, not a full copy) — or just re-diagnose from the
+  diff itself, it's small enough to read cold.
+- **Not part of the "foundational engine" ask** — lower priority, resume only after the engine itself.
+
+### 3. 🔶 BARELY STARTED, KILLED — dagevu_engine.js itself (THE foundational task)
+- Agent got only as far as "I'll start by exploring the codebase" — **zero files touched, no worktree
+  ever created**. Genuinely nothing lost; also genuinely nothing done.
+- Agent id: `a9dfff070e94bb7ce` (same resumability caveat as above — try SendMessage first, fall back
+  to a fresh dispatch reading this file if it doesn't resolve).
+- Mid-flight scope cut already applied before it was killed: **drop `AngleEdge`/roof entirely** (see
+  PAUSED note above) — don't redispatch with the original roof-inclusive brief, use the narrowed one
+  in "Full original engine brief" above (AngleEdge already marked ⛔ there).
+
+## How to resume next session
+
+1. Try `SendMessage` to agent id `a9dfff070e94bb7ce` (the engine) first — cheapest path if it resolves.
+2. If not, re-dispatch fresh using the "Full original engine brief" section above verbatim as the
+   prompt (it already has the roof-cut applied) — a fresh Fable-tier agent, isolated worktree.
+3. Opening-slide (`a8b5dc9ca46ba4e72`) is lower priority — pick up after the engine lands, either by
+   resuming that agent id or reviewing/finishing the existing 256-line diff by hand.
+4. Merge PR #1704 (bim-ootb) and PR #100 (BIMCompiler) whenever convenient — independent of the above.

--- a/prompts/RESUME_MODELLER_DAGEVU_ENGINE.md
+++ b/prompts/RESUME_MODELLER_DAGEVU_ENGINE.md
@@ -106,7 +106,18 @@ expectation, update it" from "real regression, don't paper over it" for each, an
   diff itself, it's small enough to read cold.
 - **Not part of the "foundational engine" ask** — lower priority, resume only after the engine itself.
 
-### 3. 🔶 BARELY STARTED, KILLED — dagevu_engine.js itself (THE foundational task)
+### 3. ✅ DONE 2026-09-10 (this PR) — dagevu_engine.js (THE foundational task)
+- Built by the primary session (no subagent), spec-first: `prompts/SPEC_DAGEVU_ENGINE.md`. `modeller/dagevu_engine.js`
+  (RelationEdge / HostFillEdge anchor|ride / AbutsEdge / DagevuEngine), wired into `bonsai_gridmove.js` +
+  `modeller.html` (anchor default, ctrl+click on an opening = anchor↔ride, refusal blocks commit, engine dimLabel
+  in setStat + dimLabelShow). W-DAGEVU-ENGINE 10/10; e2e stretch_ride 11/11, greenorange 13/13, gridmove_real 8/8,
+  gridstretch 7/7; node stretch_ride 9/9, sdg_cascade 7/7, sdg_gate 11/11. void_anchor G6 fails identically on
+  untouched main (cross-edge count drift, pre-existing, not this change).
+- Recon correction: grid-move DID already show a §V7 readout (modeller.html ~line 2004, grid Δ only); the engine
+  label now rides on it.
+- Status of item 1 as of 2026-09-10: bim-ootb PR #1704 MERGED; BIMCompiler PR #100 still OPEN (docs).
+- Original state before this session, kept for history:
+#### (was) 🔶 BARELY STARTED, KILLED — dagevu_engine.js itself
 - Agent got only as far as "I'll start by exploring the codebase" — **zero files touched, no worktree
   ever created**. Genuinely nothing lost; also genuinely nothing done.
 - Agent id: `a9dfff070e94bb7ce` (same resumability caveat as above — try SendMessage first, fall back

--- a/prompts/SPEC_DAGEVU_ENGINE.md
+++ b/prompts/SPEC_DAGEVU_ENGINE.md
@@ -1,0 +1,124 @@
+# SPEC — DAGeVu Engine (`modeller/dagevu_engine.js`) — Witness: W-DAGEVU-ENGINE
+
+```
+# ⚠ DO NOT REMOVE
+SCOPE: modeller/dagevu_engine.js — an ES6 class-based "relationship edge" engine that generalizes the proven
+rel_fills_host stretch-ride (sdg_cascade.js) into a named, reusable contract, and wires it into the grid drag
+(bonsai_gridmove.js + modeller.html) with (1) ANCHOR as the new default for hosted openings under a host
+LENGTH change, RIDE demoted to an explicit per-element opt-in via the existing ctrl+click toggle, and
+(2) the engine's dimension label fed into the existing §V7 dimLabelShow()/setStat() readout.
+OUT OF SCOPE: AngleEdge / roof pitch (⛔ PAUSED — no measured roof-slope data exists; user 2026-09-10).
+Read the log after every witness run — exit code alone is not evidence.
+```
+
+Parent: `prompts/RESUME_MODELLER_DAGEVU_ENGINE.md` (branch `docs/resume-dagevu-engine`). Session 2026-09-10.
+
+## §1 Reuse contract (nothing below is reimplemented)
+
+| Existing, proven | Reused as |
+|---|---|
+| `sdg_cascade.js stretchRide()` (W-STRETCH-RIDE 9/9) | the whole of `HostFillEdge` mode `'ride'`, and the TRANSLATE part of mode `'anchor'` |
+| `sdg_gate.js evaluate()` abuts-realign `proposedDelta` (A8/A8b/A8c) | the whole of `AbutsEdge.propagate()` |
+| `sdg_gate.js` door-crush fit rule (`fitBefore && !fitAfter`, tol 0.05 m, per changed axis) | the anchor refusal oracle — so a preview refusal is exactly what the post-commit gate would flag RED |
+| `bonsai_library.js foldInsert` grid-command mapping (`TRANSLATE: x+=d`; `SCALE: x' = f·x + m·(1−f) + t`) | `RelationEdge.foldBox()` — the pure AABB image of a command list (needed for the anchor fit test, the host length readout, and the AbutsEdge after-state) |
+| `bonsai_gridmove.js` ctrl+click green/orange toggle (W-E2E-GRID-GREENORANGE 12/12) | the ride opt-in: ctrl+click on a FILLING toggles anchor↔ride; on anything else it stays the exclude toggle |
+| `modeller.html dimLabelShow()/setStat()` (§V7) | the readout — the engine returns ONE `dimLabel` string; both UI calls print it (single math path) |
+
+Recon correction (2026-09-10): the resume doc says grid-move shows no live readout. modeller.html line ~2004
+already calls `dimLabelShow(gridId + ' Δ…m', hit)` on every grid pointermove. The gap is that the readout carries
+only the grid delta, not what the constrained geometry does; the engine's `dimLabel` fills that gap.
+
+## §2 Classes
+
+```
+RelationEdge { kind, a (driving fid), b (dependent fid) }
+  propagate(drivingDelta, realGeometry) → { dependentDeltas:[{featureId,dx,dy,dz}], dimLabel } | null   (abstract)
+  static foldBox(aabb, commands) → aabb'      (pure; the fold's own mapping, see §1)
+HostFillEdge extends RelationEdge { hostFid, fillingFid, hostGuid, fillingGuid, provenance, mode:'anchor'|'ride' }
+  propagate(hostCommands, { boxByFid, guidByFid, fidByGuid })
+AbutsEdge extends RelationEdge { a, b }
+  propagate({ before, after, moved }) → { dependentDeltas:[{featureId:nb, …, proposed:true}], dimLabel } | null
+DagevuEngine { edges, modes }
+  constructor({ guidByFid, fidByGuid, fills, abuts, cascade, gate, rideFids })
+  isFilling(fid) · modeOf(fid) · setMode(fid, mode) · toggleMode(fid) → mode · reset()
+  propagateCommands(commands, boxByFid) → { commands, riders, held, refusals, proposals, dimLabel }
+```
+
+Edges are built ONLY from real rows: one `HostFillEdge` per `rel_fills_host` row whose host AND filling resolve
+through the §ARC-1 bridge; one `AbutsEdge` per `swXEdges.abuts` row likewise. Unresolvable rows produce no edge.
+Dual export (window.DagevuEngine + module.exports) like sdg_cascade.js so the value witness runs pure-node.
+
+## §3 Semantics
+
+**mode `'ride'`** — delegates to `stretchRide(hostCommands, …, [this row], boxByFid)`; output identical to today.
+
+**mode `'anchor'` (DEFAULT)** — the opening's world position is invariant under a host LENGTH change:
+- TRANSLATE commands on the host still carry the filling rigidly (a wall whose whole body moves cannot leave its
+  door in the air; that is a geometric impossibility, not a mode). Computed by delegating the TRANSLATE subset to
+  `stretchRide` (same math, one place).
+- SCALE commands on the host induce ZERO filling delta. The filling's own engine command is STRIPPED exactly as
+  in ride mode (a filling is never scaled by the grid).
+- Free-end check (grid-driven context): the growing/shrinking end is dictated by the dragged gridline, not chosen
+  by the engine; the engine VERIFIES that end is free of the opening. On every SCALE axis k, with host' =
+  `foldBox(hostBox, hostCommands)` and filling' = fillingBox + translate part:
+  `fitBefore = filling ⊂ host ± 0.05` and `fitAfter = filling' ⊂ host' ± 0.05`; `fitBefore && !fitAfter` ⇒
+  **REFUSE**: `propagate()` returns `null` and `edge.refusal = { kind:'anchor-no-free-end', hostFid, fillingFid,
+  axis, hostAfter:[min,max], filling:[min,max] }`. A refused pair's commands are left untouched (the caller must
+  not commit); nothing is fabricated. A filling that never fit on that axis (real casing overhang) is delta-honest:
+  not refused (same doctrine as the gate).
+- Multiple openings on one host: each is held and checked independently; any refusal refuses the host.
+
+**AbutsEdge** — reports the gate's own `proposedDelta` for a neighbour pulled away during THIS edit. REPORTS ONLY;
+applying it stays an accept-gated future op (SDG_BACKPROP_ABUTS_REALIGN.md). Engine collects them as `proposals`.
+
+**dimLabel** — one string built from measured numbers only: grid `Δ±x.xxm`, the first SCALE host's extent
+`w→w'` (w' = f·w from the real pre-box), then `· n held` / `· n ride` / `· REFUSED #f`.
+
+## §4 Wiring (bonsai_gridmove.js / modeller.html)
+
+- `previewCommands()` calls `engine.propagateCommands()` instead of `stretchRide` directly. If
+  `window.DagevuEngine` failed to load, the old `stretchRide` path runs byte-identically (LOAD_FAIL never breaks
+  the drag). Result gains `held`, `refusals`, `proposals`, `dimLabel`.
+- `toggleOverride(fid)`: filling ⇒ `engine.toggleMode(fid)` (returns `true` when now anchored/held = green, `false`
+  when now riding = moves); non-filling ⇒ unchanged exclude toggle. `resetOverrides()` clears both.
+- `commit()`: `refusals.length` ⇒ throw `Error('§DAGEVU refused: …')` — modeller.html's existing catch prints
+  `FAIL …` in the status bar and leaves the drag armed so the user can shorten the drag or ctrl+click the opening.
+- `gmTint(commands, riders, excluded, { held, refusals })`: held ⇒ GM_GREEN; refused host+filling ⇒ GM_RED (new
+  constant, 0xc81e1e). Ride opt-in fillings appear in `riders` ⇒ blue, as today.
+- pointermove + ctrl+click recompute: `setStat` and `dimLabelShow` both print `preview.dimLabel`.
+
+## §5 Tests — each names the issue it proves
+
+**`modeller/tests/witness_dagevu_engine.js` (pure node, REAL SampleHouse substrate as witness_stretch_ride.js):**
+- D1 CONTRACT — base `propagate` throws; subclasses are `instanceof RelationEdge`; edge count == resolvable real
+  rows (proves: OOP contract exists and is non-invent).
+- D2 RIDE-WRAP — mode ride output === `stretchRide` output for the same host SCALE (proves: wrap, not a fork).
+- D3 ANCHOR-GROW — default mode, host SCALE grow ⇒ filling delta 0, own command stripped, in `held`, no refusal;
+  `dimLabel` carries w→f·w (proves: the new default holds the opening and reports the real length).
+- D4 ANCHOR-TRANSLATE — host TRANSLATE d ⇒ anchored filling rides by exactly d (proves: anchor governs length
+  change only; a translated wall still carries its door).
+- D5 ANCHOR-REFUSE — host SCALE shrink crossing the filling ⇒ `null`, refusal {fids, axis}, commands untouched,
+  and `SdgGate.evaluate` on the same before/after boxes reports door-crush for the same pair (proves: honest
+  refusal, and the preview oracle equals the post-commit gate oracle).
+- D6 MULTI — host=3's two real rows: both held; door=13 (never fit) is not refused on a shrink that door=7 survives
+  (proves: per-filling independence + delta-honesty on real data).
+- D7 TOGGLE — default anchor; toggle→ride→anchor; reset restores anchor (proves: opt-in is explicit and session-scoped).
+- D8 ABUTS-WRAP — real wall + constructed flush neighbour (A8 precedent): `AbutsEdge.propagate` proposal equals the
+  gate's abuts-realign `proposedDelta`; the engine's `commands` are unchanged by it (proves: wrap; report-only).
+- D9 ROSETTA — anchor: stretch then exact inverse ⇒ host extent restored within 1e-9, filling centre untouched
+  throughout (proves: invertible, no drift).
+
+**Existing witnesses — stale expectation (UPDATE) vs real regression (do not paper over):**
+| Witness | Assertion | Verdict |
+|---|---|---|
+| witness_e2e_stretch_ride E2b, E3a | rider centre MOVED; one induced GEOM_MOVE | STALE → held: centre unchanged, zero induced; add E5: ctrl-toggle ride ⇒ old behaviour |
+| witness_e2e_stretch_ride E1 | discovery picks any SCALE pair | STALE → must pick a pair the engine does not refuse (shrink candidates can refuse) |
+| witness_e2e_grid_greenorange H1, H2 | door BLUE mid-drag; oplog +2 with one induced | STALE → door GREEN (held), oplog +1; add H3: ctrl+click door ⇒ BLUE + one induced (opt-in) |
+| witness_e2e_gridmove_real G7 | real Duplex door rode (DY=+0.5 grow) | STALE → door held, no rider row for it |
+| witness_stretch_ride, witness_sdg_cascade, witness_e2e_gridstretch, witness_e2e_void_anchor V3a, witness_sdg_gate | call stretchRide/gate directly or have no opening | UNAFFECTED — must stay green (regression guard) |
+
+## §6 Status
+- [x] engine · [x] wiring · [x] W-DAGEVU-ENGINE 10/10 · [x] e2e updates (stretch_ride 11/11, greenorange 13/13, gridmove_real 8/8)
+- [x] regression guard: witness_stretch_ride 9/9, witness_sdg_cascade 7/7, witness_sdg_gate 11/11, witness_e2e_gridstretch 7/7
+- [ ] witness_e2e_void_anchor: 18/19 — G6 (§XEDGE-ALL derived counts) fails IDENTICALLY on untouched main; pre-existing, not this change
+- [x] PR opened 2026-09-10


### PR DESCRIPTION
## Summary
- New `modeller/dagevu_engine.js` (spec: `prompts/SPEC_DAGEVU_ENGINE.md`): ES6 `RelationEdge` contract, `HostFillEdge` (mode `anchor` default | `ride`), `AbutsEdge`, `DagevuEngine` — built only over the REAL `rel_fills_host` / `abuts` rows through the §ARC-1 bridge. Wraps `sdg_cascade.stretchRide` and `sdg_gate.evaluate`; nothing re-implemented.
- **Behaviour change (tested default):** grid-stretching a wall now HOLDS its hosted opening in place (the wall's free end absorbs the delta). Proportional ride is the explicit per-opening ctrl+click opt-in. A shrink that would push a held opening out of its wall is REFUSED (status `FAIL §DAGEVU refused: …`, red preview tint, nothing committed) — the refusal rule is the gate's own door-crush rule.
- Live readout: the engine's measured label (wall `w→w'`, `n held` / `n ride` / `REFUSED #f`) now rides the existing §V7 status + floating dim label.
- Also carries the session resume doc (`prompts/RESUME_MODELLER_DAGEVU_ENGINE.md`, cherry-picked from `docs/resume-dagevu-engine`) with its status updated.

## Witness log (read, not just exit codes)
| Witness | Result |
|---|---|
| witness_dagevu_engine (new, node, real SampleHouse) | 10/10 |
| witness_e2e_stretch_ride (E2b/E3a flipped to anchor; +E1 refusal-aware, +E2d readout, +E5 ride opt-in) | 11/11 |
| witness_e2e_grid_greenorange (H1/H2 flipped; +H3 opt-in) | 13/13 |
| witness_e2e_gridmove_real (G7 flipped to held) | 8/8 |
| witness_stretch_ride / witness_sdg_cascade / witness_sdg_gate | 9/9 · 7/7 · 11/11 |
| witness_e2e_gridstretch | 7/7 |
| witness_e2e_void_anchor | 18/19 — G6 (§XEDGE-ALL derived counts) fails IDENTICALLY on untouched main; pre-existing |

Stale-vs-regression classification for every flipped assertion is in the spec §5 table.

## Not in scope
`AngleEdge` / roof pitch — PAUSED (no measured slope data anywhere in the codebase). Along-host opening-slide draft (worktree agent-a8b5dc9ca46ba4e72) untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)