### PR TITLE
feat(modeller): GEOM_CUT_RESIZE — a held door's hole keeps its width (cut-move step 2)

### DIFF
--- a/modeller/bonsai_gridmove.js
+++ b/modeller/bonsai_gridmove.js
@@ -326,16 +326,20 @@
         const fb = boxByFid[fid], hb = boxByFid[host]; if (!fb || !hb) continue;
         for (const cutOp of CM.cutsOver(ops, host, fb)) {
           if (seen[cutOp.id]) continue; seen[cutOp.id] = 1;
-          const d = [0, 0, 0], minShift = [0, 0, 0]; let bad = null, res = 0;
+          const d = [0, 0, 0], g = [1, 1, 1], minShift = [0, 0, 0]; let bad = null, res = 0;
           for (const c of cmds) {                                  // in command order: a preceding TRANSLATE moves the anchor min
             const k = AXI[c.axis]; if (k == null) continue;
             if (c.action === 'TRANSLATE') { minShift[k] += c.delta || 0; continue; }
             const r = CM.anchorShift({ cutOp, ops, hostBox: hb, axis: k, f: c.newScale != null ? c.newScale : 1, translateDelta: c.translateDelta || 0, minShift: minShift[k] });
             if (!r.ok) { bad = r.reason; break; }
-            d[k] += r.s; if (Math.abs(r.residual) > Math.abs(res)) res = r.residual;
+            d[k] += r.s;
+            // §CUT-RESIZE (SPEC_GEOM_CUT_RESIZE.md §3): a non-through axis is fully held — accumulate the resize
+            // g=1/f and the residual on it is 0; a through axis (the bCut's thickness axis) gets NO resize and keeps
+            // reporting its residual as before (shrinking a through-void by 1/f could stop it cutting through).
+            if (!r.through) { g[k] *= r.g; } else if (Math.abs(r.residual) > Math.abs(res)) res = r.residual;
           }
           if (bad) { out.refused.push(cutOp.id); refusals.push({ kind: 'cut-move-unmappable', fillingFid: fid, hostFid: host, cutId: cutOp.id, reason: bad }); continue; }
-          out.riders.push({ cutId: cutOp.id, parent: host, dx: d[0], dy: d[1], dz: d[2], fillingFid: fid, residual: res });
+          out.riders.push({ cutId: cutOp.id, parent: host, dx: d[0], dy: d[1], dz: d[2], fx: g[0], fy: g[1], fz: g[2], fillingFid: fid, residual: res });
           if (Math.abs(res) > Math.abs(out.residual)) out.residual = res;
         }
       }
@@ -371,20 +375,25 @@
       // half-reverted stretch in between). Rider ops stay byte-identical GEOM_MOVE {parent,d*,induced} rows —
       // only the grouping changes. Zero riders ⇒ the existing single-op path below, untouched.
       // §CUT-MOVE: the held openings' carved voids ride the SAME gesture as GEOM_CUT_MOVE rows (SPEC_GEOM_CUT_MOVE.md §4).
+      // §CUT-RESIZE: when any factor ≠ 1, one GEOM_CUT_RESIZE row rides the SAME gesture too (SPEC_GEOM_CUT_RESIZE.md §3).
       const cutRiders = preview.cutRiders || [];
