### PR TITLE
feat(modeller): §DAGEVU-SLIDE — along-host opening slide via HostFillEdge.constrain() (engine's 2nd consumer)

### DIFF
--- a/modeller/bonsai_itemdrag.js
+++ b/modeller/bonsai_itemdrag.js
@@ -38,6 +38,51 @@
 //     drag time (e.g. a catalog-drop flow that still has it in hand) may pass `opts.productHint` and the drag
 //     proceeds on REAL dims. Nothing is ever derived, defaulted, or guessed.
 //
+// §SLIDE — the along-host OPENING SLIDE (spec §3.1: "A FILLING (door/window) may be dragged … but its motion is
+// constrained along its real host wall (Q5 scopes v1)"; Q5's last clause asks "whether filling-drag (along-host
+// slide) is in or out of v1 scope" — resolved IN here). Witness: W-E2E-OPENING-SLIDE (witness_e2e_opening_slide.js).
+//   S1 SESSION — a dragged fid that a REAL rel_fills_host row names as `filling_guid` (through the §ARC-1 bridge,
+//      first host that resolves to a scene feature — stretchRide's own "first host wins") starts a SLIDE session
+//      instead of the resolver-gated fixture session above. This is NOT the catch-and-substitute §3.2 forbids: the
+//      resolver is never consulted for a filling because there is nothing for it to look up — REAL_PRODUCT_DIM keys
+//      MEP product ids (TOILET/SINK/…, real_placement_resolver.js:43-62) and carries no door/window row, while BOTH
+//      inputs a slide needs are recovered rows: the host is the edge's `host_guid` (provenance ifc:recovered, never
+//      proximity) and the dims are the filling's OWN measured pre-drag AABB — the very boxByFid snapshot
+//      sdg_cascade.js stretchRide already rides on (extent never changes in a slide; a rigid translate needs no
+//      catalog). Refusals (session → null, logged `§ITEMDRAG §SLIDE REFUSED`): host not WALL-class; host obliquely
+//      yawed/tilted per GridKinematics' OWN _isObliqueYaw/_hasTilt (an oblique host's AABB long edge is not its
+//      plane — the same §ROTATION-GUARD gridmove applies); host body not a plain axis-aligned box — for a
+//      GEOM_INSERT per Bonsai._insertCutBox's OWN vertex test (a real LOD-300 wall mesh carries its door holes BAKED
+//      IN — no op can translate them; measured 2026-09-10: EVERY real SampleHouse host refuses here, honestly), for
+//      a GEOM_EXTRUDE_POLY per plainExtrudeProfile() below (a 4-point axis-aligned rectangle; its holes are GEOM_CUT
+//      ops, caught next — mirrors bonsai_kernel.js canCut's "a non-insert solid is already worker-native B-rep");
+//      host class KNOWN and not WALL (an unrecorded class = freshly-sketched content stays eligible, the SAME rule
+//      bonsai_gridmove.js elementData applies); an ACTIVE
+//      GEOM_CUT whose `parent` IS the host and whose void box overlaps the filling's pre-drag box (a REAL carved
+//      void tied to this filling — the worker has no op that translates a committed void, so the door would move
+//      and the hole would stay: REFUSE, DON'T FABRICATE); SdgGate unavailable (cannot gate honestly).
+//   S2 CONSTRAINT — 1-DOF, OWNED BY THE ENGINE (prompts/SPEC_DAGEVU_SLIDE.md §2-3): dagevu_engine.js
+//      HostFillEdge.constrain(candidate − preCentre, {boxByFid}) is the ONE place the along-host projection + bounds
+//      live — axis = the host AABB's LONG plan axis (the complement of the thin axis resolveHost's wall branch snaps
+//      along); the orthogonal coordinate and z are HELD at their pre-drag values (the filling↔host face offset stays
+//      invariant, exactly as stretchRide holds it). Bounds are delta-honest: the filling (∪ its seeded
+//      IfcOpeningElement) may slide until flush with either wall end (± FIT_TOL = HOST_TOL); an as-extracted overhang
+//      is never pushed further out, and never "fixed". Beyond the ends the engine returns null (never a clamp);
+//      snappedPos = the constrained point — a derivation from the real host (spec §3.3), never a nudge away from a
+//      conflict. The engine is a HARD dependency of the slide: absent ⇒ REFUSE (the free-drag path is untouched).
+//   S3 GATE — per frame AND at drop: SdgGate.evaluate(preBoxes, shiftedBoxes, moved, rel) — the codebase's own
+//      RED/ORANGE conformity logic, reused unmodified. Any RED (clash / door-out / door-crush) ⇒ valid:false with
+//      the offending fids; ORANGE is soft (reported, never blocks). Delta-honest by construction: a pre-existing
+//      as-extracted overlap never blocks a slide. Measured on real Duplex: a curtain-window raw bbox covers a door,
+//      two corner walls and the coverings — the ABSOLUTE overlap test the fixture path uses (overlaps() below) would
+//      refuse every real filling at t=0, so it is not the honest rule for moving an EXISTING element.
+//   S4 OP SHAPE — GEOM_MOVE {parent: fillingFid, dx,dy,dz} (the existing row shape). When the row's `opening_guid`
+//      resolves to a seeded IfcOpeningElement (a VISIBLE raw-bbox insert on this substrate — the representational
+//      void), ONE rider GEOM_MOVE {parent: openingFid, same delta, induced:'fills-opening'} rides with it, committed
+//      together through oplog.commitGesture (one gesture = one Ctrl+Z, §P8 — the exact pattern gridmove.commit uses
+//      for stretch riders). No opening seeded ⇒ the single commit() path, unchanged.
+//   S5 NOT BUILT — a void-translate op (kernel + worker surgery) for a baked GEOM_CUT; refused instead (S1).
+//
 // DUAL-EXPORT (window + node) like sdg_cascade.js / real_placement_resolver.js so the witness runs pure-node.
 (function (root, factory) {
   if (typeof module !== 'undefined' && module.exports) module.exports = factory();
@@ -81,12 +126,20 @@
            (Math.min(a[3], b[3]) - Math.max(a[2], b[2])) > -tol;
   }
 
+  // Soft dependencies resolved LAZILY at call time (cross_edges.js:52 documents why a load-time capture would
+  // freeze a null): the caller's ctx value first, then the page global, then a node require for the witnesses.
+  function _dep(ctxVal, winKey, file) {
+    if (ctxVal) return ctxVal;
+    if (typeof window !== 'undefined' && window[winKey]) return window[winKey];
+    if (typeof require === 'function') { try { return require(file); } catch (e) { } }
+    return null;
+  }
+
   // ── §3.1 ELIGIBILITY ────────────────────────────────────────────────────────────────────────────────
   // A HOST (anything appearing as `host_guid` in the REAL rel_fills_host edges) is EXCLUDED — walls move via
   // gridmove or Feature A. A structural class is excluded. A FILLING may be dragged (sdg_cascade.js's own
-  // directional rule says it never drags its host) — Q5 note: filling-drag is IN scope only insofar as the
-  // gate lets it start; there is no separate along-host slide constraint in v1 (spec §3.1 defers it to Q5,
-  // and the §3.3 host constraint already binds a WALL-hosted item to a real wall face).
+  // directional rule says it never drags its host) — its motion is the constrained along-host slide (§SLIDE in
+  // this file's header), never a free 3D drag: beginItemDragSession routes a real filling to beginSlideSession.
   function eligibility(ctx) {
     var fid = ctx.fid, guidByFid = ctx.guidByFid || {}, cls = (ctx.classByFid || {})[fid];
     var structural = ctx.structuralClasses || STRUCTURAL_CLASSES;
@@ -120,6 +173,15 @@
       console.error(TAG + ' REFUSED fid=' + fid + ' — no pre-drag AABB in the session snapshot (nothing honest to snap back to)');
       return null;
     }
+    // §SLIDE S1: a real FILLING takes the constrained slide session — the resolver is not consulted for it.
+    var fe = fillingEdge(ctx, fid);
+    if (fe) {
+      if (fe.hostFid == null) {
+        console.error(TAG + ' §SLIDE REFUSED fid=' + fid + ' — rel_fills_host names this filling but its host_guid resolves to no scene feature (no honest host to slide along; mirrors stretchRide "no fid → no ride")');
+        return null;
+      }
+      return beginSlideSession(ctx, fe, pre);
+    }
     var params = ctx.insertParams || {};
     var resolver = ctx.resolver ||
       (typeof window !== 'undefined' && window.RealPlacementResolver) || null;
@@ -148,6 +210,150 @@
     return session;
   }
 
+  // ── §SLIDE S1 — the FILLING's real edge and the constrained session ─────────────────────────────────
+  // fillingEdge(ctx, fid) → null (not a filling), or {edge, hostFid, openingFid} — hostFid null when rows exist
+  // but no host_guid resolves through the bridge. fidByGuid is the caller's (window.__arcFidByGuid) or the exact
+  // inverse of guidByFid (the §ARC-1 bridge is 1:1 — arc_editable.js buildBridge writes both from ONE list).
+  function fillingEdge(ctx, fid) {
+    var g = (ctx.guidByFid || {})[fid];
+    if (g == null || !Array.isArray(ctx.fills)) return null;
+    var fbg = ctx.fidByGuid;
+    if (!fbg) { fbg = {}; Object.keys(ctx.guidByFid).forEach(function (k) { fbg[ctx.guidByFid[k]] = isNaN(+k) ? k : +k; }); }
+    var saw = null;
+    for (var i = 0; i < ctx.fills.length; i++) {
+      var e = ctx.fills[i];
+      if (!e || e.filling_guid !== g) continue;
+      saw = e;
+      var h = fbg[e.host_guid];
+      if (h == null) continue;                                  // first host that IS a scene feature wins (stretchRide)
+      var o = e.opening_guid != null ? fbg[e.opening_guid] : null;
+      return { edge: e, hostFid: h, openingFid: o != null ? o : null };
+    }
+    return saw ? { edge: saw, hostFid: null, openingFid: null } : null;
+  }
+  // The host's in-plan pose from its committed GEOM_INSERT placement — the SAME read bonsai_gridmove.js
+  // _buildInsertMaps does (`.rot` is DEGREES at this boundary → radians; rotX/rotY already radians).
+  function hostPose(pl) {
+    if (!pl) return { yawRad: undefined, tiltX: undefined, tiltY: undefined };
+    return { yawRad: typeof pl.rot === 'number' ? pl.rot * Math.PI / 180 : undefined,
+             tiltX: typeof pl.rotX === 'number' ? pl.rotX : undefined, tiltY: typeof pl.rotY === 'number' ? pl.rotY : undefined };
+  }
+  // An ACTIVE GEOM_CUT {parent: host, void:{c1,c2}} (modeller.html bCut's own row shape) whose void box overlaps
+  // the filling's pre-drag box = a REAL carved void tied to THIS filling. Returns the cut's op id, else null.
+  function bakedVoidFor(cutOps, hostFid, box) {
+    for (var i = 0; i < cutOps.length; i++) {
+      var c = cutOps[i], P = c.parameters || c.params || {};
+      if (P.parent == null || String(P.parent) !== String(hostFid) || !P.void || !P.void.c1 || !P.void.c2) continue;
+      var a = P.void.c1, b = P.void.c2;
+      var vb = [Math.min(a[0], b[0]), Math.max(a[0], b[0]), Math.min(a[1], b[1]), Math.max(a[1], b[1]), Math.min(a[2], b[2]), Math.max(a[2], b[2])];
+      if (overlaps(vb, box)) return c.id;
+    }
+    return null;
+  }
+  // plainExtrudeProfile(points) → true iff a GEOM_EXTRUDE_POLY profile is a 4-point AXIS-ALIGNED rectangle with real
+  // extent on both axes — the sketched-wall body whose AABB long axis IS its run (an L-shaped or oblique profile has
+  // an AABB the door could slide into thin air along). Reads the op's own parameters; derives nothing.
+  function plainExtrudeProfile(points) {
+    if (!Array.isArray(points) || points.length !== 4) return false;
+    var EPS = 1e-9, xs = [], ys = [];
+    for (var i = 0; i < 4; i++) {
+      var a = points[i], b = points[(i + 1) % 4];
+      if (!a || !b || a.length < 2 || b.length < 2) return false;
+      var dx = Math.abs(a[0] - b[0]), dy = Math.abs(a[1] - b[1]);
+      if (!((dx <= EPS && dy > EPS) || (dy <= EPS && dx > EPS))) return false;   // every edge axis-parallel and non-degenerate
+      xs.push(a[0]); ys.push(a[1]);
+    }
+    return (Math.max.apply(null, xs) - Math.min.apply(null, xs)) > EPS && (Math.max.apply(null, ys) - Math.min.apply(null, ys)) > EPS;
+  }
+  // Fallback gate relation derived from the SAME fills rows when the caller passes no `rel` — the fills half of
+  // modeller.html's _gateRel (host↔filling = expected contact, hostOf drives door-out); abuts need the derived
+  // edge set the page holds, so a caller that has it passes rel:_gateRel() (the browser layer below does).
+  function relFromFills(ctx, fbg) {
+    var relSet = {}, hostOf = {};
+    (ctx.fills || []).forEach(function (e) {
+      var h = fbg[e.host_guid], f = fbg[e.filling_guid];
+      if (h == null || f == null) return;
+      relSet[Math.min(+h, +f) + '|' + Math.max(+h, +f)] = 1; hostOf[f] = h;
+    });
+    return { related: function (a, b) { return !!relSet[Math.min(+a, +b) + '|' + Math.max(+a, +b)]; }, hostOf: hostOf, abuts: [] };
+  }
+  function beginSlideSession(ctx, fe, fb) {
+    var fid = ctx.fid, boxByFid = ctx.boxByFid || {}, hb = boxByFid[fe.hostFid];
+    var refuse = function (why) { console.error(TAG + ' §SLIDE REFUSED fid=' + fid + ' host=' + fe.hostFid + ' — ' + why); return null; };
+    if (!hb) return refuse('host has no pre-drag AABB in the session snapshot');
+    var hcls = (ctx.classByFid || {})[fe.hostFid];
+    if (hcls != null && HOST_CLASSES.WALL.indexOf(hcls) === -1) return refuse('host class ' + hcls + ' is not a WALL (HOST_CLASSES.WALL) — only the wall-face slide is defined');   // unrecorded class (sketched) stays eligible, as in gridmove
+    var GK = _dep(ctx.kinematics, 'GridKinematics', './grid_kinematics.js');
+    if (!GK || !GK._isObliqueYaw || !GK._hasTilt) return refuse('GridKinematics yaw guard unavailable — cannot verify the host plane is AABB-representable');
+    var pose = hostPose((ctx.placementByFid || {})[fe.hostFid]);
+    if (GK._isObliqueYaw(pose.yawRad) || GK._hasTilt(pose.tiltX, pose.tiltY))
+      return refuse('host is obliquely yawed / tilted (§ROTATION-GUARD, yaw=' + pose.yawRad + ') — its AABB long edge is not its plane; refusing rather than sliding along an unreal axis');
+    if (typeof ctx.plainBoxOf !== 'function') return refuse('no plainBoxOf oracle supplied — cannot verify the host body carries no baked opening');
+    if (!ctx.plainBoxOf(fe.hostFid)) return refuse('host body is not a plain axis-aligned box (Bonsai._insertCutBox rule) — a real blob may carry a baked opening no op can translate; refusing rather than leaving a hole behind');
+    if (!Array.isArray(ctx.cutOps)) return refuse('no cutOps (active GEOM_CUT rows) supplied — cannot verify no baked void is tied to this filling');
+    var cutId = bakedVoidFor(ctx.cutOps, fe.hostFid, fb);
+    if (cutId != null) return refuse('a REAL baked void (GEOM_CUT #' + cutId + ', parent=host) coincides with this filling; no op exists to translate a committed void, so a slide would leave the hole behind — REFUSE, DON\'T FABRICATE (spec §1 item 5)');
+    var gate = _dep(ctx.gate, 'SdgGate', './sdg_gate.js');
+    if (!gate || !gate.evaluate) return refuse('SdgGate unavailable — cannot gate the slide honestly');
+    // S2 axis + bounds — the engine's HostFillEdge.constrain (SPEC_DAGEVU_SLIDE.md §3). Probe at t=0 (always
+    // admissible by construction) for axis/tMin/tMax; per-frame calls go through canSlideTo below.
+    var DE = _dep(ctx.dagevu, 'DagevuEngine', './dagevu_engine.js');
+    if (!DE || !DE.HostFillEdge) return refuse('DagevuEngine unavailable — the slide constraint is HostFillEdge.constrain; nothing local to fall back on');
+    var ob = fe.openingFid != null ? boxByFid[fe.openingFid] : null;
+    var e = fe.edge;
+    var edge = new DE.HostFillEdge({ hostFid: fe.hostFid, fillingFid: fid, hostGuid: e.host_guid, fillingGuid: e.filling_guid,
+      openingGuid: e.opening_guid, openingFid: ob ? fe.openingFid : null, provenance: e.provenance,
+      cascade: _dep(ctx.cascade, 'SdgCascade', './sdg_cascade.js') });
+    var probe = edge.constrain([0, 0, 0], { boxByFid: boxByFid });
+    if (!probe) return refuse('engine refused the pre-drag pose itself (' + JSON.stringify(edge.refusal) + ')');
+    var axis = probe.axis === 'x' ? 0 : 1, tMin = probe.tMin, tMax = probe.tMax;
+    var moved = [fid]; if (ob) moved.push(fe.openingFid);
+    // S3 gate inputs: every mesh box EXCEPT invisible ride anchors (modeller.html _gateBoxes excludes them too).
+    var anc = ctx.anchorFids || null, before = {};
+    Object.keys(boxByFid).forEach(function (k) { if (anc && (anc.has(+k) || anc.has(k))) return; before[k] = boxByFid[k]; });
+    var fbg = ctx.fidByGuid; if (!fbg) { fbg = {}; Object.keys(ctx.guidByFid || {}).forEach(function (k) { fbg[ctx.guidByFid[k]] = isNaN(+k) ? k : +k; }); }
+    var session = {
+      fid: fid, preBox: fb.slice(), preCentre: [(fb[0] + fb[1]) / 2, (fb[2] + fb[3]) / 2, (fb[4] + fb[5]) / 2],
+      real: { width: fb[1] - fb[0], depth: fb[3] - fb[2], height: fb[5] - fb[4], anchor: { requires_host: 'WALL', conn_points: [] },
+        matchedProductId: 'FILLING:' + (e.filling_class || (ctx.classByFid || {})[fid] || '?'),
+        source: 'rel_fills_host:' + e.opening_guid + ' (filling ' + e.filling_guid + ' → host ' + e.host_guid + '); dims = own measured pre-drag AABB' },
+      gateBoxes: (function () { var o = {}; Object.keys(boxByFid).forEach(function (k) { if (String(k) !== String(fid)) o[k] = boxByFid[k]; }); return o; })(),
+      classByFid: ctx.classByFid || {},
+      slide: { hostFid: fe.hostFid, openingFid: ob ? fe.openingFid : null, axis: axis, tMin: tMin, tMax: tMax, moved: moved,
+        before: before, gate: gate, rel: ctx.rel || relFromFills(ctx, fbg), hostBox: hb.slice(),
+        edge: edge, boxByFid: boxByFid }                              // §DAGEVU: the engine edge + its pre-drag boxes (per-frame constrain input)
+    };
+    console.log(TAG + ' §SESSION begin fid=' + fid + ' product=' + session.real.matchedProductId +
+      ' dims(w,d,h)=' + session.real.width.toFixed(3) + ',' + session.real.depth.toFixed(3) + ',' + session.real.height.toFixed(3) +
+      ' requires_host=WALL source=' + session.real.source);
+    console.log(TAG + ' §SLIDE host=' + fe.hostFid + ' axis=' + 'xy'[axis] + ' t∈[' + tMin.toFixed(3) + ',' + tMax.toFixed(3) + ']' +
+      ' opening=' + (ob ? fe.openingFid + ' (rides, induced=fills-opening)' : 'none seeded') + ' constraint=DagevuEngine.HostFillEdge.constrain gate=SdgGate.evaluate (delta-honest)');
+    return session;
+  }
+  // ── §SLIDE S2/S3 — the per-frame constraint + gate ──────────────────────────────────────────────────
+  function canSlideTo(session, x, y, z) {
+    var a = session.slide, c = session.preCentre;
+    // §DAGEVU: the engine projects + bounds (SPEC_DAGEVU_SLIDE.md §2); null = beyond the wall's ends, never clamped.
+    var r = a.edge.constrain([x - c[0], y - c[1], z - c[2]], { boxByFid: a.boxByFid });
+    if (!r) { var rf = a.edge.refusal || {}; return { valid: false, conflictIds: [], reason: 'off-host-extent', t: rf.t, hostFid: String(a.hostFid), refusal: rf }; }
+    var t = r.t, d = r.delta;
+    var after = {};
+    Object.keys(a.before).forEach(function (k) { after[k] = a.before[k]; });
+    a.moved.forEach(function (f) { var b = a.before[f]; if (b) after[f] = [b[0] + d[0], b[1] + d[0], b[2] + d[1], b[3] + d[1], b[4] + d[2], b[5] + d[2]]; });
+    var res = a.gate.evaluate(a.before, after, a.moved, a.rel, {});
+    if (res.red.length) {
+      var ids = [], kinds = {};
+      res.red.forEach(function (r) {
+        kinds[r.kind] = 1;
+        var other = a.moved.some(function (m) { return +m === +r.a; }) ? r.b : r.a;
+        if (ids.indexOf(String(other)) === -1) ids.push(String(other));
+      });
+      return { valid: false, conflictIds: ids, reason: 'gate-red:' + Object.keys(kinds).join('+'), t: t, hostFid: String(a.hostFid), gate: res };
+    }
+    return { valid: true, conflictIds: [], snappedPos: [c[0] + d[0], c[1] + d[1], c[2] + d[2]], hostFid: String(a.hostFid),
+      reason: 'ok', t: t, delta: d, moved: a.moved.slice(), gate: res, dimLabel: r.dimLabel, gapLo: r.gapLo, gapHi: r.gapHi };
+  }
+
   // ── §3.3 PER-FRAME VALIDATION CONTRACT ──────────────────────────────────────────────────────────────
   // canDropAt(session, x, y, z) -> { valid, conflictIds, snappedPos?, reason }
   // PURE. Session-cached inputs only. Validity is decided AT THE CANDIDATE; `snappedPos` is returned ONLY when
@@ -155,6 +361,7 @@
   // pascalorg's `adjustedY` we never return a corrected position that converts an invalid drop into a valid one.
   function canDropAt(session, x, y, z) {
     if (!session) return { valid: false, conflictIds: [], reason: 'no-session' };
+    if (session.slide) return canSlideTo(session, x, y, z);        // §SLIDE: 1-DOF along the real host, SdgGate-checked
     var r = session.real, need = r.anchor && r.anchor.requires_host;
     var cand = box(x, y, z, r.width, r.depth, r.height);
 
@@ -230,16 +437,20 @@
     var v = canDropAt(session, x, y, z);
     if (!v.valid) return { committed: false, op: null, verdict: v };
     var p = v.snappedPos || [x, y, z], c = session.preCentre;
-    return {
-      committed: true, verdict: v,
-      op: { op_type: 'GEOM_MOVE', parameters: { parent: session.fid, dx: p[0] - c[0], dy: p[1] - c[1], dz: p[2] - c[2] } }
-    };
+    var op = { op_type: 'GEOM_MOVE', parameters: { parent: session.fid, dx: p[0] - c[0], dy: p[1] - c[1], dz: p[2] - c[2] } };
+    // §SLIDE S4: the seeded opening element rides by the IDENTICAL delta — one induced GEOM_MOVE per rider, the
+    // row shape gridmove.commit's stretch riders already use, tagged induced:'fills-opening' (its real edge).
+    var riders = session.slide ? session.slide.moved.filter(function (f) { return String(f) !== String(session.fid); }).map(function (f) {
+      return { op_type: 'GEOM_MOVE', parameters: { parent: f, dx: op.parameters.dx, dy: op.parameters.dy, dz: op.parameters.dz, induced: 'fills-opening' } };
+    }) : [];
+    return { committed: true, verdict: v, op: op, riders: riders };
   }
 
   var API = {
     STRUCTURAL_CLASSES: STRUCTURAL_CLASSES, HOST_CLASSES: HOST_CLASSES, HOST_TOL: HOST_TOL,
     eligibility: eligibility, beginItemDragSession: beginItemDragSession,
-    canDropAt: canDropAt, resolveHost: resolveHost, resolveDrop: resolveDrop
+    canDropAt: canDropAt, resolveHost: resolveHost, resolveDrop: resolveDrop,
+    fillingEdge: fillingEdge, bakedVoidFor: bakedVoidFor, canSlideTo: canSlideTo, plainExtrudeProfile: plainExtrudeProfile
   };
 
   // ── BROWSER lifecycle — mirrors bonsai_gridmove.js in STRUCTURE (session cache at grab, one shared
@@ -259,16 +470,36 @@
         });
         return out;
       },
