### PR TITLE
feat(modeller): cut frame under a 90°-multiple GEOM_ROTATE (cut-move step 3)

### DIFF
--- a/modeller/bonsai_gridmove.js
+++ b/modeller/bonsai_gridmove.js
@@ -332,11 +332,14 @@
             if (c.action === 'TRANSLATE') { minShift[k] += c.delta || 0; continue; }
             const r = CM.anchorShift({ cutOp, ops, hostBox: hb, axis: k, f: c.newScale != null ? c.newScale : 1, translateDelta: c.translateDelta || 0, minShift: minShift[k] });
             if (!r.ok) { bad = r.reason; break; }
-            d[k] += r.s;
+            // §CUT-FRAME-ROTATE: r.s/r.g are AUTHORED-frame quantities — place them at r.authoredAxis (= M.perm[k]),
+            // NOT at the world axis k, once a post-cut rotation can permute the frame (identity-perm ⇒ same index,
+            // so this is a no-op for every unrotated host — byte-identical to step 1/2).
+            d[r.authoredAxis] += r.s;
             // §CUT-RESIZE (SPEC_GEOM_CUT_RESIZE.md §3): a non-through axis is fully held — accumulate the resize
             // g=1/f and the residual on it is 0; a through axis (the bCut's thickness axis) gets NO resize and keeps
             // reporting its residual as before (shrinking a through-void by 1/f could stop it cutting through).
-            if (!r.through) { g[k] *= r.g; } else if (Math.abs(r.residual) > Math.abs(res)) res = r.residual;
+            if (!r.through) { g[r.authoredAxis] *= r.g; } else if (Math.abs(r.residual) > Math.abs(res)) res = r.residual;
           }
           if (bad) { out.refused.push(cutOp.id); refusals.push({ kind: 'cut-move-unmappable', fillingFid: fid, hostFid: host, cutId: cutOp.id, reason: bad }); continue; }
           out.riders.push({ cutId: cutOp.id, parent: host, dx: d[0], dy: d[1], dz: d[2], fx: g[0], fy: g[1], fz: g[2], fillingFid: fid, residual: res });

--- a/modeller/bonsai_itemdrag.js
+++ b/modeller/bonsai_itemdrag.js
@@ -321,11 +321,14 @@
     var probe = edge.constrain([0, 0, 0], { boxByFid: boxByFid });
     if (!probe) return refuse('engine refused the pre-drag pose itself (' + JSON.stringify(edge.refusal) + ')');
     var axis = probe.axis === 'x' ? 0 : 1, tMin = probe.tMin, tMax = probe.tMax;
-    var cuts = [];                                                    // §CUT-MOVE: [{cutId, parent, F}] per carved void
+    var cuts = [];                                                    // §CUT-MOVE: [{cutId, parent, F, M}] per carved void
+    // §CUT-FRAME-ROTATE (prompts/SPEC_CUT_FRAME_ROTATE.md): hostFrame (not frameScale) so a host rotated by a
+    // 90°-multiple after its cut still slides — the authored shift may land on a DIFFERENT authored axis than the
+    // slide's own world axis (slideShiftM resolves this at commit time). F is kept for logging/back-compat only.
     for (var ci = 0; ci < cutRows.length; ci++) {
-      var fr = CM.frameScale(ctx.geomOps, cutRows[ci], axis);
-      if (!fr.ok) return refuse('carved void GEOM_CUT #' + cutRows[ci].id + ' cannot follow the slide — ' + fr.reason + '; refusing rather than leaving the hole behind');
-      cuts.push({ cutId: cutRows[ci].id, parent: fe.hostFid, F: fr.f });
+      var hf = CM.hostFrame(ctx.geomOps, cutRows[ci], hb);
+      if (!hf.ok) return refuse('carved void GEOM_CUT #' + cutRows[ci].id + ' cannot follow the slide — ' + hf.reason + '; refusing rather than leaving the hole behind');
+      cuts.push({ cutId: cutRows[ci].id, parent: fe.hostFid, F: Math.abs(hf.M.a[axis]), M: hf.M });
     }
     var moved = [fid]; if (ob) moved.push(fe.openingFid);
     // S3 gate inputs: every mesh box EXCEPT invisible ride anchors (modeller.html _gateBoxes excludes them too).
@@ -467,14 +470,17 @@
       return { op_type: 'GEOM_MOVE', parameters: { parent: f, dx: op.parameters.dx, dy: op.parameters.dy, dz: op.parameters.dz, induced: 'fills-opening' } };
     }) : [];
     // §CUT-MOVE S5: every carved void tied to the filling rides by the SAME world delta, expressed in the cut's
-    // AUTHORED frame on the slide axis (cut_move.js slideShift = t / F; the other components are 0 by construction) —
-    // one GEOM_CUT_MOVE rider per cut, in the same gesture group (one Ctrl+Z reverts door + hole together).
+    // AUTHORED frame — one GEOM_CUT_MOVE rider per cut, in the same gesture group (one Ctrl+Z reverts door + hole
+    // together). §CUT-FRAME-ROTATE: slideShiftM(d, cu.M) (not slideShift(t,F)) so a host rotated by a 90°-multiple
+    // after its cut lands the shift on the correct (possibly permuted) authored axis, not just the slide's own
+    // world axis; for an unrotated host (M identity-perm) this is byte-identical to `slideShift(d[axis], cu.F)`.
     if (session.slide && session.slide.cuts && session.slide.cuts.length) {
       var CMd = _dep(null, 'CutMove', './cut_move.js');
       session.slide.cuts.forEach(function (cu) {
         var d = [op.parameters.dx, op.parameters.dy, op.parameters.dz];
-        d[session.slide.axis] = CMd.slideShift(d[session.slide.axis], cu.F);
-        riders.push({ op_type: 'GEOM_CUT_MOVE', parameters: { cutId: cu.cutId, parent: cu.parent, dx: d[0], dy: d[1], dz: d[2], induced: 'fills-opening' } });
+        var dWorld = [0, 0, 0]; dWorld[session.slide.axis] = d[session.slide.axis];
+        var s = CMd.slideShiftM(dWorld, cu.M);
+        riders.push({ op_type: 'GEOM_CUT_MOVE', parameters: { cutId: cu.cutId, parent: cu.parent, dx: s[0], dy: s[1], dz: s[2], induced: 'fills-opening' } });
       });
     }
     return { committed: true, verdict: v, op: op, riders: riders };

--- a/modeller/cut_move.js
+++ b/modeller/cut_move.js
@@ -173,31 +173,138 @@
   // slideShift(t, F) → the authored-frame shift that moves the hole by world t.
   function slideShift(t, F) { return (+t || 0) / (F || 1); }
 
