### PR TITLE
feat(modeller): §CUT-MOVE — GEOM_CUT_MOVE op: a carved void follows its opening

### DIFF
--- a/modeller/bonsai_gridmove.js
+++ b/modeller/bonsai_gridmove.js
@@ -278,7 +278,15 @@
         const out = dagevu.propagateCommands(commands, this._boxByFid());
         commands = out.commands; riders = out.riders; held = out.held; refusals = out.refusals; proposals = out.proposals; dimLabel = out.dimLabel;
         const applied = this.applyOverrides(commands, riders);
-        return { commands: applied.commands, riders: applied.riders, excluded: applied.excluded, held, refusals, proposals, dimLabel };
+        // §CUT-MOVE (prompts/SPEC_GEOM_CUT_MOVE.md §4): a carved void (active GEOM_CUT on the host, overlapping an
+        // ANCHORED opening) would be carried away by the fold's SCALE while the door is held — emit the inverse shift
+        // as one GEOM_CUT_MOVE rider per hole (computed from the POST-override commands, so a green-excluded wall
+        // emits none). An unmappable frame is a refusal that blocks commit() like anchor-no-free-end.
+        const cm = this._cutRiders(applied.commands, held.concat(applied.riders.map(r => r.featureId)), dagevu, refusals);
+        if (cm.riders.length) dimLabel = (dimLabel ? dimLabel + ' · ' : '') + cm.riders.length + ' hole' + (cm.riders.length > 1 ? 's' : '') + ' held' +
+          (Math.abs(cm.residual) > 1e-9 ? ' (Δw ' + (cm.residual >= 0 ? '+' : '') + cm.residual.toFixed(2) + 'm)' : '');
+        if (cm.refused.length) dimLabel = (dimLabel ? dimLabel + ' · ' : '') + 'REFUSED hole #' + cm.refused.join(',#');
+        return { commands: applied.commands, riders: applied.riders, excluded: applied.excluded, held, refusals, proposals, dimLabel, cutRiders: cm.riders };
       }
       // §STRETCH-RIDE (pre-§DAGEVU path, kept byte-identical for a LOAD_FAIL of dagevu_engine.js or an absent bridge):
       // a hosted opening must NOT divorce or scale when its host wall is grid-stretched — the
@@ -294,7 +302,44 @@
         commands = ride.commands; riders = ride.riders;
       }
       const applied = this.applyOverrides(commands, riders);
-      return { commands: applied.commands, riders: applied.riders, excluded: applied.excluded, held, refusals, proposals, dimLabel };
+      return { commands: applied.commands, riders: applied.riders, excluded: applied.excluded, held, refusals, proposals, dimLabel, cutRiders: [] };
+    },
+    // §CUT-MOVE (SPEC_GEOM_CUT_MOVE.md §3-4): for every ANCHORED opening whose host has a SCALE command, every active
+    // GEOM_CUT {parent: host} whose (net-shifted) void overlaps the opening's pre-drag AABB gets the inverse of the
+    // fold's proportional shift, s = −Δ/(f·F), so its centre stays under the held door (cut_move.js anchorShift — the
+    // ONE definition the worker fold, the slide and this path share). TRANSLATE-only hosts need nothing (hole and
+    // held door move together); a RIDE opening needs nothing (door and hole take the same mapping). The width
+    // residual (f−1)·F·w is REPORTED (max-magnitude, signed), never corrected (a void resize is step 2).
+    _cutRiders(commands, candidateFids, dagevu, refusals) {
+      const out = { riders: [], refused: [], residual: 0 };
+      const CM = window.CutMove; if (!CM || !dagevu || !candidateFids.length) return out;
+      const O = window.Bonsai.oplog, ops = (O && O._geomOps) ? O._geomOps() : [];
+      const boxByFid = this._boxByFid(), AXI = CM.AX;
+      const cmdsByHost = {};
+      commands.forEach(c => { if (c && c.featureId != null) (cmdsByHost[c.featureId] = cmdsByHost[c.featureId] || []).push(c); });
+      const seen = {};
+      for (const fid of candidateFids) {
+        if (dagevu.modeOf(fid) !== 'anchor') continue;
+        const edge = dagevu.edgeFor(fid); if (!edge) continue;
+        const host = edge.hostFid, cmds = cmdsByHost[host] || [];
+        if (!cmds.some(c => c.action !== 'TRANSLATE')) continue;
+        const fb = boxByFid[fid], hb = boxByFid[host]; if (!fb || !hb) continue;
+        for (const cutOp of CM.cutsOver(ops, host, fb)) {
+          if (seen[cutOp.id]) continue; seen[cutOp.id] = 1;
+          const d = [0, 0, 0], minShift = [0, 0, 0]; let bad = null, res = 0;
+          for (const c of cmds) {                                  // in command order: a preceding TRANSLATE moves the anchor min
+            const k = AXI[c.axis]; if (k == null) continue;
+            if (c.action === 'TRANSLATE') { minShift[k] += c.delta || 0; continue; }
+            const r = CM.anchorShift({ cutOp, ops, hostBox: hb, axis: k, f: c.newScale != null ? c.newScale : 1, translateDelta: c.translateDelta || 0, minShift: minShift[k] });
+            if (!r.ok) { bad = r.reason; break; }
+            d[k] += r.s; if (Math.abs(r.residual) > Math.abs(res)) res = r.residual;
+          }
+          if (bad) { out.refused.push(cutOp.id); refusals.push({ kind: 'cut-move-unmappable', fillingFid: fid, hostFid: host, cutId: cutOp.id, reason: bad }); continue; }
+          out.riders.push({ cutId: cutOp.id, parent: host, dx: d[0], dy: d[1], dz: d[2], fillingFid: fid, residual: res });
+          if (Math.abs(res) > Math.abs(out.residual)) out.residual = res;
+        }
+      }
+      return out;
     },
 
     // Commit ONE signed GEOM_GRID_MOVE per drag-release; the worker folds the recompose deterministically.
@@ -307,9 +352,12 @@
       // can shorten the drag or ctrl+click the opening to let it ride.
       if (preview.refusals && preview.refusals.length) {
         const r = preview.refusals[0];
-        const msg = '§DAGEVU refused: opening #' + r.fillingFid + ' would leave wall #' + r.hostFid + ' on ' + r.axis +
+        const msg = (r.kind === 'cut-move-unmappable'
+          ? '§CUT-MOVE refused: hole GEOM_CUT #' + r.cutId + ' under held opening #' + r.fillingFid + ' on wall #' + r.hostFid + ' cannot follow the stretch (' + r.reason +
+            ') — ctrl+click the opening to let it ride, or ctrl+click the wall to exclude it'
+          : '§DAGEVU refused: opening #' + r.fillingFid + ' would leave wall #' + r.hostFid + ' on ' + r.axis +
           ' (wall ' + r.hostAfter[0].toFixed(2) + '..' + r.hostAfter[1].toFixed(2) + ' vs opening ' + r.filling[0].toFixed(2) + '..' + r.filling[1].toFixed(2) +
-          ') — drag less, or ctrl+click the opening to let it ride' + (preview.refusals.length > 1 ? ' [+' + (preview.refusals.length - 1) + ' more]' : '');
+          ') — drag less, or ctrl+click the opening to let it ride') + (preview.refusals.length > 1 ? ' [+' + (preview.refusals.length - 1) + ' more]' : '');
         console.warn(TAG + ' ' + msg);
         throw new Error(msg);
       }
@@ -322,16 +370,22 @@
       // Ctrl+Z reverts the whole thing (before: GEOM_GRID_MOVE then N separate GEOM_MOVEs = N+1 undos, a
       // half-reverted stretch in between). Rider ops stay byte-identical GEOM_MOVE {parent,d*,induced} rows —
       // only the grouping changes. Zero riders ⇒ the existing single-op path below, untouched.
-      if (riders.length && window.Bonsai.oplog.commitGesture) {
+      // §CUT-MOVE: the held openings' carved voids ride the SAME gesture as GEOM_CUT_MOVE rows (SPEC_GEOM_CUT_MOVE.md §4).
+      const cutRiders = preview.cutRiders || [];
+      if ((riders.length || cutRiders.length) && window.Bonsai.oplog.commitGesture) {
         const ops = [{ op_type: 'GEOM_GRID_MOVE', params: { gridId, delta, commands } }]
           .concat(riders.map(r => ({ op_type: 'GEOM_MOVE',
-            params: { parent: r.featureId, dx: r.dx, dy: r.dy, dz: r.dz, induced: 'hosted-by' } })));
+            params: { parent: r.featureId, dx: r.dx, dy: r.dy, dz: r.dz, induced: 'hosted-by' } })))
+          .concat(cutRiders.map(c => ({ op_type: 'GEOM_CUT_MOVE',
+            params: { cutId: c.cutId, parent: c.parent, dx: c.dx, dy: c.dy, dz: c.dz, induced: 'anchor-hold' } })));
         const gres = await window.Bonsai.oplog.commitGesture(ops);
         console.log(TAG + ' commit grid=' + gridId + ' delta=' + delta + ' cmds=' + commands.length +
-          ' §GESTURE gid=' + gres.gid + ' riders=' + riders.length + ' verify=' + gres.verify + ' tris=' + gres.triangleCount);
+          ' §GESTURE gid=' + gres.gid + ' riders=' + riders.length + ' cutRiders=' + cutRiders.length + ' verify=' + gres.verify + ' tris=' + gres.triangleCount);
         riders.forEach(r => console.log(TAG + ' §STRETCH-RIDE hosted-by rider=' + r.featureId + ' induced dx=' + r.dx.toFixed(3) +
           ' dy=' + r.dy.toFixed(3) + ' dz=' + r.dz.toFixed(3) + ' (in gesture group)'));
-        return { ...gres, commands, riders };
+        cutRiders.forEach(c => console.log(TAG + ' §CUT-MOVE anchor-hold cut=#' + c.cutId + ' (wall #' + c.parent + ', under held opening #' + c.fillingFid + ') authored shift dx=' + c.dx.toFixed(3) +
+          ' dy=' + c.dy.toFixed(3) + ' dz=' + c.dz.toFixed(3) + ' width residual=' + c.residual.toFixed(3) + 'm (reported, not corrected — void resize is step 2) (in gesture group)'));
+        return { ...gres, commands, riders, cutRiders };
       }
       const res = await window.Bonsai.oplog.commit({ op_type: 'GEOM_GRID_MOVE',
         parameters: { gridId, delta, commands } }, {});

--- a/modeller/bonsai_ifc.js
+++ b/modeller/bonsai_ifc.js
@@ -78,6 +78,7 @@
       const api = await this._init();
       const T = WebIFC;
       const ops = window.Bonsai.oplog._geomOps();          // [{id, op_type, parameters, parent}]
+      const _cutMoves = window.CutMove ? window.CutMove.netShifts(ops) : null;   // §CUT-MOVE: net void shifts (cut_move.js, one definition)
       if (!ops.length) throw new Error('nothing authored to export');
       const mID = api.CreateModel({ schema: 'IFC4', name: 'bonsai_model.ifc' });
       const len = v => api.CreateIfcType(mID, T.IFCLENGTHMEASURE, v);