-      _buildClassByFid: function () {
-        var out = {}, O = window.Bonsai && window.Bonsai.oplog;
+      // One pass over the committed GEOM_INSERT rows → ifc_class AND placement per fid (§SLIDE needs the host's
+      // pose for the yaw guard — same query, same parse, mirrors bonsai_gridmove.js _buildInsertMaps).
+      _buildInsertMaps: function () {
+        var out = { classByFid: {}, placementByFid: {} }, O = window.Bonsai && window.Bonsai.oplog;
         if (!O || !O.db) return out;
         try {
           var r = O.db.exec("SELECT id, parameters FROM kernel_ops WHERE op_type='GEOM_INSERT'");
           if (r.length) r[0].values.forEach(function (v) {
-            try { var p = JSON.parse(v[1]); if (p && p.ifc_class) out[v[0]] = p.ifc_class; } catch (e) { }
+            try { var p = JSON.parse(v[1]); if (p && p.ifc_class) out.classByFid[v[0]] = p.ifc_class; if (p && p.placement) out.placementByFid[v[0]] = p.placement; } catch (e) { }
           });
         } catch (e) { }
         return out;
+      },
+      _buildClassByFid: function () { return this._buildInsertMaps().classByFid; },
+      // §SLIDE S1 inputs, read from the LIVE op-log (active rows only — _geomOps filters undone=0):
+      //   _cutOps    → every active GEOM_CUT row (the baked-void check needs their {parent, void}).
+      //   _plainBoxOf → is this fid's insert a plain axis-aligned box? Asks the PRODUCTION cut gate itself
+      //                (bonsai_kernel.js _insertCutBox — the same function bCut/canCut use), never a re-derived test.
+      _cutOps: function () {
+        var O = window.Bonsai && window.Bonsai.oplog;
+        try { return (O && O._geomOps) ? O._geomOps().filter(function (o) { return o.op_type === 'GEOM_CUT'; }) : []; } catch (e) { return []; }
+      },
+      _plainBoxOf: function (fid) {
+        var O = window.Bonsai && window.Bonsai.oplog, K = window.Bonsai;
+        if (!O || !O._geomOps || !K || !K._insertCutBox) return null;
+        var op = O._geomOps().filter(function (o) { return String(o.id) === String(fid); })[0];
+        if (!op) return null;
+        if (op.op_type === 'GEOM_INSERT') { try { return !!K._insertCutBox(op); } catch (e) { return false; } }
+        if (op.op_type === 'GEOM_EXTRUDE_POLY') { var P = op.parameters || {}; return plainExtrudeProfile(P.profile && P.profile.points); }
+        return false;                                              // any other body → unknown → refuse
       },
       _insertParams: function (fid) {
         var O = window.Bonsai && window.Bonsai.oplog;
@@ -284,16 +515,25 @@
       // console.error'd) and counts the drag refused. Nothing is substituted.
       beginItemDragSession: function (fid, opts) {
         opts = opts || {};
+        var maps = this._buildInsertMaps(), self = this;
         this._session = beginItemDragSession({
           fid: fid,
           insertParams: this._insertParams(fid),
           boxByFid: this._buildBoxByFid(),
-          classByFid: this._buildClassByFid(),
+          classByFid: maps.classByFid,
           guidByFid: window.__arcGuidByFid || {},
           fills: (window.swXEdges && window.swXEdges.fills) || null,
           resolver: window.RealPlacementResolver,
           discipline: opts.discipline || null,
-          productHint: opts.productHint || null
+          productHint: opts.productHint || null,
+          // §SLIDE S1 — the bridge's own inverse, the host pose, the live cut rows, the production box gate, the
+          // page's gate relation (hosted-by + abuts, anchors excluded) and the anchor set _gateBoxes excludes.
+          fidByGuid: window.__arcFidByGuid || null,
+          placementByFid: maps.placementByFid,
+          cutOps: this._cutOps(),
+          plainBoxOf: function (f) { return self._plainBoxOf(f); },
+          rel: (typeof window.__gateRel === 'function') ? window.__gateRel() : null,
+          anchorFids: window.__arcAnchorFids || null
         });
         return this._session;
       },
@@ -310,12 +550,25 @@
             ' — NO COMMIT, item stays at its pre-drag position (never auto-relocated). Spec §3.4');
           return { committed: false, verdict: d.verdict };
         }