-  // anchorShift({ cutOp, ops, hostBox, axis, f, translateDelta, minShift }) → { ok, s, q, delta, residual, F, w, reason }
-  //   hostBox = the host's measured PRE-DRAG AABB (boxByFid layout); f/translateDelta = the SCALE command about to
-  //   fold; minShift = Σ TRANSLATE deltas on this axis that precede the SCALE in the same gesture (usually 0).
-  // §CUT-RESIZE additions: g = 1/f — the authored-frame resize factor that cancels THIS fold's own proportional
-  // widening (spec §1: f·(F·w·g) = F·w); through = the void OVERHANGS the host on this axis (its box extends beyond
-  // the host's measured pre-drag AABB by more than THROUGH_TOL) — a through-axis (the bCut's thickness axis) gets NO
-  // resize (shrinking a through-void by 1/f could stop it cutting through). `residual` is unchanged: what a caller
-  // that emits no resize still sees.
+  // §CUT-FRAME-ROTATE (prompts/SPEC_CUT_FRAME_ROTATE.md — cut-move step 3): hostFrame(ops, cutOp, hostBoxNow) →
+  // { ok, M:{perm,a,b}, boxAtCut, reason }. M is the affine map authored→world composed from the ACTIVE post-cut ops
+  // that transform the host, in log order: world_k = a_k · authored_{perm[k]} + b_k. With only TRANSLATE / SCALE /
+  // a 90°-multiple ROTATE this map is "axis-aligned affine" (§1). TRANSLATE and SCALE are the SAME self-referential-
+  // anchor transforms frameScale already walked (a SCALE anchors at its OWN current min, so the min's own trajectory
+  // is purely additive translateDelta regardless of intervening scale factors — this is WHY frameScale never needed
+  // to measure the host box). A 90°-multiple ROTATE has the identical property (it spins about its OWN current bbox
+  // centre), so a BACKWARD replay from the measured `hostBoxNow` — undoing each post-cut op in reverse — recovers
+  // `boxAtCut` (the host's box AT THE CUT's own moment) exactly, then a FORWARD replay from boxAtCut composes M
+  // (tracking the box forward too, since SCALE's m_k and ROTATE's centre c are read off the box AT THAT MOMENT).
+  var ROT_HALF_PI = Math.PI / 2;
+  function mapPoint(M, p) { return [M.a[0] * p[M.perm[0]] + M.b[0], M.a[1] * p[M.perm[1]] + M.b[1], M.a[2] * p[M.perm[2]] + M.b[2]]; }
+  // mapBox: authored box corners → world box (min/max per world axis; a_k may be negative under a rotation flip).
+  function mapBox(M, box) {
+    var c1 = [box[0], box[2], box[4]], c2 = [box[1], box[3], box[5]], w1 = mapPoint(M, c1), w2 = mapPoint(M, c2);
+    return [Math.min(w1[0], w2[0]), Math.max(w1[0], w2[0]), Math.min(w1[1], w2[1]), Math.max(w1[1], w2[1]), Math.min(w1[2], w2[2]), Math.max(w1[2], w2[2])];
+  }
+  // swapXYAboutCentre: the box-shape effect of a 90° OR 270° rotation about the box's OWN centre (x/y half-extents
+  // swap, centre invariant); self-inverse (applying it twice restores the original box) — used both forward and
+  // backward for odd n. A 180° rotation about its own centre leaves the box shape unchanged (only M's sign/b flip).
+  function swapXYAboutCentre(box) {
+    var cx = (box[0] + box[1]) / 2, cy = (box[2] + box[3]) / 2, hx = (box[1] - box[0]) / 2, hy = (box[3] - box[2]) / 2;
+    return [cx - hy, cx + hy, cy - hx, cy + hx, box[4], box[5]];
+  }
+  // applyRotateToM: compose a n·90° rotation (about the CURRENT box centre cx,cy) onto M — spec §1's three explicit
+  // cases (n≡1 given verbatim; n≡2/n≡3 derived the same way — substitute world_x/world_y into the point-rotation law).
+  function applyRotateToM(M, n, cx, cy) {
+    var perm = M.perm, a = M.a, b = M.b;
+    if (n === 1) { M.perm = [perm[1], perm[0], perm[2]]; M.a = [-a[1], a[0], a[2]]; M.b = [cx + cy - b[1], cy - cx + b[0], b[2]]; }
+    else if (n === 2) { M.a = [-a[0], -a[1], a[2]]; M.b = [2 * cx - b[0], 2 * cy - b[1], b[2]]; }
+    else if (n === 3) { M.perm = [perm[1], perm[0], perm[2]]; M.a = [a[1], -a[0], a[2]]; M.b = [cx - cy + b[1], cx + cy - b[0], b[2]]; }
+  }
+  function hostFrame(ops, cutOp, hostBoxNow) {
+    var host = parentOf(cutOp, params(cutOp)), events = [], i;
+    for (i = 0; i < (ops || []).length; i++) {
+      var op = ops[i]; if (!op || !(op.id > cutOp.id)) continue;
+      var P = params(op);
+      if (op.op_type === 'GEOM_GRID_MOVE') {
+        var cmds = P.commands || [];
+        for (var j = 0; j < cmds.length; j++) {
+          var c = cmds[j]; if (!c || !same(c.featureId, host)) continue;
+          var k = AX[c.axis]; if (k == null) continue;
+          if (c.action === 'TRANSLATE') { var d0 = [0, 0, 0]; d0[k] = +c.delta || 0; events.push({ type: 't', d: d0 }); continue; }
+          var tiltX = typeof c.tiltXRad === 'number' && isFinite(c.tiltXRad) ? Math.abs(c.tiltXRad) : 0;
+          var tiltY = typeof c.tiltYRad === 'number' && isFinite(c.tiltYRad) ? Math.abs(c.tiltYRad) : 0;
+          if (tiltX > YAW_TOL || tiltY > YAW_TOL) continue;                     // worker: refused no-op
+          var oblique = typeof c.yawRad === 'number' && isFinite(c.yawRad) && Math.abs(c.yawRad - Math.round(c.yawRad / HALF_PI) * HALF_PI) > YAW_TOL;
+          if (oblique && (c.axis === 'x' || c.axis === 'y')) return { ok: false, reason: 'oblique-yaw-scale-after-cut (GEOM_GRID_MOVE #' + op.id + ')' };
+          events.push({ type: 's', axis: k, f: c.newScale != null ? c.newScale : 1, t: +c.translateDelta || 0 });
+        }
+      } else if (op.op_type === 'GEOM_MOVE') {
+        if (same(parentOf(op, P), host)) events.push({ type: 't', d: [+P.dx || 0, +P.dy || 0, +P.dz || 0] });
+      } else if (op.op_type === 'GEOM_ROOM_MOVE') {
+        var mem = P.members || []; for (var m = 0; m < mem.length; m++) if (mem[m] && same(mem[m].featureId, host)) { events.push({ type: 't', d: [+P.dx || 0, +P.dy || 0, +P.dz || 0] }); break; }
+      } else if (op.op_type === 'GEOM_ROTATE') {
+        if (!same(parentOf(op, P), host)) continue;
+        var deg = P.drot != null ? P.drot : (P.deg || 0), theta = deg * Math.PI / 180, nExact = theta / ROT_HALF_PI, n = Math.round(nExact);
+        if (Math.abs(theta - n * ROT_HALF_PI) > YAW_TOL) return { ok: false, reason: 'oblique-rotate-after-cut (GEOM_ROTATE #' + op.id + ') — the authored axis is no longer a world axis' };
+        n = ((n % 4) + 4) % 4; if (n !== 0) events.push({ type: 'r', n: n });
+      } else if (op.op_type === 'GEOM_ARRAY') {
+        if (same(parentOf(op, P), host)) return { ok: false, reason: 'arrayed-after-cut (GEOM_ARRAY #' + op.id + ') — the host was replaced by clones' };
+      }
+    }
+    // BACKWARD replay: hostBoxNow → boxAtCut, undoing each event in reverse.
+    var box = hostBoxNow.slice();
+    for (i = events.length - 1; i >= 0; i--) {
+      var ev = events[i];
+      if (ev.type === 't') { for (var kk = 0; kk < 3; kk++) { box[2 * kk] -= ev.d[kk] || 0; box[2 * kk + 1] -= ev.d[kk] || 0; } }
+      else if (ev.type === 's') { var kx = ev.axis, minAfter = box[2 * kx], maxAfter = box[2 * kx + 1], minBefore = minAfter - ev.t, width = (maxAfter - minAfter) / (ev.f || 1); box[2 * kx] = minBefore; box[2 * kx + 1] = minBefore + width; }
+      else if (ev.type === 'r' && (ev.n === 1 || ev.n === 3)) { box = swapXYAboutCentre(box); }
+    }
+    var boxAtCut = box;
+    // FORWARD replay: compose M from boxAtCut, tracking the box forward for each SCALE's m_k / ROTATE's centre c.
+    var M = { perm: [0, 1, 2], a: [1, 1, 1], b: [0, 0, 0] }, curBox = boxAtCut.slice();
+    for (i = 0; i < events.length; i++) {
+      var e = events[i];
+      if (e.type === 't') { for (var kt = 0; kt < 3; kt++) { M.b[kt] += e.d[kt] || 0; curBox[2 * kt] += e.d[kt] || 0; curBox[2 * kt + 1] += e.d[kt] || 0; } }
+      else if (e.type === 's') {
+        var ks = e.axis, mk = curBox[2 * ks], fk = e.f, tk = e.t;
+        M.a[ks] *= fk; M.b[ks] = fk * M.b[ks] + mk * (1 - fk) + tk;
+        var newMin = mk + tk, widthBefore = curBox[2 * ks + 1] - curBox[2 * ks];
+        curBox[2 * ks] = newMin; curBox[2 * ks + 1] = newMin + fk * widthBefore;
+      } else if (e.type === 'r') {
+        var cx = (curBox[0] + curBox[1]) / 2, cy = (curBox[2] + curBox[3]) / 2;
+        applyRotateToM(M, e.n, cx, cy);
+        if (e.n === 1 || e.n === 3) curBox = swapXYAboutCentre(curBox);
+      }
+    }
+    var check = mapBox(M, boxAtCut), TOL9 = 1e-9;
+    for (i = 0; i < 6; i++) if (Math.abs(check[i] - hostBoxNow[i]) > TOL9) return { ok: false, reason: 'frame-replay-mismatch (axis ' + (i >> 1) + ')' };
+    return { ok: true, M: M, boxAtCut: boxAtCut, reason: null };
+  }
+  // slideShiftM(d, M) → the authored-frame shift vector that moves the hole by WORLD delta d (the frame-general form
+  // of slideShift; d is nonzero only on the slide's own world axis by construction, but this composes any 3-vector).
+  function slideShiftM(d, M) {
+    var s = [0, 0, 0];
+    for (var k = 0; k < 3; k++) s[M.perm[k]] = (d[k] || 0) / (M.a[k] || 1);
+    return s;
+  }
+
+  // anchorShift({ cutOp, ops, hostBox, axis, f, translateDelta, minShift }) → { ok, s, q, delta, residual, F, w, g,
+  //   through, authoredAxis, reason }. hostBox = the host's measured PRE-DRAG AABB; f/translateDelta = the SCALE
+  //   command about to fold; minShift = Σ TRANSLATE deltas on this axis preceding the SCALE in the same gesture.
+  // Internally calls hostFrame (§CUT-FRAME-ROTATE) instead of frameScale, so a host rotated by a 90°-multiple after
+  // its cut is handled too; for an unrotated host (M identity-perm, a=F) every number is BYTE-IDENTICAL to step 1/2.
+  // `authoredAxis` = M.perm[axis] — the AUTHORED axis `s`/`g` land on (a caller placing them into a per-axis vector
+  // MUST index by this, not by the world `axis` passed in, once a rotation can permute the frame).
+  // §CUT-RESIZE: g = 1/f cancels THIS fold's own proportional widening (f·(F·w·g) = F·w, independent of sign/perm);
+  // through = the void OVERHANGS the host on WORLD axis `axis` (mapped through M, compared with hostBox) — a
+  // through-axis (the bCut's thickness axis) gets NO resize (shrinking it by 1/f could stop it cutting through).
   function anchorShift(a) {
     var k = typeof a.axis === 'string' ? AX[a.axis] : a.axis;
-    var fr = frameScale(a.ops, a.cutOp, k);
-    if (!fr.ok) return { ok: false, reason: fr.reason, F: fr.f };
+    var hf = hostFrame(a.ops, a.cutOp, a.hostBox);
+    if (!hf.ok) return { ok: false, reason: hf.reason, F: null };
+    var M = hf.M, pk = M.perm[k], ak = M.a[k];
     var net = netOverrides(a.ops), P = params(a.cutOp);
     var vb = voidBox(applyOverrides(P.void, net.byCut[String(a.cutOp.id)]));
-    var vc = (vb[2 * k] + vb[2 * k + 1]) / 2, w = vb[2 * k + 1] - vb[2 * k];
-    var minNow = a.hostBox[2 * k] + (+a.minShift || 0), minCut = a.hostBox[2 * k] - fr.tPost;
+    var vCentre = [(vb[0] + vb[1]) / 2, (vb[2] + vb[3]) / 2, (vb[4] + vb[5]) / 2];
+    var w = vb[2 * pk + 1] - vb[2 * pk];                                       // authored-axis width on the pre-image axis
+    var q = mapPoint(M, vCentre)[k];                                          // the hole's CURRENT world centre on axis k
+    var minNow = a.hostBox[2 * k] + (+a.minShift || 0);
     var f = a.f != null ? a.f : 1, t = +a.translateDelta || 0;
-    var q = minNow + fr.f * (vc - minCut);                                     // the hole's CURRENT world centre
     var delta = (q - minNow) * (f - 1) + t;                                    // the fold's proportional shift of it
-    var s = -delta / (f * fr.f);
-    var through = vb[2 * k] < a.hostBox[2 * k] - THROUGH_TOL || vb[2 * k + 1] > a.hostBox[2 * k + 1] + THROUGH_TOL;
-    return { ok: true, s: s, q: q, delta: delta, residual: (f - 1) * fr.f * w, F: fr.f, w: w, g: 1 / f, through: through, reason: null };
+    var s = -delta / (f * ak);
+    var Fmag = Math.abs(ak);
+    var wvb = mapBox(M, vb);                                                   // the void box mapped into WORLD
+    var through = wvb[2 * k] < a.hostBox[2 * k] - THROUGH_TOL || wvb[2 * k + 1] > a.hostBox[2 * k + 1] + THROUGH_TOL;
+    return { ok: true, s: s, q: q, delta: delta, residual: (f - 1) * Fmag * w, F: Fmag, w: w, g: 1 / f, through: through, authoredAxis: pk, reason: null };
   }
 
   return { TAG: TAG, AX: AX, OVERLAP_EPS: OVERLAP_EPS, THROUGH_TOL: THROUGH_TOL, voidBox: voidBox, shiftVoid: shiftVoid,
     applyOverrides: applyOverrides, netShifts: netShifts, netOverrides: netOverrides, keySuffix: keySuffix,
-    cutsOver: cutsOver, frameScale: frameScale, slideShift: slideShift, anchorShift: anchorShift };
+    cutsOver: cutsOver, frameScale: frameScale, slideShift: slideShift, hostFrame: hostFrame, mapPoint: mapPoint,
+    mapBox: mapBox, slideShiftM: slideShiftM, anchorShift: anchorShift };
 });