@@ -120,7 +121,10 @@
           wallByFeature.set(op.id, wall); walls++;
           if (!firstWall) firstWall = { points: pts, depth };
         } else if (op.op_type === 'GEOM_CUT') {
-          const { c1, c2 } = op.parameters.void;
+          // §CUT-MOVE: the IfcOpeningElement is the SAME net-shifted void the worker subtracts — an active
+          // GEOM_CUT_MOVE on this cut moves the exported void too; the signed GEOM_CUT row is never rewritten.
+          const _cmShift = _cutMoves ? _cutMoves.byCut[String(op.id)] : null;
+          const { c1, c2 } = _cmShift ? window.CutMove.shiftVoid(op.parameters.void, _cmShift) : op.parameters.void;
           const dx = Math.abs(c2[0] - c1[0]), dy = Math.abs(c2[1] - c1[1]), dz = Math.abs(c2[2] - c1[2]);
           const cx = (c1[0] + c2[0]) / 2, cy = (c1[1] + c2[1]) / 2, z0 = Math.min(c1[2], c2[2]);
           const rectPlace = api.CreateIfcEntity(mID, T.IFCAXIS2PLACEMENT2D, api.CreateIfcEntity(mID, T.IFCCARTESIANPOINT, [len(0), len(0)]), null);

--- a/modeller/bonsai_itemdrag.js
+++ b/modeller/bonsai_itemdrag.js
@@ -57,10 +57,12 @@
 //      a GEOM_EXTRUDE_POLY per plainExtrudeProfile() below (a 4-point axis-aligned rectangle; its holes are GEOM_CUT
 //      ops, caught next — mirrors bonsai_kernel.js canCut's "a non-insert solid is already worker-native B-rep");
 //      host class KNOWN and not WALL (an unrecorded class = freshly-sketched content stays eligible, the SAME rule
-//      bonsai_gridmove.js elementData applies); an ACTIVE
-//      GEOM_CUT whose `parent` IS the host and whose void box overlaps the filling's pre-drag box (a REAL carved
-//      void tied to this filling — the worker has no op that translates a committed void, so the door would move
-//      and the hole would stay: REFUSE, DON'T FABRICATE); SdgGate unavailable (cannot gate honestly).
+//      bonsai_gridmove.js elementData applies); SdgGate unavailable (cannot gate honestly). An ACTIVE GEOM_CUT whose
+//      `parent` IS the host and whose void box overlaps the filling's pre-drag box (a REAL carved void tied to this
+//      filling) NO LONGER refuses — §CUT-MOVE (prompts/SPEC_GEOM_CUT_MOVE.md §4): the session records every such cut
+//      and the slide commits one GEOM_CUT_MOVE rider per cut (S5), so the hole travels with the door. It still refuses
+//      when cut_move.js or the full active op list is unavailable, or the host was rotated/arrayed after the cut
+//      (cut_move.js frameScale: no honest authored→world frame) — never a guessed frame.
 //   S2 CONSTRAINT — 1-DOF, OWNED BY THE ENGINE (prompts/SPEC_DAGEVU_SLIDE.md §2-3): dagevu_engine.js
 //      HostFillEdge.constrain(candidate − preCentre, {boxByFid}) is the ONE place the along-host projection + bounds
 //      live — axis = the host AABB's LONG plan axis (the complement of the thin axis resolveHost's wall branch snaps
@@ -81,7 +83,10 @@
 //      void), ONE rider GEOM_MOVE {parent: openingFid, same delta, induced:'fills-opening'} rides with it, committed
 //      together through oplog.commitGesture (one gesture = one Ctrl+Z, §P8 — the exact pattern gridmove.commit uses
 //      for stretch riders). No opening seeded ⇒ the single commit() path, unchanged.
-//   S5 NOT BUILT — a void-translate op (kernel + worker surgery) for a baked GEOM_CUT; refused instead (S1).
+//   S5 BUILT 2026-09-11 — GEOM_CUT_MOVE {cutId, parent, dx,dy,dz, induced:'fills-opening'} (prompts/SPEC_GEOM_CUT_MOVE.md):
+//      the worker fold shifts the cut's void BEFORE subtracting; the slide's world delta rides in the cut's AUTHORED
+//      frame (cut_move.js slideShift = t / F, F = the host's post-cut SCALE product). One rider per overlapping cut,
+//      same gesture group as S4. Holes BAKED into extracted LOD-300 meshes stay refused (the plain-box rule above).
 //
 // DUAL-EXPORT (window + node) like sdg_cascade.js / real_placement_resolver.js so the witness runs pure-node.
 (function (root, factory) {
@@ -290,9 +295,18 @@
       return refuse('host is obliquely yawed / tilted (§ROTATION-GUARD, yaw=' + pose.yawRad + ') — its AABB long edge is not its plane; refusing rather than sliding along an unreal axis');
     if (typeof ctx.plainBoxOf !== 'function') return refuse('no plainBoxOf oracle supplied — cannot verify the host body carries no baked opening');
     if (!ctx.plainBoxOf(fe.hostFid)) return refuse('host body is not a plain axis-aligned box (Bonsai._insertCutBox rule) — a real blob may carry a baked opening no op can translate; refusing rather than leaving a hole behind');
-    if (!Array.isArray(ctx.cutOps)) return refuse('no cutOps (active GEOM_CUT rows) supplied — cannot verify no baked void is tied to this filling');
-    var cutId = bakedVoidFor(ctx.cutOps, fe.hostFid, fb);
-    if (cutId != null) return refuse('a REAL baked void (GEOM_CUT #' + cutId + ', parent=host) coincides with this filling; no op exists to translate a committed void, so a slide would leave the hole behind — REFUSE, DON\'T FABRICATE (spec §1 item 5)');
+    if (!Array.isArray(ctx.cutOps)) return refuse('no cutOps (active GEOM_CUT rows) supplied — cannot verify whether a carved void is tied to this filling');
+    // §CUT-MOVE (prompts/SPEC_GEOM_CUT_MOVE.md §4): a REAL carved void over the filling used to REFUSE here ("no op
+    // exists to translate a committed void"). It now RIDES — every overlapping active GEOM_CUT (cut_move.js cutsOver,
+    // over the CURRENT net-shifted voids) is recorded and resolveDrop emits one GEOM_CUT_MOVE per cut. Its frame
+    // factor F needs the host's post-cut transform history (frameScale over the FULL active op list) — refuse without.
+    var CM = _dep(ctx.cutMove, 'CutMove', './cut_move.js');
+    if (!CM) {
+      var legacyCutId = bakedVoidFor(ctx.cutOps, fe.hostFid, fb);
+      if (legacyCutId != null) return refuse('a REAL carved void (GEOM_CUT #' + legacyCutId + ', parent=host) coincides with this filling and cut_move.js is unavailable — no honest way to carry the hole; refusing rather than leaving it behind');
+    }
+    var cutRows = CM ? CM.cutsOver(ctx.cutOps, fe.hostFid, fb) : [];
+    if (cutRows.length && !Array.isArray(ctx.geomOps)) return refuse('a REAL carved void (GEOM_CUT #' + cutRows[0].id + ', parent=host) coincides with this filling but no geomOps (full active op list) was supplied — cannot derive the cut\'s frame (post-cut host transforms); refusing rather than assuming F=1');
     var gate = _dep(ctx.gate, 'SdgGate', './sdg_gate.js');
     if (!gate || !gate.evaluate) return refuse('SdgGate unavailable — cannot gate the slide honestly');
     // S2 axis + bounds — the engine's HostFillEdge.constrain (SPEC_DAGEVU_SLIDE.md §3). Probe at t=0 (always
@@ -307,6 +321,12 @@
     var probe = edge.constrain([0, 0, 0], { boxByFid: boxByFid });
     if (!probe) return refuse('engine refused the pre-drag pose itself (' + JSON.stringify(edge.refusal) + ')');
     var axis = probe.axis === 'x' ? 0 : 1, tMin = probe.tMin, tMax = probe.tMax;
+    var cuts = [];                                                    // §CUT-MOVE: [{cutId, parent, F}] per carved void
+    for (var ci = 0; ci < cutRows.length; ci++) {
+      var fr = CM.frameScale(ctx.geomOps, cutRows[ci], axis);
+      if (!fr.ok) return refuse('carved void GEOM_CUT #' + cutRows[ci].id + ' cannot follow the slide — ' + fr.reason + '; refusing rather than leaving the hole behind');
+      cuts.push({ cutId: cutRows[ci].id, parent: fe.hostFid, F: fr.f });
+    }
     var moved = [fid]; if (ob) moved.push(fe.openingFid);
     // S3 gate inputs: every mesh box EXCEPT invisible ride anchors (modeller.html _gateBoxes excludes them too).
     var anc = ctx.anchorFids || null, before = {};
@@ -321,13 +341,16 @@
       classByFid: ctx.classByFid || {},
       slide: { hostFid: fe.hostFid, openingFid: ob ? fe.openingFid : null, axis: axis, tMin: tMin, tMax: tMax, moved: moved,
         before: before, gate: gate, rel: ctx.rel || relFromFills(ctx, fbg), hostBox: hb.slice(),
-        edge: edge, boxByFid: boxByFid }                              // §DAGEVU: the engine edge + its pre-drag boxes (per-frame constrain input)
+        edge: edge, boxByFid: boxByFid,                               // §DAGEVU: the engine edge + its pre-drag boxes (per-frame constrain input)
+        cuts: cuts }                                                  // §CUT-MOVE: carved voids that ride (GEOM_CUT_MOVE riders)
     };
     console.log(TAG + ' §SESSION begin fid=' + fid + ' product=' + session.real.matchedProductId +
       ' dims(w,d,h)=' + session.real.width.toFixed(3) + ',' + session.real.depth.toFixed(3) + ',' + session.real.height.toFixed(3) +
       ' requires_host=WALL source=' + session.real.source);
     console.log(TAG + ' §SLIDE host=' + fe.hostFid + ' axis=' + 'xy'[axis] + ' t∈[' + tMin.toFixed(3) + ',' + tMax.toFixed(3) + ']' +
-      ' opening=' + (ob ? fe.openingFid + ' (rides, induced=fills-opening)' : 'none seeded') + ' constraint=DagevuEngine.HostFillEdge.constrain gate=SdgGate.evaluate (delta-honest)');
+      ' opening=' + (ob ? fe.openingFid + ' (rides, induced=fills-opening)' : 'none seeded') +
+      ' §CUT-MOVE cuts=' + (cuts.length ? cuts.map(function (c) { return '#' + c.cutId + '(F=' + c.F + ')'; }).join(',') + ' (ride, GEOM_CUT_MOVE induced=fills-opening)' : 'none') +
+      ' constraint=DagevuEngine.HostFillEdge.constrain gate=SdgGate.evaluate (delta-honest)');
     return session;
   }
   // ── §SLIDE S2/S3 — the per-frame constraint + gate ──────────────────────────────────────────────────
@@ -443,6 +466,17 @@
     var riders = session.slide ? session.slide.moved.filter(function (f) { return String(f) !== String(session.fid); }).map(function (f) {
       return { op_type: 'GEOM_MOVE', parameters: { parent: f, dx: op.parameters.dx, dy: op.parameters.dy, dz: op.parameters.dz, induced: 'fills-opening' } };
     }) : [];
+    // §CUT-MOVE S5: every carved void tied to the filling rides by the SAME world delta, expressed in the cut's
+    // AUTHORED frame on the slide axis (cut_move.js slideShift = t / F; the other components are 0 by construction) —
+    // one GEOM_CUT_MOVE rider per cut, in the same gesture group (one Ctrl+Z reverts door + hole together).
+    if (session.slide && session.slide.cuts && session.slide.cuts.length) {
+      var CMd = _dep(null, 'CutMove', './cut_move.js');
+      session.slide.cuts.forEach(function (cu) {
+        var d = [op.parameters.dx, op.parameters.dy, op.parameters.dz];
+        d[session.slide.axis] = CMd.slideShift(d[session.slide.axis], cu.F);
+        riders.push({ op_type: 'GEOM_CUT_MOVE', parameters: { cutId: cu.cutId, parent: cu.parent, dx: d[0], dy: d[1], dz: d[2], induced: 'fills-opening' } });
+      });
+    }
     return { committed: true, verdict: v, op: op, riders: riders };
   }
 
@@ -492,6 +526,11 @@
         var O = window.Bonsai && window.Bonsai.oplog;
         try { return (O && O._geomOps) ? O._geomOps().filter(function (o) { return o.op_type === 'GEOM_CUT'; }) : []; } catch (e) { return []; }
       },
+      //   _geomOps   → EVERY active GEOM row (§CUT-MOVE frameScale walks the host's post-cut transforms in it).
+      _geomOps: function () {
+        var O = window.Bonsai && window.Bonsai.oplog;
+        try { return (O && O._geomOps) ? O._geomOps() : []; } catch (e) { return []; }
+      },
       _plainBoxOf: function (fid) {
         var O = window.Bonsai && window.Bonsai.oplog, K = window.Bonsai;
         if (!O || !O._geomOps || !K || !K._insertCutBox) return null;
@@ -531,6 +570,7 @@
           fidByGuid: window.__arcFidByGuid || null,
           placementByFid: maps.placementByFid,
           cutOps: this._cutOps(),
+          geomOps: this._geomOps(),                              // §CUT-MOVE: the full active log for frameScale
           plainBoxOf: function (f) { return self._plainBoxOf(f); },
           rel: (typeof window.__gateRel === 'function') ? window.__gateRel() : null,
           anchorFids: window.__arcAnchorFids || null
@@ -560,11 +600,16 @@
         } else {
           res = await window.Bonsai.oplog.commit({ op_type: d.op.op_type, parameters: P }, {});
         }
-        var moved = [s.fid].concat(riders.map(function (r) { return r.parameters.parent; }));
+        // §CUT-MOVE: a GEOM_CUT_MOVE rider moves a VOID, not an element — it is NOT in the gate's changed set.
+        var mvRiders = riders.filter(function (r) { return r.op_type === 'GEOM_MOVE'; });
+        var cutRiders = riders.filter(function (r) { return r.op_type === 'GEOM_CUT_MOVE'; });
+        var moved = [s.fid].concat(mvRiders.map(function (r) { return r.parameters.parent; }));
         console.log(TAG + ' commit fid=' + s.fid + ' Δ(' + P.dx.toFixed(3) + ',' + P.dy.toFixed(3) + ',' + P.dz.toFixed(3) + ')' +
           ' host=' + d.verdict.hostFid +
           (s.slide ? (' §SLIDE axis=' + 'xy'[s.slide.axis] + ' t=' + d.verdict.t.toFixed(3) +
-            (riders.length ? ' rider=' + riders.map(function (r) { return r.parameters.parent; }).join(',') + ' induced=fills-opening §GESTURE gid=' + res.gid : ' rider=none') +
+            (mvRiders.length ? ' rider=' + mvRiders.map(function (r) { return r.parameters.parent; }).join(',') + ' induced=fills-opening' : ' rider=none') +
+            (cutRiders.length ? ' §CUT-MOVE cut=' + cutRiders.map(function (r) { var q = r.parameters; return '#' + q.cutId + ' d=(' + q.dx.toFixed(3) + ',' + q.dy.toFixed(3) + ',' + q.dz.toFixed(3) + ')'; }).join(',') : '') +
+            (riders.length ? ' §GESTURE gid=' + res.gid : '') +
             ' orange=' + ((d.verdict.gate && d.verdict.gate.orange) ? d.verdict.gate.orange.length : 0))
             : (d.verdict.snappedPos ? ' snapped-to-real-host-face' : '')) +
           ' verify=' + res.verify);

