### PR TITLE
docs(prompts): spec cut-move step 2 (GEOM_CUT_RESIZE) + step 3 (rotate frame)

### DIFF
--- a/prompts/RESUME_MODELLER_CUT_MOVE_STEP2.md
+++ b/prompts/RESUME_MODELLER_CUT_MOVE_STEP2.md
@@ -1,0 +1,45 @@
+# RESUME — cut-move step 2 (GEOM_CUT_RESIZE) then step 3 (rotate frame) — dispatch brief for a fresh coding session
+
+```
+# ⚠ DO NOT REMOVE
+SCOPE: implement prompts/SPEC_GEOM_CUT_RESIZE.md exactly (step 2). Only after it is merged and every witness in its
+§4 is green, implement prompts/SPEC_CUT_FRAME_ROTATE.md (step 3) — and ask first, it is low priority. Do NOT touch:
+holes baked into extracted LOD-300 meshes (never); roof/AngleEdge (⛔ paused); the abuts-realign APPLY (report-only by
+design, separate spec). Spec before code, spec before tests. Read the log after every witness run — exit code alone is
+not evidence; SKIP and silent failures only appear in the log. Honour this until §4 of each spec is all ✅.
+```
+
+## Where things are (2026-09-11)
+- Merged on main: engine #1706, slide #1710, GEOM_CUT_MOVE step 1 #1711 (8df2568d). Read, in this order:
+  1. `prompts/SPEC_GEOM_CUT_MOVE.md` (step 1 — §2 contract, §3 frame math, §6 every witness count)
+  2. `modeller/cut_move.js` (154 lines — the ONE definition; everything you add goes here first)
+  3. `modeller/bonsai_kernel_worker.js` buildSolids ~:405-430 (pre-scan + GEOM_CUT branch + the GEOM_CUT_MOVE skip)
+  4. `modeller/bonsai_gridmove.js` `_cutRiders` ~:313-340 and `commit()` ~:360-380 (the anchor rider + gesture group)
+  5. `modeller/tests/witness_cut_move.mjs` (how the REAL worker is driven in node; copy its fixture helpers, add cases)
+  6. `modeller/tests/witness_e2e_cut_move.js` (real bCut + real mouse + real Ctrl+Z; extend M5/M6, don't fork it)
+- Then the step 2 spec: `prompts/SPEC_GEOM_CUT_RESIZE.md`. Step 3 (later): `prompts/SPEC_CUT_FRAME_ROTATE.md`.
+
+## Mechanics (non-negotiable)
+- `~/bim-ootb` main checkout is HOOK-READ-ONLY. Work in a worktree from origin/main:
+  `git -C ~/bim-ootb fetch origin && git -C ~/bim-ootb worktree add /tmp/wt-cut-resize -b feat/cut-resize origin/main`
+- One PR per step, based on `main` (a bot auto-merges — NEVER stack a PR on a feature branch). PR body = the spec's §4/§5
+  witness table with the counts you actually read from the logs.
+- Run witnesses from `modeller/tests/`:
+  node: `node witness_cut_move.mjs` (≈10 s) · `node witness_opening_slide.js` · `node witness_gridmove_fold_pure.mjs` ·
+  `node witness_dagevu_engine.js`. e2e (puppeteer from ~/bim-compiler/node_modules, headless swiftshader, 1-3 min each,
+  run ≤3 in parallel): `node witness_e2e_cut_move.js` · `witness_e2e_opening_slide.js` · `witness_e2e_gridstretch.js` ·
+  `witness_e2e_stretch_ride.js` · `witness_e2e_grid_greenorange.js`.
+- Any node harness that copies `bonsai_kernel_worker.js` into a temp dir MUST also copy `cut_move.js` (the worker
+  `import`s it). Both existing .mjs harnesses already do.
+- Cache-bust every `<script src="…?v=N">` you touch in `modeller/modeller.html`; the worker URL lives in
+  `bonsai_kernel.js` (`bonsai_kernel_worker.js?v=8` → v9 for step 2).
+- In e2e, `t.undoToCursor()` is a SCRUB (rows stay active). Use the real Ctrl+Z helper already in
+  witness_e2e_cut_move.js (`ctrlZ(t)`) when a later commit must build on the reverted log.
+- Known pre-existing failure, not yours: `witness_e2e_cut` C4/C6 (framebuffer pixel-sum checks) fail identically on
+  untouched main. Note it in the PR; do not fix it in these PRs.
+
+## Definition of done (step 2)
+- `SPEC_GEOM_CUT_RESIZE.md` §5 all [x] with the counts pasted; W-CUT-MOVE ≥16/16 (C0-C6 + R1-R5), W-E2E-CUT-MOVE 8/8
+  with M5 asserting hole width UNCHANGED and three gesture rows; the five guard e2e + four node guards green.
+- The dimLabel on the e2e fixture reads exactly `… · 1 held · 1 hole held` (no `(Δw …)`).
+- Commit message + PR body end with the attribution lines the session provides.

--- a/prompts/SPEC_CUT_FRAME_ROTATE.md
+++ b/prompts/SPEC_CUT_FRAME_ROTATE.md
@@ -1,0 +1,74 @@
+# SPEC — Cut frame under a 90°-multiple GEOM_ROTATE (cut-move step 3) — Witness: W-CUT-MOVE F*
+
+```
+# ⚠ DO NOT REMOVE
+SCOPE: replace cut_move.js `frameScale` (a per-axis scale F + translation tPost, which REFUSES any post-cut GEOM_ROTATE)
+with `hostFrame` — a per-axis affine map from the cut's AUTHORED frame to the CURRENT world frame that also handles a
+post-cut GEOM_ROTATE by a multiple of 90° (axis permutation + sign). Oblique rotations, tilted/obliquely-yawed SCALEs
+and GEOM_ARRAY-after-cut keep REFUSING. Everything step 1/2 emits (slide shift, anchor shift, anchor resize) is
+re-expressed through this one map; for a host with no rotation the numbers are BYTE-IDENTICAL to step 1/2.
+DO THIS ONLY AFTER prompts/SPEC_GEOM_CUT_RESIZE.md is merged and green. Low priority — a sketched wall that is CUT
+and THEN rotated is rare; the honest refusal that exists today is acceptable if this is never built. Spec before
+code; read the log after every witness run.
+```
+
+Parents: `prompts/SPEC_GEOM_CUT_MOVE.md` §3 (the frame: u = x − min scales by f, invariant under translate),
+`prompts/SPEC_GEOM_CUT_RESIZE.md`, worker branches `GEOM_ROTATE` (bonsai_kernel_worker.js ~:660: yaw about the shape's
+bbox-centre Z, `P.drot` DEGREES) and `GEOM_GRID_MOVE` SCALE (about the shape's CURRENT world bbox min on the axis).
+
+## §1 The model
+Let M be the affine map authored → world composed from the ACTIVE post-cut ops that transform the host, in log order.
+With only TRANSLATE / SCALE / 90°-multiple ROTATE, M is "axis-aligned affine": world_k = a_k · authored_{π(k)} + b_k
+with a permutation π and signed scalars a_k. Represent it as `{ perm:[i0,i1,i2], a:[a0,a1,a2], b:[b0,b1,b2] }` meaning
+world axis k reads authored axis perm[k]. Identity = perm [0,1,2], a [1,1,1], b [0,0,0].
+Compose a new world-frame op W onto M (M ← W∘M):
+- TRANSLATE d: b_k += d_k.
+- SCALE on world axis k, factor f, translateDelta t, about the host's world min m_k at that moment:
+  a_k *= f; b_k = f·b_k + m_k(1−f) + t.
+- ROTATE by θ = drot° about the host's world bbox centre c (x,y only; z untouched). Require θ/90 within 0.01 rad of an
+  integer n (same tolerance as the worker's §SCALE-YAW-GUARD), else `ok:false 'oblique-rotate-after-cut'`.
+  R = rotation by n·90°: for n ≡ 1: (x,y) → (c_x − (y − c_y), c_y + (x − c_x)); n ≡ 2: reflect both through c;
+  n ≡ 3: (x,y) → (c_x + (y − c_y), c_y − (x − c_x)); n ≡ 0: identity. Apply R to the map: new perm/a/b follow from
+  substituting world_x, world_y — e.g. n ≡ 1: perm' = [perm[1], perm[0], perm[2]], a' = [−a_1, a_0, a_2],
+  b' = [c_x + c_y − b_1, c_y − c_x + b_0, b_2]. Write the three cases out explicitly; witness each (F1).
+- GEOM_MOVE / GEOM_ROOM_MOVE on the host: TRANSLATE. GEOM_SCALE: no-op (worker no-op on a B-rep). GEOM_ARRAY: refuse.
+The host's world box at each step is needed for m_k and c. It is NOT stored anywhere; derive it by a BACKWARD replay
+from the measured current box (`hostBoxNow`, the pre-drag AABB): walk the post-cut ops in REVERSE un-applying each:
+TRANSLATE: box −= d; SCALE(k,f,t): min_before = min_after − t, max_before = (max_after − min_before(1−f) − t)/f;
+ROTATE n·90° about c: c = centre of box_after (invariant), un-rotate the box about c (swap x/y extents for odd n).
+That yields box_at_cut and box_before(i) for every op i; then walk FORWARD composing M with the right m_k / c.
+`hostFrame(ops, cutOp, hostBoxNow) → { ok, M, boxAtCut, reason }`. Sanity invariant to assert in every witness:
+`mapBox(M, boxAtCut) == hostBoxNow` (≤1e-9) — if it does not hold the replay is wrong, refuse (`ok:false 'frame-replay-mismatch'`).
+
+## §2 Re-expressing step 1/2 through M (all in cut_move.js; consumers unchanged in shape)
+Let L = the linear part (perm + a), so L(s)_k = a_k · s_{perm[k]} and L⁻¹(d)_{perm[k]} = d_k / a_k.
+- SLIDE (world delta d, axis-only): authored shift s = L⁻¹(d). Step 1's `slideShift(t, F)` = the no-rotation special
+  case (perm identity, a_k = F). Keep `slideShift` exported; add `slideShiftM(d, M)`.
+- ANCHOR (new SCALE on world axis k, f, t, about m_k = hostBoxNow min + minShift): hole world centre q = M(v_c) where
+  v_c = the overridden authored void centre; Δ = (q_k − m_k)(f − 1) + t; authored shift s = L⁻¹(−Δ/f · e_k) (only the
+  pre-image axis perm[k] is non-zero: s_{perm[k]} = −Δ/(f·a_k)). Resize factor on authored axis perm[k]: g = 1/f.
+  `through` is evaluated in WORLD (map the void box through M, compare with hostBoxNow). Step 1's `anchorShift` =
+  identity-perm case (a_k = F, tPost folded into b). Keep its signature; internally call hostFrame.
+- `frameScale(ops, cutOp, axis)` becomes a wrapper: ok:false if perm is not identity or any a_k < 0 (a caller that
+  cannot express a permuted axis), else `{ f: a_axis, tPost: b_axis − (a_axis − 1)·boxAtCut.min_axis … }` — simpler:
+  drop `tPost` from the contract once itemdrag/gridmove call `slideShiftM`/`anchorShift` only (grep first; witness C5
+  asserts tPost — update C5 to assert the M fields instead, keeping the SAME numbers: a=[1.25,1,1], b=[0.5,0,0]).
+
+## §3 Tests (extend witness_cut_move.mjs; every case ALSO folds through the real worker where a fold exists)
+- F0 IDENTITY — a chain with no rotation gives M = {perm id, a=[F,1,1], b=[tPost,0,0]} and byte-identical s to C3/C6.
+- F1 ROTATE-90 — wall+cut+GEOM_ROTATE drot=90: fold the chain; the hole's world extent is now along Y; `hostFrame`
+  invariant holds; a SLIDE of world +0.8 along Y maps to authored s = (+0.8 or −0.8 on x, sign per the rotation) and the
+  folded hole moves +0.8 in world Y (measure the hole on the rotated wall: vertices strictly between z faces, Y range).
+- F2 ROTATE-180 — the mirror: world min = authored max; an ANCHOR stretch f=1.25 of the rotated wall holds the hole
+  centre (fold-verified) and the resize keeps its width.
+- F3 ROTATE-270 and TWO rotations (90+90 = 180) compose to F2's map.
+- F4 OBLIQUE — drot=30 ⇒ ok:false 'oblique-rotate-after-cut'; itemdrag S6b still refuses (its message changes; update
+  the witness string only).
+- F5 REPLAY — TRANSLATE 0.5 then SCALE f=1.25 then ROTATE 90: `mapBox(M, boxAtCut)` == hostBoxNow ≤1e-9.
+E2E: add M7 to witness_e2e_cut_move.js — after M6, commit a GEOM_ROTATE {parent: wall, drot: 90} via the real Rotate
+gizmo if one exists for solids (grep `GEOM_ROTATE` commits in modeller.html; else `Bonsai.oplog.commit` is acceptable
+for the fixture, say so in the assert name), re-inject the fills row, real-drag the door along the wall's NEW long axis
+(y) by 0.8 and assert hole + door moved together in Y, x unchanged, one gesture, Ctrl+Z reverts.
+
+## §4 Status
+- [ ] hostFrame + backward replay · [ ] slideShiftM / anchorShift via M · [ ] itemdrag/gridmove switched · [ ] F0-F5 · [ ] M7

--- a/prompts/SPEC_GEOM_CUT_RESIZE.md
+++ b/prompts/SPEC_GEOM_CUT_RESIZE.md
@@ -1,0 +1,95 @@
+# SPEC — GEOM_CUT_RESIZE (cut-move step 2): a held door's hole keeps its width — Witness: W-CUT-RESIZE / W-E2E-CUT-MOVE R*
+
+```
+# ⚠ DO NOT REMOVE
+SCOPE: (1) a new signed op `GEOM_CUT_RESIZE {cutId, parent, fx, fy, fz}` — a multiplicative, per-axis resize of an
+earlier GEOM_CUT's void ABOUT ITS OWN CENTRE, folded exactly like GEOM_CUT_MOVE (pre-scan + override at the cut's own
+log position; the signed GEOM_CUT row is never rewritten); (2) cut_move.js grows from "net shifts" to "net overrides"
+(shift + resize) with ONE signature function; (3) the grid ANCHOR path emits a resize rider g = 1/f alongside its
+GEOM_CUT_MOVE rider so the hole's WORLD width is unchanged after the stretch — the residual step 1 only reported.
+Out of scope: rotated-after-cut hosts (prompts/SPEC_CUT_FRAME_ROTATE.md, step 3); holes baked into extracted LOD-300
+meshes (never); roof/AngleEdge (⛔ paused). Spec before code; read the log after every witness run.
+```
+
+Parent: `prompts/SPEC_GEOM_CUT_MOVE.md` (step 1, merged as #1711 → 8df2568d). Read it FIRST — §2 (contract), §3 (frame
+math), §5 (witness shapes). This spec changes NOTHING about step 1's centre-hold; it adds width-hold on top.
+
+## §1 The issue (measured, W-CUT-MOVE C3a and W-E2E-CUT-MOVE M5)
+The fold's GRID SCALE maps every point of the host, hole included: x → f·x + min·(1−f) + t. Step 1's GEOM_CUT_MOVE rider
+s = −Δ/(f·F) keeps the hole's CENTRE under the held door, but the hole's width still becomes f·F·w. On the e2e fixture
+(wall 4 m → 5 m, hole 1.6 m) the hole ends 2.0 m wide under a 1.0 m door — reported as `1 hole held (Δw +0.40m)`.
+A void resize in the cut's authored frame by g = 1/f cancels it exactly: f · (F · w · g) = F · w.
+
+## §2 Contract
+```
+GEOM_CUT_RESIZE  parameters { cutId, parent, fx, fy, fz, induced? }
+  cutId, parent = as GEOM_CUT_MOVE (the active GEOM_CUT row id; its host solid)
+  fx, fy, fz    = per-axis factors (>0) applied to the void's half-extents ABOUT THE VOID'S OWN CENTRE, in the cut's
+                  AUTHORED frame; absent field ⇒ 1. induced = 'anchor-hold' (grid) — the slide never emits one.
+```
+FOLD ORDER (one definition, `cut_move.js applyOverrides(void, ov)`): from the authored `{c1,c2}`:
+  centre' = centre + Σshift · half' = half ⊙ Πfactor · c1' = centre' − half' · c2' = centre' + half'.
+Because the resize is about the void's OWN centre and the shift moves that centre, shift and resize COMMUTE — the row
+order in the log is irrelevant, exactly as GEOM_CUT_MOVE rows already sum in any order (witness this: R4).
+Tolerance: a factor ≤ 0 or non-finite ⇒ that row is IGNORED (tolerant, like a cut-move naming a non-active cut) and
+logged `§CUT-MOVE ignored GEOM_CUT_RESIZE #id: non-positive factor`. Never a throw, never a clamp.
+
+## §3 Changes, file by file (anchors are 8df2568d line numbers)
+`modeller/cut_move.js`
+- ADD `netOverrides(ops) → { byCut: { [cutId]: { s:[dx,dy,dz], f:[fx,fy,fz] } }, sig }`. Same walk as `netShifts`
+  (:64) — sums GEOM_CUT_MOVE into `s`, multiplies GEOM_CUT_RESIZE into `f` (start [1,1,1]); only active-cut ids count.
+  `sig` = per cut `id:sx,sy,sz*fx,fy,fz` for every cut whose s≠0 OR f≠1, sorted by id, `;`-joined ('' when none).
+  KEEP `netShifts(ops)` as a thin wrapper (`byCut[id] = ov.s` for entries whose shift ≠ 0, same `sig`) so step 1's
+  witnesses and bonsai_ifc keep working unchanged until switched.
+- ADD `applyOverrides(void, ov) → {c1,c2}` (§2 order; `ov` = one byCut entry or undefined ⇒ returns a copy).
+- `cutsOver` (:84): use `netOverrides` + `applyOverrides` for the overlap box (a resized hole is still found).
+- `anchorShift` (:138): return TWO more fields — `g = 1/f` (the resize factor for this axis) and `through:boolean`
+  (true when the void OVERHANGS the host on this axis: vb lo < hb lo − TOL or vb hi > hb hi + TOL, TOL = 0.05).
+  A through-axis (the bCut's thickness axis, void ±0.5 m beyond the wall) gets NO resize — shrinking a through-void by
+  1/f could stop it cutting through; the fold scaling it is harmless. Keep `residual` as-is (it is what a caller that
+  emits no resize still sees).
+- `keySuffix` unchanged (`'|cm:' + sig`).
+`modeller/bonsai_kernel_worker.js` (:411, :421)
+- `const cutMoves = CutMove.netOverrides(ops)` and `const vd = ov ? CutMove.applyOverrides(P.void, ov) : P.void`.
+- ADD branch `else if (op.op_type === 'GEOM_CUT_RESIZE') { continue; }` next to the GEOM_CUT_MOVE one (:426).
+- Worker URL in `bonsai_kernel.js` `?v=8` → `?v=9` (append "v9: §CUT-RESIZE" to the version comment).
+`modeller/bonsai_gridmove.js` `_cutRiders` (:313-340)
+- For every SCALE command on the host: after `anchorShift`, if `!r.through` accumulate `g[k] *= r.g` and set
+  `res = 0` for that axis (the width is now held); if `r.through` leave `g[k]` at 1 (and the residual as reported).
+- Rider shape becomes `{ cutId, parent, dx,dy,dz, fx,fy,fz, fillingFid, residual }`. In `commit()` emit, per rider,
+  the GEOM_CUT_MOVE row as today AND, when any factor ≠ 1, one GEOM_CUT_RESIZE row `{cutId, parent, fx,fy,fz,
+  induced:'anchor-hold'}` — same gesture group (one Ctrl+Z). Log line: append ` resize=(fx,fy,fz)`.
+- dimLabel: `N hole(s) held` with the `(Δw …)` suffix ONLY when a residual remains (through axes) — for the e2e fixture
+  the label becomes exactly `… · 1 held · 1 hole held`.
+`modeller/bonsai_itemdrag.js` — NO change (the slide never scales). `modeller/bonsai_ifc.js` (:81, :126) — switch to
+`netOverrides`/`applyOverrides` (the exported IfcOpeningElement is the resized void). `modeller/modeller_history.js`
+(:21, :30) — add `'GEOM_CUT_RESIZE': true` and label `'Cut resize #' + p.cutId`. `modeller.html` — bump cache
+versions of every file touched (kernel v9, worker via kernel, gridmove, ifc, history; cut_move.js?v=2).
+`modeller/tests/witness_gridmove_fold_pure.mjs` — no change (it already copies cut_move.js).
+
+## §4 Tests — each names the issue it proves
+Extend `modeller/tests/witness_cut_move.mjs` (keep C0-C6 byte-identical in intent; add):
+- R1 NET-OVERRIDES — two GEOM_CUT_RESIZE rows fx=0.5 and fx=0.8 on cut #2 ⇒ f=[0.4,1,1]; a row with fx=0 is ignored;
+  `sig` contains both s and f; `netShifts` wrapper still returns step 1's shape and the SAME `sig` when only shifts
+  exist (proves: one signature, backwards-compatible keys).
+- R2 FOLD-RESIZE — wall+cut + GEOM_CUT_RESIZE fx=0.5 ⇒ hole [1.6,2.4] (centre 2.0 kept, width 0.8) (proves: the worker
+  resizes about the void's own centre).
+- R3 WIDTH-HOLD — wall+cut + GRID SCALE f=1.25 + GEOM_CUT_MOVE s=−0.4 + GEOM_CUT_RESIZE fx=0.8 ⇒ hole centre 2.0 AND
+  width 1.6 EXACTLY; `anchorShift` returns g=0.8, through=false on x and through=true on y (the ±0.5 thickness
+  overhang) (proves: the residual is gone; through-axes are left alone).
+- R4 COMMUTE — the R3 chain with the MOVE and RESIZE rows swapped in id order ⇒ byte-identical hole (proves: §2 order
+  is well-defined regardless of log order).
+- R5 CACHE — after R2/R3, folding the plain wall+cut chain (same op_hashes as C0) is a hit with the original hole;
+  the R3 fold's signature differs from C3b's (proves: resize is in the key; no stale hits either way).
+Extend `modeller/tests/witness_e2e_cut_move.js` M5/M6 (same fixture, same real gridline drag):
+- M5 now asserts THREE rows in the gesture (GEOM_GRID_MOVE + GEOM_CUT_MOVE + GEOM_CUT_RESIZE{fx≈1/f, fy=fz=1}), hole
+  centre unchanged ≤1e-3 AND hole width unchanged ≤1e-3 (1.6 m), door unchanged, dimLabel matches `/1 hole held(?! \()/`
+  (no Δw suffix), verifyChain true. M6: one real Ctrl+Z reverts all three rows.
+Guards to re-run and paste counts into §5: witness_opening_slide (10/10), witness_e2e_opening_slide (8/8; O0 stays
+7/7 refusals), witness_e2e_gridstretch 7/7, witness_e2e_stretch_ride 11/11, witness_e2e_grid_greenorange 13/13,
+witness_gridmove_fold_pure 12/12, witness_dagevu_engine 13/13. Known pre-existing: witness_e2e_cut C4/C6 fail on
+untouched main (pixel-sum checks) — do not "fix" them here, note them.
+
+## §5 Status
+- [ ] cut_move.js netOverrides/applyOverrides/anchorShift.g,through · [ ] worker fold + v9 · [ ] gridmove resize rider
+- [ ] ifc/history/html registration · [ ] W-CUT-MOVE R1-R5 · [ ] W-E2E-CUT-MOVE M5/M6 updated · [ ] guards pasted


### PR DESCRIPTION
## Summary
Docs only — no code. Specs the next two increments of the DAGeVu cut-move work, implementation-ready, for a fresh coding session to pick up.

Step 1 (`GEOM_CUT_MOVE`, #1711) merged with a known residual: a held door's carved hole **widens** by `(f−1)·F·w` under a grid stretch — reported in the dimLabel, never corrected.

- **`prompts/SPEC_GEOM_CUT_RESIZE.md`** (step 2, ready to code) — a new signed `GEOM_CUT_RESIZE {cutId, parent, fx, fy, fz}` op, folded exactly like `GEOM_CUT_MOVE`. `cut_move.js` grows `netShifts` → `netOverrides` (shift + resize, one signature, backwards-compatible). `anchorShift` gains `g = 1/f` and a through-axis exemption (the bCut thickness axis never resizes). The grid anchor path emits the resize rider alongside the shift rider so the hole's world width is unchanged after a stretch. Every file change is anchored to exact line numbers in the merged commit; 5 new node witness cases (R1–R5) and e2e M5/M6 updates are specified with the exact expected numbers.
- **`prompts/SPEC_CUT_FRAME_ROTATE.md`** (step 3, low priority — ask before starting) — replaces the scale-only frame with an axis-permuting affine map (`hostFrame`) so a host rotated 90° after its cut can still carry the cut-move/resize riders. Oblique rotations keep refusing. Includes the backward-replay algorithm for deriving the host's box-at-cut-time from its current measured box.
- **`prompts/RESUME_MODELLER_CUT_MOVE_STEP2.md`** — dispatch brief for the next session: reading order, worktree/PR mechanics, how to run each witness, and two gotchas (node harnesses that clone the worker must also copy `cut_move.js`; `witness_e2e_cut` C4/C6 fail identically on untouched main — don't chase it).

🤖 Generated with [Claude Code](https://claude.com/claude-code)