--- a/modeller/tests/witness_cut_move.mjs
+++ b/modeller/tests/witness_cut_move.mjs
@@ -50,6 +50,13 @@ function holeX(p, zlo, zhi) {
   for (let i = 0; i < p.length; i += 3) { const z = p[i + 2]; if (z > zlo + 1e-6 && z < zhi - 1e-6) { xmin = Math.min(xmin, p[i]); xmax = Math.max(xmax, p[i]); n++; } }
   return { xmin, xmax, c: (xmin + xmax) / 2, w: xmax - xmin, n };
 }
+// §CUT-FRAME-ROTATE: the same technique, generalized to any axis (0=x,1=y) — after a 90°/270° rotation the hole's
+// long axis is Y, not X.
+function holeExtent(p, axis, zlo, zhi) {
+  let mn = Infinity, mx = -Infinity, n = 0;
+  for (let i = 0; i < p.length; i += 3) { const z = p[i + 2]; if (z > zlo + 1e-6 && z < zhi - 1e-6) { const v = p[i + axis]; mn = Math.min(mn, v); mx = Math.max(mx, v); n++; } }
+  return { min: mn, max: mx, c: (mn + mx) / 2, w: mx - mn, n };
+}
 
 console.log('═══ W-CUT-MOVE — GEOM_CUT_MOVE through the REAL worker fold + cut_move.js frame math (node, occt-wasm) ═══');
 