--- a/modeller/bonsai_kernel.js
+++ b/modeller/bonsai_kernel.js
@@ -32,7 +32,7 @@
     init() {
       if (this._worker) return this._worker;
       if (!this.isSupported()) { console.warn(TAG + ' unsupported host (needs WASM tail-calls + Worker)'); return null; }
-      const url = new URL('bonsai_kernel_worker.js?v=7', _self);   // v2: GEOM_MOVE PATH A · v3: GEOM_ROTATE tolerant branch · v4: GEOM_ROTATE real occt solid spin · v5: GEOM_SCALE tolerant no-op (W-BONSAI-SCALE; solid scale deferred #3b) · v6: §CUT-ON-ARC seedBoxes (promote box-like insert to B-rep for GEOM_CUT/FILLET) · v7: Tier 1 shoulders GEOM_REVOLVE/SHELL/OFFSET/FILLET_VARIABLE/CHAMFER_DIST_ANGLE/DRAFT + listFaces
+      const url = new URL('bonsai_kernel_worker.js?v=8', _self);   // v8: §CUT-MOVE GEOM_CUT_MOVE fold override (cut_move.js) · v2: GEOM_MOVE PATH A · v3: GEOM_ROTATE tolerant branch · v4: GEOM_ROTATE real occt solid spin · v5: GEOM_SCALE tolerant no-op (W-BONSAI-SCALE; solid scale deferred #3b) · v6: §CUT-ON-ARC seedBoxes (promote box-like insert to B-rep for GEOM_CUT/FILLET) · v7: Tier 1 shoulders GEOM_REVOLVE/SHELL/OFFSET/FILLET_VARIABLE/CHAMFER_DIST_ANGLE/DRAFT + listFaces
       this._worker = new Worker(url.href, { type: 'module' });
       this._worker.onmessage = (e) => {
         const d = e.data || {};

--- a/modeller/bonsai_kernel_worker.js
+++ b/modeller/bonsai_kernel_worker.js
@@ -4,6 +4,10 @@
 // typed arrays. The fold is the SAME code path proven by W-KERNEL-FOLD (build/kernel/spike.html).
 // occt needs WASM tail-calls => Chrome 114+/Safari 17.2+, NO Firefox (gated host-side in bonsai_kernel.js).
 import { OcctKernel } from './lib/kernel/index.js';
+// §CUT-MOVE (prompts/SPEC_GEOM_CUT_MOVE.md): the ONE definition of GEOM_CUT_MOVE's meaning — a classic triple-export
+// script evaluated here as a module (it binds `self.CutMove`; the main thread's <script> binds window.CutMove).
+import './cut_move.js?v=1';
+const CutMove = self.CutMove;
 
 let kernelPromise = null;
 let _wasmBytes = null;   // pre-fetched bytes handed in by the host (preload) → single download, no re-fetch
@@ -397,18 +401,30 @@ function buildSolids(kernel, ops, seedBoxes, seedLayers) {
       solids.set(+fid, { shape: combined, hash: 'seedlayers:' + fid + ':' + ranges.length });
     }
   }
+  // §CUT-MOVE (prompts/SPEC_GEOM_CUT_MOVE.md §2 — Witness: W-CUT-MOVE): a GEOM_CUT_MOVE {cutId, dx,dy,dz} is a pure
+  // FOLD OVERRIDE of an EARLIER GEOM_CUT's void (the signed row is never rewritten). Pre-scan THIS fold's rows → net
+  // shift per cutId (cut_move.js netShifts — rows naming a cut that is not active here are ignored, tolerant like
+  // GEOM_MOVE on a missing parent); the GEOM_CUT branch below subtracts `void + shift` at the cut's own position.
+  // CACHE: op_hash keys assume output = f(prefix); a cut-move is retroactive, so when any shift is non-zero EVERY key
+  // in this fold carries the fold's cut-move signature — one rebuild per distinct shift set, and a scrub/undo back to
+  // a prefix without the move hits the original (unsuffixed) keys. Zero cut-moves ⇒ keys byte-identical to before.
+  const cutMoves = CutMove.netShifts(ops), cmKey = CutMove.keySuffix(cutMoves.sig);
   for (const op of ops) {
     const P = typeof op.parameters === 'string' ? JSON.parse(op.parameters) : op.parameters;
-    const key = op.op_hash || ('nohash:' + op.id);    // op_hash = unique per immutable prefix → the cache key
+    const key = (op.op_hash || ('nohash:' + op.id)) + cmKey;    // op_hash = unique per immutable prefix → the cache key (+ §CUT-MOVE suffix)
     if (op.op_type === 'GEOM_CUT') {
       const pe = solids.get(op.parent); if (!pe) throw new Error('GEOM_CUT parent ' + op.parent + ' not found');
       if (shapeCache.has(key)) { _stats.hits++; solids.set(op.parent, { shape: shapeCache.get(key), hash: key }); continue; }
       _stats.rebuilt++;
       const v = (a) => ({ x: a[0], y: a[1], z: a[2] });
-      const void_ = kernel.makeBoxFromCorners(v(P.void.c1), v(P.void.c2));
+      const shift = cutMoves.byCut[String(op.id)];
+      const vd = shift ? CutMove.shiftVoid(P.void, shift) : P.void;   // §CUT-MOVE: the void at its net-shifted place
+      const void_ = kernel.makeBoxFromCorners(v(vd.c1), v(vd.c2));
       const cut = kernel.cut(pe.shape, void_);
       kernel.release(void_);                          // local intermediate (parent is cached → NOT released)
       shapeCache.set(key, cut); solids.set(op.parent, { shape: cut, hash: key });
+    } else if (op.op_type === 'GEOM_CUT_MOVE') {       // §CUT-MOVE: folded at ITS CUT's position via the pre-scan above
+      continue;                                        // (a no-op here; never a leaf, never a parent lookup)
     } else if (op.op_type === 'GEOM_FILLET') {
       const pe = solids.get(op.parent); if (!pe) throw new Error('GEOM_FILLET parent ' + op.parent + ' not found');
       if (shapeCache.has(key)) { _stats.hits++; solids.set(op.parent, { shape: shapeCache.get(key), hash: key }); continue; }

--- a/modeller/cut_move.js
+++ b/modeller/cut_move.js
@@ -1,0 +1,155 @@
+// Copyright (c) 2025-2026 Redhuan D. Oon <red1org@gmail.com>
+// SPDX-License-Identifier: MIT
+// cut_move.js — §CUT-MOVE (prompts/SPEC_GEOM_CUT_MOVE.md — Witness: W-CUT-MOVE / W-E2E-CUT-MOVE): the ONE definition
+// of what a `GEOM_CUT_MOVE {cutId, parent, dx, dy, dz}` row MEANS, shared by the worker fold (bonsai_kernel_worker.js
+// buildSolids), the IFC export (bonsai_ifc.js), the along-host slide (bonsai_itemdrag.js) and the grid ANCHOR path
+// (bonsai_gridmove.js) — the bonsai_roommove.js pattern ("the production fold and the pure-node witnesses share exactly
+// ONE definition of what the op means"). Nothing here touches occt or the DOM; every number is read from op rows and
+// measured AABBs.
+//
+// THE OP: a signed GEOM_CUT row's `void` is hashed and can never be edited. GEOM_CUT_MOVE is a pure FOLD OVERRIDE (like
+// GEOM_MOVE on an insert, bonsai_kernel.js foldChainToScene's summed `moveBy`): the fold pre-scans the active rows,
+// sums the shifts per cutId, and subtracts the cut's void at `void + Σshift` AT THE CUT'S OWN LOG POSITION. The row is
+// a no-op at its own position. A row naming a cut that is not an active GEOM_CUT in the same fold is IGNORED (tolerant,
+// the worker's GEOM_MOVE-on-a-missing-parent rule) — never a throw, never a guess.
+//
+// THE FRAME (spec §3): the void is authored in world coordinates at the cut's log position; ops AFTER the cut that
+// transform the host map it (TRANSLATE shifts; a GRID SCALE maps x → f·x + min·(1−f) + t about the host's CURRENT min;
+// GEOM_ROTATE spins). Per axis the void's OFFSET from the host min, u = x − min, obeys u' = f·u under SCALE and is
+// invariant under TRANSLATE, so with F = Π f_i over the post-cut SCALE commands on that axis:
+//   slide  — a door slid by world t needs the hole moved by world t ⇒ authored shift s = t / F
+//   anchor — a new SCALE (f, t) moves the hole's current world centre q by Δ = (q − min)(f − 1) + t (the fold's own
+//            proportional shift); holding it ⇒ s = −Δ / (f · F). The width residual (f − 1)·F·w is REPORTED, not
+//            corrected (a void RESIZE is step 2, spec preamble).
+// A post-cut GEOM_ROTATE / GEOM_ARRAY on the host, or an obliquely-yawed SCALE (the worker's §SCALE-YAW-GUARD path),
+// means the authored axis is no longer a world axis ⇒ ok:false — the consumer REFUSES (never approximates).
+//
+// TRIPLE-EXPORT: CommonJS (node witnesses), `self` (the module Web Worker imports this file; the main thread's
+// <script> sees self === window). In the worker the file is evaluated as an ES module — no `require`, no `this`.
+(function (root, factory) {
+  if (typeof module !== 'undefined' && module.exports) module.exports = factory();
+  else root.CutMove = factory();
+})(typeof self !== 'undefined' ? self : (typeof window !== 'undefined' ? window : this), function () {
+  'use strict';
+  var TAG = '§CUT-MOVE';
+  var AX = { x: 0, y: 1, z: 2 };
+  var OVERLAP_EPS = 1e-6;     // m — bonsai_itemdrag.js's own flush-contact rule (0 overlap = adjacency, not a hit)
+  var HALF_PI = Math.PI / 2;
+  var YAW_TOL = 0.01;         // rad — bonsai_kernel_worker.js §SCALE-YAW-GUARD / GRID_ROTATION_GUARD.md §1
+
+  function params(op) { var P = op && op.parameters; return typeof P === 'string' ? JSON.parse(P) : (P || {}); }
+  function parentOf(op, P) { return P && P.parent != null ? P.parent : op.parent; }
+  function same(a, b) { return a != null && b != null && String(a) === String(b); }
+
+  // voidBox({c1,c2}) → [xmin,xmax,ymin,ymax,zmin,zmax] (the _gateBoxes / boxByFid layout). Corner order is free.
+  function voidBox(v) {
+    var a = v.c1, b = v.c2;
+    return [Math.min(a[0], b[0]), Math.max(a[0], b[0]), Math.min(a[1], b[1]), Math.max(a[1], b[1]), Math.min(a[2], b[2]), Math.max(a[2], b[2])];
+  }
+  function overlaps(a, b) {
+    return (Math.min(a[1], b[1]) - Math.max(a[0], b[0])) > OVERLAP_EPS &&
+           (Math.min(a[3], b[3]) - Math.max(a[2], b[2])) > OVERLAP_EPS &&
+           (Math.min(a[5], b[5]) - Math.max(a[4], b[4])) > OVERLAP_EPS;
+  }
+  // shiftVoid({c1,c2}, [dx,dy,dz]) → a NEW {c1,c2}; the input is untouched (the signed row is never rewritten).
+  function shiftVoid(v, s) {
+    var d = s || [0, 0, 0];
+    return { c1: [v.c1[0] + (d[0] || 0), v.c1[1] + (d[1] || 0), v.c1[2] + (d[2] || 0)],
+             c2: [v.c2[0] + (d[0] || 0), v.c2[1] + (d[1] || 0), v.c2[2] + (d[2] || 0)] };
+  }
+
+  // netShifts(ops) → { byCut: {cutId: [dx,dy,dz]}, sig } over the ACTIVE rows of one fold. Only cutIds that are an
+  // active GEOM_CUT in the same list count; `sig` is a deterministic, order-independent signature of the non-zero
+  // shifts ('' when none) — the cache-key suffix (spec §2 CACHE).
+  function netShifts(ops) {
+    var cuts = {}, byCut = {}, i, op, P, id;
+    for (i = 0; i < (ops || []).length; i++) { op = ops[i]; if (op && op.op_type === 'GEOM_CUT') cuts[String(op.id)] = 1; }
+    for (i = 0; i < (ops || []).length; i++) {
+      op = ops[i]; if (!op || op.op_type !== 'GEOM_CUT_MOVE') continue;
+      P = params(op); id = P.cutId != null ? String(P.cutId) : null;
+      if (id == null || !cuts[id]) continue;                                      // tolerant: names no active cut → ignored
+      var s = byCut[id] || (byCut[id] = [0, 0, 0]);
+      s[0] += +P.dx || 0; s[1] += +P.dy || 0; s[2] += +P.dz || 0;
+    }
+    var keys = Object.keys(byCut).filter(function (k) { var s = byCut[k]; return s[0] !== 0 || s[1] !== 0 || s[2] !== 0; })
+      .sort(function (a, b) { return (+a) - (+b); });
+    var sig = keys.map(function (k) { var s = byCut[k]; return k + ':' + s[0] + ',' + s[1] + ',' + s[2]; }).join(';');
+    return { byCut: byCut, sig: sig };
+  }
+  function keySuffix(sig) { return sig ? '|cm:' + sig : ''; }
+
+  // cutsOver(ops, hostFid, box) → every ACTIVE GEOM_CUT {parent: host} whose (net-shifted) void overlaps `box` — the
+  // "a REAL carved void tied to THIS filling" rule bonsai_itemdrag.js bakedVoidFor introduced, now over the CURRENT
+  // void (prior cut-moves applied) so a hole that was already slid is still found under its door.
+  function cutsOver(ops, hostFid, box) {
+    var net = netShifts(ops), out = [];
+    for (var i = 0; i < (ops || []).length; i++) {
+      var op = ops[i]; if (!op || op.op_type !== 'GEOM_CUT') continue;
+      var P = params(op);
+      if (!same(parentOf(op, P), hostFid) || !P.void || !P.void.c1 || !P.void.c2) continue;
+      if (overlaps(voidBox(shiftVoid(P.void, net.byCut[String(op.id)])), box)) out.push(op);
+    }
+    return out;
+  }
+
+  // frameScale(ops, cutOp, axis) → { ok, f:F, tPost, reason }. Walks the ACTIVE rows AFTER the cut that transform its
+  // host on `axis` (0|1|2), mirroring bonsai_kernel_worker.js's own branches: GRID TRANSLATE / GEOM_MOVE / ROOM_MOVE
+  // shift (tPost); GRID SCALE multiplies F and shifts by translateDelta (a TILTED scale is the worker's refuse-no-op ⇒
+  // no effect; an OBLIQUE yaw is the worker's rotate→scale→rotate-back path ⇒ ok:false); GEOM_SCALE is the worker's
+  // tolerant no-op on a B-rep solid ⇒ no effect; GEOM_ROTATE / GEOM_ARRAY ⇒ ok:false.
+  function frameScale(ops, cutOp, axis) {
+    var k = typeof axis === 'string' ? AX[axis] : axis, host = parentOf(cutOp, params(cutOp));
+    var F = 1, tPost = 0, name = 'xyz'[k];
+    for (var i = 0; i < (ops || []).length; i++) {
+      var op = ops[i]; if (!op || !(op.id > cutOp.id)) continue;
+      var P = params(op);
+      if (op.op_type === 'GEOM_GRID_MOVE') {
+        var cmds = P.commands || [];
+        for (var j = 0; j < cmds.length; j++) {
+          var c = cmds[j]; if (!c || !same(c.featureId, host) || c.axis !== name) continue;
+          if (c.action === 'TRANSLATE') { tPost += +c.delta || 0; continue; }
+          var tiltX = typeof c.tiltXRad === 'number' && isFinite(c.tiltXRad) ? Math.abs(c.tiltXRad) : 0;
+          var tiltY = typeof c.tiltYRad === 'number' && isFinite(c.tiltYRad) ? Math.abs(c.tiltYRad) : 0;
+          if (tiltX > YAW_TOL || tiltY > YAW_TOL) continue;                     // worker: refused no-op
+          var oblique = typeof c.yawRad === 'number' && isFinite(c.yawRad) && Math.abs(c.yawRad - Math.round(c.yawRad / HALF_PI) * HALF_PI) > YAW_TOL;
+          if (oblique && (c.axis === 'x' || c.axis === 'y')) return { ok: false, f: F, tPost: tPost, reason: 'oblique-yaw-scale-after-cut (GEOM_GRID_MOVE #' + op.id + ')' };
+          F *= c.newScale != null ? c.newScale : 1; tPost += +c.translateDelta || 0;
+        }
+      } else if (op.op_type === 'GEOM_MOVE') {
+        if (same(parentOf(op, P), host)) tPost += +(k === 0 ? P.dx : k === 1 ? P.dy : P.dz) || 0;
+      } else if (op.op_type === 'GEOM_ROOM_MOVE') {
+        var mem = P.members || [];
+        for (var m = 0; m < mem.length; m++) if (mem[m] && same(mem[m].featureId, host)) { tPost += +(k === 0 ? P.dx : k === 1 ? P.dy : P.dz) || 0; break; }
+      } else if (op.op_type === 'GEOM_ROTATE') {
+        if (same(parentOf(op, P), host)) return { ok: false, f: F, tPost: tPost, reason: 'rotated-after-cut (GEOM_ROTATE #' + op.id + ') — the authored axis is no longer a world axis' };
+      } else if (op.op_type === 'GEOM_ARRAY') {
+        if (same(parentOf(op, P), host)) return { ok: false, f: F, tPost: tPost, reason: 'arrayed-after-cut (GEOM_ARRAY #' + op.id + ') — the host was replaced by clones' };
+      }
+    }
+    return { ok: true, f: F, tPost: tPost, reason: null };
+  }
+
+  // slideShift(t, F) → the authored-frame shift that moves the hole by world t.
+  function slideShift(t, F) { return (+t || 0) / (F || 1); }
+
+  // anchorShift({ cutOp, ops, hostBox, axis, f, translateDelta, minShift }) → { ok, s, q, delta, residual, F, w, reason }
+  //   hostBox = the host's measured PRE-DRAG AABB (boxByFid layout); f/translateDelta = the SCALE command about to
+  //   fold; minShift = Σ TRANSLATE deltas on this axis that precede the SCALE in the same gesture (usually 0).
+  function anchorShift(a) {
+    var k = typeof a.axis === 'string' ? AX[a.axis] : a.axis;
+    var fr = frameScale(a.ops, a.cutOp, k);
+    if (!fr.ok) return { ok: false, reason: fr.reason, F: fr.f };
+    var net = netShifts(a.ops), P = params(a.cutOp);
+    var vb = voidBox(shiftVoid(P.void, net.byCut[String(a.cutOp.id)]));
+    var vc = (vb[2 * k] + vb[2 * k + 1]) / 2, w = vb[2 * k + 1] - vb[2 * k];
+    var minNow = a.hostBox[2 * k] + (+a.minShift || 0), minCut = a.hostBox[2 * k] - fr.tPost;
+    var f = a.f != null ? a.f : 1, t = +a.translateDelta || 0;
+    var q = minNow + fr.f * (vc - minCut);                                     // the hole's CURRENT world centre
+    var delta = (q - minNow) * (f - 1) + t;                                    // the fold's proportional shift of it
+    var s = -delta / (f * fr.f);
+    return { ok: true, s: s, q: q, delta: delta, residual: (f - 1) * fr.f * w, F: fr.f, w: w, reason: null };
+  }
+
+  return { TAG: TAG, AX: AX, OVERLAP_EPS: OVERLAP_EPS, voidBox: voidBox, shiftVoid: shiftVoid, netShifts: netShifts,
+    keySuffix: keySuffix, cutsOver: cutsOver, frameScale: frameScale, slideShift: slideShift, anchorShift: anchorShift };
+});

--- a/modeller/modeller.html
+++ b/modeller/modeller.html
@@ -203,7 +203,10 @@
 <div id="stat">booting…</div>
 
 <!-- Bonsai kernel host (classic global window.Bonsai) — author() spawns the worker lazily. -->
-<script src="bonsai_kernel.js?v=7" onerror="console.warn('§BONSAI LOAD_FAIL bonsai_kernel.js')"></script>
+<!-- §CUT-MOVE (prompts/SPEC_GEOM_CUT_MOVE.md): the ONE definition of GEOM_CUT_MOVE — zero deps, loaded first; the
+     module worker imports the SAME file (self.CutMove); bonsai_ifc / gridmove / itemdrag read window.CutMove at call time. -->
+<script src="cut_move.js?v=1" onerror="console.warn('§CUT-MOVE LOAD_FAIL cut_move.js')"></script>
+<script src="bonsai_kernel.js?v=8" onerror="console.warn('§BONSAI LOAD_FAIL bonsai_kernel.js')"></script>
 <!-- Bonsai 2D sketch front: planegcs constraint solver -> solved profile -> GEOM_EXTRUDE_POLY. -->
 <script src="bonsai_sketch.js?v=1" onerror="console.warn('§SKETCH LOAD_FAIL bonsai_sketch.js')"></script>
 <!-- Signed op-log engine (shipped kernel_ops: hash chain + edge signature) + sql.js it commits into. -->
@@ -231,16 +234,16 @@ if (window.WholeHistory && WholeHistory.mount) WholeHistory.mount({ page: 'model
      tree engine the Viewer runs (common/history_bar.js), reused — not a second branch mechanism. The
      adapter wraps Bonsai.oplog.commit/commitGesture so every real edit lands as one tree node. -->
 <script src="../common/history_bar.js?v=1" onerror="console.warn('§MHIST LOAD_FAIL history_bar.js')"></script>
-<script src="modeller_history.js?v=1" onerror="console.warn('§MHIST LOAD_FAIL modeller_history.js')"></script>
+<script src="modeller_history.js?v=2" onerror="console.warn('§MHIST LOAD_FAIL modeller_history.js')"></script>
 <!-- Bonsai IFC export: the authored op-log -> a standards IFC4 file via web-ifc (author->sign->export). -->
 <script src="lib/web-ifc-api-iife.js" onerror="console.warn('§IFC LOAD_FAIL web-ifc-api-iife.js')"></script>
-<script src="bonsai_ifc.js?v=1" onerror="console.warn('§IFC LOAD_FAIL bonsai_ifc.js')"></script>
+<script src="bonsai_ifc.js?v=2" onerror="console.warn('§IFC LOAD_FAIL bonsai_ifc.js')"></script>
 <script src="bcf_export.js?v=1" onerror="console.warn('§BCF LOAD_FAIL bcf_export.js')"></script>
 <!-- Bonsai architectural authoring grid: column grid on the sketch plane + snap-to-grid (2D correlation). -->
 <script src="bonsai_grid.js?v=1" onerror="console.warn('§GRID LOAD_FAIL bonsai_grid.js')"></script>
 <!-- Grid Kinematics engine (§S270, pure recompose math) + the modeller adapter (gridline-drag → GEOM_GRID_MOVE). -->
 <script src="grid_kinematics.js" onerror="console.warn('§GRIDMOVE LOAD_FAIL grid_kinematics.js')"></script>
-<script src="bonsai_gridmove.js?v=1" onerror="console.warn('§GRIDMOVE LOAD_FAIL bonsai_gridmove.js')"></script>
+<script src="bonsai_gridmove.js?v=2" onerror="console.warn('§GRIDMOVE LOAD_FAIL bonsai_gridmove.js')"></script>
 <!-- Bonsai-faithful Outliner (the richer Find): Blender-style feature tree over the signed op-log. -->
 <script src="bonsai_outliner.js?v=13" onerror="console.warn('§OUTLINER LOAD_FAIL bonsai_outliner.js')"></script>
 <!-- BOM Tree composition facet (the ARC BOM editor): Open any extracted.db → seed an editable BOM tree; re-parent = signed op. -->
@@ -287,7 +290,7 @@ if (window.WholeHistory && WholeHistory.mount) WholeHistory.mount({ page: 'model
      real_placement_resolver.js (loaded immediately above) as its up-front gate — both load AFTER their
      dependencies, and both are additive: neither modifies the grid, BOM or walker modules. -->
 <script src="bonsai_roommove.js?v=1" onerror="console.warn('§ROOMMOVE LOAD_FAIL bonsai_roommove.js')"></script>
-<script src="bonsai_itemdrag.js?v=2" onerror="console.warn('§ITEMDRAG LOAD_FAIL bonsai_itemdrag.js')"></script>
+<script src="bonsai_itemdrag.js?v=3" onerror="console.warn('§ITEMDRAG LOAD_FAIL bonsai_itemdrag.js')"></script>
 <!-- RouteWalker (port of RouteWalker.java): routes MEP from real mep_rw.db recipes. rwRouteSegments→rwSweepOps
      bridge the routed runs to signed GEOM_SWEEP ops, so a dropped building's MEP folds into the op-log. -->
 <script src="routewalker.js?v=6" onerror="console.warn('§RW LOAD_FAIL routewalker.js')"></script>

--- a/modeller/modeller_history.js
+++ b/modeller/modeller_history.js
@@ -18,7 +18,7 @@
   var OP_TYPES = { 'BUILDING_OPEN': true, 'GEOM_EXTRUDE': true, 'GEOM_EXTRUDE_POLY': true,
     'GEOM_SWEEP': true, 'GEOM_CUT': true, 'GEOM_FILLET': true, 'GEOM_GRID_MOVE': true,
     'GEOM_MOVE': true, 'GEOM_ROTATE': true, 'GEOM_SCALE': true, 'GEOM_INSERT': true,
-    'GEOM_OPENING': true, 'STR_WALK_EDIT': true, 'GEOM_DELETE': true };
+    'GEOM_OPENING': true, 'STR_WALK_EDIT': true, 'GEOM_DELETE': true, 'GEOM_CUT_MOVE': true };
   var PROFILES = { high: { op: OP_TYPES } };
   PROFILES.all = PROFILES.high; PROFILES.doc = PROFILES.high;   // legacy aliases HistoryBar falls back to
 
@@ -27,6 +27,7 @@
     if (opType === 'BUILDING_OPEN') return 'Opened ' + (p.building || p.name || 'building');
     if (opType === 'GEOM_GRID_MOVE') return 'Grid ' + (p.label || p.gridId || '') + ' move';
     if (opType === 'GEOM_CUT') return 'Cut';
+    if (opType === 'GEOM_CUT_MOVE') return 'Cut move #' + p.cutId;   // §CUT-MOVE (a lone commit; inside a gesture the first op labels the node)
     if (opType === 'GEOM_FILLET') return 'Fillet';
     if (opType === 'GEOM_ROTATE') return 'Rotate';
     if (opType === 'GEOM_SCALE') return 'Scale';

--- a/modeller/tests/witness_cut_move.mjs
+++ b/modeller/tests/witness_cut_move.mjs
@@ -1,0 +1,149 @@
+#!/usr/bin/env node
+/**
+ * # ⚠ DO NOT REMOVE — W-CUT-MOVE: GEOM_CUT_MOVE folded by the REAL worker (pure node, real occt-wasm) + the shared
+ * frame math (modeller/cut_move.js). Implementing prompts/SPEC_GEOM_CUT_MOVE.md §5. Read the log after every run —
+ * exit code alone is not evidence.
+ *
+ * Issue under test: a signed GEOM_CUT's void could never move — the slide REFUSED any filling over a carved void
+ * (witness_opening_slide S6 "no op can move a committed void"), and a grid stretch with the door HELD let the fold's
+ * SCALE carry the hole away from the door. This proves the ONE new op fixes both, at the kernel level, with numbers:
+ *
+ *   C0 BASE        — wall [0,4]×[0,0.2]×[0,3] + through-void x∈[1.2,2.8] z∈[0.9,2.1]: hole measured off the vertices
+ *   C1 NET-SHIFT   — netShifts sums per cut, ignores a row naming a non-active cut, '' signature when unused
+ *   C2 FOLD-SHIFT  — + GEOM_CUT_MOVE dx=0.8 ⇒ the hole is at [2.0,3.6], width unchanged, wall outline unchanged
+ *   C3 ANCHOR      — GRID SCALE f=1.25 alone moves the hole centre 2.0→2.5; with the anchorShift rider s=−0.4 the
+ *                    centre STAYS at 2.0 (min-edge drag with translateDelta, and a prior stretch F=1.25, likewise);
+ *                    the width residual (f−1)·F·w is reported exactly
+ *   C4 CACHE       — the original chain folded again after a moved fold hits the cache AND yields the original hole
+ *   C5 FRAME       — frameScale: post-cut SCALE/MOVE counted, pre-cut ignored, ROTATE after cut ⇒ ok:false; slideShift
+ *   C6 SLIDE-FOLD  — after a prior stretch, a slide of world 0.8 rides as authored 0.64 and the folded hole moves 0.8
+ *
+ * TECHNIQUE (verbatim from witness_gridmove_fold_pure.mjs): the REAL bonsai_kernel_worker.js + its real lib/kernel/
+ * + the real cut_move.js it imports are copied byte-identical into a scoped ESM temp dir; only self/postMessage are
+ * stubbed. Zero fold math is re-implemented here.
+ */
+'use strict';
+import fs from 'fs';
+import path from 'path';
+import os from 'os';
+import { fileURLToPath } from 'url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const MOD = path.join(__dirname, '..');
+
+let pass = 0, fail = 0;
+function chk(name, cond, extra) {
+  if (cond) { pass++; console.log('  ✅ ' + name + (extra ? '  ' + extra : '')); }
+  else { fail++; console.log('  ❌ ' + name + (extra ? '  ' + extra : '')); }
+}
+const approx = (a, b, tol) => Math.abs(a - b) <= (tol != null ? tol : 1e-6);
+const j = (x) => JSON.stringify(x);
+function aabb(p) {
+  let b = [Infinity, -Infinity, Infinity, -Infinity, Infinity, -Infinity];
+  for (let i = 0; i < p.length; i += 3) for (let k = 0; k < 3; k++) { b[2 * k] = Math.min(b[2 * k], p[i + k]); b[2 * k + 1] = Math.max(b[2 * k + 1], p[i + k]); }
+  return b;
+}
+// The hole's x-extent: a through-void's edge loops are the ONLY vertices strictly between the wall's top and bottom
+// (the wall's own corners sit at z=0 / z=3; OCCT triangulates a planar face from its boundary nodes only).
+function holeX(p, zlo, zhi) {
+  let xmin = Infinity, xmax = -Infinity, n = 0;
+  for (let i = 0; i < p.length; i += 3) { const z = p[i + 2]; if (z > zlo + 1e-6 && z < zhi - 1e-6) { xmin = Math.min(xmin, p[i]); xmax = Math.max(xmax, p[i]); n++; } }
+  return { xmin, xmax, c: (xmin + xmax) / 2, w: xmax - xmin, n };
+}
+
+console.log('═══ W-CUT-MOVE — GEOM_CUT_MOVE through the REAL worker fold + cut_move.js frame math (node, occt-wasm) ═══');
+
+const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'cutmove-witness-'));
+fs.mkdirSync(path.join(tmp, 'lib', 'kernel'), { recursive: true });
+for (const f of fs.readdirSync(path.join(MOD, 'lib', 'kernel'))) fs.copyFileSync(path.join(MOD, 'lib', 'kernel', f), path.join(tmp, 'lib', 'kernel', f));
+fs.writeFileSync(path.join(tmp, 'package.json'), '{"type":"module"}');
+fs.copyFileSync(path.join(MOD, 'bonsai_kernel_worker.js'), path.join(tmp, 'worker.mjs'));
+fs.copyFileSync(path.join(MOD, 'cut_move.js'), path.join(tmp, 'cut_move.js'));   // the worker's own `import './cut_move.js?v=1'`
+
+globalThis.self = globalThis.self || {};
+self.postMessage = () => {};
+await import(path.join(tmp, 'worker.mjs'));
+const CM = self.CutMove;   // bound by the worker's import — the SAME object the fold uses
+chk('C0 cut_move.js is bound on the worker global by the worker\'s own import', !!(CM && CM.netShifts && CM.anchorShift));
+
+function send(data) {
+  return new Promise((resolve) => { self.postMessage = (msg) => { if (msg.id === data.id) resolve(msg); }; self.onmessage({ data }); });
+}
+let seq = 0;
+const WALL_BOX = [0, 4, 0, 0.2, 0, 3];
+const wallOp = (h) => ({ id: 1, op_hash: 'wall:' + h, op_type: 'GEOM_EXTRUDE_POLY', parameters: { profile: { points: [[0, 0], [4, 0], [4, 0.2], [0, 0.2]] }, depth: 3 } });
+const cutOp = (h) => ({ id: 2, op_hash: 'cut:' + h, op_type: 'GEOM_CUT', parent: 1, parameters: { parent: 1, void: { c1: [1.2, -0.5, 0.9], c2: [2.8, 0.7, 2.1] } } });
+const cmOp = (id, h, s, cutId) => ({ id, op_hash: 'cm:' + h + ':' + id, op_type: 'GEOM_CUT_MOVE', parent: 1, parameters: { cutId: cutId == null ? 2 : cutId, parent: 1, dx: s[0], dy: s[1], dz: s[2], induced: 'test' } });
+const gridOp = (id, h, f, td) => ({ id, op_hash: 'grid:' + h + ':' + id, op_type: 'GEOM_GRID_MOVE', parameters: { gridId: 'gx1', delta: 1, commands: [{ featureId: 1, action: 'SCALE', axis: 'x', newScale: f, translateDelta: td }] } });
+async function fold(ops) { const r = await send({ id: ++seq, ops }); if (!r.ok) throw new Error('fold failed: ' + r.error); const m = r.meshes.find(x => x.featureId === 1); return { box: aabb(m.positions), hole: holeX(m.positions, 0, 3), stats: r.stats }; }
+
+// ── C0 BASE ──────────────────────────────────────────────────────────────────────────────────────────────────
+const c0 = await fold([wallOp('A'), cutOp('A')]);
+console.log('  C0 box=' + j(c0.box.map(v => +v.toFixed(4))) + ' hole=' + j(c0.hole));
+chk('C0 BASE: wall [0,4]×[0,0.2]×[0,3] with a through-void ⇒ hole x∈[1.2,2.8] (8 loop vertices), outline unchanged',
+  approx(c0.box[0], 0) && approx(c0.box[1], 4) && approx(c0.box[5], 3) && approx(c0.hole.xmin, 1.2) && approx(c0.hole.xmax, 2.8) && c0.hole.n >= 8, j(c0.hole));
+
+// ── C1 NET-SHIFT (pure) ──────────────────────────────────────────────────────────────────────────────────────
+const n1 = CM.netShifts([wallOp('A'), cutOp('A'), cmOp(3, 'n', [0.5, 0, 0]), cmOp(4, 'n', [0.3, 0, 0.1]), cmOp(5, 'n', [9, 9, 9], 777)]);
+const n1b = CM.netShifts([wallOp('A'), cutOp('A'), cmOp(4, 'n', [0.3, 0, 0.1]), cmOp(3, 'n', [0.5, 0, 0])]);
+const n0 = CM.netShifts([wallOp('A'), cutOp('A')]);
+chk('C1 NET-SHIFT: two rows on cut #2 sum to (0.8,0,0.1); a row naming non-active cut #777 is IGNORED; the signature is order-independent; no rows ⇒ \'\' (keys byte-identical when unused)',
+  n1.byCut['2'] && approx(n1.byCut['2'][0], 0.8) && approx(n1.byCut['2'][2], 0.1) && !n1.byCut['777'] && n1.sig === n1b.sig && /^2:0\.8,0,0\.1$/.test(n1.sig) &&
+  n0.sig === '' && CM.keySuffix(n0.sig) === '' && CM.keySuffix(n1.sig) === '|cm:2:0.8,0,0.1', j({ sig: n1.sig, sigB: n1b.sig, byCut: n1.byCut }));
+
+// ── C2 FOLD-SHIFT ────────────────────────────────────────────────────────────────────────────────────────────
+const c2 = await fold([wallOp('A'), cutOp('A'), cmOp(3, 'c2', [0.8, 0, 0])]);
+console.log('  C2 hole=' + j(c2.hole) + ' box=' + j(c2.box.map(v => +v.toFixed(4))) + ' stats=' + j(c2.stats));
+chk('C2 FOLD-SHIFT: + GEOM_CUT_MOVE {cutId:2, dx:0.8} ⇒ the worker subtracts the void at [2.0,3.6] (width 1.6 unchanged); the wall outline stays [0,4]; the cut was REBUILT (not a stale cache hit)',
+  approx(c2.hole.xmin, 2.0) && approx(c2.hole.xmax, 3.6) && approx(c2.hole.w, 1.6) && approx(c2.box[0], 0) && approx(c2.box[1], 4) && c2.stats.rebuilt >= 1, j(c2.hole));
+
+// ── C3 ANCHOR ────────────────────────────────────────────────────────────────────────────────────────────────
+const c3a = await fold([wallOp('A'), cutOp('A'), gridOp(3, 'c3', 1.25, 0)]);
+const a3 = CM.anchorShift({ cutOp: cutOp('A'), ops: [wallOp('A'), cutOp('A')], hostBox: WALL_BOX, axis: 0, f: 1.25, translateDelta: 0 });
+const c3b = await fold([wallOp('A'), cutOp('A'), gridOp(3, 'c3', 1.25, 0), cmOp(4, 'c3', [a3.s, 0, 0])]);
+console.log('  C3 no-rider hole=' + j(c3a.hole) + '  anchorShift=' + j(a3) + '  with-rider hole=' + j(c3b.hole) + ' box=' + j(c3b.box.map(v => +v.toFixed(4))));
+chk('C3a ANCHOR (the issue): GRID SCALE f=1.25 about min 0 alone carries the hole centre 2.0→2.5 and widens it 1.6→2.0 while a held door stays at 2.0',
+  approx(c3a.hole.c, 2.5) && approx(c3a.hole.w, 2.0) && approx(c3a.box[1], 5), j(c3a.hole));
+chk('C3b ANCHOR inverse: anchorShift ⇒ s=−Δ/(f·F)=−0.4 (Δ=0.5, F=1, q=2.0); folding the rider AFTER the grid op keeps the hole centre at 2.0 exactly; width 2.0 = the reported residual +0.4',
+  a3.ok && approx(a3.s, -0.4) && approx(a3.q, 2.0) && approx(a3.delta, 0.5) && approx(a3.residual, 0.4) && approx(c3b.hole.c, 2.0) && approx(c3b.hole.w, 2.0) && approx(c3b.box[1], 5), j({ s: a3.s, hole: c3b.hole }));
+// min-edge drag: the left gridline moves −1 ⇒ SCALE f=1.25 with translateDelta=−1 (wall → [−1,4])
+const a3c = CM.anchorShift({ cutOp: cutOp('A'), ops: [wallOp('A'), cutOp('A')], hostBox: WALL_BOX, axis: 0, f: 1.25, translateDelta: -1 });
+const c3c = await fold([wallOp('A'), cutOp('A'), gridOp(3, 'c3c', 1.25, -1), cmOp(4, 'c3c', [a3c.s, 0, 0])]);
+console.log('  C3c anchorShift=' + j(a3c) + ' hole=' + j(c3c.hole) + ' box=' + j(c3c.box.map(v => +v.toFixed(4))));
+chk('C3c ANCHOR min-edge: f=1.25, translateDelta=−1 ⇒ Δ=2.0·0.25−1=−0.5, s=+0.4; folded wall is [−1,4] and the hole centre stays at 2.0',
+  a3c.ok && approx(a3c.delta, -0.5) && approx(a3c.s, 0.4) && approx(c3c.box[0], -1) && approx(c3c.box[1], 4) && approx(c3c.hole.c, 2.0), j({ s: a3c.s, hole: c3c.hole }));
+// a PRIOR stretch (F=1.25, hole unheld then ⇒ centre 2.5 in world) followed by a second stretch f=1.2 with the door held
+const prior = [wallOp('A'), cutOp('A'), gridOp(3, 'c3d', 1.25, 0)];
+const a3d = CM.anchorShift({ cutOp: cutOp('A'), ops: prior, hostBox: [0, 5, 0, 0.2, 0, 3], axis: 0, f: 1.2, translateDelta: 0 });
+const c3d = await fold(prior.concat([gridOp(4, 'c3d', 1.2, 0), cmOp(5, 'c3d', [a3d.s, 0, 0])]));
+console.log('  C3d anchorShift=' + j(a3d) + ' hole=' + j(c3d.hole) + ' box=' + j(c3d.box.map(v => +v.toFixed(4))));
+chk('C3d ANCHOR with a prior stretch: F=1.25 ⇒ q=2.5 (the hole\'s CURRENT world centre, read from the log), Δ=0.5, s=−0.5/(1.2·1.25)=−0.3333; the doubly-scaled fold keeps the centre at 2.5',
+  a3d.ok && approx(a3d.F, 1.25) && approx(a3d.q, 2.5) && approx(a3d.s, -0.5 / 1.5) && approx(c3d.box[1], 6) && approx(c3d.hole.c, 2.5, 1e-6), j({ s: a3d.s, hole: c3d.hole }));
+
+// ── C4 CACHE ─────────────────────────────────────────────────────────────────────────────────────────────────
+const c4 = await fold([wallOp('A'), cutOp('A')]);   // the SAME op_hashes as C0 — must hit the ORIGINAL (unsuffixed) keys
+console.log('  C4 hole=' + j(c4.hole) + ' stats=' + j(c4.stats));
+chk('C4 CACHE: re-folding the original chain (same op_hashes) after the moved folds is a cache HIT and yields the ORIGINAL hole [1.2,2.8] — no stale shifted shape under the old key',
+  approx(c4.hole.xmin, 1.2) && approx(c4.hole.xmax, 2.8) && c4.stats.hits >= 1 && c4.stats.rebuilt === 0, j(c4.stats));
+
+// ── C5 FRAME (pure) ──────────────────────────────────────────────────────────────────────────────────────────
+const mv = { id: 4, op_type: 'GEOM_MOVE', parent: 1, parameters: { parent: 1, dx: 0.5, dy: 0, dz: 0 } };
+const preGrid = { id: 0, op_type: 'GEOM_GRID_MOVE', parameters: { commands: [{ featureId: 1, action: 'SCALE', axis: 'x', newScale: 3, translateDelta: 0 }] } };
+const f5 = CM.frameScale([preGrid, wallOp('A'), cutOp('A'), gridOp(3, 'f5', 1.25, 0), mv], cutOp('A'), 0);
+const f5y = CM.frameScale([wallOp('A'), cutOp('A'), gridOp(3, 'f5', 1.25, 0), mv], cutOp('A'), 1);
+const f5r = CM.frameScale([wallOp('A'), cutOp('A'), { id: 3, op_type: 'GEOM_ROTATE', parent: 1, parameters: { parent: 1, drot: 30 } }], cutOp('A'), 0);
+const f5o = CM.frameScale([wallOp('A'), cutOp('A'), { id: 3, op_type: 'GEOM_GRID_MOVE', parameters: { commands: [{ featureId: 1, action: 'SCALE', axis: 'x', newScale: 1.1, yawRad: 0.4 }] } }], cutOp('A'), 0);
+chk('C5 FRAME: post-cut SCALE×1.25 + MOVE 0.5 ⇒ {F:1.25, tPost:0.5} on x, {1,0} on y; a PRE-cut scale (id<cut) is ignored; ROTATE after cut ⇒ ok:false; oblique-yaw SCALE ⇒ ok:false; slideShift(0.8,1.25)=0.64',
+  f5.ok && approx(f5.f, 1.25) && approx(f5.tPost, 0.5) && f5y.ok && f5y.f === 1 && f5y.tPost === 0 && f5r.ok === false && /rotated-after-cut/.test(f5r.reason) &&
+  f5o.ok === false && /oblique/.test(f5o.reason) && approx(CM.slideShift(0.8, 1.25), 0.64) && approx(CM.slideShift(0.8, 1), 0.8), j({ f5, f5y, f5r: f5r.reason, f5o: f5o.reason }));
+
+// ── C6 SLIDE-FOLD ────────────────────────────────────────────────────────────────────────────────────────────
+const s6 = CM.slideShift(0.8, CM.frameScale(prior, cutOp('A'), 0).f);
+const c6 = await fold(prior.concat([cmOp(4, 'c6', [s6, 0, 0])]));
+console.log('  C6 authored shift=' + s6 + ' hole=' + j(c6.hole));
+chk('C6 SLIDE-FOLD: after the prior stretch (hole centre 2.5), a slide of world +0.8 rides as authored 0.64; the folded hole centre is 3.3 = 2.5 + 0.8 exactly',
+  approx(s6, 0.64) && approx(c6.hole.c, 3.3) && approx(c6.hole.w, 2.0), j(c6.hole));
+
+console.log('W-CUT-MOVE: ' + pass + ' PASS / ' + fail + ' FAIL');
+try { fs.rmSync(tmp, { recursive: true, force: true }); } catch (e) {}
+process.exit(fail ? 1 : 0);

--- a/modeller/tests/witness_e2e_cut_move.js
+++ b/modeller/tests/witness_e2e_cut_move.js
@@ -1,0 +1,161 @@
+#!/usr/bin/env node
+/**
+ * # ⚠ DO NOT REMOVE — W-E2E-CUT-MOVE: real-user, maths-asserted E2E of GEOM_CUT_MOVE — a carved void follows its
+ * opening (prompts/SPEC_GEOM_CUT_MOVE.md §5; parents SPEC_DAGEVU_SLIDE.md §3 S5, SPEC_DAGEVU_ENGINE.md §3 anchor).
+ * Read the log after every run.
+ *
+ * FIXTURE — a sketched rectangular wall (GEOM_EXTRUDE_POLY [0,4]×[0,0.2]×3, the tool's primary use case), a REAL bCut
+ * (the toolbar's own #b-cut on the real-clicked wall — its 40%-centred through-void is x∈[1.2,2.8] z∈[0.9,2.1]), a
+ * sketched door inside that hole (x∈[1.5,2.5]) and a rel_fills_host row injected in the exact shape the §ARC-1/CrossEdges
+ * pipeline produces (witness_e2e_opening_slide's pattern). The constraint/fold/commit MATH is production code.
+ * The hole is MEASURED off the wall mesh's vertices: a through-void's edge loops are the only vertices strictly between
+ * the wall's top (z=3) and bottom (z=0).
+ *
+ *   M1 GRAB        — the door grabs into a SLIDE session that CARRIES the cut (the old S6 refusal is gone for a movable void)
+ *   M2 COMMIT      — a real +0.8 m mouse drag commits ONE gesture: GEOM_MOVE(door) + GEOM_CUT_MOVE{cutId, dx, 0, 0}
+ *   M3 HOLE-FOLLOWS — the rendered hole moved by the SAME dx as the door (vertex-measured); width unchanged
+ *   M4 UNDO        — ONE real Ctrl+Z (one gesture) deactivates both rows and restores door AND hole
+ *   M5 ANCHOR      — Move-Grid: drag gridline B (x=4) +1 with the door HELD (anchor default) ⇒ GEOM_GRID_MOVE +
+ *                    GEOM_CUT_MOVE (the inverse shift); door centre unchanged, hole centre unchanged (≤1e-3), the wall
+ *                    is 5 m, the hole is 1.25× wide (the reported residual); §V7 label says "1 hole held"; verifyChain
+ *   M6 UNDO        — ONE real Ctrl+Z restores wall, door and hole (the GEOM_CUT_MOVE rider undoes with its gesture)
+ */
+'use strict';
+const { runE2E } = require('./e2e_harness');
+
+const centreOf = (t, fid) => t.pg.evaluate((f) => {
+  const g = window.Bonsai.group(); const m = g.children.find(o => o.isMesh && o.userData.featureId === f);
+  if (!m) return null; m.geometry.computeBoundingBox(); const b = m.geometry.boundingBox;
+  return [(b.min.x + b.max.x) / 2, (b.min.y + b.max.y) / 2, (b.min.z + b.max.z) / 2];
+}, fid);
+// the through-void's x-extent on the wall mesh: vertices strictly between the wall's z-faces
+const holeOf = (t, fid) => t.pg.evaluate((f) => {
+  const g = window.Bonsai.group(); const m = g.children.find(o => o.isMesh && o.userData.featureId === f);
+  if (!m) return null; m.geometry.computeBoundingBox(); const bb = m.geometry.boundingBox;
+  const p = m.geometry.getAttribute('position').array; let xmin = Infinity, xmax = -Infinity, n = 0;
+  for (let i = 0; i < p.length; i += 3) { const z = p[i + 2]; if (z > bb.min.z + 1e-6 && z < bb.max.z - 1e-6) { xmin = Math.min(xmin, p[i]); xmax = Math.max(xmax, p[i]); n++; } }
+  return { xmin, xmax, c: (xmin + xmax) / 2, w: xmax - xmin, n, wall: [bb.min.x, bb.max.x] };
+}, fid);
+const near = (a, b, tol) => Math.abs(a - b) <= tol;
+// the REAL undo path (modeller.html keydown → doUndo): ONE gesture = ONE Ctrl+Z — unlike the history slider (a scrub:
+// a prefix re-fold that leaves every row ACTIVE), this deactivates the gesture's rows so the NEXT commit builds on the
+// reverted log — exactly what M5 needs after M2.
+const ctrlZ = async (t) => { await t.pg.keyboard.down('Control'); await t.pg.keyboard.press('z'); await t.pg.keyboard.up('Control'); await t.sleep(1200); };
+
+runE2E('W-E2E-CUT-MOVE', async (t) => {
+  await t.open('Duplex'); await t.shot('01-open');
+  await t.clickSel('#b-clear'); await t.sleep(400);
+  const wallId = await t.pg.evaluate(async () => {
+    window.Bonsai.grid.define({ xs: [0, 4, 8], ys: [0, 3], xlabels: ['A', 'B', 'C'], ylabels: ['1', '2'] });
+    const O = window.Bonsai.oplog;
+    const wall = await O.commit({ op_type: 'GEOM_EXTRUDE_POLY', parameters: { profile: { points: [[0, 0], [4, 0], [4, 0.2], [0, 0.2]] }, depth: 3 } }, { color: 0x9fb4c8 });
+    if (typeof syncHistory === 'function') syncHistory();
+    return wall.id;
+  });
+  await t.clickSel('#b-fit'); await t.sleep(500);
+  // the REAL bCut: real click selects the wall, the toolbar's own Cut derives the void from the wall's bbox
+  await t.clickOn(wallId); await t.sleep(200); await t.clickSel('#b-cut'); await t.sleep(1500);
+  const cut = await t.pg.evaluate(() => { const c = window.Bonsai.oplog._geomOps().find(o => o.op_type === 'GEOM_CUT'); return c ? { id: c.id, parent: c.parent, void: c.parameters.void } : null; });
+  const ids = await t.pg.evaluate(async (host) => {
+    const O = window.Bonsai.oplog;
+    const door = await O.commit({ op_type: 'GEOM_EXTRUDE_POLY', parameters: { profile: { points: [[1.5, 0.05], [2.5, 0.05], [2.5, 0.15], [1.5, 0.15]] }, depth: 2.1 } }, { color: 0xc8a06a });
+    if (typeof syncHistory === 'function') syncHistory();
+    window.__arcGuidByFid = { [host]: 'g-host', [door.id]: 'g-door' };
+    window.__arcFidByGuid = { 'g-host': host, 'g-door': door.id };
+    window.swXEdges = { fills: [{ host_guid: 'g-host', filling_guid: 'g-door', opening_guid: null, provenance: 'ifc:recovered' }], abuts: [] };
+    window.__arcAnchorFids = null;
+    return { host, door: door.id };
+  }, wallId);
+  await t.clickSel('#b-fit'); await t.sleep(500);
+  const hole0 = await holeOf(t, ids.host), pre = await centreOf(t, ids.door);
+  console.log('  §CUT-MOVE fixture wall=' + ids.host + ' cut=' + JSON.stringify(cut) + ' door=' + ids.door + ' hole0=' + JSON.stringify(hole0) + ' door0=' + JSON.stringify(pre));
+  t.assert('FIXTURE (real bCut void x∈[1.2,2.8] on the sketched wall; measured hole matches; door inside it)',
+    cut && cut.parent === ids.host && hole0 && near(hole0.xmin, 1.2, 1e-6) && near(hole0.xmax, 2.8, 1e-6) && pre && near(pre[0], 2.0, 1e-6), JSON.stringify({ cut, hole0 }));
+  await t.shot('02-fixture');
+
+  // ── M1 GRAB ───────────────────────────────────────────────────────────────────────────────────────────────────
+  const grab = await t.pg.evaluate((fid) => {
+    const ok = window.__armItemDrag(fid, {}); const s = window.Bonsai.itemdrag._session;
+    return ok && s && s.slide ? { ok, axis: s.slide.axis, cuts: s.slide.cuts, tMin: s.slide.tMin, tMax: s.slide.tMax } : { ok, slide: false };
+  }, ids.door);
+  let logAt = 0;
+  t.slog.slice(logAt).filter(l => /§SLIDE|§CUT-MOVE/.test(l)).forEach(l => console.log('    ' + l.slice(0, 300))); logAt = t.slog.length;
+  t.assert('M1 GRAB (the door over a REAL carved void grabs into a SLIDE session carrying cuts=[{cutId,F:1}] — no S6 refusal)',
+    grab.ok && grab.axis === 0 && Array.isArray(grab.cuts) && grab.cuts.length === 1 && grab.cuts[0].cutId === cut.id && grab.cuts[0].F === 1, JSON.stringify(grab));
+  if (!grab.ok || grab.slide === false) return;
+
+  // ── M2 COMMIT: real drag +0.8 m along the wall (with a 0.2 m off-axis drift) ─────────────────────────────────
+  const T = 0.8;
+  const p0 = await t.proj(pre[0], pre[1], pre[2]), p1 = await t.proj(pre[0] + T, pre[1] + 0.2, pre[2]);
+  const before = await t.oplog();
+  await t.pg.mouse.move(p0[0], p0[1]); await t.sleep(40); await t.pg.mouse.down(); await t.sleep(40);
+  await t.pg.mouse.move((p0[0] + p1[0]) / 2, (p0[1] + p1[1]) / 2, { steps: 5 }); await t.sleep(120);
+  await t.pg.mouse.move(p1[0], p1[1], { steps: 5 }); await t.sleep(150);
+  await t.shot('03-mid-slide');
+  await t.pg.mouse.up(); await t.sleep(1200);
+  const after = await t.oplog(); const chain = await t.verifyChain();
+  const ops2 = await t.pg.evaluate((fromLen) => {
+    const added = window.Bonsai.oplog._geomOps().slice(fromLen);
+    const r = window.Bonsai.oplog.db.exec('SELECT id, gid FROM kernel_ops ORDER BY id DESC LIMIT 2');
+    return { types: added.map(o => o.op_type), mv: (added.find(o => o.op_type === 'GEOM_MOVE') || {}).parameters, cm: (added.find(o => o.op_type === 'GEOM_CUT_MOVE') || {}).parameters,
+      gids: r.length ? r[0].values.map(v => v[1]) : [] };
+  }, before.len);
+  t.slog.slice(logAt).filter(l => /§ITEMDRAG commit|§CUT-MOVE/.test(l)).forEach(l => console.log('    ' + l.slice(0, 320))); logAt = t.slog.length;
+  console.log('  §CUT-MOVE M2 ' + JSON.stringify(ops2) + ' oplog ' + before.len + '→' + after.len + ' chain=' + chain);
+  t.assert('M2 COMMIT (ONE gesture: GEOM_MOVE(door) + GEOM_CUT_MOVE{cutId, dx=door dx, dy=dz=0, induced fills-opening}, same gid; verifyChain true)',
+    after.len === before.len + 2 && ops2.types.length === 2 && ops2.mv && ops2.cm && ops2.cm.cutId === cut.id && ops2.cm.parent === ids.host &&
+    near(ops2.cm.dx, ops2.mv.dx, 1e-9) && ops2.cm.dy === 0 && ops2.cm.dz === 0 && near(ops2.mv.dx, T, 0.06) && ops2.gids[0] === ops2.gids[1] && /^gesture-grp-/.test(ops2.gids[0] || '') && chain === true,
+    JSON.stringify(ops2));
+  await t.shot('04-slid');
+
+  // ── M3 HOLE-FOLLOWS ───────────────────────────────────────────────────────────────────────────────────────────
+  const hole1 = await holeOf(t, ids.host), post = await centreOf(t, ids.door);
+  console.log('  §CUT-MOVE M3 hole1=' + JSON.stringify(hole1) + ' door1=' + JSON.stringify(post));
+  t.assert('M3 HOLE-FOLLOWS (the rendered hole moved by exactly the committed dx; width 1.6 unchanged; wall outline [0,4] unchanged; door and hole centres stay 0 apart as before)',
+    hole1 && ops2.cm && near(hole1.xmin - hole0.xmin, ops2.cm.dx, 1e-6) && near(hole1.w, hole0.w, 1e-6) && near(hole1.wall[0], 0, 1e-6) && near(hole1.wall[1], 4, 1e-6) &&
+    post && near(post[0] - pre[0], hole1.c - hole0.c, 1e-6), 'Δhole=' + (hole1 ? (hole1.xmin - hole0.xmin).toFixed(4) : '?') + ' Δdoor=' + (post ? (post[0] - pre[0]).toFixed(4) : '?'));
+
+  // ── M4 UNDO ───────────────────────────────────────────────────────────────────────────────────────────────────
+  await ctrlZ(t);
+  const undone = await t.oplog(); const hole2 = await holeOf(t, ids.host); const back = await centreOf(t, ids.door);
+  t.assert('M4 UNDO (ONE real Ctrl+Z deactivates BOTH gesture rows: active len restored, hole back at [1.2,2.8], door back at its pre-drag centre)',
+    undone.len === before.len && hole2 && near(hole2.xmin, 1.2, 1e-6) && near(hole2.xmax, 2.8, 1e-6) && back && near(back[0], pre[0], 1e-6), JSON.stringify({ len: undone.len, want: before.len, hole2 }));
+  await t.shot('05-undone');
+
+  // ── M5 ANCHOR: Move-Grid, drag gridline B (x=4) +1 with the door held ────────────────────────────────────────
+  const hole4 = await holeOf(t, ids.host), door4 = await centreOf(t, ids.door);   // the measured PRE-stretch state M5 must hold
+  await t.clickSel('#b-gridmove'); await t.sleep(400);
+  const DX = 1.0;
+  const gd = await t.proj(4, 1.5, 0), gu = await t.proj(4 + DX, 1.5, 0);
+  const before5 = await t.oplog();
+  await t.pg.mouse.move(gd[0], gd[1]); await t.sleep(40); await t.pg.mouse.down(); await t.sleep(40);
+  await t.pg.mouse.move((gd[0] + gu[0]) / 2, (gd[1] + gu[1]) / 2, { steps: 6 }); await t.sleep(60);
+  await t.pg.mouse.move(gu[0], gu[1], { steps: 6 }); await t.sleep(200);
+  const mid5 = await t.pg.evaluate(() => ({ dim: window.__dimLabel ? window.__dimLabel.text : null, stat: (document.getElementById('stat') || {}).textContent || '' }));
+  await t.shot('06-mid-stretch');
+  await t.pg.mouse.up(); await t.sleep(1500);
+  const after5 = await t.oplog(); const chain5 = await t.verifyChain();
+  const ops5 = await t.pg.evaluate((fromLen) => {
+    const added = window.Bonsai.oplog._geomOps().slice(fromLen);
+    const gm = added.find(o => o.op_type === 'GEOM_GRID_MOVE'), cm = added.find(o => o.op_type === 'GEOM_CUT_MOVE');
+    return { types: added.map(o => o.op_type), cmds: gm ? gm.parameters.commands : null, cm: cm ? cm.parameters : null };
+  }, before5.len);
+  const hole5 = await holeOf(t, ids.host), door5 = await centreOf(t, ids.door);
+  t.slog.slice(logAt).filter(l => /§GRIDMOVE commit|§CUT-MOVE|§DAGEVU/.test(l)).forEach(l => console.log('    ' + l.slice(0, 320))); logAt = t.slog.length;
+  console.log('  §CUT-MOVE M5 dimLabel="' + mid5.dim + '" ops=' + JSON.stringify(ops5) + ' hole5=' + JSON.stringify(hole5) + ' door5=' + JSON.stringify(door5) + ' oplog ' + before5.len + '→' + after5.len + ' chain=' + chain5);
+  const sc = ops5.cmds && ops5.cmds.find(c => c.featureId === ids.host && c.action === 'SCALE');
+  const f = sc ? sc.newScale : NaN, wantS = sc ? -((hole4.c - hole4.wall[0]) * (f - 1) + (sc.translateDelta || 0)) / f : NaN;   // spec §3: s = −Δ/(f·F), F=1 here
+  t.assert('M5 ANCHOR (gesture = GEOM_GRID_MOVE(SCALE wall) + GEOM_CUT_MOVE{dx = −Δ/f}; the HELD door\'s centre is unchanged; the hole\'s centre is unchanged ≤1e-3 under the fold\'s own scale; hole width = f×1.6 (the reported residual); mid-drag §V7 label says "1 hole held"; verifyChain)',
+    after5.len === before5.len + 2 && ops5.cm && ops5.cm.cutId === cut.id && ops5.cm.induced === 'anchor-hold' && sc && near(ops5.cm.dx, wantS, 1e-6) && ops5.cm.dy === 0 &&
+    door5 && near(door5[0], door4[0], 1e-6) && hole5 && near(hole5.c, hole4.c, 1e-3) && near(hole5.w, hole4.w * f, 1e-3) && hole5.wall[1] > 4.5 &&
+    typeof mid5.dim === 'string' && /1 hole held/.test(mid5.dim) && chain5 === true,
+    'f=' + f + ' wantS=' + (isFinite(wantS) ? wantS.toFixed(4) : '?') + ' cm.dx=' + (ops5.cm ? ops5.cm.dx.toFixed(4) : '?') + ' hole4.c=' + hole4.c.toFixed(4) + ' hole5=' + JSON.stringify(hole5) + ' door4.x=' + door4[0].toFixed(4) + ' door5.x=' + (door5 ? door5[0].toFixed(4) : '?') + ' dim="' + mid5.dim + '"');
+  await t.shot('07-stretched-held');
+
+  // ── M6 UNDO ───────────────────────────────────────────────────────────────────────────────────────────────────
+  await ctrlZ(t);
+  const undone6 = await t.oplog(); const hole6 = await holeOf(t, ids.host); const door6 = await centreOf(t, ids.door);
+  t.assert('M6 UNDO (ONE real Ctrl+Z: both gesture rows deactivated, wall back to 4 m, hole back at its pre-stretch extent, door unchanged)',
+    undone6.len === before5.len && hole6 && near(hole6.wall[1], 4, 1e-6) && near(hole6.xmin, hole4.xmin, 1e-6) && near(hole6.xmax, hole4.xmax, 1e-6) && door6 && near(door6[0], door4[0], 1e-6), JSON.stringify({ len: undone6.len, want: before5.len, hole6 }));
+  await t.shot('08-undone');
+}, { width: 1280, height: 860, dpr: 2 });

--- a/modeller/tests/witness_gridmove_fold_pure.mjs
+++ b/modeller/tests/witness_gridmove_fold_pure.mjs
@@ -67,6 +67,7 @@ for (const f of fs.readdirSync(path.join(MOD, 'lib', 'kernel'))) {
 }
 fs.writeFileSync(path.join(tmp, 'package.json'), '{"type":"module"}');
 fs.copyFileSync(path.join(MOD, 'bonsai_kernel_worker.js'), path.join(tmp, 'worker.mjs'));
+fs.copyFileSync(path.join(MOD, 'cut_move.js'), path.join(tmp, 'cut_move.js'));   // §CUT-MOVE: the worker's own `import './cut_move.js?v=1'` (harness plumbing, byte-identical copy)
 
 globalThis.self = globalThis.self || {};
 self.postMessage = () => {}; // top-level `self.postMessage({ready:true})` fires at import time

--- a/modeller/tests/witness_opening_slide.js
+++ b/modeller/tests/witness_opening_slide.js
@@ -17,10 +17,12 @@
  *   S4 OP          — resolveDrop ⇒ GEOM_MOVE {parent:filling, constrained delta}; one 'fills-opening' rider iff a
  *                    seeded opening resolves (same delta)
  *   S5 GATE-RED    — a constructed blocker box on the slide path ⇒ valid:false 'gate-red:clash', conflictIds names it
- *   S6 BAKED-VOID  — an active GEOM_CUT {parent:host} over the filling ⇒ session null (refuse, don't leave a hole)
+ *   S6 CARVED-VOID — an active GEOM_CUT {parent:host} over the filling ⇒ the session CARRIES the cut and resolveDrop adds a
+ *                    GEOM_CUT_MOVE rider (§CUT-MOVE, prompts/SPEC_GEOM_CUT_MOVE.md); REFUSED without an honest frame (no
+ *                    geomOps supplied / the host was rotated after the cut) — never a guessed frame
  *   S7 NO-ENGINE   — DagevuEngine absent ⇒ session null (the constraint has no local fallback)
  *   S8 PLAIN-EXTRUDE — plainExtrudeProfile: a 4-point axis-aligned rectangle ⇒ true; L-shape / rotated / 3-point ⇒ false
- *                    (a sketched rectangular wall is a slide host; its holes are GEOM_CUT ops, caught by S6)
+ *                    (a sketched rectangular wall is a slide host; its holes are GEOM_CUT ops, riding per S6)
  */
 'use strict';
 var fs = require('fs'), path = require('path');
@@ -152,11 +154,24 @@ initSqlJs({ wasmBinary: wasmBinary }).then(async function (SQL) {
     tB >= sl.tMin && tB <= sl.tMax && v5 && v5.valid === false && /^gate-red:/.test(v5.reason) && /clash/.test(v5.reason) && v5.conflictIds.indexOf('9100') >= 0,
     j({ tB: tB, reason: v5 && v5.reason, conflicts: v5 && v5.conflictIds }));
 
-  // S6 — BAKED VOID
-  var cut = { id: 777, op_type: 'GEOM_CUT', parameters: { parent: pick.host, void: { c1: [fb[0], fb[2], fb[4]], c2: [fb[1], fb[3], fb[5]] } } };
-  var S6 = ItemDrag.beginItemDragSession(ctxFor(pick.fid, { cutOps: [cut] }));
-  chk('S6 BAKED-VOID: an active GEOM_CUT {parent:host} whose void overlaps the filling ⇒ session REFUSED (no op can move a committed void — never leave the hole behind)',
-    S6 === null && ItemDrag.bakedVoidFor([cut], pick.host, fb) === 777);
+  // S6 — CARVED VOID (§CUT-MOVE, prompts/SPEC_GEOM_CUT_MOVE.md §4): an active GEOM_CUT over the filling no longer
+  // refuses — it RIDES as a GEOM_CUT_MOVE rider in the cut's authored frame. Refuses only without an honest frame.
+  var cut = { id: 777, op_type: 'GEOM_CUT', parent: pick.host, parameters: { parent: pick.host, void: { c1: [fb[0], fb[2], fb[4]], c2: [fb[1], fb[3], fb[5]] } } };
+  var S6a = ItemDrag.beginItemDragSession(ctxFor(pick.fid, { cutOps: [cut] }));                 // no geomOps ⇒ no frame ⇒ refuse
+  var S6 = ItemDrag.beginItemDragSession(ctxFor(pick.fid, { cutOps: [cut], geomOps: [cut] }));
+  var c6 = c.slice(); c6[K] += (tOK != null ? tOK : 0); c6[other] += 0.3; c6[2] += 0.1;
+  var d6 = S6 ? ItemDrag.resolveDrop(S6, c6[0], c6[1], c6[2]) : null;
+  var cr6 = d6 && d6.riders ? d6.riders.filter(function (r) { return r.op_type === 'GEOM_CUT_MOVE'; }) : [];
+  var dk = ax === 'x' ? 'dx' : 'dy';
+  chk('S6 CARVED-VOID rides (§CUT-MOVE): an active GEOM_CUT {parent:host} over the filling ⇒ session carries cuts=[{cutId:777,F:1}]; resolveDrop adds ONE GEOM_CUT_MOVE {cutId:777, parent:host, d = the door\'s delta (F=1), induced:fills-opening}; WITHOUT geomOps (no frame) ⇒ REFUSED',
+    S6a === null && !!S6 && S6.slide.cuts.length === 1 && S6.slide.cuts[0].cutId === 777 && S6.slide.cuts[0].F === 1 && ItemDrag.bakedVoidFor([cut], pick.host, fb) === 777 &&
+    !!d6 && d6.committed && cr6.length === 1 && cr6[0].parameters.cutId === 777 && String(cr6[0].parameters.parent) === String(pick.host) &&
+    Math.abs(cr6[0].parameters[dk] - d6.op.parameters[dk]) < 1e-12 && cr6[0].parameters.induced === 'fills-opening',
+    j({ S6a: S6a, cuts: S6 && S6.slide.cuts, rider: cr6[0] && cr6[0].parameters, door: d6 && d6.op && d6.op.parameters }));
+  // S6b — a post-cut GEOM_ROTATE on the host ⇒ no honest authored→world frame ⇒ REFUSED (never a guessed F)
+  var rot = { id: 778, op_type: 'GEOM_ROTATE', parent: pick.host, parameters: { parent: pick.host, drot: 30 } };
+  var S6b = ItemDrag.beginItemDragSession(ctxFor(pick.fid, { cutOps: [cut], geomOps: [cut, rot] }));
+  chk('S6b CARVED-VOID after a host ROTATE ⇒ session REFUSED (frameScale: rotated-after-cut — the authored axis is no longer a world axis)', S6b === null);
 
   // S7 — NO ENGINE
   var S7 = ItemDrag.beginItemDragSession(ctxFor(pick.fid, { dagevu: { HostFillEdge: null } }));

--- a/prompts/SPEC_GEOM_CUT_MOVE.md
+++ b/prompts/SPEC_GEOM_CUT_MOVE.md
@@ -1,0 +1,114 @@
+# SPEC — GEOM_CUT_MOVE: a carved void follows its opening — Witness: W-CUT-MOVE / W-E2E-CUT-MOVE
+
+```
+# ⚠ DO NOT REMOVE
+SCOPE (step 1 of the void-linking work, and ONLY step 1): (1) a new signed op `GEOM_CUT_MOVE {cutId, dx, dy, dz}`
+registered through the kernel-op chain like every other GEOM op; (2) the worker fold shifts that GEOM_CUT's void box
+BEFORE subtracting it (a pure fold override, like GEOM_MOVE on an insert — the signed GEOM_CUT row is never rewritten);
+(3) the along-host slide (bonsai_itemdrag.js) emits it as a rider where bakedVoidFor currently REFUSES; (4) the grid
+ANCHOR path (bonsai_gridmove.js via the DAGeVu engine) emits the inverse of the fold's proportional shift so a carved
+hole stays centred on its HELD door. Out of scope: holes baked into extracted LOD-300 meshes (all 7 real SampleHouse
+fillings keep refusing the slide — asserted in witness_e2e_opening_slide O0); a void RESIZE (the fold's SCALE also
+widens the hole by f — reported, not corrected; step 2); roof/AngleEdge (⛔ paused). Read the log after every run.
+```
+
+Parents: `prompts/SPEC_DAGEVU_SLIDE.md` §3 (S5 "NOT BUILT — a void-translate op … refused instead"),
+`prompts/SPEC_DAGEVU_ENGINE.md` §3 (anchor = the opening keeps its world position), `bonsai_kernel_worker.js`
+buildSolids GEOM_CUT branch (the void is `kernel.makeBoxFromCorners(P.void.c1, P.void.c2)` subtracted from the parent's
+CURRENT solid at the cut's log position), `bonsai_kernel.js` foldChainToScene (GEOM_MOVE on inserts = a net delta
+summed from active rows, "a pure fold override like LOD"). Session 2026-09-11.
+
+## §1 Why an op, not a rewrite
+The signed chain is append-only: a GEOM_CUT row's `void` is hashed and can never be edited. Today the ONLY dependent
+still unlinked from its opening is the carved void: the slide refuses any filling whose host carries a real GEOM_CUT
+over it (S6), and a grid stretch with the door HELD (anchor default) lets the fold carry the hole away proportionally
+(hole centre → f·c + min·(1−f) + t, the SCALE mapping) while the door stays — a silent mismatch on every sketched wall
+with a bCut hole. Both need the same primitive: "this cut's void is now at void + s".
+
+## §2 Contract
+```
+GEOM_CUT_MOVE  parameters { cutId, parent, dx, dy, dz, induced? }
+  cutId   = kernel_ops id of an ACTIVE GEOM_CUT row            (the void being shifted)
+  parent  = that cut's parent (the host solid)                 (so deleteFeature(host) soft-deletes it with the cut, and
+                                                                redo's ancestor walk re-activates host → this row)
+  dx,dy,dz = the shift, in the cut's AUTHORED frame (see §3)   induced = 'fills-opening' (slide) | 'anchor-hold' (grid)
+```
+- FOLD (worker `buildSolids`): pre-scan the ops of THIS fold → `netShift[cutId] = Σ(dx,dy,dz)` over active
+  GEOM_CUT_MOVE rows. At the GEOM_CUT's own position the void box is `{c1 + s, c2 + s}`; the cut is subtracted exactly
+  as before. The GEOM_CUT_MOVE row itself is a no-op at its own position. A row whose cutId is not an active GEOM_CUT in
+  this fold is IGNORED (tolerant, like GEOM_MOVE on a missing parent) — never a throw, never a guess.
+- CACHE: op_hash keys assume "output = f(prefix)". A cut-move is retroactive (it changes an EARLIER op's output), so
+  when any net shift is non-zero in a fold, EVERY shape/mesh key in that fold carries the fold's cut-move signature
+  (`|cm:<cutId>:<dx>,<dy>,<dz>;…`, sorted by cutId). Zero cut-moves ⇒ keys byte-identical to today. One rebuild per
+  distinct shift set; scrub/undo back to a prefix without the move hits the original keys.
+- KERNEL host side: `_geomOps()` already returns every `GEOM%` row; GEOM_CUT_MOVE is NOT LEAF (authoritative re-fold);
+  not PARENT_MUTATING for seeding (its cut already promotes the host). `modeller_history.js` OP_TYPES gets the type.
+- IFC export (`bonsai_ifc.js`): the IfcOpeningElement is built from the SAME net-shifted void (one definition).
+
+## §3 Frame math — one definition, shared (`modeller/cut_move.js`, dual-export window+node+worker)
+The void is authored in world coordinates at the cut's log position. Ops AFTER the cut that transform the host map it:
+TRANSLATE (GEOM_MOVE / GRID TRANSLATE / ROOM_MOVE) shifts; GRID SCALE maps x → f·x + min·(1−f) + t; GEOM_ROTATE spins
+about the bbox centre. Per axis, the void's OFFSET from the host's min `u = x − min` obeys u' = f·u under SCALE and is
+invariant under TRANSLATE. Hence with `F = Π f_i` over post-cut SCALE commands on that axis:
+- `frameScale(ops, cutOp, axis) → { f:F, ok, reason }` — ok:false when a post-cut GEOM_ROTATE (any angle) or an
+  obliquely-yawed SCALE (worker's §SCALE-YAW-GUARD path) touches the host: the authored axis is no longer a world axis
+  ⇒ the consumer REFUSES (never approximates).
+- SLIDE: a door slid by world `t` on the axis needs the hole moved by `t` in world ⇒ authored shift `s = t / F`.
+- ANCHOR: the new SCALE `(f, t)` would move the hole's current world centre `q` by `Δ = (q − min)(f − 1) + t`
+  (the fold's own proportional shift). Holding it: `s = −Δ / (f · F)`. `q − min = F · u_cut` where
+  `u_cut = (authored void centre + net existing shifts) − (min_now − T_post)` and `T_post` = Σ post-cut host
+  translations (GEOM_MOVE d, GRID TRANSLATE delta, GRID SCALE translateDelta, ROOM_MOVE d) on that axis — every term
+  read from the log + the host's measured pre-drag AABB. Width residual `|f − 1| · w` is REPORTED (log + dimLabel).
+- TRANSLATE commands in the same gesture carry the hole and the held door alike ⇒ no correction. RIDE mode ⇒ door and
+  hole take the same proportional mapping ⇒ no rider.
+
+## §4 Consumers
+- `bonsai_itemdrag.js` beginSlideSession: `bakedVoidFor` no longer refuses — the session records `slide.cutId` (+
+  frame F per axis from `frameScale`, refusing on ok:false with the reason). `resolveDrop` adds ONE rider
+  `GEOM_CUT_MOVE {cutId, parent:host, d/F on the slide axis, induced:'fills-opening'}` to the existing gesture group.
+- `bonsai_gridmove.js` previewCommands: for every HELD filling whose host has a SCALE command in the post-override
+  command list, every active GEOM_CUT (parent = host) whose void overlaps the filling's pre-drag AABB gets one
+  `GEOM_CUT_MOVE {…, induced:'anchor-hold'}` rider (`cutRiders`); commit() appends them to the gesture group.
+  frameScale ok:false ⇒ a refusal `{kind:'cut-move-unmappable'}` that blocks commit exactly like anchor-no-free-end.
+  dimLabel gains ` · N hole(s) held (Δw +0.23m)`.
+
+## §5 Tests — each names the issue it proves
+`witness_cut_move.mjs` (node, drives the REAL worker fold like witness_gridmove_fold_pure.mjs):
+- C1 NET-SHIFT — two cut-moves on one cut sum; a cut-move naming a non-active cut is ignored; no cut-moves ⇒ empty
+  signature (proves: the fold override is additive and tolerant; keys unchanged when unused).
+- C2 FOLD-SHIFT — box [0,4]×[0,0.2]×[0,3] with a through-void at x∈[1.2,2.8]; adding GEOM_CUT_MOVE dx=0.8 moves the
+  hole's measured vertex extent to [2.0,3.6], width unchanged (proves: the worker shifts the void before subtracting).
+- C3 FOLD-SCALE-INVERSE — the same wall + a GRID SCALE f=1.25 (min fixed): without a rider the hole centre goes
+  2.0→2.5; with the anchor rider s=−0.4 it stays at 2.0, width 1.6→2.0 (proves: the inverse shift holds the centre
+  under the fold's own mapping; the width residual is real and reported).
+- C4 CACHE — folding chain A (no move) then A+move then A again yields the original hole (proves: no stale hit).
+- C5 FRAME — frameScale: post-cut SCALE ⇒ F; pre-cut SCALE ignored; post-cut ROTATE ⇒ ok:false; slideShift(0.8,F=1.25)
+  = 0.64; anchorShift with translateDelta≠0 and with F≠1 verified against the composed mapping.
+`witness_e2e_cut_move.js` (e2e, sketched wall + the REAL bCut button + a sketched door in the hole):
+- M1 GRAB — the door grabs into a SLIDE session carrying cutId (the S6 refusal is gone for a movable void).
+- M2 COMMIT — a real +0.8 m mouse drag commits ONE gesture: GEOM_MOVE + GEOM_CUT_MOVE {cutId, dx≈0.8, dy=dz=0}.
+- M3 HOLE-FOLLOWS — the wall mesh's hole extent moved by the same dx (vertex-measured); door and hole centres coincide.
+- M4 UNDO — one undo restores hole and door.
+- M5 ANCHOR — grid-stretch B(4)→5 with the door held: gesture = GEOM_GRID_MOVE + GEOM_CUT_MOVE; door centre unchanged,
+  hole centre unchanged (≤1e-3), hole width = 1.25× (reported residual), verifyChain true; undo restores.
+Regression guard: witness_opening_slide (S6 becomes "session carries cutId"), witness_e2e_opening_slide 8/8,
+witness_dagevu_engine, witness_gridmove_fold_pure, witness_e2e_gridstretch, witness_e2e_stretch_ride, witness_e2e_cut.
+
+## §6 Status (2026-09-11)
+- [x] `modeller/cut_move.js` (triple-export; the worker imports it, main thread + node share it) · [x] worker fold (pre-scan +
+  cache-key signature; worker URL v8) · [x] registration: modeller_history OP_TYPES/label, bonsai_ifc net-shifted void,
+  modeller.html script tag + cache bumps · [x] slide rider (bonsai_itemdrag S5; S6 refusal replaced) · [x] anchor rider
+  (bonsai_gridmove `_cutRiders` → GEOM_CUT_MOVE induced:'anchor-hold'; dimLabel "N hole(s) held (Δw ±x.xxm)")
+- [x] witness_cut_move.mjs 11/11 (REAL worker fold: C2 hole [1.2,2.8]→[2.0,3.6]; C3 centre held at 2.0 under f=1.25, min-edge
+  translateDelta, and a prior F=1.25; C4 cache no stale hit; C6 slide after a stretch rides 0.64 authored = 0.8 world)
+- [x] witness_e2e_cut_move.js 8/8 (real bCut + real mouse slide: GEOM_MOVE + GEOM_CUT_MOVE one gesture, hole follows 0.8 m;
+  real Ctrl+Z; real gridline drag with the door held: cut rider dx=−0.40, hole centre unchanged, width 1.6→2.0 reported)
+- [x] guards: witness_opening_slide 10/10 (S6 rewritten: carved void now RIDES; S6b rotate-after-cut refuses) ·
+  witness_e2e_opening_slide 8/8 (O0 still 7/7 real SampleHouse refusals — baked meshes) · witness_e2e_gridstretch 7/7 ·
+  witness_e2e_stretch_ride 11/11 · witness_e2e_grid_greenorange 13/13 · witness_gridmove_fold_pure 12/12 (harness copies
+  cut_move.js) · witness_dagevu_engine 13/13 · witness_stretch_ride 9/9 · witness_item_drag_gate 9/9 · sdg_cascade 7/7 · sdg_gate 11/11
+- witness_e2e_cut C4/C6 (framebuffer pixel-sum checks on a real Duplex element) FAIL IDENTICALLY on untouched origin/main
+  20e4fd28 (pix 9970636→9970636 both trees) — pre-existing, not this change; C1-C3/C5 (commit, chain, undo) pass in both.
+- Known residual (spec preamble): a held door's hole is (f−1)·F·w wider after a stretch — REPORTED in the log/dimLabel, not
+  corrected. Step 2 = a void resize op. Not started.
+- STEP 2 candidates (not built): void resize; a 90°-multiple GEOM_ROTATE frame mapping (today: refuse); baked LOD-300 holes (never).


### PR DESCRIPTION
## Summary
Step 1 of the void-linking work, spec first: `prompts/SPEC_GEOM_CUT_MOVE.md`.

One new signed op **`GEOM_CUT_MOVE {cutId, parent, dx, dy, dz, induced}`** — a pure fold override of an earlier `GEOM_CUT`'s void (the signed cut row is never rewritten).

- **`modeller/cut_move.js`** — the ONE definition (`netShifts` / `shiftVoid` / `cutsOver` / `frameScale` / `slideShift` / `anchorShift`), triple-export so the module worker, the main thread and node witnesses share it.
- **Worker fold** — pre-scans active cut-moves and subtracts the cut's void at `void + Σshift` at the cut's own log position. Every cache key in a fold with a non-zero shift carries the shift signature (a cut-move is retroactive; prefix-keyed hits would be stale). Zero cut-moves ⇒ keys byte-identical. Worker URL v8.
- **Slide rider** (`bonsai_itemdrag.js`) — the along-host slide no longer refuses a filling over a real `GEOM_CUT`; it emits one `GEOM_CUT_MOVE` per overlapping cut, delta in the cut's authored frame (`t / F`), same gesture group. Still refuses without an honest frame (no op list; host rotated/arrayed after the cut).
- **Grid anchor inverse** (`bonsai_gridmove.js`) — for a HELD opening whose host SCALEs, emits `s = −Δ/(f·F)` so the hole stays centred under the door. The width residual `(f−1)·F·w` is reported in the log and the §V7 dimLabel (`1 hole held (Δw +0.40m)`), not corrected — a void resize is step 2.
- Registration: `modeller_history` OP_TYPES/label, `bonsai_ifc` exports the net-shifted `IfcOpeningElement`, `modeller.html` script tag + cache bumps.

Out of scope, unchanged: holes baked into extracted LOD-300 meshes — all 7 real SampleHouse fillings still refuse the slide (asserted in `witness_e2e_opening_slide` O0).

## Witnesses (all read from the log)
| witness | result |
|---|---|
| `witness_cut_move.mjs` (REAL worker fold in node) | 11/11 — hole [1.2,2.8]→[2.0,3.6]; centre held at 2.0 under f=1.25, min-edge drag, and a prior F=1.25; cache no stale hit; slide after a stretch rides 0.64 authored = 0.8 world |
| `witness_e2e_cut_move.js` (real bCut, real mouse, real Ctrl+Z) | 8/8 — GEOM_MOVE + GEOM_CUT_MOVE one gesture, hole follows 0.8 m; gridline drag with the door held: rider dx=−0.40, hole centre unchanged, width 1.6→2.0 reported |
| `witness_opening_slide` (S6 rewritten: carved void RIDES; S6b rotate-after-cut refuses) | 10/10 |
| guards: e2e opening_slide / gridstretch / stretch_ride / greenorange | 8/8 · 7/7 · 11/11 · 13/13 |
| guards: fold_pure (harness now copies cut_move.js) / dagevu / stretch_ride / item_drag_gate / sdg_cascade / sdg_gate | 12/12 · 13/13 · 9/9 · 9/9 · 7/7 · 11/11 |
| `witness_e2e_cut` C4/C6 (pixel-sum checks) | FAIL identically on untouched origin/main 20e4fd28 — pre-existing, not this change |

🤖 Generated with [Claude Code](https://claude.com/claude-code)