-        var P = d.op.parameters;
-        var res = await window.Bonsai.oplog.commit({ op_type: d.op.op_type, parameters: P }, {});
+        var P = d.op.parameters, riders = d.riders || [], res;
+        if (riders.length) {
+          // §SLIDE S4: filling + its opening rider = ONE user gesture → one signed gesture group (bonsai_oplog.js
+          // commitGesture, the path gridmove.commit takes for stretch riders) so a single Ctrl+Z reverts both.
+          if (!window.Bonsai.oplog.commitGesture) throw new Error(TAG + ' commitGesture unavailable — refusing to move the filling without its opening rider');
+          res = await window.Bonsai.oplog.commitGesture([{ op_type: d.op.op_type, params: P }].concat(
+            riders.map(function (r) { return { op_type: r.op_type, params: r.parameters }; })));
+        } else {
+          res = await window.Bonsai.oplog.commit({ op_type: d.op.op_type, parameters: P }, {});
+        }
+        var moved = [s.fid].concat(riders.map(function (r) { return r.parameters.parent; }));
         console.log(TAG + ' commit fid=' + s.fid + ' Δ(' + P.dx.toFixed(3) + ',' + P.dy.toFixed(3) + ',' + P.dz.toFixed(3) + ')' +
-          ' host=' + d.verdict.hostFid + (d.verdict.snappedPos ? ' snapped-to-real-host-face' : '') +
+          ' host=' + d.verdict.hostFid +
+          (s.slide ? (' §SLIDE axis=' + 'xy'[s.slide.axis] + ' t=' + d.verdict.t.toFixed(3) +
+            (riders.length ? ' rider=' + riders.map(function (r) { return r.parameters.parent; }).join(',') + ' induced=fills-opening §GESTURE gid=' + res.gid : ' rider=none') +
+            ' orange=' + ((d.verdict.gate && d.verdict.gate.orange) ? d.verdict.gate.orange.length : 0))
+            : (d.verdict.snappedPos ? ' snapped-to-real-host-face' : '')) +
           ' verify=' + res.verify);