@@ -76,7 +83,8 @@ const cutOp = (h) => ({ id: 2, op_hash: 'cut:' + h, op_type: 'GEOM_CUT', parent:
 const cmOp = (id, h, s, cutId) => ({ id, op_hash: 'cm:' + h + ':' + id, op_type: 'GEOM_CUT_MOVE', parent: 1, parameters: { cutId: cutId == null ? 2 : cutId, parent: 1, dx: s[0], dy: s[1], dz: s[2], induced: 'test' } });
 const rzOp = (id, h, fx, fy, fz, cutId) => ({ id, op_hash: 'rz:' + h + ':' + id, op_type: 'GEOM_CUT_RESIZE', parent: 1, parameters: { cutId: cutId == null ? 2 : cutId, parent: 1, fx: fx, fy: fy, fz: fz, induced: 'test' } });
 const gridOp = (id, h, f, td) => ({ id, op_hash: 'grid:' + h + ':' + id, op_type: 'GEOM_GRID_MOVE', parameters: { gridId: 'gx1', delta: 1, commands: [{ featureId: 1, action: 'SCALE', axis: 'x', newScale: f, translateDelta: td }] } });
-async function fold(ops) { const r = await send({ id: ++seq, ops }); if (!r.ok) throw new Error('fold failed: ' + r.error); const m = r.meshes.find(x => x.featureId === 1); return { box: aabb(m.positions), hole: holeX(m.positions, 0, 3), stats: r.stats }; }
+const rotOp = (id, h, drot) => ({ id, op_hash: 'rot:' + h + ':' + id, op_type: 'GEOM_ROTATE', parent: 1, parameters: { parent: 1, drot } });
+async function fold(ops) { const r = await send({ id: ++seq, ops }); if (!r.ok) throw new Error('fold failed: ' + r.error); const m = r.meshes.find(x => x.featureId === 1); return { box: aabb(m.positions), hole: holeX(m.positions, 0, 3), positions: m.positions, stats: r.stats }; }
 
 // ── C0 BASE ──────────────────────────────────────────────────────────────────────────────────────────────────
 const c0 = await fold([wallOp('A'), cutOp('A')]);
@@ -181,6 +189,86 @@ const sigR3 = CM.netOverrides([wallOp('A'), cutOp('A'), gridOp(3, 'r3', 1.25, 0)
 console.log('  R5 hole=' + j(r5.hole) + ' stats=' + j(r5.stats) + ' sigR3=' + sigR3);
 chk('R5 CACHE: after the R2/R3 folds, re-folding the plain wall+cut chain (same op_hashes as C0) is a cache HIT and yields the ORIGINAL hole [1.2,2.8]; the R3 fold\'s cut-move+resize signature differs from step 1\'s shift-only signature (\'2:-0.4,0,0\') — resize is in the cache key, no stale hits either way',
   approx(r5.hole.xmin, 1.2) && approx(r5.hole.xmax, 2.8) && r5.stats.hits >= 1 && r5.stats.rebuilt === 0 && sigR3 !== '2:-0.4,0,0', j({ hole: r5.hole, stats: r5.stats, sigR3 }));
+
+// ── F0 IDENTITY (pure) ───────────────────────────────────────────────────────────────────────────────────────
+// A chain with no rotation: hostFrame must give byte-identical numbers to frameScale/anchorShift/slideShift (step 1/2).
+const f0hf = CM.hostFrame([wallOp('A'), cutOp('A'), gridOp(3, 'f0', 1.25, 0), mv], cutOp('A'), [0, 5, 0.5, 0.7, 0, 3]);
+const f0anchor = CM.anchorShift({ cutOp: cutOp('A'), ops: [wallOp('A'), cutOp('A')], hostBox: WALL_BOX, axis: 0, f: 1.25, translateDelta: 0 });
+const f0slide = CM.slideShiftM([0.8, 0, 0], CM.hostFrame(prior, cutOp('A'), [0, 5, 0, 0.2, 0, 3]).M);
+console.log('  F0 hostFrame=' + j(f0hf) + ' anchorShift.s=' + f0anchor.s + ' slideShiftM=' + j(f0slide));
+chk('F0 IDENTITY: a chain with no rotation gives M = {perm id, a=[1.25,1,1], b=[0.5,0,0]} for the C5 fixture (SCALE f=1.25 then MOVE dx=0.5 — the general-point affine offset b, NOT frameScale\'s old tPost which only tracked the min\'s own telescoping trajectory: here hostBoxNow starts at [0,5,0.5,0.7,...] so boxAtCut is [-0.5,3.5,0.5,0.7,...], and b = 0.5 − 0.25·boxAtCut.min = 0.625, independently verified by direct point-mapping below); anchorShift/slideShiftM reduce to the EXACT C3b/C6 numbers (s=−0.4, slideShiftM=0.64)',
+  f0hf.ok && JSON.stringify(f0hf.M.perm) === '[0,1,2]' && approx(f0hf.M.a[0], 1.25) && approx(f0hf.M.b[0], 0.625) &&
+  approx(f0anchor.s, -0.4) && approx(f0slide[0], 0.64), j({ M: f0hf.M, anchorS: f0anchor.s, slide: f0slide }));
+// independent cross-check of b via direct point-mapping (authored x=2 → world, through SCALE then MOVE, by hand):
+// SCALE(f=1.25, m=boxAtCut.min=-0.5, t=0): world = 1.25*2 + (-0.5)*(1-1.25) = 2.5+0.125 = 2.625; MOVE +0.5 ⇒ 3.125.
+const f0check = CM.mapPoint(f0hf.M, [2, 0, 0])[0];
+chk('F0 CROSS-CHECK: mapPoint(M,[2,0,0]) on x = 3.125 (independently hand-derived above) — confirms M.b is correct even though it differs from the spec text\'s parenthetical example (b=[0.5,0,0], which conflates b with frameScale\'s tPost)',
+  approx(f0check, 3.125), 'mapPoint=' + f0check);
+
+// ── F1 ROTATE-90 ─────────────────────────────────────────────────────────────────────────────────────────────
+const r1pre = await fold([wallOp('A'), cutOp('A'), rotOp(3, 'f1', 90)]);
+console.log('  F1 pre-slide box=' + j(r1pre.box.map(v => +v.toFixed(4))));
+const f1hf = CM.hostFrame([wallOp('A'), cutOp('A'), rotOp(3, 'f1', 90)], cutOp('A'), r1pre.box);
+const holeY1 = holeExtent(r1pre.positions, 1, r1pre.box[4], r1pre.box[5]);
+const holeXr1 = holeExtent(r1pre.positions, 0, r1pre.box[4], r1pre.box[5]);
+console.log('  F1 hostFrame=' + j(f1hf) + ' holeY=' + j(holeY1) + ' holeX=' + j(holeXr1));
+chk('F1 ROTATE-90: wall+cut+GEOM_ROTATE drot=90 ⇒ hostFrame gives perm=[1,0,2] (world x reads authored y, world y reads authored x), a=[-1,1,1] (a 90° spin swaps axes and flips one sign), the sanity invariant mapBox(M,boxAtCut)==hostBoxNow held (hf.ok); folded through the REAL worker the hole\'s world extent is now along Y (centre 0.1, width 1.6 = the authored X/door-width, unchanged by rotation) with a narrow X extent (centre 2.0, width 0.2 = the wall\'s own thickness — the void\'s oversized authored through-overshoot on Y was already CLIPPED to the wall\'s [0,0.2] at cut time, before the rotate) — the hole followed the host\'s spin',
+  f1hf.ok && JSON.stringify(f1hf.M.perm) === '[1,0,2]' && approx(f1hf.M.a[0], -1) && approx(f1hf.M.a[1], 1) &&
+  approx(holeY1.c, 0.1, 1e-3) && approx(holeY1.w, 1.6, 1e-3) && approx(holeXr1.c, 2.0, 1e-3) && approx(holeXr1.w, 0.2, 1e-3), j({ M: f1hf.M, holeY1, holeXr1 }));
+// SLIDE after the rotate: a world +0.8 along Y maps to authored s — sign/axis per the rotation (slideShiftM, not slideShift/F).
+const f1slide = CM.slideShiftM([0, 0.8, 0], f1hf.M);
+const r1post = await fold([wallOp('A'), cutOp('A'), rotOp(3, 'f1', 90), cmOp(4, 'f1', f1slide)]);
+const holeY1b = holeExtent(r1post.positions, 1, r1post.box[4], r1post.box[5]);
+console.log('  F1 SLIDE authored s=' + j(f1slide) + ' holeY-after=' + j(holeY1b));
+chk('F1 SLIDE: slideShiftM([0,0.8,0], M) ⇒ authored shift lands on x (s=[0.8,0,0], the pre-image axis perm[1]=0) since a[1]=1 (no sign flip on this component); folding the resulting GEOM_CUT_MOVE moves the hole +0.8 in world Y exactly (0.1→0.9)',
+  approx(f1slide[0], 0.8) && f1slide[1] === 0 && f1slide[2] === 0 && approx(holeY1b.c, 0.9, 1e-3) && approx(holeY1b.w, 1.6, 1e-3), j({ f1slide, holeY1b }));
+
+// ── F2 ROTATE-180 ────────────────────────────────────────────────────────────────────────────────────────────
+const r2pre = await fold([wallOp('A'), cutOp('A'), rotOp(3, 'f2', 180)]);
+const f2hf = CM.hostFrame([wallOp('A'), cutOp('A'), rotOp(3, 'f2', 180)], cutOp('A'), r2pre.box);
+console.log('  F2 pre-stretch box=' + j(r2pre.box.map(v => +v.toFixed(4))) + ' hostFrame=' + j(f2hf));
+chk('F2 ROTATE-180: perm stays identity (no axis swap) but a=[-1,-1,1] and b=[4,0.2,0] — a point reflection through the box\'s own centre, so world min = authored max on this axis (authored x=0 maps to world x=4, the wall\'s hi edge)',
+  f2hf.ok && JSON.stringify(f2hf.M.perm) === '[0,1,2]' && approx(f2hf.M.a[0], -1) && approx(f2hf.M.a[1], -1) && approx(f2hf.M.b[0], 4) && approx(f2hf.M.b[1], 0.2), j(f2hf.M));
+// ANCHOR stretch f=1.25 on the rotated wall — the void happens to be centred on the host's own bbox centre in this
+// fixture, so a 180° spin leaves its WORLD position unchanged (2.0,0.1) and the held-centre/width numbers match F0/C3b
+// exactly, reached through the sign-flipped (mirrored) authored path instead of the identity one.
+const f2anchorX = CM.anchorShift({ cutOp: cutOp('A'), ops: [wallOp('A'), cutOp('A'), rotOp(3, 'f2', 180)], hostBox: r2pre.box, axis: 0, f: 1.25, translateDelta: 0 });
+const f2anchorY = CM.anchorShift({ cutOp: cutOp('A'), ops: [wallOp('A'), cutOp('A'), rotOp(3, 'f2', 180)], hostBox: r2pre.box, axis: 1, f: 1, translateDelta: 0 });
+const f2moveVec = [0, 0, 0]; f2moveVec[f2anchorX.authoredAxis] = f2anchorX.s;
+const f2resizeVec = [1, 1, 1]; f2resizeVec[f2anchorX.authoredAxis] = f2anchorX.g;
+const r2post = await fold([wallOp('A'), cutOp('A'), rotOp(3, 'f2', 180), gridOp(4, 'f2', 1.25, 0),
+  cmOp(5, 'f2', f2moveVec), rzOp(6, 'f2', f2resizeVec[0], f2resizeVec[1], f2resizeVec[2])]);
+const holeXr2 = holeExtent(r2post.positions, 0, r2post.box[4], r2post.box[5]);
+console.log('  F2 anchorShift.x=' + j(f2anchorX) + ' anchorShift.y=' + j(f2anchorY) + ' holeX-after=' + j(holeXr2) + ' box=' + j(r2post.box.map(v => +v.toFixed(4))));
+chk('F2 ANCHOR: a GRID SCALE f=1.25 stretch of the 180°-rotated wall, held via anchorShift\'s computed rider (authoredAxis, s, g placed correctly despite the sign flip) ⇒ hole centre AND width EXACTLY UNCHANGED at 2.0/1.6 (fold-verified) — the resize keeps its width under the mirrored frame too; anchorShift.y.through=true (the ±0.5 thickness overhang, unaffected by the in-plane rotation)',
+  f2anchorX.ok && f2anchorX.authoredAxis === 0 && f2anchorY.through === true &&
+  approx(holeXr2.c, 2.0, 1e-3) && approx(holeXr2.w, 1.6, 1e-3) && approx(r2post.box[1], 5, 1e-3), j({ f2anchorX, holeXr2 }));
+
+// ── F3 ROTATE-270 and 90+90 COMPOSE TO 180 ──────────────────────────────────────────────────────────────────
+const r3pre = await fold([wallOp('A'), cutOp('A'), rotOp(3, 'f3', 270)]);
+const f3hf = CM.hostFrame([wallOp('A'), cutOp('A'), rotOp(3, 'f3', 270)], cutOp('A'), r3pre.box);
+console.log('  F3 ROTATE-270 hostFrame=' + j(f3hf));
+chk('F3 ROTATE-270: perm=[1,0,2] (axes swap, same as 90°) but a=[1,-1,1] (the OPPOSITE sign pattern to 90°) — folded, the hole is along Y again but on the other side',
+  f3hf.ok && JSON.stringify(f3hf.M.perm) === '[1,0,2]' && approx(f3hf.M.a[0], 1) && approx(f3hf.M.a[1], -1), j(f3hf.M));
+const r3double = await fold([wallOp('A'), cutOp('A'), rotOp(3, 'f3d', 90), rotOp(4, 'f3d', 90)]);
+const f3dhf = CM.hostFrame([wallOp('A'), cutOp('A'), rotOp(3, 'f3d', 90), rotOp(4, 'f3d', 90)], cutOp('A'), r3double.box);
+console.log('  F3 TWO×90 hostFrame=' + j(f3dhf) + ' box=' + j(r3double.box.map(v => +v.toFixed(4))));
+chk('F3 COMPOSE: TWO GEOM_ROTATE drot=90 rows in the log compose to the SAME M as F2\'s single drot=180 (perm identity, a=[-1,-1,1], b matches F2\'s [4,0.2,0]) — rotation composition is associative regardless of how many discrete 90° rows produced it',
+  f3dhf.ok && JSON.stringify(f3dhf.M.perm) === '[0,1,2]' && approx(f3dhf.M.a[0], -1) && approx(f3dhf.M.a[1], -1) && approx(f3dhf.M.b[0], f2hf.M.b[0], 1e-6) && approx(f3dhf.M.b[1], f2hf.M.b[1], 1e-6), j({ f3dhf: f3dhf.M, f2: f2hf.M }));
+
+// ── F4 OBLIQUE ───────────────────────────────────────────────────────────────────────────────────────────────
+const f4hf = CM.hostFrame([wallOp('A'), cutOp('A'), rotOp(3, 'f4', 30)], cutOp('A'), WALL_BOX);
+console.log('  F4 hostFrame=' + j(f4hf));
+chk('F4 OBLIQUE: drot=30 (not a 90°-multiple) ⇒ hostFrame REFUSES (ok:false, reason oblique-rotate-after-cut) — never an approximated frame; bonsai_itemdrag.js S6b (witness_opening_slide.js) independently confirms the slide session still refuses for this same fixture',
+  f4hf.ok === false && /oblique-rotate-after-cut/.test(f4hf.reason), j(f4hf));
+
+// ── F5 REPLAY ────────────────────────────────────────────────────────────────────────────────────────────────
+const r5pre = await fold([wallOp('A'), cutOp('A'), mv, gridOp(5, 'f5', 1.25, 0), rotOp(6, 'f5', 90)]);
+const f5hf = CM.hostFrame([wallOp('A'), cutOp('A'), mv, gridOp(5, 'f5', 1.25, 0), rotOp(6, 'f5', 90)], cutOp('A'), r5pre.box);
+const f5check = f5hf.ok ? CM.mapBox(f5hf.M, f5hf.boxAtCut) : null;
+console.log('  F5 hostBoxNow=' + j(r5pre.box.map(v => +v.toFixed(6))) + ' hostFrame=' + j(f5hf) + ' mapBox(M,boxAtCut)=' + j(f5check && f5check.map(v => +v.toFixed(6))));
+chk('F5 REPLAY: TRANSLATE 0.5 then SCALE f=1.25 then ROTATE 90 ⇒ hostFrame succeeds (its OWN internal sanity check already asserts this) AND an independent re-computation here of mapBox(M,boxAtCut) matches the REAL measured hostBoxNow (from the actual worker fold) to ≤1e-6 on every one of the 6 box numbers — the backward/forward replay is self-consistent, not just internally trusted',
+  f5hf.ok && f5check && f5check.every((v, i) => approx(v, r5pre.box[i], 1e-6)), j({ mapBox: f5check, hostBoxNow: r5pre.box }));
 
 console.log('W-CUT-MOVE: ' + pass + ' PASS / ' + fail + ' FAIL');
 try { fs.rmSync(tmp, { recursive: true, force: true }); } catch (e) {}

--- a/modeller/tests/witness_e2e_cut_move.js
+++ b/modeller/tests/witness_e2e_cut_move.js
@@ -38,6 +38,14 @@ const holeOf = (t, fid) => t.pg.evaluate((f) => {
   return { xmin, xmax, c: (xmin + xmax) / 2, w: xmax - xmin, n, wall: [bb.min.x, bb.max.x] };
 }, fid);
 const near = (a, b, tol) => Math.abs(a - b) <= tol;
+// §CUT-FRAME-ROTATE (M7): holeOf generalized to any axis (0=x,1=y) — after a 90° rotate the hole's long axis is Y.
+const holeOnAxis = (t, fid, axis) => t.pg.evaluate((f, ax) => {
+  const g = window.Bonsai.group(); const m = g.children.find(o => o.isMesh && o.userData.featureId === f);
+  if (!m) return null; m.geometry.computeBoundingBox(); const bb = m.geometry.boundingBox;
+  const p = m.geometry.getAttribute('position').array; let mn = Infinity, mx = -Infinity, n = 0;
+  for (let i = 0; i < p.length; i += 3) { const z = p[i + 2]; if (z > bb.min.z + 1e-6 && z < bb.max.z - 1e-6) { const v = p[i + ax]; mn = Math.min(mn, v); mx = Math.max(mx, v); n++; } }
+  return { min: mn, max: mx, c: (mn + mx) / 2, w: mx - mn, n };
+}, fid, axis);
 // the REAL undo path (modeller.html keydown → doUndo): ONE gesture = ONE Ctrl+Z — unlike the history slider (a scrub:
 // a prefix re-fold that leaves every row ACTIVE), this deactivates the gesture's rows so the NEXT commit builds on the
 // reverted log — exactly what M5 needs after M2.
@@ -162,5 +170,68 @@ runE2E('W-E2E-CUT-MOVE', async (t) => {
   const undone6 = await t.oplog(); const hole6 = await holeOf(t, ids.host); const door6 = await centreOf(t, ids.door);
   t.assert('M6 UNDO (ONE real Ctrl+Z: all three gesture rows — GRID_MOVE, CUT_MOVE, CUT_RESIZE — deactivated, wall back to 4 m, hole back at its pre-stretch extent, door unchanged)',
     undone6.len === before5.len && hole6 && near(hole6.wall[1], 4, 1e-6) && near(hole6.xmin, hole4.xmin, 1e-6) && near(hole6.xmax, hole4.xmax, 1e-6) && door6 && near(door6[0], door4[0], 1e-6), JSON.stringify({ len: undone6.len, want: before5.len, hole6 }));
+
+  // ── M7 ROTATE-90 + SLIDE (SPEC_CUT_FRAME_ROTATE.md §3, cut-move step 3): a host rotated after its cut still
+  // slides — hostFrame (not frameScale) resolves the authored→world map through the 90° spin. The ROTATE itself
+  // is committed via the REAL production path: select the wall, enter Move mode, type 90⏎ into #dim-rot (the SAME
+  // typed-commit path W-E2E-NUMROT/W-E2E-SCALEROT prove for a standalone B-rep solid — modeller.html's own comment
+  // at the GEOM_ROTATE worker branch lists "extrude/poly walls" as spinnable). No fallback to oplog.commit needed.
+  await t.pg.evaluate((f) => window.Bonsai.select(f), ids.host); await t.sleep(150);
+  await t.clickSel('#b-move'); await t.sleep(350);
+  const before7 = await t.oplog();
+  await t.pg.click('#dim-rot'); await t.pg.type('#dim-rot', '90'); await t.pg.keyboard.press('Enter'); await t.sleep(1000);
+  const rot7 = await t.lastOp(); const after7 = await t.oplog();
+  t.slog.slice(logAt).filter(l => /§CUT-MOVE|ROTATE/.test(l)).forEach(l => console.log('    ' + l.slice(0, 320))); logAt = t.slog.length;
+  console.log('  §CUT-MOVE M7a rot7=' + JSON.stringify(rot7) + ' oplog ' + before7.len + '→' + after7.len);
+  t.assert('M7a ROTATE (real #dim-rot typed commit on the wall, a standalone GEOM_EXTRUDE_POLY solid: ONE signed GEOM_ROTATE {parent:host, drot:90})',
+    after7.len === before7.len + 1 && rot7 && rot7.op_type === 'GEOM_ROTATE' && rot7.parameters.parent === ids.host && rot7.parameters.drot === 90,
+    JSON.stringify({ before: before7.len, after: after7.len, rot7 }));
+  await t.clickSel('#b-move'); await t.sleep(250);   // exit move mode — back to the neutral state M1/M2/M5 ran from
+  await t.shot('08-rotated');
+  const holeY7pre = await holeOnAxis(t, ids.host, 1), door7pre = await centreOf(t, ids.door);
+  console.log('  §CUT-MOVE M7 post-rotate holeY=' + JSON.stringify(holeY7pre) + ' door=' + JSON.stringify(door7pre));
+
+  // ── M7b GRAB: the door (still authored along the OLD x-axis, unrotated itself) grabs into a slide session whose
+  // axis is now the wall's NEW long axis — world Y (HostFillEdge.constrain reads the host's CURRENT AABB).
+  const grab7 = await t.pg.evaluate((fid) => {
+    const ok = window.__armItemDrag(fid, {}); const s = window.Bonsai.itemdrag._session;
+    return ok && s && s.slide ? { ok, axis: s.slide.axis, cuts: s.slide.cuts, tMin: s.slide.tMin, tMax: s.slide.tMax } : { ok, slide: false };
+  }, ids.door);
+  t.slog.slice(logAt).filter(l => /§SLIDE|§CUT-MOVE/.test(l)).forEach(l => console.log('    ' + l.slice(0, 300))); logAt = t.slog.length;
+  console.log('  §CUT-MOVE M7b grab7=' + JSON.stringify(grab7));
+  t.assert('M7b GRAB (post-rotate, the door grabs into a SLIDE session on the wall\'s NEW long axis — world Y — carrying the same cut; hostFrame replaces frameScale so this is no longer the S6b oblique-rotate refusal, a CLEAN 90° spin is honestly mappable)',
+    grab7.ok && grab7.axis === 1 && Array.isArray(grab7.cuts) && grab7.cuts.length === 1 && grab7.cuts[0].cutId === cut.id, JSON.stringify(grab7));
+  if (!grab7.ok || grab7.slide === false) { console.log('  M7 SKIPPED (grab refused) — see §SLIDE REFUSED reason in the log above'); }
+  else {
+    // ── M7c COMMIT+MATHS: a real +0.8m mouse drag along world Y ─────────────────────────────────────────────────
+    const T7 = 0.8;
+    const q0 = await t.proj(door7pre[0], door7pre[1], door7pre[2]), q1 = await t.proj(door7pre[0], door7pre[1] + T7, door7pre[2]);
+    const before7b = await t.oplog();
+    await t.pg.mouse.move(q0[0], q0[1]); await t.sleep(40); await t.pg.mouse.down(); await t.sleep(40);
+    await t.pg.mouse.move((q0[0] + q1[0]) / 2, (q0[1] + q1[1]) / 2, { steps: 5 }); await t.sleep(120);
+    await t.pg.mouse.move(q1[0], q1[1], { steps: 5 }); await t.sleep(150);
+    await t.pg.mouse.up(); await t.sleep(1200);
+    const after7b = await t.oplog(); const chain7 = await t.verifyChain();
+    const ops7 = await t.pg.evaluate((fromLen) => {
+      const added = window.Bonsai.oplog._geomOps().slice(fromLen);
+      const mv = added.find(o => o.op_type === 'GEOM_MOVE'), cm = added.find(o => o.op_type === 'GEOM_CUT_MOVE');
+      return { types: added.map(o => o.op_type), mv: mv ? mv.parameters : null, cm: cm ? cm.parameters : null };
+    }, before7b.len);
+    const holeY7post = await holeOnAxis(t, ids.host, 1), door7post = await centreOf(t, ids.door);
+    t.slog.slice(logAt).filter(l => /§ITEMDRAG commit|§CUT-MOVE/.test(l)).forEach(l => console.log('    ' + l.slice(0, 320))); logAt = t.slog.length;
+    console.log('  §CUT-MOVE M7c ops=' + JSON.stringify(ops7) + ' holeY ' + JSON.stringify(holeY7pre) + '→' + JSON.stringify(holeY7post) + ' door ' + JSON.stringify(door7pre) + '→' + JSON.stringify(door7post) + ' oplog ' + before7b.len + '→' + after7b.len + ' chain=' + chain7);
+    t.assert('M7c COMMIT+MATHS (ONE gesture: GEOM_MOVE(door) + GEOM_CUT_MOVE{cutId, via slideShiftM — the authored shift may land on a DIFFERENT axis than the slide\'s own world axis}; door AND hole moved together in world Y by ≈0.8m, x unchanged on both; verifyChain true)',
+      after7b.len === before7b.len + 2 && ops7.mv && ops7.cm && ops7.cm.cutId === cut.id &&
+      near(door7post[1] - door7pre[1], T7, 0.06) && near(door7post[0], door7pre[0], 1e-6) &&
+      near(holeY7post.c - holeY7pre.c, T7, 0.05) && near(holeY7post.w, holeY7pre.w, 1e-3) && chain7 === true,
+      JSON.stringify({ ops7, dDoorY: door7post[1] - door7pre[1], dHoleY: holeY7post.c - holeY7pre.c }));
+
+    // ── M7d UNDO ───────────────────────────────────────────────────────────────────────────────────────────────
+    await ctrlZ(t);
+    const undone7 = await t.oplog(); const holeY7undo = await holeOnAxis(t, ids.host, 1); const door7undo = await centreOf(t, ids.door);
+    t.assert('M7d UNDO (ONE real Ctrl+Z reverts the slide gesture: hole and door back at their post-rotate, pre-slide positions)',
+      undone7.len === before7b.len && near(holeY7undo.c, holeY7pre.c, 1e-3) && door7undo && near(door7undo[1], door7pre[1], 1e-3),
+      JSON.stringify({ len: undone7.len, want: before7b.len, holeY7undo, door7undo }));
+  }
   await t.shot('08-undone');
 }, { width: 1280, height: 860, dpr: 2 });

--- a/prompts/SPEC_CUT_FRAME_ROTATE.md
+++ b/prompts/SPEC_CUT_FRAME_ROTATE.md
@@ -70,5 +70,51 @@ gizmo if one exists for solids (grep `GEOM_ROTATE` commits in modeller.html; els
 for the fixture, say so in the assert name), re-inject the fills row, real-drag the door along the wall's NEW long axis
 (y) by 0.8 and assert hole + door moved together in Y, x unchanged, one gesture, Ctrl+Z reverts.
 
-## §4 Status
-- [ ] hostFrame + backward replay · [ ] slideShiftM / anchorShift via M · [ ] itemdrag/gridmove switched · [ ] F0-F5 · [ ] M7
+## §4 Status (2026-09-11)
+- [x] hostFrame + backward/forward replay (cut_move.js) · [x] slideShiftM · [x] anchorShift rewritten to call
+  hostFrame internally (byte-identical for an unrotated host) · [x] itemdrag/gridmove switched · [x] F0-F5 · [x] M7
+- **Deviations from the spec text** (both deliberate, both explained where they land in the code):
+  1. `frameScale`/`slideShift` are left COMPLETELY UNTOUCHED rather than rewritten as a "thin wrapper over
+     hostFrame" — the existing standalone algorithm is already exact for an identity-perm host (proved: a SCALE
+     anchors at its own current min, so the min's trajectory is pure additive `ΣtranslateDelta` regardless of
+     intervening scale factors — this is WHY frameScale never needed to measure the host box), and rewriting it
+     added risk for zero behavioral gain. `hostFrame` is the new general primitive; both are exported side by side.
+  2. The spec's own C5 example numbers (`a=[1.25,1,1], b=[0.5,0,0]`) are WRONG — `b` is the general-point affine
+     offset (needed to map the void's CENTRE, not just the host's min), which is a genuinely different quantity
+     from frameScale's `tPost` (a min-only telescoping sum). For the exact C5 fixture (hostBoxNow starting at
+     `[0,5,0.5,0.7,...]`), the correct `b.x = 0.625`, independently verified two ways in witness_cut_move.mjs's F0
+     (direct point-mapping AND anchorShift/slideShiftM reducing to the EXACT byte-identical step-1/2 numbers,
+     s=−0.4, slideShiftM=0.64 — which a `b=0.5` would NOT reproduce). Documented inline in the F0 witness.
+  3. `bonsai_gridmove.js`'s `_cutRiders` needed a real (small) fix, not zero changes as first assumed: `d[k] +=
+     r.s` / `g[k] *= r.g` were indexed by the SCALE command's WORLD axis `k`, but `r.s`/`r.g` are AUTHORED-frame
+     quantities — under a permuted frame these belong at `r.authoredAxis` (`M.perm[k]`), not `k`. Fixed by adding
+     `authoredAxis` to anchorShift's return and indexing by it (byte-identical for an unrotated host, since
+     `authoredAxis === k` there).
+  4. **Known, undocumented-until-now limitation, left OUT of scope**: `cutsOver` (used by
+     `bonsai_itemdrag.js beginSlideSession` and `bonsai_gridmove.js _cutRiders` to discover "is this GEOM_CUT
+     coincident with this filling") compares the void's box in the cut's AUTHORED frame directly against the
+     filling's WORLD box — correct for an unrotated host (authored ≡ world), but NOT rotation-aware: it never maps
+     the void through `hostFrame` before the overlap check. M7's witness happens to pass because the fixture's
+     void and door boxes still numerically overlap post-rotation by coincidence (the void was never moved off its
+     original X-position before the rotate); a differently-positioned fixture could fail to discover a real
+     coincident cut under a rotated host. Fixing this is a discovery-heuristic problem, not a frame-math one —
+     outside this spec's stated scope ("Everything step 1/2 emits [...] is re-expressed through this one map",
+     which lists slide/anchor shift/resize, not `cutsOver`). Flagged here for a future spec if it ever bites.
+- [x] witness_cut_move.mjs 26/26 (C0-C6 + R1-R5 unchanged + F0 IDENTITY×2, F1 ROTATE-90×2 — real worker fold,
+  hole's world extent swaps to Y width 1.6 centred 0.1, X width 0.2 (the wall's own thickness, the void's oversized
+  through-overshoot having already been CLIPPED to it at cut time, before the rotate) — F2 ROTATE-180×1 (mirror,
+  `a=[-1,-1,1]`, anchor-held centre/width EXACT through the sign-flipped path), F3 ROTATE-270×1 + two 90°s compose
+  to F2's map×1, F4 OBLIQUE×1 (drot=30 ⇒ ok:false), F5 REPLAY×1 (mapBox(M,boxAtCut)==hostBoxNow ≤1e-6, independently
+  re-derived, not just internally trusted))
+- [x] witness_e2e_cut_move.js 12/12 (M1-M6 unchanged from step 2 + M7: a REAL `#dim-rot` typed commit — the SAME
+  production path W-E2E-NUMROT/W-E2E-SCALEROT prove for a standalone solid, no `oplog.commit` fallback needed —
+  rotates the wall 90°, then a REAL mouse drag slides the door +0.8m along the wall's NEW long axis (world Y); the
+  gesture is GEOM_MOVE + GEOM_CUT_MOVE with the authored shift correctly landing on x (via slideShiftM, not the
+  slide's own world axis); one real Ctrl+Z reverts it)
+- [x] guards: witness_opening_slide 10/10 (S6b's drot=30 fixture still refuses, now via hostFrame's
+  oblique-rotate-after-cut reason instead of frameScale's rotated-after-cut — same net effect, label text
+  unchanged since the assertion only checks `=== null`) · witness_gridmove_fold_pure 12/12 · witness_dagevu_engine
+  13/13 · witness_e2e_opening_slide 8/8 (O0 7/7 real SampleHouse refusals) · witness_e2e_gridstretch 7/7 ·
+  witness_e2e_stretch_ride 11/11 · witness_e2e_grid_greenorange 13/13
+- witness_e2e_cut C4/C6 (pix 9970636→9970636) FAIL IDENTICALLY to untouched main and to the step-2 branch —
+  pre-existing, not this change.


### PR DESCRIPTION
## Summary
- Replaces `cut_move.js`'s `frameScale` (which refused any post-cut `GEOM_ROTATE`) with `hostFrame` — a per-axis affine map `{perm, a, b}` from the cut's authored frame to the current world frame, computed by a backward replay from the measured host box (undoing each post-cut op in reverse) followed by a forward replay that composes the map. Handles a 90°-multiple `GEOM_ROTATE` (axis permutation + sign flip) in addition to everything `frameScale` already handled; oblique rotations, tilted/yawed scales and `GEOM_ARRAY`-after-cut still honestly refuse.
- `anchorShift` is rewritten to call `hostFrame` internally — byte-identical output for an unrotated host.
- `slideShiftM` is the frame-general form of `slideShift`, now used by `bonsai_itemdrag.js`'s slide path so a door still slides correctly after its host wall has been rotated.
- `bonsai_gridmove.js`'s `_cutRiders` gets a small correctness fix: the shift/resize factor must be placed at the AUTHORED axis (`M.perm[k]`), not the world axis, once a rotation can permute the frame.

Implements `prompts/SPEC_CUT_FRAME_ROTATE.md` (step 3; parents `SPEC_GEOM_CUT_MOVE.md` step 1 #1711, `SPEC_GEOM_CUT_RESIZE.md` step 2 #1714, both merged). No new op type — zero changes to the worker, IFC export, history labels, or cache versions.

## Deviations from the spec text (documented in full in the spec's §4)
1. `frameScale`/`slideShift` left **untouched** rather than rewritten as a "thin wrapper over hostFrame" — the old algorithm is already exact for an unrotated host (a SCALE anchors at its own current min, so the min's trajectory is pure additive translation regardless of intervening scale factors — why `frameScale` never needed to measure the host box), and rewriting it added risk for zero behavioral gain.
2. The spec text's own C5 example numbers (`a=[1.25,1,1], b=[0.5,0,0]`) are **wrong** — `b` is the general-point affine offset (needed to map the void's centre), a different quantity from `frameScale`'s `tPost` (a min-only telescoping sum). The correct `b.x = 0.625` for that fixture, independently verified two ways in the F0 witness case.
3. `bonsai_gridmove.js` needed a real fix, not "zero changes" as first assumed — `d[k]`/`g[k]` were indexed by world axis; fixed to index by `r.authoredAxis`.
4. **Known limitation, left out of scope**: `cutsOver` (the "is this cut coincident with this filling" discovery check) compares the void's authored-frame box directly against the filling's world box — correct only for an unrotated host. M7's witness passes because its fixture's boxes still coincide numerically post-rotation; a differently-positioned fixture could fail to discover a real coincident cut. This is a discovery-heuristic problem, not a frame-math one — outside this spec's stated scope. Flagged for a future spec if it ever bites.

## Witnesses (§4 of the spec — counts read from the logs)

| Witness | Result |
|---|---|
| W-CUT-MOVE (`witness_cut_move.mjs`, real worker fold) | 26/26 — C0-C6 + R1-R5 unchanged, F0-F5 new |
| W-E2E-CUT-MOVE (`witness_e2e_cut_move.js`, real mouse + real UI) | 12/12 — M1-M6 unchanged, M7 new: real `#dim-rot` typed rotate + real mouse slide along the new axis |
| witness_opening_slide | 10/10 (S6b's oblique fixture still refuses, now via hostFrame's reason string) |
| witness_gridmove_fold_pure | 12/12 |
| witness_dagevu_engine | 13/13 |
| witness_e2e_opening_slide | 8/8 (O0 7/7 real SampleHouse refusals) |
| witness_e2e_gridstretch | 7/7 |
| witness_e2e_stretch_ride | 11/11 |
| witness_e2e_grid_greenorange | 13/13 |
| witness_e2e_cut | 5/7 — C4/C6 (pix 9970636→9970636) fail identically to untouched main; pre-existing, not this change |

F1 key numbers: wall+cut rotated 90° ⇒ `hostFrame` gives `perm=[1,0,2], a=[-1,1,1]`; the hole's world extent moves to Y (centre 0.1, width 1.6) with X now 0.2 (the wall's own thickness — the void's oversized through-overshoot was already clipped to it at cut time). M7: a real 90° rotate via `#dim-rot`, then a real +0.8m mouse drag along the wall's new long axis (world Y) commits `GEOM_MOVE + GEOM_CUT_MOVE{dx=+0.8 on x}` — the authored shift correctly lands on a *different* axis than the slide's own world axis.

## Test plan
- [x] `node witness_cut_move.mjs` — 26/26
- [x] `node witness_e2e_cut_move.js` — 12/12
- [x] All 7 guards above green; `witness_e2e_cut` C4/C6 confirmed pre-existing (not fixed here)

🤖 Generated with [Claude Code](https://claude.com/claude-code)