+      const resizeRiders = cutRiders.filter(c => c.fx !== 1 || c.fy !== 1 || c.fz !== 1);
       if ((riders.length || cutRiders.length) && window.Bonsai.oplog.commitGesture) {
         const ops = [{ op_type: 'GEOM_GRID_MOVE', params: { gridId, delta, commands } }]
           .concat(riders.map(r => ({ op_type: 'GEOM_MOVE',
             params: { parent: r.featureId, dx: r.dx, dy: r.dy, dz: r.dz, induced: 'hosted-by' } })))
           .concat(cutRiders.map(c => ({ op_type: 'GEOM_CUT_MOVE',
-            params: { cutId: c.cutId, parent: c.parent, dx: c.dx, dy: c.dy, dz: c.dz, induced: 'anchor-hold' } })));
+            params: { cutId: c.cutId, parent: c.parent, dx: c.dx, dy: c.dy, dz: c.dz, induced: 'anchor-hold' } })))
+          .concat(resizeRiders.map(c => ({ op_type: 'GEOM_CUT_RESIZE',
+            params: { cutId: c.cutId, parent: c.parent, fx: c.fx, fy: c.fy, fz: c.fz, induced: 'anchor-hold' } })));
         const gres = await window.Bonsai.oplog.commitGesture(ops);
         console.log(TAG + ' commit grid=' + gridId + ' delta=' + delta + ' cmds=' + commands.length +
           ' §GESTURE gid=' + gres.gid + ' riders=' + riders.length + ' cutRiders=' + cutRiders.length + ' verify=' + gres.verify + ' tris=' + gres.triangleCount);
         riders.forEach(r => console.log(TAG + ' §STRETCH-RIDE hosted-by rider=' + r.featureId + ' induced dx=' + r.dx.toFixed(3) +
           ' dy=' + r.dy.toFixed(3) + ' dz=' + r.dz.toFixed(3) + ' (in gesture group)'));
         cutRiders.forEach(c => console.log(TAG + ' §CUT-MOVE anchor-hold cut=#' + c.cutId + ' (wall #' + c.parent + ', under held opening #' + c.fillingFid + ') authored shift dx=' + c.dx.toFixed(3) +
-          ' dy=' + c.dy.toFixed(3) + ' dz=' + c.dz.toFixed(3) + ' width residual=' + c.residual.toFixed(3) + 'm (reported, not corrected — void resize is step 2) (in gesture group)'));
+          ' dy=' + c.dy.toFixed(3) + ' dz=' + c.dz.toFixed(3) + ' resize=(' + c.fx.toFixed(3) + ',' + c.fy.toFixed(3) + ',' + c.fz.toFixed(3) + ')' +
+          ' width residual=' + c.residual.toFixed(3) + 'm (reported for through-axes only, not corrected) (in gesture group)'));
         return { ...gres, commands, riders, cutRiders };
       }
       const res = await window.Bonsai.oplog.commit({ op_type: 'GEOM_GRID_MOVE',

--- a/modeller/bonsai_ifc.js
+++ b/modeller/bonsai_ifc.js
@@ -78,7 +78,7 @@
       const api = await this._init();
       const T = WebIFC;
       const ops = window.Bonsai.oplog._geomOps();          // [{id, op_type, parameters, parent}]
-      const _cutMoves = window.CutMove ? window.CutMove.netShifts(ops) : null;   // §CUT-MOVE: net void shifts (cut_move.js, one definition)
+      const _cutMoves = window.CutMove ? window.CutMove.netOverrides(ops) : null;   // §CUT-MOVE/§CUT-RESIZE: net void overrides (cut_move.js, one definition)
       if (!ops.length) throw new Error('nothing authored to export');
       const mID = api.CreateModel({ schema: 'IFC4', name: 'bonsai_model.ifc' });
       const len = v => api.CreateIfcType(mID, T.IFCLENGTHMEASURE, v);
@@ -121,10 +121,11 @@
           wallByFeature.set(op.id, wall); walls++;
           if (!firstWall) firstWall = { points: pts, depth };
         } else if (op.op_type === 'GEOM_CUT') {
-          // §CUT-MOVE: the IfcOpeningElement is the SAME net-shifted void the worker subtracts — an active
-          // GEOM_CUT_MOVE on this cut moves the exported void too; the signed GEOM_CUT row is never rewritten.
-          const _cmShift = _cutMoves ? _cutMoves.byCut[String(op.id)] : null;
-          const { c1, c2 } = _cmShift ? window.CutMove.shiftVoid(op.parameters.void, _cmShift) : op.parameters.void;
+          // §CUT-MOVE/§CUT-RESIZE: the IfcOpeningElement is the SAME net-overridden void the worker subtracts — an
+          // active GEOM_CUT_MOVE/GEOM_CUT_RESIZE on this cut moves/resizes the exported void too; the signed
+          // GEOM_CUT row is never rewritten.
+          const _cmOv = _cutMoves ? _cutMoves.byCut[String(op.id)] : null;
+          const { c1, c2 } = _cmOv ? window.CutMove.applyOverrides(op.parameters.void, _cmOv) : op.parameters.void;
           const dx = Math.abs(c2[0] - c1[0]), dy = Math.abs(c2[1] - c1[1]), dz = Math.abs(c2[2] - c1[2]);
           const cx = (c1[0] + c2[0]) / 2, cy = (c1[1] + c2[1]) / 2, z0 = Math.min(c1[2], c2[2]);
           const rectPlace = api.CreateIfcEntity(mID, T.IFCAXIS2PLACEMENT2D, api.CreateIfcEntity(mID, T.IFCCARTESIANPOINT, [len(0), len(0)]), null);

--- a/modeller/bonsai_kernel.js
+++ b/modeller/bonsai_kernel.js
@@ -32,7 +32,7 @@
     init() {
       if (this._worker) return this._worker;
       if (!this.isSupported()) { console.warn(TAG + ' unsupported host (needs WASM tail-calls + Worker)'); return null; }
-      const url = new URL('bonsai_kernel_worker.js?v=8', _self);   // v8: §CUT-MOVE GEOM_CUT_MOVE fold override (cut_move.js) · v2: GEOM_MOVE PATH A · v3: GEOM_ROTATE tolerant branch · v4: GEOM_ROTATE real occt solid spin · v5: GEOM_SCALE tolerant no-op (W-BONSAI-SCALE; solid scale deferred #3b) · v6: §CUT-ON-ARC seedBoxes (promote box-like insert to B-rep for GEOM_CUT/FILLET) · v7: Tier 1 shoulders GEOM_REVOLVE/SHELL/OFFSET/FILLET_VARIABLE/CHAMFER_DIST_ANGLE/DRAFT + listFaces
+      const url = new URL('bonsai_kernel_worker.js?v=9', _self);   // v9: §CUT-RESIZE GEOM_CUT_RESIZE fold override (cut_move.js netOverrides/applyOverrides) · v8: §CUT-MOVE GEOM_CUT_MOVE fold override (cut_move.js) · v2: GEOM_MOVE PATH A · v3: GEOM_ROTATE tolerant branch · v4: GEOM_ROTATE real occt solid spin · v5: GEOM_SCALE tolerant no-op (W-BONSAI-SCALE; solid scale deferred #3b) · v6: §CUT-ON-ARC seedBoxes (promote box-like insert to B-rep for GEOM_CUT/FILLET) · v7: Tier 1 shoulders GEOM_REVOLVE/SHELL/OFFSET/FILLET_VARIABLE/CHAMFER_DIST_ANGLE/DRAFT + listFaces
       this._worker = new Worker(url.href, { type: 'module' });
       this._worker.onmessage = (e) => {
         const d = e.data || {};

--- a/modeller/bonsai_kernel_worker.js
+++ b/modeller/bonsai_kernel_worker.js
@@ -6,7 +6,7 @@
 import { OcctKernel } from './lib/kernel/index.js';
 // §CUT-MOVE (prompts/SPEC_GEOM_CUT_MOVE.md): the ONE definition of GEOM_CUT_MOVE's meaning — a classic triple-export
 // script evaluated here as a module (it binds `self.CutMove`; the main thread's <script> binds window.CutMove).
-import './cut_move.js?v=1';
+import './cut_move.js?v=2';
 const CutMove = self.CutMove;
 
 let kernelPromise = null;
@@ -408,7 +408,7 @@ function buildSolids(kernel, ops, seedBoxes, seedLayers) {
   // CACHE: op_hash keys assume output = f(prefix); a cut-move is retroactive, so when any shift is non-zero EVERY key
   // in this fold carries the fold's cut-move signature — one rebuild per distinct shift set, and a scrub/undo back to
   // a prefix without the move hits the original (unsuffixed) keys. Zero cut-moves ⇒ keys byte-identical to before.
-  const cutMoves = CutMove.netShifts(ops), cmKey = CutMove.keySuffix(cutMoves.sig);
+  const cutMoves = CutMove.netOverrides(ops), cmKey = CutMove.keySuffix(cutMoves.sig);
   for (const op of ops) {
     const P = typeof op.parameters === 'string' ? JSON.parse(op.parameters) : op.parameters;
     const key = (op.op_hash || ('nohash:' + op.id)) + cmKey;    // op_hash = unique per immutable prefix → the cache key (+ §CUT-MOVE suffix)
@@ -417,13 +417,15 @@ function buildSolids(kernel, ops, seedBoxes, seedLayers) {
       if (shapeCache.has(key)) { _stats.hits++; solids.set(op.parent, { shape: shapeCache.get(key), hash: key }); continue; }
       _stats.rebuilt++;
       const v = (a) => ({ x: a[0], y: a[1], z: a[2] });
-      const shift = cutMoves.byCut[String(op.id)];
-      const vd = shift ? CutMove.shiftVoid(P.void, shift) : P.void;   // §CUT-MOVE: the void at its net-shifted place
+      const ov = cutMoves.byCut[String(op.id)];
+      const vd = ov ? CutMove.applyOverrides(P.void, ov) : P.void;   // §CUT-MOVE/§CUT-RESIZE: the void at its net-overridden place
       const void_ = kernel.makeBoxFromCorners(v(vd.c1), v(vd.c2));
       const cut = kernel.cut(pe.shape, void_);
       kernel.release(void_);                          // local intermediate (parent is cached → NOT released)
       shapeCache.set(key, cut); solids.set(op.parent, { shape: cut, hash: key });
     } else if (op.op_type === 'GEOM_CUT_MOVE') {       // §CUT-MOVE: folded at ITS CUT's position via the pre-scan above
+      continue;                                        // (a no-op here; never a leaf, never a parent lookup)
+    } else if (op.op_type === 'GEOM_CUT_RESIZE') {     // §CUT-RESIZE: folded at ITS CUT's position via the pre-scan above
       continue;                                        // (a no-op here; never a leaf, never a parent lookup)
     } else if (op.op_type === 'GEOM_FILLET') {
       const pe = solids.get(op.parent); if (!pe) throw new Error('GEOM_FILLET parent ' + op.parent + ' not found');

--- a/modeller/cut_move.js
+++ b/modeller/cut_move.js
@@ -34,6 +34,7 @@
   var TAG = '§CUT-MOVE';
   var AX = { x: 0, y: 1, z: 2 };
   var OVERLAP_EPS = 1e-6;     // m — bonsai_itemdrag.js's own flush-contact rule (0 overlap = adjacency, not a hit)
+  var THROUGH_TOL = 0.05;     // m — SPEC_GEOM_CUT_RESIZE.md §3 anchorShift.through: the void overhangs the host
   var HALF_PI = Math.PI / 2;
   var YAW_TOL = 0.01;         // rad — bonsai_kernel_worker.js §SCALE-YAW-GUARD / GRID_ROTATION_GUARD.md §1
 
@@ -58,36 +59,76 @@
              c2: [v.c2[0] + (d[0] || 0), v.c2[1] + (d[1] || 0), v.c2[2] + (d[2] || 0)] };
   }
 
-  // netShifts(ops) → { byCut: {cutId: [dx,dy,dz]}, sig } over the ACTIVE rows of one fold. Only cutIds that are an
-  // active GEOM_CUT in the same list count; `sig` is a deterministic, order-independent signature of the non-zero
-  // shifts ('' when none) — the cache-key suffix (spec §2 CACHE).
-  function netShifts(ops) {
+  // applyOverrides({c1,c2}, ov) → a NEW {c1,c2}; `ov` = one netOverrides byCut entry ({s,f}) or undefined ⇒ a copy.
+  // SPEC_GEOM_CUT_RESIZE.md §2 FOLD ORDER: centre' = centre + Σshift; half' = half ⊙ Πfactor; c1' = centre' − half';
+  // c2' = centre' + half' — the resize is about the void's OWN (already-shifted) centre, so shift and resize commute.
+  function applyOverrides(v, ov) {
+    if (!ov) return { c1: v.c1.slice(), c2: v.c2.slice() };
+    var s = ov.s || [0, 0, 0], f = ov.f || [1, 1, 1], c1 = v.c1, c2 = v.c2, out1 = [0, 0, 0], out2 = [0, 0, 0];
+    for (var k = 0; k < 3; k++) {
+      var centre = (c1[k] + c2[k]) / 2 + (s[k] || 0);
+      var half = Math.abs(c2[k] - c1[k]) / 2 * (f[k] != null ? f[k] : 1);
+      var sign = c2[k] >= c1[k] ? 1 : -1;
+      out1[k] = centre - sign * half; out2[k] = centre + sign * half;
+    }
+    return { c1: out1, c2: out2 };
+  }
+
+  // netOverrides(ops) → { byCut: {cutId: {s:[dx,dy,dz], f:[fx,fy,fz]}}, sig } over the ACTIVE rows of one fold. Same
+  // walk as netShifts — sums GEOM_CUT_MOVE into s, multiplies GEOM_CUT_RESIZE into f (start [1,1,1]); only cutIds
+  // that are an active GEOM_CUT in the same list count. A GEOM_CUT_RESIZE row with any factor ≤0 or non-finite is
+  // IGNORED WHOLE (tolerant, like a cut-move naming a non-active cut) and logged. `sig` is a deterministic,
+  // order-independent signature ('' when none) — the cache-key suffix (spec §2 CACHE); an entry whose resize is
+  // still identity (f=[1,1,1]) prints the OLD shift-only shape so step 1's cache keys/signatures stay byte-identical
+  // when no resize is in play; a resize (alone or with a shift) appends `*fx,fy,fz`.
+  function netOverrides(ops) {
     var cuts = {}, byCut = {}, i, op, P, id;
     for (i = 0; i < (ops || []).length; i++) { op = ops[i]; if (op && op.op_type === 'GEOM_CUT') cuts[String(op.id)] = 1; }
     for (i = 0; i < (ops || []).length; i++) {
-      op = ops[i]; if (!op || op.op_type !== 'GEOM_CUT_MOVE') continue;
-      P = params(op); id = P.cutId != null ? String(P.cutId) : null;
-      if (id == null || !cuts[id]) continue;                                      // tolerant: names no active cut → ignored
-      var s = byCut[id] || (byCut[id] = [0, 0, 0]);
-      s[0] += +P.dx || 0; s[1] += +P.dy || 0; s[2] += +P.dz || 0;
+      op = ops[i]; if (!op) continue;
+      if (op.op_type === 'GEOM_CUT_MOVE') {
+        P = params(op); id = P.cutId != null ? String(P.cutId) : null;
+        if (id == null || !cuts[id]) continue;                                    // tolerant: names no active cut → ignored
+        var ov = byCut[id] || (byCut[id] = { s: [0, 0, 0], f: [1, 1, 1] });
+        ov.s[0] += +P.dx || 0; ov.s[1] += +P.dy || 0; ov.s[2] += +P.dz || 0;
+      } else if (op.op_type === 'GEOM_CUT_RESIZE') {
+        P = params(op); id = P.cutId != null ? String(P.cutId) : null;
+        if (id == null || !cuts[id]) continue;
+        var fx = P.fx != null ? +P.fx : 1, fy = P.fy != null ? +P.fy : 1, fz = P.fz != null ? +P.fz : 1;
+        var bad = function (v) { return !(v > 0) || !isFinite(v); };
+        if (bad(fx) || bad(fy) || bad(fz)) { console.log(TAG + ' ignored GEOM_CUT_RESIZE #' + op.id + ': non-positive factor'); continue; }
+        var ovr = byCut[id] || (byCut[id] = { s: [0, 0, 0], f: [1, 1, 1] });
+        ovr.f[0] *= fx; ovr.f[1] *= fy; ovr.f[2] *= fz;
+      }
     }
-    var keys = Object.keys(byCut).filter(function (k) { var s = byCut[k]; return s[0] !== 0 || s[1] !== 0 || s[2] !== 0; })
+    var keys = Object.keys(byCut).filter(function (k) { var o = byCut[k]; return o.s[0] !== 0 || o.s[1] !== 0 || o.s[2] !== 0 || o.f[0] !== 1 || o.f[1] !== 1 || o.f[2] !== 1; })
       .sort(function (a, b) { return (+a) - (+b); });
-    var sig = keys.map(function (k) { var s = byCut[k]; return k + ':' + s[0] + ',' + s[1] + ',' + s[2]; }).join(';');
+    var sig = keys.map(function (k) {
+      var o = byCut[k], out = k + ':' + o.s[0] + ',' + o.s[1] + ',' + o.s[2];
+      if (o.f[0] !== 1 || o.f[1] !== 1 || o.f[2] !== 1) out += '*' + o.f[0] + ',' + o.f[1] + ',' + o.f[2];
+      return out;
+    }).join(';');
     return { byCut: byCut, sig: sig };
+  }
+  // netShifts(ops) → { byCut: {cutId: [dx,dy,dz]}, sig } — a thin backwards-compatible wrapper over netOverrides
+  // (step 1's shape; bonsai_ifc keeps calling this) so callers unaware of resize see byte-identical output.
+  function netShifts(ops) {
+    var ov = netOverrides(ops), byCut = {};
+    Object.keys(ov.byCut).forEach(function (k) { var s = ov.byCut[k].s; if (s[0] !== 0 || s[1] !== 0 || s[2] !== 0) byCut[k] = s; });
+    return { byCut: byCut, sig: ov.sig };
   }
   function keySuffix(sig) { return sig ? '|cm:' + sig : ''; }
 
-  // cutsOver(ops, hostFid, box) → every ACTIVE GEOM_CUT {parent: host} whose (net-shifted) void overlaps `box` — the
-  // "a REAL carved void tied to THIS filling" rule bonsai_itemdrag.js bakedVoidFor introduced, now over the CURRENT
-  // void (prior cut-moves applied) so a hole that was already slid is still found under its door.
+  // cutsOver(ops, hostFid, box) → every ACTIVE GEOM_CUT {parent: host} whose (net-overridden) void overlaps `box` —
+  // the "a REAL carved void tied to THIS filling" rule bonsai_itemdrag.js bakedVoidFor introduced, now over the
+  // CURRENT void (prior cut-moves/resizes applied) so a hole that was already slid/resized is still found under its door.
   function cutsOver(ops, hostFid, box) {
-    var net = netShifts(ops), out = [];
+    var net = netOverrides(ops), out = [];
     for (var i = 0; i < (ops || []).length; i++) {
       var op = ops[i]; if (!op || op.op_type !== 'GEOM_CUT') continue;
       var P = params(op);
       if (!same(parentOf(op, P), hostFid) || !P.void || !P.void.c1 || !P.void.c2) continue;
-      if (overlaps(voidBox(shiftVoid(P.void, net.byCut[String(op.id)])), box)) out.push(op);
+      if (overlaps(voidBox(applyOverrides(P.void, net.byCut[String(op.id)])), box)) out.push(op);
     }
     return out;
   }
@@ -135,21 +176,28 @@
   // anchorShift({ cutOp, ops, hostBox, axis, f, translateDelta, minShift }) → { ok, s, q, delta, residual, F, w, reason }
   //   hostBox = the host's measured PRE-DRAG AABB (boxByFid layout); f/translateDelta = the SCALE command about to
   //   fold; minShift = Σ TRANSLATE deltas on this axis that precede the SCALE in the same gesture (usually 0).
+  // §CUT-RESIZE additions: g = 1/f — the authored-frame resize factor that cancels THIS fold's own proportional
+  // widening (spec §1: f·(F·w·g) = F·w); through = the void OVERHANGS the host on this axis (its box extends beyond
+  // the host's measured pre-drag AABB by more than THROUGH_TOL) — a through-axis (the bCut's thickness axis) gets NO
+  // resize (shrinking a through-void by 1/f could stop it cutting through). `residual` is unchanged: what a caller
+  // that emits no resize still sees.
   function anchorShift(a) {
     var k = typeof a.axis === 'string' ? AX[a.axis] : a.axis;
     var fr = frameScale(a.ops, a.cutOp, k);
     if (!fr.ok) return { ok: false, reason: fr.reason, F: fr.f };
-    var net = netShifts(a.ops), P = params(a.cutOp);
-    var vb = voidBox(shiftVoid(P.void, net.byCut[String(a.cutOp.id)]));
+    var net = netOverrides(a.ops), P = params(a.cutOp);
+    var vb = voidBox(applyOverrides(P.void, net.byCut[String(a.cutOp.id)]));
     var vc = (vb[2 * k] + vb[2 * k + 1]) / 2, w = vb[2 * k + 1] - vb[2 * k];
     var minNow = a.hostBox[2 * k] + (+a.minShift || 0), minCut = a.hostBox[2 * k] - fr.tPost;
     var f = a.f != null ? a.f : 1, t = +a.translateDelta || 0;
     var q = minNow + fr.f * (vc - minCut);                                     // the hole's CURRENT world centre
     var delta = (q - minNow) * (f - 1) + t;                                    // the fold's proportional shift of it
     var s = -delta / (f * fr.f);
-    return { ok: true, s: s, q: q, delta: delta, residual: (f - 1) * fr.f * w, F: fr.f, w: w, reason: null };
+    var through = vb[2 * k] < a.hostBox[2 * k] - THROUGH_TOL || vb[2 * k + 1] > a.hostBox[2 * k + 1] + THROUGH_TOL;
+    return { ok: true, s: s, q: q, delta: delta, residual: (f - 1) * fr.f * w, F: fr.f, w: w, g: 1 / f, through: through, reason: null };
   }
 
-  return { TAG: TAG, AX: AX, OVERLAP_EPS: OVERLAP_EPS, voidBox: voidBox, shiftVoid: shiftVoid, netShifts: netShifts,
-    keySuffix: keySuffix, cutsOver: cutsOver, frameScale: frameScale, slideShift: slideShift, anchorShift: anchorShift };
+  return { TAG: TAG, AX: AX, OVERLAP_EPS: OVERLAP_EPS, THROUGH_TOL: THROUGH_TOL, voidBox: voidBox, shiftVoid: shiftVoid,
+    applyOverrides: applyOverrides, netShifts: netShifts, netOverrides: netOverrides, keySuffix: keySuffix,
+    cutsOver: cutsOver, frameScale: frameScale, slideShift: slideShift, anchorShift: anchorShift };
 });

--- a/modeller/modeller.html
+++ b/modeller/modeller.html
@@ -205,8 +205,8 @@
 <!-- Bonsai kernel host (classic global window.Bonsai) — author() spawns the worker lazily. -->
 <!-- §CUT-MOVE (prompts/SPEC_GEOM_CUT_MOVE.md): the ONE definition of GEOM_CUT_MOVE — zero deps, loaded first; the
      module worker imports the SAME file (self.CutMove); bonsai_ifc / gridmove / itemdrag read window.CutMove at call time. -->
-<script src="cut_move.js?v=1" onerror="console.warn('§CUT-MOVE LOAD_FAIL cut_move.js')"></script>
-<script src="bonsai_kernel.js?v=8" onerror="console.warn('§BONSAI LOAD_FAIL bonsai_kernel.js')"></script>
+<script src="cut_move.js?v=2" onerror="console.warn('§CUT-MOVE LOAD_FAIL cut_move.js')"></script>
+<script src="bonsai_kernel.js?v=9" onerror="console.warn('§BONSAI LOAD_FAIL bonsai_kernel.js')"></script>
 <!-- Bonsai 2D sketch front: planegcs constraint solver -> solved profile -> GEOM_EXTRUDE_POLY. -->
 <script src="bonsai_sketch.js?v=1" onerror="console.warn('§SKETCH LOAD_FAIL bonsai_sketch.js')"></script>
 <!-- Signed op-log engine (shipped kernel_ops: hash chain + edge signature) + sql.js it commits into. -->
@@ -234,16 +234,16 @@ if (window.WholeHistory && WholeHistory.mount) WholeHistory.mount({ page: 'model
      tree engine the Viewer runs (common/history_bar.js), reused — not a second branch mechanism. The
      adapter wraps Bonsai.oplog.commit/commitGesture so every real edit lands as one tree node. -->
 <script src="../common/history_bar.js?v=1" onerror="console.warn('§MHIST LOAD_FAIL history_bar.js')"></script>
-<script src="modeller_history.js?v=2" onerror="console.warn('§MHIST LOAD_FAIL modeller_history.js')"></script>
+<script src="modeller_history.js?v=3" onerror="console.warn('§MHIST LOAD_FAIL modeller_history.js')"></script>
 <!-- Bonsai IFC export: the authored op-log -> a standards IFC4 file via web-ifc (author->sign->export). -->
 <script src="lib/web-ifc-api-iife.js" onerror="console.warn('§IFC LOAD_FAIL web-ifc-api-iife.js')"></script>
-<script src="bonsai_ifc.js?v=2" onerror="console.warn('§IFC LOAD_FAIL bonsai_ifc.js')"></script>
+<script src="bonsai_ifc.js?v=3" onerror="console.warn('§IFC LOAD_FAIL bonsai_ifc.js')"></script>
 <script src="bcf_export.js?v=1" onerror="console.warn('§BCF LOAD_FAIL bcf_export.js')"></script>
 <!-- Bonsai architectural authoring grid: column grid on the sketch plane + snap-to-grid (2D correlation). -->
 <script src="bonsai_grid.js?v=1" onerror="console.warn('§GRID LOAD_FAIL bonsai_grid.js')"></script>
 <!-- Grid Kinematics engine (§S270, pure recompose math) + the modeller adapter (gridline-drag → GEOM_GRID_MOVE). -->
 <script src="grid_kinematics.js" onerror="console.warn('§GRIDMOVE LOAD_FAIL grid_kinematics.js')"></script>
-<script src="bonsai_gridmove.js?v=2" onerror="console.warn('§GRIDMOVE LOAD_FAIL bonsai_gridmove.js')"></script>
+<script src="bonsai_gridmove.js?v=3" onerror="console.warn('§GRIDMOVE LOAD_FAIL bonsai_gridmove.js')"></script>
 <!-- Bonsai-faithful Outliner (the richer Find): Blender-style feature tree over the signed op-log. -->
 <script src="bonsai_outliner.js?v=13" onerror="console.warn('§OUTLINER LOAD_FAIL bonsai_outliner.js')"></script>
 <!-- BOM Tree composition facet (the ARC BOM editor): Open any extracted.db → seed an editable BOM tree; re-parent = signed op. -->

--- a/modeller/modeller_history.js
+++ b/modeller/modeller_history.js
@@ -18,7 +18,7 @@
   var OP_TYPES = { 'BUILDING_OPEN': true, 'GEOM_EXTRUDE': true, 'GEOM_EXTRUDE_POLY': true,
     'GEOM_SWEEP': true, 'GEOM_CUT': true, 'GEOM_FILLET': true, 'GEOM_GRID_MOVE': true,
     'GEOM_MOVE': true, 'GEOM_ROTATE': true, 'GEOM_SCALE': true, 'GEOM_INSERT': true,
-    'GEOM_OPENING': true, 'STR_WALK_EDIT': true, 'GEOM_DELETE': true, 'GEOM_CUT_MOVE': true };
+    'GEOM_OPENING': true, 'STR_WALK_EDIT': true, 'GEOM_DELETE': true, 'GEOM_CUT_MOVE': true, 'GEOM_CUT_RESIZE': true };
   var PROFILES = { high: { op: OP_TYPES } };
   PROFILES.all = PROFILES.high; PROFILES.doc = PROFILES.high;   // legacy aliases HistoryBar falls back to
 
@@ -28,6 +28,7 @@
     if (opType === 'GEOM_GRID_MOVE') return 'Grid ' + (p.label || p.gridId || '') + ' move';
     if (opType === 'GEOM_CUT') return 'Cut';
     if (opType === 'GEOM_CUT_MOVE') return 'Cut move #' + p.cutId;   // §CUT-MOVE (a lone commit; inside a gesture the first op labels the node)
+    if (opType === 'GEOM_CUT_RESIZE') return 'Cut resize #' + p.cutId;   // §CUT-RESIZE (ditto)
     if (opType === 'GEOM_FILLET') return 'Fillet';
     if (opType === 'GEOM_ROTATE') return 'Rotate';
     if (opType === 'GEOM_SCALE') return 'Scale';

--- a/modeller/tests/witness_cut_move.mjs
+++ b/modeller/tests/witness_cut_move.mjs
@@ -74,6 +74,7 @@ const WALL_BOX = [0, 4, 0, 0.2, 0, 3];
 const wallOp = (h) => ({ id: 1, op_hash: 'wall:' + h, op_type: 'GEOM_EXTRUDE_POLY', parameters: { profile: { points: [[0, 0], [4, 0], [4, 0.2], [0, 0.2]] }, depth: 3 } });
 const cutOp = (h) => ({ id: 2, op_hash: 'cut:' + h, op_type: 'GEOM_CUT', parent: 1, parameters: { parent: 1, void: { c1: [1.2, -0.5, 0.9], c2: [2.8, 0.7, 2.1] } } });
 const cmOp = (id, h, s, cutId) => ({ id, op_hash: 'cm:' + h + ':' + id, op_type: 'GEOM_CUT_MOVE', parent: 1, parameters: { cutId: cutId == null ? 2 : cutId, parent: 1, dx: s[0], dy: s[1], dz: s[2], induced: 'test' } });
+const rzOp = (id, h, fx, fy, fz, cutId) => ({ id, op_hash: 'rz:' + h + ':' + id, op_type: 'GEOM_CUT_RESIZE', parent: 1, parameters: { cutId: cutId == null ? 2 : cutId, parent: 1, fx: fx, fy: fy, fz: fz, induced: 'test' } });
 const gridOp = (id, h, f, td) => ({ id, op_hash: 'grid:' + h + ':' + id, op_type: 'GEOM_GRID_MOVE', parameters: { gridId: 'gx1', delta: 1, commands: [{ featureId: 1, action: 'SCALE', axis: 'x', newScale: f, translateDelta: td }] } });
 async function fold(ops) { const r = await send({ id: ++seq, ops }); if (!r.ok) throw new Error('fold failed: ' + r.error); const m = r.meshes.find(x => x.featureId === 1); return { box: aabb(m.positions), hole: holeX(m.positions, 0, 3), stats: r.stats }; }
 
@@ -143,6 +144,43 @@ const c6 = await fold(prior.concat([cmOp(4, 'c6', [s6, 0, 0])]));
 console.log('  C6 authored shift=' + s6 + ' hole=' + j(c6.hole));
 chk('C6 SLIDE-FOLD: after the prior stretch (hole centre 2.5), a slide of world +0.8 rides as authored 0.64; the folded hole centre is 3.3 = 2.5 + 0.8 exactly',
   approx(s6, 0.64) && approx(c6.hole.c, 3.3) && approx(c6.hole.w, 2.0), j(c6.hole));
+
+// ── R1 NET-OVERRIDES (pure) ─────────────────────────────────────────────────────────────────────────────────
+const n1r = CM.netOverrides([wallOp('A'), cutOp('A'), rzOp(3, 'r1', 0.5), rzOp(4, 'r1', 0.8), rzOp(5, 'r1', 0), rzOp(6, 'r1', 9, 9, 9, 777)]);
+const nsOnly = CM.netShifts([wallOp('A'), cutOp('A'), cmOp(3, 'r1s', [0.5, 0, 0]), cmOp(4, 'r1s', [0.3, 0, 0.1])]);
+console.log('  R1 f=' + j(n1r.byCut['2'] && n1r.byCut['2'].f) + ' sig=' + n1r.sig + ' netShifts-only sig=' + nsOnly.sig);
+chk('R1 NET-OVERRIDES: two GEOM_CUT_RESIZE rows fx=0.5 and fx=0.8 on cut #2 multiply to f=[0.4,1,1]; a row with fx=0 is IGNORED (and one naming non-active cut #777); sig contains both s and f; the netShifts wrapper (shift rows only, no resize in play) still returns the SAME sig SHAPE step 1 produced (backwards-compatible keys)',
+  n1r.byCut['2'] && approx(n1r.byCut['2'].f[0], 0.4) && approx(n1r.byCut['2'].f[1], 1) && approx(n1r.byCut['2'].f[2], 1) && !n1r.byCut['777'] &&
+  /^2:0,0,0\*0\.4,1,1$/.test(n1r.sig) && nsOnly.sig === '2:0.8,0,0.1' && CM.keySuffix(nsOnly.sig) === '|cm:2:0.8,0,0.1',
+  j({ sig: n1r.sig, f: n1r.byCut['2'].f, nsOnlySig: nsOnly.sig }));
+
+// ── R2 FOLD-RESIZE ───────────────────────────────────────────────────────────────────────────────────────────
+const r2 = await fold([wallOp('A'), cutOp('A'), rzOp(3, 'r2', 0.5)]);
+console.log('  R2 hole=' + j(r2.hole) + ' box=' + j(r2.box.map(v => +v.toFixed(4))));
+chk('R2 FOLD-RESIZE: + GEOM_CUT_RESIZE {cutId:2, fx:0.5} ⇒ the worker resizes the void ABOUT ITS OWN CENTRE to [1.6,2.4] (centre 2.0 kept, width 0.8); wall outline unchanged',
+  approx(r2.hole.xmin, 1.6) && approx(r2.hole.xmax, 2.4) && approx(r2.hole.c, 2.0) && approx(r2.hole.w, 0.8) && approx(r2.box[0], 0) && approx(r2.box[1], 4), j(r2.hole));
+
+// ── R3 WIDTH-HOLD ────────────────────────────────────────────────────────────────────────────────────────────
+const a3x = CM.anchorShift({ cutOp: cutOp('A'), ops: [wallOp('A'), cutOp('A')], hostBox: WALL_BOX, axis: 0, f: 1.25, translateDelta: 0 });
+const a3y = CM.anchorShift({ cutOp: cutOp('A'), ops: [wallOp('A'), cutOp('A')], hostBox: WALL_BOX, axis: 1, f: 1, translateDelta: 0 });
+const r3 = await fold([wallOp('A'), cutOp('A'), gridOp(3, 'r3', 1.25, 0), cmOp(4, 'r3', [a3x.s, 0, 0]), rzOp(5, 'r3', a3x.g)]);
+console.log('  R3 anchorShift.x=' + j(a3x) + ' anchorShift.y=' + j(a3y) + ' hole=' + j(r3.hole) + ' box=' + j(r3.box.map(v => +v.toFixed(4))));
+chk('R3 WIDTH-HOLD: GRID SCALE f=1.25 + GEOM_CUT_MOVE s=−0.4 (step 1\'s centre-hold) + GEOM_CUT_RESIZE fx=1/f=0.8 (the width-hold) ⇒ hole centre 2.0 AND width 1.6 EXACTLY (the step-1 residual is gone); anchorShift returns g=0.8 on x, through=false on x (in-plane) and through=true on y (the ±0.5 thickness overhang past the 0.2m-thick wall)',
+  a3x.ok && approx(a3x.g, 0.8) && a3x.through === false && a3y.through === true &&
+  approx(r3.hole.c, 2.0) && approx(r3.hole.w, 1.6) && approx(r3.box[1], 5), j({ a3x, a3y, hole: r3.hole }));
+
+// ── R4 COMMUTE ───────────────────────────────────────────────────────────────────────────────────────────────
+const r4 = await fold([wallOp('A'), cutOp('A'), gridOp(3, 'r4', 1.25, 0), rzOp(4, 'r4', a3x.g), cmOp(5, 'r4', [a3x.s, 0, 0])]);
+console.log('  R4 hole=' + j(r4.hole) + ' box=' + j(r4.box.map(v => +v.toFixed(4))));
+chk('R4 COMMUTE: the R3 chain with the MOVE and RESIZE rows swapped in id/array order ⇒ byte-identical hole (the resize is about the void\'s OWN centre and the shift moves that centre, so shift and resize commute — the row order in the log is irrelevant)',
+  approx(r4.hole.c, r3.hole.c, 1e-9) && approx(r4.hole.w, r3.hole.w, 1e-9) && approx(r4.hole.xmin, r3.hole.xmin, 1e-9) && approx(r4.hole.xmax, r3.hole.xmax, 1e-9), j({ r3: r3.hole, r4: r4.hole }));
+
+// ── R5 CACHE ─────────────────────────────────────────────────────────────────────────────────────────────────
+const r5 = await fold([wallOp('A'), cutOp('A')]);   // the SAME op_hashes as C0/C4 — must hit the ORIGINAL (unsuffixed) keys
+const sigR3 = CM.netOverrides([wallOp('A'), cutOp('A'), gridOp(3, 'r3', 1.25, 0), cmOp(4, 'r3', [a3x.s, 0, 0]), rzOp(5, 'r3', a3x.g)]).sig;
+console.log('  R5 hole=' + j(r5.hole) + ' stats=' + j(r5.stats) + ' sigR3=' + sigR3);
+chk('R5 CACHE: after the R2/R3 folds, re-folding the plain wall+cut chain (same op_hashes as C0) is a cache HIT and yields the ORIGINAL hole [1.2,2.8]; the R3 fold\'s cut-move+resize signature differs from step 1\'s shift-only signature (\'2:-0.4,0,0\') — resize is in the cache key, no stale hits either way',
+  approx(r5.hole.xmin, 1.2) && approx(r5.hole.xmax, 2.8) && r5.stats.hits >= 1 && r5.stats.rebuilt === 0 && sigR3 !== '2:-0.4,0,0', j({ hole: r5.hole, stats: r5.stats, sigR3 }));
 
 console.log('W-CUT-MOVE: ' + pass + ' PASS / ' + fail + ' FAIL');
 try { fs.rmSync(tmp, { recursive: true, force: true }); } catch (e) {}

--- a/modeller/tests/witness_e2e_cut_move.js
+++ b/modeller/tests/witness_e2e_cut_move.js
@@ -16,9 +16,10 @@
  *   M3 HOLE-FOLLOWS — the rendered hole moved by the SAME dx as the door (vertex-measured); width unchanged
  *   M4 UNDO        — ONE real Ctrl+Z (one gesture) deactivates both rows and restores door AND hole
  *   M5 ANCHOR      — Move-Grid: drag gridline B (x=4) +1 with the door HELD (anchor default) ⇒ GEOM_GRID_MOVE +
- *                    GEOM_CUT_MOVE (the inverse shift); door centre unchanged, hole centre unchanged (≤1e-3), the wall
- *                    is 5 m, the hole is 1.25× wide (the reported residual); §V7 label says "1 hole held"; verifyChain
- *   M6 UNDO        — ONE real Ctrl+Z restores wall, door and hole (the GEOM_CUT_MOVE rider undoes with its gesture)
+ *                    GEOM_CUT_MOVE (the inverse shift) + GEOM_CUT_RESIZE{fx≈1/f} (SPEC_GEOM_CUT_RESIZE.md §4 — the
+ *                    width-hold that fixes step 1's residual); door centre unchanged, hole centre AND WIDTH unchanged
+ *                    (≤1e-3, 1.6 m), the wall is 5 m; §V7 label says "1 hole held" with no "(Δw …)" suffix; verifyChain
+ *   M6 UNDO        — ONE real Ctrl+Z restores wall, door and hole (all three gesture rows undo together)
  */
 'use strict';
 const { runE2E } = require('./e2e_harness');
@@ -137,25 +138,29 @@ runE2E('W-E2E-CUT-MOVE', async (t) => {
   const after5 = await t.oplog(); const chain5 = await t.verifyChain();
   const ops5 = await t.pg.evaluate((fromLen) => {
     const added = window.Bonsai.oplog._geomOps().slice(fromLen);
-    const gm = added.find(o => o.op_type === 'GEOM_GRID_MOVE'), cm = added.find(o => o.op_type === 'GEOM_CUT_MOVE');
-    return { types: added.map(o => o.op_type), cmds: gm ? gm.parameters.commands : null, cm: cm ? cm.parameters : null };
+    const gm = added.find(o => o.op_type === 'GEOM_GRID_MOVE'), cm = added.find(o => o.op_type === 'GEOM_CUT_MOVE'), rz = added.find(o => o.op_type === 'GEOM_CUT_RESIZE');
+    return { types: added.map(o => o.op_type), cmds: gm ? gm.parameters.commands : null, cm: cm ? cm.parameters : null, rz: rz ? rz.parameters : null };
   }, before5.len);
   const hole5 = await holeOf(t, ids.host), door5 = await centreOf(t, ids.door);
   t.slog.slice(logAt).filter(l => /§GRIDMOVE commit|§CUT-MOVE|§DAGEVU/.test(l)).forEach(l => console.log('    ' + l.slice(0, 320))); logAt = t.slog.length;
   console.log('  §CUT-MOVE M5 dimLabel="' + mid5.dim + '" ops=' + JSON.stringify(ops5) + ' hole5=' + JSON.stringify(hole5) + ' door5=' + JSON.stringify(door5) + ' oplog ' + before5.len + '→' + after5.len + ' chain=' + chain5);
   const sc = ops5.cmds && ops5.cmds.find(c => c.featureId === ids.host && c.action === 'SCALE');
   const f = sc ? sc.newScale : NaN, wantS = sc ? -((hole4.c - hole4.wall[0]) * (f - 1) + (sc.translateDelta || 0)) / f : NaN;   // spec §3: s = −Δ/(f·F), F=1 here
-  t.assert('M5 ANCHOR (gesture = GEOM_GRID_MOVE(SCALE wall) + GEOM_CUT_MOVE{dx = −Δ/f}; the HELD door\'s centre is unchanged; the hole\'s centre is unchanged ≤1e-3 under the fold\'s own scale; hole width = f×1.6 (the reported residual); mid-drag §V7 label says "1 hole held"; verifyChain)',
-    after5.len === before5.len + 2 && ops5.cm && ops5.cm.cutId === cut.id && ops5.cm.induced === 'anchor-hold' && sc && near(ops5.cm.dx, wantS, 1e-6) && ops5.cm.dy === 0 &&
-    door5 && near(door5[0], door4[0], 1e-6) && hole5 && near(hole5.c, hole4.c, 1e-3) && near(hole5.w, hole4.w * f, 1e-3) && hole5.wall[1] > 4.5 &&
-    typeof mid5.dim === 'string' && /1 hole held/.test(mid5.dim) && chain5 === true,
-    'f=' + f + ' wantS=' + (isFinite(wantS) ? wantS.toFixed(4) : '?') + ' cm.dx=' + (ops5.cm ? ops5.cm.dx.toFixed(4) : '?') + ' hole4.c=' + hole4.c.toFixed(4) + ' hole5=' + JSON.stringify(hole5) + ' door4.x=' + door4[0].toFixed(4) + ' door5.x=' + (door5 ? door5[0].toFixed(4) : '?') + ' dim="' + mid5.dim + '"');
+  // §CUT-RESIZE (SPEC_GEOM_CUT_RESIZE.md §4 M5): a THIRD row rides the SAME gesture — GEOM_CUT_RESIZE{fx≈1/f, fy=fz=1} —
+  // and the hole's WORLD width is now UNCHANGED (1.6 m, not f×1.6): the step 1 residual is gone.
+  t.assert('M5 ANCHOR (gesture = GEOM_GRID_MOVE(SCALE wall) + GEOM_CUT_MOVE{dx = −Δ/f} + GEOM_CUT_RESIZE{fx≈1/f, fy=fz=1}; the HELD door\'s centre is unchanged; the hole\'s centre AND WIDTH are unchanged ≤1e-3 (1.6 m, the step-1 residual is gone); mid-drag §V7 label matches "1 hole held" with NO "(Δw …)" suffix; verifyChain)',
+    after5.len === before5.len + 3 && ops5.cm && ops5.cm.cutId === cut.id && ops5.cm.induced === 'anchor-hold' && sc && near(ops5.cm.dx, wantS, 1e-6) && ops5.cm.dy === 0 &&
+    ops5.rz && ops5.rz.cutId === cut.id && ops5.rz.induced === 'anchor-hold' && near(ops5.rz.fx, 1 / f, 1e-6) && ops5.rz.fy === 1 && ops5.rz.fz === 1 &&
+    door5 && near(door5[0], door4[0], 1e-6) && hole5 && near(hole5.c, hole4.c, 1e-3) && near(hole5.w, hole4.w, 1e-3) && hole5.wall[1] > 4.5 &&
+    typeof mid5.dim === 'string' && /1 hole held(?! \()/.test(mid5.dim) && chain5 === true,
+    'f=' + f + ' wantS=' + (isFinite(wantS) ? wantS.toFixed(4) : '?') + ' cm.dx=' + (ops5.cm ? ops5.cm.dx.toFixed(4) : '?') + ' rz.fx=' + (ops5.rz ? ops5.rz.fx.toFixed(4) : '?') +
+    ' hole4.c=' + hole4.c.toFixed(4) + ' hole5=' + JSON.stringify(hole5) + ' door4.x=' + door4[0].toFixed(4) + ' door5.x=' + (door5 ? door5[0].toFixed(4) : '?') + ' dim="' + mid5.dim + '"');
   await t.shot('07-stretched-held');
 
   // ── M6 UNDO ───────────────────────────────────────────────────────────────────────────────────────────────────
   await ctrlZ(t);
   const undone6 = await t.oplog(); const hole6 = await holeOf(t, ids.host); const door6 = await centreOf(t, ids.door);
-  t.assert('M6 UNDO (ONE real Ctrl+Z: both gesture rows deactivated, wall back to 4 m, hole back at its pre-stretch extent, door unchanged)',
+  t.assert('M6 UNDO (ONE real Ctrl+Z: all three gesture rows — GRID_MOVE, CUT_MOVE, CUT_RESIZE — deactivated, wall back to 4 m, hole back at its pre-stretch extent, door unchanged)',
     undone6.len === before5.len && hole6 && near(hole6.wall[1], 4, 1e-6) && near(hole6.xmin, hole4.xmin, 1e-6) && near(hole6.xmax, hole4.xmax, 1e-6) && door6 && near(door6[0], door4[0], 1e-6), JSON.stringify({ len: undone6.len, want: before5.len, hole6 }));
   await t.shot('08-undone');
 }, { width: 1280, height: 860, dpr: 2 });

--- a/prompts/SPEC_GEOM_CUT_RESIZE.md
+++ b/prompts/SPEC_GEOM_CUT_RESIZE.md
@@ -90,6 +90,22 @@ Guards to re-run and paste counts into §5: witness_opening_slide (10/10), witne
 witness_gridmove_fold_pure 12/12, witness_dagevu_engine 13/13. Known pre-existing: witness_e2e_cut C4/C6 fail on
 untouched main (pixel-sum checks) — do not "fix" them here, note them.
 
-## §5 Status
-- [ ] cut_move.js netOverrides/applyOverrides/anchorShift.g,through · [ ] worker fold + v9 · [ ] gridmove resize rider
-- [ ] ifc/history/html registration · [ ] W-CUT-MOVE R1-R5 · [ ] W-E2E-CUT-MOVE M5/M6 updated · [ ] guards pasted
+## §5 Status (2026-09-11)
+- [x] cut_move.js netOverrides/applyOverrides/anchorShift.g,through · [x] worker fold + v9 · [x] gridmove resize rider
+- [x] ifc/history/html registration · [x] W-CUT-MOVE R1-R5 · [x] W-E2E-CUT-MOVE M5/M6 updated · [x] guards pasted
+- [x] witness_cut_move.mjs 16/16 (REAL worker fold: C0-C6 as step 1 + R1 f=[0.4,1,1] sig with *fx,fy,fz suffix, netShifts
+  wrapper byte-identical when shift-only; R2 fx=0.5 ⇒ hole [1.6,2.4]; R3 GRID SCALE f=1.25 + s=−0.4 + fx=g=0.8 ⇒ hole
+  centre 2.0 AND width 1.6 EXACTLY, anchorShift.through=false on x / true on y; R4 MOVE/RESIZE swapped in log order ⇒
+  byte-identical hole; R5 plain wall+cut re-fold is a cache HIT with the original hole, R3's signature differs from
+  step 1's shift-only signature)
+- [x] witness_e2e_cut_move.js 8/8 (real bCut + real mouse: M1-M4 unchanged from step 1; M5 gesture = GEOM_GRID_MOVE +
+  GEOM_CUT_MOVE{dx=-0.4} + GEOM_CUT_RESIZE{fx=0.8,fy=fz=1}, hole centre AND width unchanged (1.6 m, the step 1
+  residual is gone), dimLabel exactly "… · 1 held · 1 hole held" (no Δw suffix); M6 one real Ctrl+Z reverts all three
+  gesture rows)
+- [x] guards: witness_opening_slide 10/10 · witness_gridmove_fold_pure 12/12 · witness_dagevu_engine 13/13 ·
+  witness_e2e_opening_slide 8/8 (O0 7/7 real SampleHouse refusals) · witness_e2e_gridstretch 7/7 ·
+  witness_e2e_stretch_ride 11/11 · witness_e2e_grid_greenorange 13/13
+- witness_e2e_cut C4/C6 (framebuffer pixel-sum checks, pix 9970636→9970636) FAIL IDENTICALLY to untouched main —
+  pre-existing (spec preamble step 1 §6), not this change; C1-C3/C5 pass.
+- STEP 3 (not built): a 90°-multiple GEOM_ROTATE frame mapping for a host rotated after its cut — spec
+  prompts/SPEC_CUT_FRAME_ROTATE.md, flagged ask-first, low priority.


### PR DESCRIPTION
## Summary
- New signed op `GEOM_CUT_RESIZE {cutId, parent, fx, fy, fz}`: a multiplicative, per-axis resize of an earlier GEOM_CUT's void about its own centre, folded like `GEOM_CUT_MOVE` (pre-scan + override at the cut's own log position; the signed `GEOM_CUT` row is never rewritten).
- `cut_move.js` grows from `netShifts` (shift-only) to `netOverrides` (shift+resize, one signature, backwards-compatible when no resize is in play) with a shared `applyOverrides` fold; `netShifts` kept as a thin wrapper.
- The grid ANCHOR path (`bonsai_gridmove.js`) now also emits a resize rider `g = 1/f` alongside its `GEOM_CUT_MOVE` rider, so a held door's hole WORLD WIDTH is unchanged after a stretch — fixing the width residual step 1 only reported.
- A through-axis (the bCut's thickness axis) gets NO resize — only the in-plane axis is held.

Implements `prompts/SPEC_GEOM_CUT_RESIZE.md` (step 2 of `prompts/SPEC_GEOM_CUT_MOVE.md`, merged as #1711). Step 3 (`prompts/SPEC_CUT_FRAME_ROTATE.md`, rotated-after-cut hosts) is out of scope — flagged ask-first, low priority.

## Witnesses (§4/§5 of the spec — counts read from the logs)

| Witness | Result |
|---|---|
| W-CUT-MOVE (`witness_cut_move.mjs`, real worker fold) | 16/16 — C0-C6 (step 1) + R1-R5 (new) |
| W-E2E-CUT-MOVE (`witness_e2e_cut_move.js`, real bCut + real mouse) | 8/8 — M1-M4 unchanged, M5 gesture = GRID_MOVE + CUT_MOVE + CUT_RESIZE, hole width unchanged (1.6 m), dimLabel `… · 1 held · 1 hole held` (no Δw suffix), M6 one Ctrl+Z reverts all three rows |
| witness_opening_slide | 10/10 |
| witness_gridmove_fold_pure | 12/12 |
| witness_dagevu_engine | 13/13 |
| witness_e2e_opening_slide | 8/8 (O0 7/7 real SampleHouse refusals) |
| witness_e2e_gridstretch | 7/7 |
| witness_e2e_stretch_ride | 11/11 |
| witness_e2e_grid_greenorange | 13/13 |
| witness_e2e_cut | 5/7 — C4/C6 (framebuffer pixel-sum checks, pix 9970636→9970636) fail identically on untouched main; pre-existing, not this change |

R2/R3 numbers: `fx=0.5` on the [1.2,2.8] void ⇒ [1.6,2.4] (centre kept); GRID SCALE f=1.25 + `dx=-0.4` + `fx=0.8` ⇒ hole centre 2.0 AND width 1.6 EXACTLY (the step-1 residual is gone).

## Test plan
- [x] `node witness_cut_move.mjs` — 16/16
- [x] `node witness_e2e_cut_move.js` — 8/8
- [x] Guards above — all green except the documented pre-existing `witness_e2e_cut` C4/C6

🤖 Generated with [Claude Code](https://claude.com/claude-code)