-        return Object.assign({ committed: true, verdict: d.verdict }, res);
+        return Object.assign({ committed: true, verdict: d.verdict, moved: moved }, res);
       },
 
       endDragSession: function () {

--- a/modeller/dagevu_engine.js
+++ b/modeller/dagevu_engine.js
@@ -14,6 +14,11 @@
 // leave its door in the air). The grid dictates which end grows; the edge VERIFIES that end is free of the opening
 // with the gate's own fit rule (fitBefore && !fitAfter, tol 0.05 on the changed axis) and REFUSES otherwise.
 // mode 'ride' = today's proportional ride, now an explicit per-element opt-in.
+// HostFillEdge.constrain() (SPEC_DAGEVU_SLIDE.md §2) — the INVERSE direction: a FILLING-driven drag constrained by
+// its host. 1-DOF along the host's long plan axis; orthogonal + z dropped (the face offset stays invariant); bounds
+// are delta-honest (an as-extracted overhang may slide back in, never further out); beyond the wall's ends ⇒ null
+// + refusal — never a clamp (ROOM_MOVE_AND_ITEM_DRAG_SPEC.md §3.3 forbids the nudge that converts an invalid drop
+// into a valid one). The seeded opening element (the row's opening_guid) travels with the door and bounds the slide.
 // AbutsEdge: reports the gate's proposedDelta for a neighbour pulled away — REPORTS ONLY (accept-gated apply is a
 // future op per SDG_BACKPROP_ABUTS_REALIGN.md). AngleEdge: ⛔ PAUSED, not built (no measured roof-slope data).
 //
@@ -55,10 +60,32 @@
 
   class HostFillEdge extends RelationEdge {
     // row = one REAL rel_fills_host row {host_guid, filling_guid, provenance}; fids resolved through the §ARC-1 bridge
-    constructor({ hostFid, fillingFid, hostGuid, fillingGuid, provenance, mode, cascade }) {
+    constructor({ hostFid, fillingFid, hostGuid, fillingGuid, openingGuid, openingFid, provenance, mode, cascade }) {
       super('fills', hostFid, fillingFid);
       this.hostFid = hostFid; this.fillingFid = fillingFid; this.hostGuid = hostGuid; this.fillingGuid = fillingGuid;
+      this.openingGuid = openingGuid != null ? openingGuid : null; this.openingFid = openingFid != null ? openingFid : null;
       this.provenance = provenance; this.cascade = cascade; this.setMode(mode || 'anchor');
+    }
+    // constrain(candidateDelta, { boxByFid }) → { delta, axis, t, tMin, tMax, gapLo, gapHi, dimLabel } | null (refused)
+    //   candidateDelta = the pointer's world offset from the filling's PRE-DRAG centre. SPEC_DAGEVU_SLIDE.md §2.
+    constrain(candidateDelta, geo) {
+      this.refusal = null;
+      const hb = geo && geo.boxByFid && geo.boxByFid[this.hostFid], fb = geo && geo.boxByFid && geo.boxByFid[this.fillingFid];
+      if (!hb || !fb || !Array.isArray(candidateDelta)) return null;              // no honest pre-state → no claim
+      const ob = this.openingFid != null ? geo.boxByFid[this.openingFid] : null;   // the seeded void rides with the door
+      const k = (hb[1] - hb[0]) <= (hb[3] - hb[2]) ? 1 : 0;                        // thin axis = x when ex ≤ ey → slide along y (resolveHost's wall rule)
+      const lo = ob ? Math.min(fb[2 * k], ob[2 * k]) : fb[2 * k], hi = ob ? Math.max(fb[2 * k + 1], ob[2 * k + 1]) : fb[2 * k + 1];
+      const tMin = -Math.max(0, lo - hb[2 * k]) - FIT_TOL, tMax = Math.max(0, hb[2 * k + 1] - hi) + FIT_TOL;
+      const t = candidateDelta[k] || 0;
+      if (t < tMin || t > tMax) {
+        this.refusal = { kind: 'slide-off-host', fillingFid: this.fillingFid, hostFid: this.hostFid, axis: 'xy'[k], t, tMin, tMax };
+        return null;
+      }
+      const delta = [0, 0, 0]; delta[k] = t;
+      const gapLo = (lo + t) - hb[2 * k], gapHi = hb[2 * k + 1] - (hi + t);
+      const dimLabel = '#' + this.fillingFid + ' along #' + this.hostFid + ' ' + 'xy'[k] + ' ' + (t >= 0 ? '+' : '') + t.toFixed(2) + 'm · ' +
+        gapLo.toFixed(2) + '|' + gapHi.toFixed(2) + 'm to ends';
+      return { delta, axis: 'xy'[k], t, tMin, tMax, gapLo, gapHi, dimLabel };
     }
     setMode(mode) { if (MODES.indexOf(mode) < 0) throw new Error('HostFillEdge mode must be anchor|ride, got ' + mode); this.mode = mode; return this; }
     row() { return { host_guid: this.hostGuid, filling_guid: this.fillingGuid, provenance: this.provenance }; }
@@ -122,7 +149,9 @@
       for (const e of fills || []) {
         const h = this.fidByGuid[e.host_guid], f = this.fidByGuid[e.filling_guid];
         if (h == null || f == null || !cascade) continue;                 // unresolvable row → no edge (non-invent)
+        const o = e.opening_guid != null ? this.fidByGuid[e.opening_guid] : null;
         const edge = new HostFillEdge({ hostFid: h, fillingFid: f, hostGuid: e.host_guid, fillingGuid: e.filling_guid,
+          openingGuid: e.opening_guid, openingFid: o != null ? o : null,
           provenance: e.provenance, mode: ride.has(f) ? 'ride' : 'anchor', cascade });
         this.edges.push(edge); (this.byFilling[f] = this.byFilling[f] || []).push(edge); (this.byHost[h] = this.byHost[h] || []).push(edge);
       }
@@ -133,6 +162,13 @@
       }
     }
     isFilling(fid) { return !!this.byFilling[fid]; }
+    edgeFor(fid) { const es = this.byFilling[fid]; return es ? es[0] : null; }   // first host that resolves (stretchRide's "first host wins")
+    // constrainSlide(fillingFid, candidateDelta, boxByFid) → HostFillEdge.constrain result + { edge } | null. SPEC_DAGEVU_SLIDE.md §2.
+    constrainSlide(fid, candidateDelta, boxByFid) {
+      const edge = this.edgeFor(fid); if (!edge) return null;
+      const r = edge.constrain(candidateDelta, { boxByFid: boxByFid || {} });
+      return r ? Object.assign(r, { edge }) : null;
+    }
     modeOf(fid) { const es = this.byFilling[fid]; return es ? es[0].mode : null; }
     setMode(fid, mode) { (this.byFilling[fid] || []).forEach(e => e.setMode(mode)); return this.modeOf(fid); }
     toggleMode(fid) { return this.setMode(fid, this.modeOf(fid) === 'ride' ? 'anchor' : 'ride'); }

--- a/modeller/modeller.html
+++ b/modeller/modeller.html
@@ -287,7 +287,7 @@ if (window.WholeHistory && WholeHistory.mount) WholeHistory.mount({ page: 'model
      real_placement_resolver.js (loaded immediately above) as its up-front gate — both load AFTER their
      dependencies, and both are additive: neither modifies the grid, BOM or walker modules. -->
 <script src="bonsai_roommove.js?v=1" onerror="console.warn('§ROOMMOVE LOAD_FAIL bonsai_roommove.js')"></script>
-<script src="bonsai_itemdrag.js?v=1" onerror="console.warn('§ITEMDRAG LOAD_FAIL bonsai_itemdrag.js')"></script>
+<script src="bonsai_itemdrag.js?v=2" onerror="console.warn('§ITEMDRAG LOAD_FAIL bonsai_itemdrag.js')"></script>
 <!-- RouteWalker (port of RouteWalker.java): routes MEP from real mep_rw.db recipes. rwRouteSegments→rwSweepOps
      bridge the routed runs to signed GEOM_SWEEP ops, so a dropped building's MEP folds into the op-log. -->
 <script src="routewalker.js?v=6" onerror="console.warn('§RW LOAD_FAIL routewalker.js')"></script>
@@ -2136,6 +2136,7 @@ function enterItemDrag() {
 function exitItemDrag() {
   itemDragging = false; _itemDrag = null; bItemDrag.innerHTML = IDRAG_ARM; controls.enabled = true; applyModeCursor();
   gmClearTints();
+  if (typeof dimLabelHide === 'function') dimLabelHide();       // §V7 / §DAGEVU: the readout lives only while the drag is live
   if (window.Bonsai.itemdrag && window.Bonsai.itemdrag.endDragSession) window.Bonsai.itemdrag.endDragSession();
 }
 bItemDrag.onclick = () => itemDragging ? exitItemDrag() : enterItemDrag();
@@ -2188,7 +2189,10 @@ canvas.addEventListener('pointermove', (e) => {
   const v = window.Bonsai.itemdrag.canDropAt(hit.x, hit.y, z);
   idTint(_itemDrag.fid, v.valid);
   _itemDrag.candidate = [hit.x, hit.y, z];
-  setStat((v.valid ? 'valid drop' : 'blocked: ' + v.reason) + ' — release to ' + (v.valid ? 'commit' : 'cancel'));
+  // §DAGEVU (SPEC_DAGEVU_SLIDE.md §4): a constrained drag carries the engine's measured readout (t along the host,
+  // clearance to both wall ends) — printed in the status line AND the §V7 floating label, the SAME string.
+  setStat((v.valid ? 'valid drop' : 'blocked: ' + v.reason) + ' — release to ' + (v.valid ? 'commit' : 'cancel') + (v.dimLabel ? ' · ' + v.dimLabel : ''));
+  if (typeof dimLabelShow === 'function') { if (v.valid && v.dimLabel) dimLabelShow(v.dimLabel, hit); else if (typeof dimLabelHide === 'function') dimLabelHide(); }
 });
 canvas.addEventListener('pointerup', async () => {
   if (!itemDragging || !_itemDrag) return;
@@ -2198,7 +2202,9 @@ canvas.addEventListener('pointerup', async () => {
   try {
     const res = await window.Bonsai.itemdrag.commit(x, y, z);
     if (res.committed) {
-      const gateMsg = _runGate(_gateBefore, [_itemDrag.fid]);
+      // §SLIDE S3/S4: a filling slide moves its opening rider too — gate BOTH (mirror commitGridMove's ids.concat(riders)).
+      const gateMsg = _runGate(_gateBefore, res.moved || [_itemDrag.fid]);
+      window.__lastGate = gateMsg;                          // test hook (W-E2E-OPENING-SLIDE) — same as commitGridMove/commitMove
       setStat('item #' + _itemDrag.fid + ' moved verify=' + res.verify + (gateMsg ? '  ' + gateMsg : ''));
       audioCue('commit'); syncHistory(); if (window.Bonsai.outliner) window.Bonsai.outliner.refresh();
     } else {

--- a/modeller/tests/witness_dagevu_engine.js
+++ b/modeller/tests/witness_dagevu_engine.js
@@ -20,6 +20,9 @@
  *   D8 ABUTS-WRAP       — real wall + constructed flush neighbour (A8 precedent): proposal == gate proposedDelta;
  *                         the commands list is NOT changed by it (report-only)
  *   D9 ROSETTA          — anchor: stretch then exact inverse ⇒ host extent restored ≤1e-9, filling delta 0 both ways
+ *   D10 CONSTRAIN-PROJECT — (SPEC_DAGEVU_SLIDE.md §5) filling-driven: orthogonal + z DROPPED, t exact, axis = host long axis
+ *   D11 CONSTRAIN-BOUNDS  — t beyond either end ⇒ null + refusal (no clamp); t = tMax exactly ⇒ ok; an overhang has tMax = TOL
+ *   D12 CONSTRAIN-OPENING — a wider opening box tightens the bounds vs filling-only (the void travels with the door)
  */
 'use strict';
 var fs = require('fs'), path = require('path');
@@ -183,6 +186,29 @@ initSqlJs({ wasmBinary: wasmBinary }).then(async function (SQL) {
   chk('D9 ROSETTA: stretch then exact inverse ⇒ host extent + min restored ≤1e-9; the held filling never moved (0 both ways)',
     extErr <= 1e-9 && minErr <= 1e-9 && r3.held.indexOf(doorFid) >= 0 && r9.held.indexOf(doorFid) >= 0 && !r9.riders.some(function (r) { return r.featureId === doorFid; }),
     'extErr=' + extErr.toExponential(2) + ' minErr=' + minErr.toExponential(2));
+
+  // ── D10-D12 CONSTRAIN (SPEC_DAGEVU_SLIDE.md) — the inverse direction: the filling drives, the host constrains ──
+  var edgeS = eng.edgeFor(doorFid);
+  var cand = [0.3, 0.7, 0.2], other = 1 - K;
+  var c10 = edgeS.constrain(cand, { boxByFid: boxByFid });
+  chk('D10 CONSTRAIN-PROJECT: 1-DOF along the host long axis — t = candidate[' + ax + '] exactly, orthogonal + z dropped, label names both fids',
+    c10 && c10.axis === ax && c10.t === cand[K] && c10.delta[K] === cand[K] && c10.delta[other] === 0 && c10.delta[2] === 0 &&
+    c10.dimLabel.indexOf('#' + doorFid + ' along #' + hostFid) === 0 && edgeS.openingFid === (fbg[edgeRow.opening_guid] != null ? fbg[edgeRow.opening_guid] : null),
+    'r=' + j(c10));
+  var atMax = [0, 0, 0]; atMax[K] = c10.tMax; var pastMax = atMax.slice(); pastMax[K] += 1e-6; var pastMin = [0, 0, 0]; pastMin[K] = c10.tMin - 1e-6;
+  var okMax = edgeS.constrain(atMax, { boxByFid: boxByFid }), refMax = edgeS.constrain(pastMax, { boxByFid: boxByFid }), rfMax = edgeS.refusal;
+  var refMin = edgeS.constrain(pastMin, { boxByFid: boxByFid }), rfMin = edgeS.refusal;
+  var boxOver = Object.assign({}, boxByFid); var fbo = fb.slice(); var push = (hb[2 * K + 1] - fb[2 * K + 1]) + 0.3; fbo[2 * K] += push; fbo[2 * K + 1] += push; boxOver[doorFid] = fbo;
+  var over = edgeS.constrain([0, 0, 0], { boxByFid: boxOver });
+  chk('D11 CONSTRAIN-BOUNDS: t=tMax ok (gapHi=0.05 exactly); t past either end ⇒ null + refusal{slide-off-host,t}, never clamped; an as-extracted overhang gets tMax = TOL (slides back in, never further out)',
+    okMax && Math.abs(okMax.gapHi + 0.05) < 1e-9 && refMax === null && rfMax && rfMax.kind === 'slide-off-host' && rfMax.t === pastMax[K] &&
+    refMin === null && rfMin && rfMin.kind === 'slide-off-host' && over && Math.abs(over.tMax - 0.05) < 1e-12 && over.tMin < -0.3,
+    'tMax=' + c10.tMax.toFixed(3) + ' tMin=' + c10.tMin.toFixed(3) + ' overhang tMax=' + (over && over.tMax) + ' tMin=' + (over && over.tMin.toFixed(3)));
+  var OP = 9003, boxOp = Object.assign({}, boxByFid); var opb = fb.slice(); opb[2 * K + 1] += 0.5; boxOp[OP] = opb;
+  var edgeOp = new D.HostFillEdge({ hostFid: hostFid, fillingFid: doorFid, hostGuid: edgeRow.host_guid, fillingGuid: edgeRow.filling_guid, openingGuid: 'g-op', openingFid: OP, provenance: 'fixture' });
+  var c12 = edgeOp.constrain([0, 0, 0], { boxByFid: boxOp });
+  chk('D12 CONSTRAIN-OPENING: a seeded opening box 0.5m wider on the hi side tightens tMax by exactly 0.5 and leaves tMin unchanged (the void bounds the slide)',
+    c12 && Math.abs((c10.tMax - c12.tMax) - 0.5) < 1e-9 && Math.abs(c12.tMin - c10.tMin) < 1e-12, 'tMax ' + c10.tMax.toFixed(3) + '→' + (c12 && c12.tMax.toFixed(3)));
 
   console.log('W-DAGEVU-ENGINE: ' + pass + ' PASS / ' + fail + ' FAIL');
   process.exit(fail ? 1 : 0);

--- a/modeller/tests/witness_e2e_opening_slide.js
+++ b/modeller/tests/witness_e2e_opening_slide.js
@@ -1,0 +1,127 @@
+#!/usr/bin/env node
+/**
+ * # ⚠ DO NOT REMOVE — W-E2E-OPENING-SLIDE: real-user, maths-asserted E2E of the along-host opening slide
+ * (prompts/SPEC_DAGEVU_SLIDE.md §5; parent ROOM_MOVE_AND_ITEM_DRAG_SPEC.md §3.1/§3.3/Q5). Read the log after every run.
+ *
+ * Two scenarios, both on the real production path (the Drag-Item tool's own grab — window.__armItemDrag is the
+ * same grabItem the canvas pick calls — a REAL mouse down→move→up, the real pointerup commit, the real gate):
+ *
+ *   O0 REAL-REFUSAL (SampleHouse) — every real rel_fills_host filling REFUSES the slide, and for the honest reason:
+ *      the §ARC-1 seed resolves REAL LOD-300 wall meshes whose door holes are BAKED INTO the mesh; no op can move a
+ *      baked hole, so a slide would leave it behind. Measured 2026-09-10: 7/7 refuse at Bonsai._insertCutBox. This
+ *      is asserted (not skipped) so the guard is proven live on real data, never a dead branch.
+ *   O1-O6 SKETCHED (fixture, same pattern as witness_e2e_grid_greenorange.js scenario B) — a sketched rectangular
+ *      wall (GEOM_EXTRUDE_POLY, the tool's primary use case) hosting a sketched door, with a rel_fills_host row
+ *      injected in the exact shape the real §ARC-1/CrossEdges pipeline produces. The constraint/gate/commit MATH is
+ *      production code; only the {host, filling} wiring is a fixture.
+ *   O1 GRAB      — the door grabs into a SLIDE session (engine edge, bounded t) — not a free drag, resolver unconsulted
+ *   O2 READOUT   — mid-drag the §V7 floating label (window.__dimLabel oracle) carries the engine's along-host string
+ *   O3 COMMIT    — pointerup commits exactly ONE GEOM_MOVE for the door; verifyChain true
+ *   O4 KINEMATIC — the door's rendered centre moved along the wall by ≈ the drag t; orthogonal + z UNCHANGED (≤1e-6)
+ *                  although the real mouse path drifted 0.25 m off-axis
+ *   O5 GATE      — no door-out / door-crush RED (the door is still inside its wall)
+ *   O6 UNDO      — one undo restores the cursor and the door's pre-drag centre
+ */
+'use strict';
+const { runE2E } = require('./e2e_harness');
+
+const centreOf = (t, fid) => t.pg.evaluate((f) => {
+  const g = window.Bonsai.group(); const m = g.children.find(o => o.isMesh && o.userData.featureId === f);
+  if (!m) return null; m.geometry.computeBoundingBox(); const b = m.geometry.boundingBox;
+  return [(b.min.x + b.max.x) / 2, (b.min.y + b.max.y) / 2, (b.min.z + b.max.z) / 2];
+}, fid);
+
+runE2E('W-E2E-OPENING-SLIDE', async (t) => {
+  await t.open('SampleHouse'); await t.shot('01-open');
+  await t.pg.waitForFunction(() => !!(window.__arcFidByGuid && window.__arcGuidByFid && window.swXEdges && window.swXEdges.fills && window.swXEdges.fills.length), { timeout: 20000 }).catch(() => {});
+
+  // ── O0: REAL SampleHouse — every real filling must refuse, for the baked-hole reason ──────────────────────────
+  const real = await t.pg.evaluate(() => {
+    const fbg = window.__arcFidByGuid, fills = window.swXEdges.fills, out = [];
+    for (const e of fills) {
+      const f = fbg[e.filling_guid], h = fbg[e.host_guid];
+      if (f == null || h == null) continue;
+      const ok = window.__armItemDrag(f, {});
+      const s = window.Bonsai.itemdrag._session;
+      out.push({ fid: f, host: h, slide: !!(ok && s && s.slide) });
+      if (typeof exitItemDrag === 'function') exitItemDrag();
+    }
+    return out;
+  });
+  const refusalLines = t.slog.filter(l => /§SLIDE REFUSED/.test(l));
+  const bakedReason = refusalLines.filter(l => /not a plain axis-aligned box/.test(l)).length;
+  console.log('  §SLIDE O0 real fillings=' + JSON.stringify(real));
+  refusalLines.forEach(l => console.log('    ' + l.slice(0, 220)));
+  t.assert('O0 REAL-REFUSAL (SampleHouse: every real filling refuses the slide — host is a real LOD-300 mesh with baked holes, Bonsai._insertCutBox says not a plain box)',
+    real.length >= 1 && real.every(r => !r.slide) && bakedReason === real.length, 'fillings=' + real.length + ' refusals(plain-box)=' + bakedReason);
+
+  // ── FIXTURE: sketched rectangular wall + sketched door + injected fills row (greenorange scenario-B pattern) ──
+  await t.clickSel('#b-clear').catch(() => {}); await t.sleep(400);
+  const ids = await t.pg.evaluate(async () => {
+    const O = window.Bonsai.oplog;
+    const host = await O.commit({ op_type: 'GEOM_EXTRUDE_POLY', parameters: { profile: { points: [[0, 0], [4, 0], [4, 0.2], [0, 0.2]] }, depth: 3 } }, { color: 0x9fb4c8 });
+    const door = await O.commit({ op_type: 'GEOM_EXTRUDE_POLY', parameters: { profile: { points: [[1.0, 0.05], [1.9, 0.05], [1.9, 0.15], [1.0, 0.15]] }, depth: 2.1 } }, { color: 0xc8a06a });
+    if (typeof syncHistory === 'function') syncHistory();
+    window.__arcGuidByFid = { [host.id]: 'g-host', [door.id]: 'g-door' };
+    window.__arcFidByGuid = { 'g-host': host.id, 'g-door': door.id };
+    window.swXEdges = { fills: [{ host_guid: 'g-host', filling_guid: 'g-door', opening_guid: null, provenance: 'ifc:recovered' }], abuts: [] };
+    window.__arcAnchorFids = null;                     // fixture hygiene: the previous resident's anchor fid set must not mask fids 1/2
+    return { host: host.id, door: door.id };
+  });
+  await t.clickSel('#b-fit'); await t.sleep(500);
+  const pre = await centreOf(t, ids.door);
+
+  // O1 — grab into a slide session
+  const grab = await t.pg.evaluate((fid) => {
+    const ok = window.__armItemDrag(fid, {});
+    const s = window.Bonsai.itemdrag._session;
+    return ok && s && s.slide ? { ok, axis: s.slide.axis, tMin: s.slide.tMin, tMax: s.slide.tMax, opening: s.slide.openingFid, product: s.real.matchedProductId, pre: s.preCentre.slice() } : { ok, slide: false };
+  }, ids.door);
+  t.slog.filter(l => /§ITEMDRAG|§SLIDE/.test(l) && !/REFUSED fid=(7|11|12|13|14|15|34)/.test(l)).forEach(l => console.log('    ' + l.slice(0, 300)));
+  console.log('  §SLIDE O1 ' + JSON.stringify(grab));
+  t.assert('O1 GRAB (sketched door grabs into a SLIDE session: engine edge, axis x, tMin=-(1.0+0.05), tMax=(4-1.9)+0.05, product FILLING:*)',
+    grab.ok && grab.axis === 0 && Math.abs(grab.tMin + 1.05) < 1e-6 && Math.abs(grab.tMax - 2.15) < 1e-6 && /^FILLING:/.test(grab.product), JSON.stringify(grab));
+  if (!grab.ok || grab.slide === false) return;
+
+  // real drag: +0.8 m along the wall with a deliberate 0.25 m off-axis drift in the mouse path
+  const T = 0.8, K = 0, other = 1;
+  const tgt = [pre[0] + T, pre[1] + 0.25, pre[2]];
+  const p0 = await t.proj(pre[0], pre[1], pre[2]), p1 = await t.proj(tgt[0], tgt[1], tgt[2]);
+  const before = await t.oplog();
+  await t.pg.mouse.move(p0[0], p0[1]); await t.sleep(40);
+  await t.pg.mouse.down(); await t.sleep(40);
+  await t.pg.mouse.move((p0[0] + p1[0]) / 2, (p0[1] + p1[1]) / 2, { steps: 5 }); await t.sleep(120);
+  await t.pg.mouse.move(p1[0], p1[1], { steps: 5 }); await t.sleep(150);
+  const mid = await t.pg.evaluate(() => ({ dim: window.__dimLabel ? window.__dimLabel.text : null, stat: (document.getElementById('stat') || {}).textContent || '' }));
+  await t.shot('02-mid-slide');
+  console.log('  §SLIDE O2 dimLabel="' + mid.dim + '" stat="' + String(mid.stat).slice(0, 160) + '"');
+  t.assert('O2 READOUT (mid-drag §V7 floating label = the engine\'s "#door along #host x +t · lo|hi to ends" string; status line carries the same)',
+    typeof mid.dim === 'string' && mid.dim.indexOf('#' + ids.door + ' along #' + ids.host + ' x +') === 0 && /to ends/.test(mid.dim) && String(mid.stat).indexOf(mid.dim) >= 0, 'dimLabel="' + mid.dim + '"');
+
+  await t.pg.mouse.up(); await t.sleep(900);
+  const after = await t.oplog(); const chain = await t.verifyChain();
+  const ops = await t.pg.evaluate((fromLen, fid) => {
+    const added = window.Bonsai.oplog._geomOps().slice(fromLen);
+    const mv = added.find(o => o.op_type === 'GEOM_MOVE' && o.parameters && o.parameters.parent === fid && !o.parameters.induced);
+    return { addedTypes: added.map(o => o.op_type), mv: mv ? mv.parameters : null, lastGate: window.__lastGate || '' };
+  }, before.len, ids.door);
+  console.log('  §SLIDE O3 ' + JSON.stringify(ops) + ' oplog ' + before.len + '→' + after.len + ' chain=' + chain);
+  t.slog.filter(l => /§ITEMDRAG commit|§GATE|§DAGEVU/.test(l)).forEach(l => console.log('    ' + l.slice(0, 300)));
+  await t.shot('03-committed');
+  t.assert('O3 COMMIT (exactly ONE GEOM_MOVE for the door — no rider, no opening seeded; verifyChain true)',
+    after.len === before.len + 1 && ops.addedTypes.length === 1 && ops.mv && chain === true, JSON.stringify(ops));
+
+  const post = await centreOf(t, ids.door);
+  const dAlong = post ? post[K] - pre[K] : NaN, dOrtho = post ? Math.abs(post[other] - pre[other]) : NaN, dZ = post ? Math.abs(post[2] - pre[2]) : NaN;
+  console.log('  §SLIDE O4 pre=' + JSON.stringify(pre.map(v => +v.toFixed(4))) + ' post=' + JSON.stringify(post && post.map(v => +v.toFixed(4))) + ' dAlong=' + dAlong.toFixed(4) + ' (want≈' + T + ') dOrtho=' + dOrtho.toExponential(2) + ' dZ=' + dZ.toExponential(2));
+  t.assert('O4 KINEMATIC (door centre moved along the wall by ≈0.8 m; y and z UNCHANGED ≤1e-6 despite the 0.25 m off-axis mouse path; committed dy=dz=0)',
+    post && Math.abs(dAlong - T) < 0.06 && dOrtho < 1e-6 && dZ < 1e-6 && ops.mv && Math.abs(ops.mv.dx - dAlong) < 1e-6 && ops.mv.dy === 0 && ops.mv.dz === 0,
+    'dAlong=' + dAlong.toFixed(4) + ' dOrtho=' + dOrtho.toExponential(2) + ' dZ=' + dZ.toExponential(2));
+  t.assert('O5 GATE (no door-out / door-crush RED — the slid door is still inside its wall)', !/door-(out|crush)/.test(ops.lastGate), 'lastGate="' + ops.lastGate + '"');
+
+  await t.undoToCursor(before.cur);
+  const undone = await t.oplog(); const back = await centreOf(t, ids.door);
+  const dBack = back ? Math.hypot(back[0] - pre[0], back[1] - pre[1], back[2] - pre[2]) : NaN;
+  await t.shot('04-undone');
+  t.assert('O6 UNDO (cursor restored, door back at its pre-drag centre ≤1e-3)', undone.cur === before.cur && dBack < 1e-3, 'cursor ' + after.cur + '→' + undone.cur + ' dBack=' + dBack.toExponential(2));
+}, { width: 1280, height: 860, dpr: 2 });

--- a/modeller/tests/witness_opening_slide.js
+++ b/modeller/tests/witness_opening_slide.js
@@ -1,0 +1,174 @@
+#!/usr/bin/env node
+/**
+ * # ⚠ DO NOT REMOVE — W-DAGEVU-SLIDE: the along-host OPENING SLIDE through the engine (PURE NODE, REAL SampleHouse).
+ * Implementing prompts/SPEC_DAGEVU_SLIDE.md §5 (parent: ROOM_MOVE_AND_ITEM_DRAG_SPEC.md §3.1/§3.3/Q5). Read the log
+ * after every run — exit code alone is not evidence.
+ *
+ * Issue under test: bonsai_itemdrag.js's own header used to say "no separate along-host slide constraint in v1";
+ * a hosted door/window dragged with the item tool was a FREE 3-D drag gated by the MEP product resolver (which has
+ * no door/window row → refused). This proves a real filling now takes a 1-DOF slide session whose constraint is
+ * the engine's HostFillEdge.constrain (DagevuEngine's SECOND consumer), gated per frame by the production SdgGate,
+ * committed as the existing GEOM_MOVE shape — and refuses honestly where it cannot be honest.
+ *
+ *   S0 SUBSTRATE   — real seeded SampleHouse, real rel_fills_host rows, a real WALL-hosted filling picked live
+ *   S1 SESSION     — the filling gets a slide session carrying the engine edge; the resolver is NEVER consulted
+ *   S2 IN-BOUNDS   — a candidate off-axis + above ⇒ valid, snappedPos holds orthogonal+z, t exact, dimLabel present
+ *   S3 OFF-HOST    — a candidate past the wall end ⇒ valid:false 'off-host-extent', NO snappedPos (never a clamp)
+ *   S4 OP          — resolveDrop ⇒ GEOM_MOVE {parent:filling, constrained delta}; one 'fills-opening' rider iff a
+ *                    seeded opening resolves (same delta)
+ *   S5 GATE-RED    — a constructed blocker box on the slide path ⇒ valid:false 'gate-red:clash', conflictIds names it
+ *   S6 BAKED-VOID  — an active GEOM_CUT {parent:host} over the filling ⇒ session null (refuse, don't leave a hole)
+ *   S7 NO-ENGINE   — DagevuEngine absent ⇒ session null (the constraint has no local fallback)
+ *   S8 PLAIN-EXTRUDE — plainExtrudeProfile: a 4-point axis-aligned rectangle ⇒ true; L-shape / rotated / 3-point ⇒ false
+ *                    (a sketched rectangular wall is a slide host; its holes are GEOM_CUT ops, caught by S6)
+ */
+'use strict';
+var fs = require('fs'), path = require('path');
+global.window = global.window || {};
+global.fetch = undefined;
+global.location = { href: 'http://localhost/' };
+if (typeof global.crypto === 'undefined') global.crypto = require('crypto').webcrypto;
+
+var ROOT = path.join(__dirname, '..');
+var ArcEditable = require(path.join(ROOT, 'arc_editable.js'));
+var CrossEdges = require(path.join(ROOT, 'cross_edges.js'));
+var ItemDrag = require(path.join(ROOT, 'bonsai_itemdrag.js'));
+var DE = require(path.join(ROOT, 'dagevu_engine.js'));
+var SdgGate = require(path.join(ROOT, 'sdg_gate.js'));
+var SdgCascade = require(path.join(ROOT, 'sdg_cascade.js'));
+var GK = require(path.join(ROOT, 'grid_kinematics.js'));
+var kernelLoaded = false;
+try { require(path.join(ROOT, 'bonsai_kernel.js')); kernelLoaded = !!(global.window.Bonsai && global.window.Bonsai._insertCutBox); } catch (e) { kernelLoaded = false; }
+require(path.join(ROOT, 'kernel_ops.js'));
+require(path.join(ROOT, 'bonsai_library.js'));
+var KernelOps = global.window.KernelOps, Library = global.window.Bonsai.library;
+var initSqlJs = require(path.join(ROOT, 'lib', 'sql-wasm.js'));
+var wasmBinary = fs.readFileSync(path.join(ROOT, 'lib', 'sql-wasm.wasm'));
+var DBPATH = path.join(ROOT, 'SampleHouse_extracted.db');
+
+var pass = 0, fail = 0;
+function chk(n, c, e) { if (c) { pass++; console.log('  ✅ ' + n + (e ? '  ' + e : '')); } else { fail++; console.log('  ❌ ' + n + (e ? '  ' + e : '')); } }
+function bboxOf(positions) {
+  var mn = [1e9, 1e9, 1e9], mx = [-1e9, -1e9, -1e9];
+  for (var i = 0; i < positions.length; i += 3) for (var k = 0; k < 3; k++) { if (positions[i + k] < mn[k]) mn[k] = positions[i + k]; if (positions[i + k] > mx[k]) mx[k] = positions[i + k]; }
+  return [mn[0], mx[0], mn[1], mx[1], mn[2], mx[2]];
+}
+function centreOf(b) { return [(b[0] + b[1]) / 2, (b[2] + b[3]) / 2, (b[4] + b[5]) / 2]; }
+function withinXY(box, pt, tol) { return pt[0] >= box[0] - tol && pt[0] <= box[1] + tol && pt[1] >= box[2] - tol && pt[1] <= box[3] + tol; }
+function j(x) { return JSON.stringify(x); }
+
+initSqlJs({ wasmBinary: wasmBinary }).then(async function (SQL) {
+  console.log('═══ W-DAGEVU-SLIDE — along-host opening slide through the engine (node, REAL SampleHouse) ═══');
+  var bdb = new SQL.Database(fs.readFileSync(DBPATH));
+  var oplog = new SQL.Database();
+  var seed = await ArcEditable.seedArc(bdb, {
+    commitGroup: function (ops, gid) { return KernelOps.commitGroup(oplog, ops, { gid: gid, baseTs: 1700000000000 }); },
+    building: 'SampleHouse'
+  });
+  var fbg = seed.bridge.fidByGuid, gbf = seed.bridge.guidByFid;
+  var opByFid = {}; seed.ops.forEach(function (o) { opByFid[fbg[o.outputGuid]] = o; });
+  var fills = CrossEdges.deriveAll(bdb).fills;
+  var boxByFid = {}, classByFid = {}, placementByFid = {};
+  Object.keys(opByFid).forEach(function (fid) {
+    boxByFid[fid] = bboxOf(Library.foldInsert({ id: +fid, op_type: 'GEOM_INSERT', parameters: opByFid[fid].params }, null).positions);
+    if (opByFid[fid].params && opByFid[fid].params.ifc_class) classByFid[fid] = opByFid[fid].params.ifc_class;
+    if (opByFid[fid].params && opByFid[fid].params.placement) placementByFid[fid] = opByFid[fid].params.placement;
+  });
+  // plainBoxOf: the PRODUCTION cut gate (bonsai_kernel.js _insertCutBox) when it loads under node, else an explicit
+  // fixture (logged) — never a re-derived vertex test.
+  var plainBoxOf = kernelLoaded
+    ? function (fid) { var op = opByFid[fid]; if (!op) return null; try { return !!global.window.Bonsai._insertCutBox({ id: +fid, op_type: 'GEOM_INSERT', parameters: op.params }); } catch (e) { return false; } }
+    : function () { return true; };
+  console.log('  §SLIDE plainBoxOf oracle = ' + (kernelLoaded ? 'PRODUCTION Bonsai._insertCutBox' : 'FIXTURE (bonsai_kernel.js did not load under node) — always true'));
+  var resolverTouched = 0;
+  var resolverTrap = new Proxy({}, { get: function (_, k) { resolverTouched++; throw new Error('§SLIDE resolver consulted for a filling (' + String(k) + ')'); } });
+  function ctxFor(fid, extra) {
+    return Object.assign({ fid: fid, insertParams: opByFid[fid] ? opByFid[fid].params : {}, boxByFid: boxByFid, classByFid: classByFid,
+      guidByFid: gbf, fidByGuid: fbg, fills: fills, resolver: resolverTrap, placementByFid: placementByFid, cutOps: [],
+      plainBoxOf: plainBoxOf, kinematics: GK, gate: SdgGate, dagevu: DE, cascade: SdgCascade }, extra || {});
+  }
+
+  // S0 — pick a REAL wall-hosted filling whose slide session actually forms (log every refusal on the way)
+  var pick = null, tried = [];
+  for (var i = 0; i < fills.length && !pick; i++) {
+    var e = fills[i], h = fbg[e.host_guid], f = fbg[e.filling_guid];
+    if (h == null || f == null || !boxByFid[h] || !boxByFid[f]) continue;
+    if (ItemDrag.HOST_CLASSES.WALL.indexOf(classByFid[h]) === -1) { tried.push(f + ':host-not-wall'); continue; }
+    if (!withinXY(boxByFid[h], centreOf(boxByFid[f]), 0.05)) { tried.push(f + ':centre-outside-host'); continue; }
+    var s = ItemDrag.beginItemDragSession(ctxFor(f));
+    if (s && s.slide) pick = { fid: f, host: h, row: e, session: s }; else tried.push(f + ':refused');
+  }
+  chk('S0 SUBSTRATE: real seeded SampleHouse + real rel_fills_host + a real WALL-hosted filling whose slide session forms',
+    !!pick, pick ? ('filling=' + pick.fid + '(' + classByFid[pick.fid] + ') host=' + pick.host + '(' + classByFid[pick.host] + ') opening=' + pick.session.slide.openingFid + ' tried=' + j(tried)) : 'tried=' + j(tried));
+  if (!pick) { console.log('W-DAGEVU-SLIDE: ' + pass + ' PASS / ' + (fail + 7) + ' FAIL (no fixture — S1-S7 not run)'); process.exit(1); }
+  var S = pick.session, sl = S.slide, c = S.preCentre, K = sl.axis, other = 1 - K, ax = 'xy'[K];
+  var fb = boxByFid[pick.fid], hb = boxByFid[pick.host];
+
+  // S1 — SESSION
+  chk('S1 SESSION: slide session carries the engine edge (HostFillEdge), product=FILLING:*, dims = own AABB, resolver NEVER consulted',
+    sl.edge instanceof DE.HostFillEdge && sl.edge.hostFid === pick.host && sl.edge.fillingFid === pick.fid && /^FILLING:/.test(S.real.matchedProductId) &&
+    Math.abs(S.real.width - (fb[1] - fb[0])) < 1e-12 && resolverTouched === 0 && sl.tMin <= 0 && sl.tMax >= 0,
+    'axis=' + ax + ' t∈[' + sl.tMin.toFixed(3) + ',' + sl.tMax.toFixed(3) + '] resolverTouched=' + resolverTouched);
+
+  // S2 — IN-BOUNDS: scan admissible t (gate may RED on a real neighbour at some t — take the first valid)
+  var tOK = null, v2 = null, scan = [0.2, -0.2, 0.4, -0.4, 0.1, -0.1, 0.6, -0.6];
+  for (var si = 0; si < scan.length && tOK == null; si++) {
+    var t = scan[si]; if (t < sl.tMin || t > sl.tMax) continue;
+    var cand = c.slice(); cand[K] += t; cand[other] += 0.3; cand[2] += 0.1;          // off-axis + above: must be dropped
+    var v = ItemDrag.canDropAt(S, cand[0], cand[1], cand[2]);
+    if (v.valid) { tOK = t; v2 = v; } else console.log('  §SLIDE S2 scan t=' + t + ' → ' + v.reason + ' conflicts=' + j(v.conflictIds));
+  }
+  chk('S2 IN-BOUNDS: valid; snappedPos = preCentre + t on ' + ax + ' only (orthogonal + z HELD); t exact; dimLabel from the engine',
+    v2 && v2.valid && tOK != null && Math.abs(v2.t - tOK) < 1e-12 && Math.abs(v2.snappedPos[K] - (c[K] + tOK)) < 1e-12 && v2.snappedPos[other] === c[other] && v2.snappedPos[2] === c[2] &&
+    typeof v2.dimLabel === 'string' && v2.dimLabel.indexOf('#' + pick.fid + ' along #' + pick.host) === 0,
+    v2 ? ('t=' + tOK + ' snapped=' + j(v2.snappedPos.map(function (x) { return +x.toFixed(3); })) + ' label="' + v2.dimLabel + '"') : 'no valid t in scan');
+
+  // S3 — OFF-HOST
+  var c3 = c.slice(); c3[K] += sl.tMax + 0.5;
+  var v3 = ItemDrag.canDropAt(S, c3[0], c3[1], c3[2]);
+  chk('S3 OFF-HOST: past the wall end ⇒ valid:false reason=off-host-extent, NO snappedPos, refusal {slide-off-host,t}',
+    v3 && v3.valid === false && v3.reason === 'off-host-extent' && v3.snappedPos == null && v3.refusal && v3.refusal.kind === 'slide-off-host',
+    j({ reason: v3.reason, t: v3.t, tMax: sl.tMax }));
+
+  // S4 — OP shape (+ rider iff a seeded opening resolves)
+  var c4 = c.slice(); c4[K] += (tOK != null ? tOK : 0); c4[other] += 0.3; c4[2] += 0.1;
+  var d4 = ItemDrag.resolveDrop(S, c4[0], c4[1], c4[2]);
+  var P = d4.op && d4.op.parameters, wantRiders = sl.openingFid != null ? 1 : 0;
+  var riderOk = d4.riders && d4.riders.length === wantRiders && d4.riders.every(function (r) {
+    return r.op_type === 'GEOM_MOVE' && r.parameters.induced === 'fills-opening' && r.parameters.parent === sl.openingFid &&
+      r.parameters.dx === P.dx && r.parameters.dy === P.dy && r.parameters.dz === P.dz; });
+  chk('S4 OP: GEOM_MOVE {parent:filling} with the CONSTRAINED delta (off-axis + z components 0); ' + wantRiders + ' fills-opening rider(s) with the same delta',
+    d4.committed && d4.op.op_type === 'GEOM_MOVE' && P.parent === pick.fid && Math.abs((K === 0 ? P.dx : P.dy) - (tOK != null ? tOK : 0)) < 1e-12 &&
+    (K === 0 ? P.dy : P.dx) === 0 && P.dz === 0 && riderOk,
+    j({ op: P, riders: d4.riders }));
+
+  // S5 — GATE-RED: a constructed blocker box sitting exactly where the filling would land at t_b
+  var w = fb[2 * K + 1] - fb[2 * K], tB = (w + 0.2 <= sl.tMax) ? (w + 0.2) : -(w + 0.2);
+  var box5 = Object.assign({}, boxByFid), blk = fb.slice(); blk[2 * K] += tB; blk[2 * K + 1] += tB; box5[9100] = blk;
+  var S5 = ItemDrag.beginItemDragSession(ctxFor(pick.fid, { boxByFid: box5 }));
+  var c5 = c.slice(); c5[K] += tB;
+  var v5 = S5 ? ItemDrag.canDropAt(S5, c5[0], c5[1], c5[2]) : null;
+  chk('S5 GATE-RED: a blocker box on the slide path ⇒ valid:false reason=gate-red:clash, conflictIds names the blocker (the production SdgGate, delta-honest)',
+    tB >= sl.tMin && tB <= sl.tMax && v5 && v5.valid === false && /^gate-red:/.test(v5.reason) && /clash/.test(v5.reason) && v5.conflictIds.indexOf('9100') >= 0,
+    j({ tB: tB, reason: v5 && v5.reason, conflicts: v5 && v5.conflictIds }));
+
+  // S6 — BAKED VOID
+  var cut = { id: 777, op_type: 'GEOM_CUT', parameters: { parent: pick.host, void: { c1: [fb[0], fb[2], fb[4]], c2: [fb[1], fb[3], fb[5]] } } };
+  var S6 = ItemDrag.beginItemDragSession(ctxFor(pick.fid, { cutOps: [cut] }));
+  chk('S6 BAKED-VOID: an active GEOM_CUT {parent:host} whose void overlaps the filling ⇒ session REFUSED (no op can move a committed void — never leave the hole behind)',
+    S6 === null && ItemDrag.bakedVoidFor([cut], pick.host, fb) === 777);
+
+  // S7 — NO ENGINE
+  var S7 = ItemDrag.beginItemDragSession(ctxFor(pick.fid, { dagevu: { HostFillEdge: null } }));
+  chk('S7 NO-ENGINE: DagevuEngine absent ⇒ slide session REFUSED (the constraint has no local fallback); free-drag path untouched', S7 === null);
+
+  // S8 — PLAIN-EXTRUDE oracle (the sketched-wall host, the tool's primary use case)
+  var PE = ItemDrag.plainExtrudeProfile;
+  chk('S8 PLAIN-EXTRUDE: 4-point axis-aligned rectangle ⇒ true; L-shape (6 pts), rotated square, degenerate 3-point, zero-width ⇒ false',
+    PE([[0, 0], [4, 0], [4, 0.2], [0, 0.2]]) === true && PE([[0, 0], [0, 0.2], [4, 0.2], [4, 0]]) === true &&
+    PE([[0, 0], [4, 0], [4, 2], [2, 2], [2, 4], [0, 4]]) === false && PE([[0, 0], [1, 1], [0, 2], [-1, 1]]) === false &&
+    PE([[0, 0], [4, 0], [4, 0.2]]) === false && PE([[0, 0], [4, 0], [4, 0], [0, 0]]) === false);
+
+  console.log('W-DAGEVU-SLIDE: ' + pass + ' PASS / ' + fail + ' FAIL');
+  process.exit(fail ? 1 : 0);
+}).catch(function (e) { console.error('WITNESS ERROR', e && e.stack || e); process.exit(1); });

--- a/prompts/RESUME_MODELLER_DAGEVU_ENGINE.md
+++ b/prompts/RESUME_MODELLER_DAGEVU_ENGINE.md
@@ -87,7 +87,15 @@ expectation, update it" from "real regression, don't paper over it" for each, an
   publicly, held for explicit go-ahead).
 - **Next session: just merge both PRs if the diffs still look right — no further coding needed here.**
 
-### 2. 🔶 IN PROGRESS, KILLED MID-TASK — along-host opening-slide drag (separate feature, not the engine)
+### 2. ✅ DONE 2026-09-10 (stacked PR on feat/dagevu-engine) — along-host opening-slide drag, finished AS THE ENGINE'S SECOND CONSUMER
+- The killed agent's 256-line draft was reviewed cold, applied, and its S2 constraint math moved into
+  `dagevu_engine.js` `HostFillEdge.constrain()` (spec: `prompts/SPEC_DAGEVU_SLIDE.md`). Witnesses: node
+  witness_opening_slide 9/9, e2e witness_e2e_opening_slide 8/8, engine 13/13; guards green.
+- Real-data finding: on real SampleHouse EVERY filling refuses the slide (7/7) because the seeded walls are real
+  LOD-300 meshes with the door holes baked in — honest, asserted in O0. The slide is live for sketched rectangular
+  walls (GEOM_EXTRUDE_POLY) + sketched doors; a void-translate op for baked holes remains NOT BUILT.
+- Original state before this session, kept for history:
+#### (was) 🔶 IN PROGRESS, KILLED MID-TASK — along-host opening-slide drag
 - Scope was: let `bonsai_itemdrag.js`'s free single-item drag constrain a hosted filling to slide
   along its OWN host wall's plane/bounds (not free 3D), and either keep a real carved cut void in sync
   or honestly refuse — the gap that file's own header flags at line ~88 ("no separate along-host

--- a/prompts/SPEC_DAGEVU_SLIDE.md
+++ b/prompts/SPEC_DAGEVU_SLIDE.md
@@ -1,0 +1,82 @@
+# SPEC — DAGeVu Slide: along-host opening drag as the engine's second consumer — Witness: W-DAGEVU-SLIDE
+
+```
+# ⚠ DO NOT REMOVE
+SCOPE: (1) add a `constrain()` contract to `HostFillEdge` in modeller/dagevu_engine.js — the 1-DOF along-host
+projection + bounds for a FILLING-driven drag; (2) finish the along-host opening-slide draft in
+modeller/bonsai_itemdrag.js (worktree agent-a8b5dc9ca46ba4e72, 256 lines, never run) by making it CALL the engine
+for its constraint instead of owning the math; (3) feed the engine's dimLabel into the item-drag pointermove
+(the §V7 readout the item drag never had). Out of scope: a void-translate op for a baked GEOM_CUT (refused, as
+the draft already does); roof/AngleEdge (⛔ paused). Read the log after every witness run.
+```
+
+Parents: `prompts/SPEC_DAGEVU_ENGINE.md` (the engine), `bim-compiler/prompts/Modeller/ROOM_MOVE_AND_ITEM_DRAG_SPEC.md`
+§3.1 ("its motion is constrained along its real host wall (Q5 scopes v1)"), §3.3 (snappedPos only as a derivation
+from the real host, never a nudge that converts an invalid drop into a valid one), §5 Q5 (along-host slide in/out of v1
+— resolved IN by the draft, kept). Session 2026-09-10.
+
+## §1 Why this is an engine task
+`DagevuEngine` shipped with one consumer (the grid drag). "Reusable" is unproven until a second constrained drag
+routes through the SAME `HostFillEdge` and the SAME readout path. The slide is that consumer: filling-driven, host
+as the constraint — the inverse direction of `propagate()` — using the same measured AABBs, the same real
+`rel_fills_host` row and the same 0.05 m tolerance.
+
+## §2 Contract added to the engine
+```
+HostFillEdge { …, openingGuid, openingFid }          // the row's opening_guid, resolved through the bridge (null if unseeded)
+  constrain(candidateDelta[3], { boxByFid }) → { delta[3], axis:'x'|'y', t, tMin, tMax, gapLo, gapHi, dimLabel } | null
+DagevuEngine.edgeFor(fillingFid) → HostFillEdge | null (first host that resolves — stretchRide's "first host wins")
+DagevuEngine.constrainSlide(fillingFid, candidateDelta, boxByFid) → constrain() result + { edge } | null
+```
+- axis = the host AABB's LONG plan axis (thin axis = x when ex ≤ ey, resolveHost's own wall rule; slide along the other).
+- body = filling AABB ∪ seeded opening AABB (when `openingFid` resolves and has a box) — the void moves with the door.
+- `t` = candidateDelta[axis]; orthogonal and z components are DROPPED (held at pre-drag values: the filling↔host
+  face offset stays invariant, exactly as stretchRide holds it). `delta` = t on axis, 0 elsewhere.
+- bounds are delta-honest: `tMin = −max(0, body.lo − host.lo) − TOL`, `tMax = max(0, host.hi − body.hi) + TOL`.
+  An as-extracted overhang can slide back in but never further out, and is never "fixed". t ∉ [tMin,tMax] ⇒
+  **null**, `edge.refusal = { kind:'slide-off-host', fillingFid, hostFid, axis, t, tMin, tMax }`. No clamp: a clamp
+  would be the §3.3-forbidden nudge.
+- `gapLo/gapHi` = post-slide clearances to the wall ends; `dimLabel` = `#f along #h x +0.35m · 0.12|1.80m to ends`.
+
+## §3 The draft, kept vs moved
+Kept in `bonsai_itemdrag.js` (all sourced from real functions, verified live: `GridKinematics._isObliqueYaw/_hasTilt`
+exported; `Bonsai._insertCutBox` at bonsai_kernel.js:190; `oplog._geomOps`; `window.__gateRel`, `__arcAnchorFids`):
+S1 routing + refusals (non-WALL host, oblique/tilted host, non-plain host body, baked GEOM_CUT void tied to the
+filling, gate unavailable), S3 per-frame `SdgGate.evaluate` (RED blocks, ORANGE reports), S4 op shape (GEOM_MOVE +
+one induced `fills-opening` rider per seeded opening, one gesture group), S5 not built.
+MOVED to the engine: S2 axis / bounds / projection — `beginSlideSession` probes `edge.constrain([0,0,0])` for
+axis+bounds; `canSlideTo` calls `edge.constrain(candidate − preCentre)` and refuses on null. Nothing computed twice.
+NEW: the engine is a hard dependency of the slide (missing ⇒ the slide REFUSES; the free-drag path is untouched).
+
+## §4 Readout (ask 2 of the parent brief)
+`modeller.html` item-drag pointermove calls `dimLabelShow(v.dimLabel, hit)` when the frame is valid and the verdict
+carries a label, `dimLabelHide()` otherwise and on exit. Status line prints the same string (§V7 single-math-path rule).
+
+## §5 Tests — each names the issue it proves
+`witness_dagevu_engine.js` (extend, node, real SampleHouse):
+- D10 CONSTRAIN-PROJECT — orthogonal + z dropped, t exact, axis = host long axis (proves: 1-DOF, face offset invariant).
+- D11 CONSTRAIN-BOUNDS — t beyond either end ⇒ null + refusal; t = tMax exactly ⇒ ok; a body already overhanging
+  has tMax = TOL on that side (proves: honest refusal, no clamp, delta-honest).
+- D12 CONSTRAIN-OPENING — a wider constructed opening box tightens the bounds vs filling-only (proves: the void
+  travels with the door and bounds the slide).
+`witness_opening_slide.js` (new, node, real SampleHouse, resolver stub that THROWS if consulted):
+- S0 substrate; S1 SESSION — a real filling gets a slide session carrying the engine edge, resolver never called;
+  S2 IN-BOUNDS — valid, snappedPos holds orthogonal+z, dimLabel present; S3 OFF-HOST — beyond the end ⇒ valid:false
+  'off-host-extent', no snappedPos; S4 OP — GEOM_MOVE parent=filling with the constrained delta, rider iff a seeded
+  opening resolves; S5 GATE-RED — a constructed blocker box on the slide path ⇒ valid:false 'gate-red:clash';
+  S6 BAKED-VOID — a GEOM_CUT parent=host over the filling ⇒ session null; S7 NO-ENGINE — ctx.dagevu=false ⇒ refused.
+`witness_e2e_opening_slide.js` (new, e2e, SampleHouse): real arm + real mouse drag along the host of a discovered
+filling; mid-drag `window.__dimLabel` shows the engine label; commit = GEOM_MOVE (+rider) with the door's centre
+shifted on the axis only; orthogonal unchanged to 1e-6; undo restores; gate no new RED.
+Regression guard: witness_item_drag_gate (node), witness_e2e_itemdrag_ui, witness_dagevu_engine D1-D9, e2e stretch_ride.
+
+## §6 Status
+- [x] engine constrain (D10-D12, witness_dagevu_engine 13/13) · [x] itemdrag refactor · [x] readout
+- [x] witness_opening_slide (node) 9/9 · [x] witness_e2e_opening_slide 8/8 — O0 proves 7/7 real SampleHouse fillings REFUSE
+  (real LOD-300 wall meshes carry baked holes; Bonsai._insertCutBox says not a plain box); O1-O6 prove the sketched
+  rectangular-wall path (the tool's primary use case) end to end with the §V7 readout
+- [x] guard: witness_item_drag_gate 9/9 · witness_e2e_itemdrag_ui 8/8 · witness_e2e_stretch_ride 11/11
+- Recon finding folded into §3: the draft's `_plainBoxOf` returned false for every non-GEOM_INSERT body, which would
+  have refused sketched walls too (a permanently dead feature); fixed to accept a 4-point axis-aligned extrude
+  (`plainExtrudeProfile`, S8) and an UNRECORDED host class (gridmove's own sketched-content rule).
+- [x] PR opened 2026-09-10 (stacked on feat/dagevu-engine)


### PR DESCRIPTION
Stacked on #1706 (`feat/dagevu-engine`). Spec: `prompts/SPEC_DAGEVU_SLIDE.md`.

## Summary
- **Engine:** `HostFillEdge.constrain(candidateDelta, {boxByFid})` — the inverse direction of `propagate()`: a filling-driven drag constrained by its host. 1-DOF along the host's long plan axis (orthogonal + z dropped), delta-honest bounds over filling ∪ seeded opening, `null` + refusal beyond the wall ends (never a clamp). `DagevuEngine.edgeFor` / `constrainSlide`.
- **Opening slide:** the killed agent's 256-line draft in `bonsai_itemdrag.js` reviewed cold, applied, and finished by routing its constraint through the engine; its refusals, per-frame `SdgGate`, and GEOM_MOVE (+ `fills-opening` rider gesture) kept.
- **Readout:** item-drag pointermove now prints the engine label (`#2 along #1 x +0.80m · 1.80|1.30m to ends`) in the status line and the §V7 floating label.

## Real-data finding (folded into the spec)
On real SampleHouse **every filling refuses the slide (7/7)**: the ARC seed resolves real LOD-300 wall meshes with the door holes baked in, and no op can move a baked hole. The refusal is honest and is asserted (O0), not skipped. The draft's plain-box oracle would also have refused every sketched wall (non-GEOM_INSERT ⇒ false) and every unrecorded host class, making the feature permanently dead; both fixed (`plainExtrudeProfile`, gridmove's sketched-content rule). The slide is live for sketched rectangular walls + sketched doors. A void-translate op for baked holes is not built.

## Witness log
| Witness | Result |
|---|---|
| witness_dagevu_engine (+D10-D12 constrain) | 13/13 |
| witness_opening_slide (new, node, real SampleHouse) | 9/9 |
| witness_e2e_opening_slide (new): O0 real refusal 7/7 · O1-O6 sketched path, real mouse drag with 0.25 m off-axis drift → dOrtho 0, readout, commit, gate, undo | 8/8 |
| witness_item_drag_gate · witness_e2e_itemdrag_ui · witness_e2e_stretch_ride | 9/9 · 8/8 · 11/11 |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01K66nqKEanpiRrpp6hQBUDi