### PR TITLE
§RULE_REPORT: the Sanity/Egress findings without the film, with a data-sufficiency and per-finding witness pass

### DIFF
--- a/cli_silent_bake.js
+++ b/cli_silent_bake.js
@@ -11,6 +11,8 @@
 //     [--clash] [--no-clash]                          mesh-true clash pairs as world content (§CLASH_FILM_P1)
 //     [--measure] [--no-measure]                      setting-out datum drawing (§FLYTHRU_DATUM, MEP_CLASH_REVEAL_MOVIE.md §28.1)
 //     [--nohome] [--opening-only]                     §33 §CLI_BAKE_OPENING: skip the datum-legibility gate / judge the opening and exit
+//     [--findings-only]                               §RULE_REPORT (STRUCTURAL_SANITY.md T8): run the Sanity + Egress
+//                                                       evaluators, write <out>.json, exit before ANY cinema work
 //     [--storey-reveal] [--no-storey-reveal]           each storey tints in sequence during the closing
 //                                                       orbit (§STOREY_HIGHLIGHT_REVEAL)
 //     [--no-buildup] [--no-label] [--no-reveal]       turn a SAVED setting off for this run
@@ -294,6 +296,91 @@ const server = http.createServer((req, res) => {
   ]);
   log('§CLI_BAKE_LOADED building=' + await page.evaluate(() => window.APP.activeBuilding +
     ' meshes=' + (window.APP.scene ? window.APP.scene.children.length : -1)));
+  // ── §RULE_REPORT (prompts/STRUCTURAL_SANITY.md T8) — the findings WITHOUT the film ──────────
+  // MEASURED case for the flag: Hospital knows all 509 findings at +101.3s and finishes the film
+  // at ~+6,000s (1.7% analysis); Terminal, 3.5%. Of Hospital's 101.3s, 71.3s is the model load
+  // just logged above and ~29s is the cinema path planning + render staging BELOW this block —
+  // which is exactly why the exit goes HERE, before the datum gate, not next to --opening-only.
+  //
+  // ⚠ T8.3 — this must NOT call A.ruleFindingsFilmBuild. That needs a plan (its dwell precompute
+  // calls plan.poseAt), a tint and later a camera: everything findings-only exists to skip. Call
+  // the evaluators directly — the same two the panels use, with zero duplicated rule logic.
+  if (has('findings-only')) {
+    const jsonOut = OUT.replace(/\.mp4$/i, '') + '.json';
+    const report = await page.evaluate(async () => {
+      const A = window.APP;
+      const out = { err: null };
+      try {
+        if (typeof RuleReport === 'undefined') return { err: 'rule_report.js not loaded' };
+        if (!A.dbQuery) return { err: 'no A.dbQuery' };
+        const fetchRules = async (url, fallbackKey) => {
+          try {
+            const r = await fetch(url); if (!r.ok) throw new Error('HTTP ' + r.status);
+            return { rules: await r.json(), source: 'fetched' };
+          } catch (e) { return { rules: null, source: 'fallback', error: e.message }; }
+        };
+        const sj = await fetchRules('rates/structural_rules.json');
+        const ej = await fetchRules('rates/egress_rules.json');
+        // A missing rules file is NOT silently replaced with an invented default here: the
+        // evaluators carry their own documented fallbacks, and rulesSource records which ran.
+        let rowsS = [], rowsE = [], rgFacts = null;
+        const logS = [], logE = [];
+        if (typeof StructuralSanity !== 'undefined') {
+          // witness:true — T8.12. A report exists to be inspected; a row that cannot show WHY it
+          // fired is the thing this whole surface is trying to stop being. Additive only.
+          rowsS = StructuralSanity.evaluate(A.dbQuery, sj.rules || {}, { log: (m) => { logS.push(m); console.log(m); }, witness: true }) || [];
+        }
+        if (typeof EgressSanity !== 'undefined') {
+          // RoomGraph genuinely IS needed by egress rules 2/3 — findings-only skips the film, not
+          // the data. Same lazy loader the Egress panel awaits (§EGRESS_ROOMGRAPH_LATE_BIND).
+          if (!window.RoomGraph && A.loadNavigate) { try { await A.loadNavigate(); } catch (e) {} }
+          rowsE = EgressSanity.evaluate(A.dbQuery, ej.rules || {}, { log: (m) => { logE.push(m); console.log(m); }, witness: true }) || [];
+          if (window.RoomGraph) {
+            // §ROOM_GRAPH_EXITS is emitted by buildGraph, whose log egress_sanity.js silences.
+            const capt = [];
+            try { window.RoomGraph.buildGraph(A.dbQuery, { log: (m) => capt.push(m) }); } catch (e) {}
+            rgFacts = RuleReport.parseRoomGraphExits(capt);
+          }
+        }
+        const pops = RuleReport.rulePopulations(A.dbQuery);
+        const suff = RuleReport.runSufficiencyProbes(A.dbQuery, { log: console.log });
+        out.report = RuleReport.buildRuleReport({
+          rowsS: rowsS, rowsE: rowsE,
+          ruleDefs: [sj.rules, ej.rules].filter(Boolean),
+          meta: {
+            building: A.activeBuilding,
+            rulesSource: { structural: sj.source, egress: ej.source },
+            roomGraph: rgFacts, sufficiency: suff, populations: pops
+          }
+        });
+      } catch (e) { out.err = e.message; }
+      return out;
+    });
+    if (report.err) {
+      log('§RULE_REPORT_FAIL ' + report.err);
+      try { await browser.close(); } catch (e) {}
+      server.close(); process.exit(1);
+    }
+    const r = report.report;
+    r.db = DB; r.commit = (() => { try { return execFileSync('git', ['-C', ROOT, 'rev-parse', '--short', 'HEAD'], { encoding: 'utf8' }).trim(); } catch (e) { return null; } })();
+    try { r.dbBytes = fs.statSync(DB.includes('/') ? DB : path.join(ROOT, 'buildings', DB + '.db')).size; } catch (e) { r.dbBytes = null; }
+    fs.writeFileSync(jsonOut, JSON.stringify(r, null, 2));
+    log('§RULE_REPORT building=' + r.building + ' findings=' + r.totals.findings + ' rules=' + r.totals.rules +
+        ' critical=' + r.totals.severity.CRITICAL + ' warning=' + r.totals.severity.WARNING +
+        ' rulesSource=' + JSON.stringify(r.rulesSource) +
+        ' roomGraph=' + (r.roomGraph ? JSON.stringify(r.roomGraph) : 'null') +
+        ' out=' + jsonOut);
+    (r.rules || []).forEach(x => log('§RULE_REPORT_SET rule=' + x.rule + ' count=' + x.count +
+        ' critical=' + x.severity.CRITICAL + ' warning=' + x.severity.WARNING + ' unit=' + x.unit));
+    (r.dataSufficiency || []).forEach(x => log('§RULE_REPORT_SUFFICIENCY check=' + x.check + ' verdict=' + x.verdict +
+        ' rules=' + x.rules.join(',') + ' measured=' + JSON.stringify(x.measured)));
+    (r.flagRates || []).forEach(x => log('§RULE_REPORT_RATE rule=' + x.rule + ' flagged=' + x.flagged +
+        ' population=' + x.population + ' rate=' + x.rate));
+    log('§RULE_REPORT_ONLY exit — no bake requested, no frame drawn');
+    try { await browser.close(); } catch (e) {}
+    server.close(); process.exit(0);
+  }
+
   // §CLI_BAKE_OPENING (MEP_CLASH_REVEAL_MOVIE.md §33 CORRECTED, user 2026-09-08: "The HHS opening frame has to
   // be some distance away to let the dive in catch the 2D Z plane"). The film opens from the DB's SAVED VIEW
   // (scene_state, restored at load by main.js §SCENE_STATE_RESTORE) — the user's own framing — UNLESS Measure

--- a/eslint.globals.json
+++ b/eslint.globals.json
@@ -65,6 +65,7 @@
   "ScheduleGate": "readonly",
   "SectionCut": "readonly",
   "SettingsEditor": "readonly",
+  "RuleReport": "readonly",
   "StructuralSanity": "readonly",
   "SupportSweep": "readonly",
   "SwipeStack": "readonly",

--- a/prompts/STRUCTURAL_SANITY.md
+++ b/prompts/STRUCTURAL_SANITY.md
@@ -331,3 +331,196 @@ Whitebox §-log first (`§STRUCT_SANITY rule=<name> severity=<n>`). `node --chec
 edited JS. Worktree `feat/structural-sanity` off fresh origin/main. Witness each rule with
 a fixture assertion (exact severity), not the exit code. No live-panel screenshot claim
 without an actual browser run (`run` skill) against a real building DB.
+
+## T8 §RULE_REPORT — the findings WITHOUT the film, and a Report button on both panels
+**Spec origin: `bim-compiler prompts/MEP_CLASH_REVEAL_MOVIE.md §87` (2026-09-12), authored by
+the movie-bake session off its own measured bake logs.** Restated here because the
+implementation lands in THIS repo; §87 is the authority on rationale, this section on contract.
+
+**T8.1 THE MEASURED CASE.** From that session's bakes: Terminal knows all 205 findings at
+**+42s** and finishes the film at +1,194s (3.5% analysis); Hospital knows all 509 at **+101.3s**
+and finishes at ~+6,000s (1.7%). Of Hospital's 101.3s, **71.3s is model load** (`§CLI_BAKE_LOADED`)
+and ~29s is cinema path planning + render staging a report does not need. The rules themselves
+cost about a second. `cli_silent_bake.js` had `--opening-only` but nothing that stops at the
+knowing.
+
+**T8.2 ONE PURE BUILDER, THREE SURFACES.** `viewer/rule_report.js` exports
+`buildRuleReport({ rowsS, rowsE, ruleDefs, meta })` → a plain object. No DOM, no THREE, no
+camera, no `plan` — same portability contract as `viewer/structural_sanity.js`. Surfaces:
+
+| surface | how it gets there | in this repo? |
+|---|---|---|
+| CLI | `cli_silent_bake.js --findings-only` → writes `<out>.json`, exits before the first frame | ✅ this PR |
+| Sanity/Egress panels | a **Report** button → the same object → Blob download | ✅ this PR |
+| the film's closing card | `rule_findings_film.js` `_stats` reads the SAME builder | ⛔ that file is on `feat/rule-findings-film`, not on main — wired by that session when it merges |
+
+All surfaces must be unable to disagree about one building. This is the lesson of `0.75` m/step
+being written twice across two branches, applied BEFORE the drift rather than after.
+
+**T8.3 ⚠ THE REPORT MUST NOT RIDE `A.ruleFindingsFilmBuild`.** That function needs a `plan`
+(§77.3's dwell precompute calls `plan.poseAt`), `A.showRuleModeTint`, and later a camera —
+everything findings-only exists to skip. Call `StructuralSanity.evaluate(dbQuery, rules)` and
+`EgressSanity.evaluate(dbQuery, rules)` DIRECTLY, the same evaluators the panels already share.
+RoomGraph still loads, because egress genuinely needs it.
+
+**T8.4 WHAT IS IN IT — only what already exists, nothing composed.**
+- **Provenance**: db name, commit, sw `CACHE_VERSION`, ISO timestamp, and **`rulesSource` per
+  rule file: `fetched` | `fallback` | `unknown`.** The panels already draw that distinction
+  (`§STRUCT_RULES_JSON loaded=json|fallback`); a report that hid it would present this repo's
+  hardcoded fallback thresholds as the project's authored ones.
+- **Per-rule set totals** — the same grouping the panel headers and the film boxes state.
+- **Per-finding rows**: `guid, ifc_class, name, shortName, storey, rule, severity` and the value
+  as `{ value, unit }` — **never a bare `ratio`**, which is metres for `door_clear_width` /
+  `circulation_distance` and a dimensionless ratio for `span_depth_*`.
+- **Egress stats**: `maxExitDistM`, `maxExitSteps`, carrying the `~` estimate disclosure and the
+  `0.75 m/step` assumption as a named field, read from `rule_checklist.js`'s own
+  `longestExitSteps()` — not a second copy of the arithmetic.
+- **Room-graph facts**: `exits`, `noRaster`, `doors` from `§ROOM_GRAPH_EXITS`. `buildGraph` is
+  called by `egress_sanity.js` with its log SILENCED, so the builder cannot see that line; the
+  CALLER captures it and passes it in `meta.roomGraph`. Absent → `null` with a stated reason,
+  never a fabricated 0.
+
+**T8.5 A ZERO IS A RESULT HERE — a deliberate divergence from the film, stated so nobody
+"fixes" it.** The film drops a vacuous card ("never a fabricated zero"). A report lists a rule
+with **0 findings explicitly**: "we checked `door_clear_width` and found none" is information on
+a page and noise on a moving card. Same data, different surface, different right answer. The
+builder therefore needs `ruleDefs` — the rule NAMES it was asked to check — not just the rows.
+
+**T8.6 DETERMINISM IS THE POINT.** Same DB → byte-identical JSON but for the timestamp. That is
+what makes it diffable across builds and across rule changes, which is the actual disruption:
+today sharpening any of the eight rules costs a full bake to see on a real model.
+
+**T8.7 FORMAT.** One JSON object. CLI writes `<out>.json`; the panel downloads the same bytes
+through the convention already in the tree (`variation_order.js` ~267: Blob → `a.download` →
+`URL.revokeObjectURL`, plus a `§`-tagged console line). NOT xlsx now — `exceljs` is already here
+for Variation Orders and can layer on the same builder later.
+
+**T8.8 THE PIN.** `_buildRuleChecklistHtml(config)` is a GENERIC chassis already rendering a
+button row ("All" + one per `config.categories`) and a Close button; both `A.showStructuralSanity`
+and `A.showEgressSanity` call it with their own config. **The Report button joins that row, once**
+— not per panel — so a third rule panel added later inherits it for free. It reports what the
+panel is currently showing (`config.rows`), so an applied category filter is honoured rather than
+silently ignored.
+
+**T8.9 TESTS (R-series), `tests/test_rule_report.js`.**
+- **R1 PURE** — the builder runs in Node with no DOM/THREE/camera/plan. Fails any version that
+  reaches for film state.
+- **R2 SAME-NUMBERS** — builder per-rule totals equal a direct count over the same rows. (§87's
+  own R2 compares against `ruleFindingsFilm.stats()`; that file is not on main — the film session
+  adds that half on its branch. Stated, not silently dropped.)
+- **R3 ZERO-IS-LISTED** — a rule in `ruleDefs` with 0 rows appears with `count: 0`.
+- **R4 PROVENANCE** — `rulesSource: 'fallback'` survives into the report; a missing source reads
+  `unknown`, never `fetched`.
+- **R5 UNIT-NOT-BARE** — `door_clear_width` reports `unit: 'm'` and `span_depth_steel` reports
+  `unit: 'ratio'`. The overloaded `ratio` field never printed bare.
+- **R6 DETERMINISTIC** — the same rows twice give identical JSON but for the timestamp.
+- **R7 NO-FILM-DEPS** — a real `--findings-only` run emits no `§MAXQ_*` line and no frames. Grep
+  the log; exit code is not evidence.
+- **R8 REAL-BUILDING** — the builder over real `buildings/Hospital_meta.db` reproduces the
+  evaluators' own `§`-logged counts.
+
+**T8.10 OPEN, NOT SOLVED BY THIS — THE LOAD.** 71.3s of Hospital's 101.3s is model load and the
+report cannot go below it. Findings-only makes that the WHOLE cost instead of 1.7% of it, which
+is what makes it worth attacking next; measure peak RSS across the load phase before changing
+anything.
+
+**T8.11 §RULE_SUFFICIENCY — the report reviews ITS OWN INPUT DATA, not just the findings.**
+*(User directive, 2026-09-12: "use it to do the review of data sufficiency also." Added to T8
+because a findings file that does not say what it could not see invites the reader to treat a
+metadata gap as a structural defect.)*
+
+Measured on the bake DBs this session, by running the shipped evaluators in Node against
+`buildings/{Hospital,Terminal,HHS_Office_Federated}_silent.db` — the gaps are not hypothetical:
+- `Terminal` and `HHS_Office_Federated` contain **0 `IfcFooting`**. HHS flags **131/131** of its
+  Level 1 columns on `column_continuity`, 61% of that building's entire finding count. Terminal
+  flags 108/158, of which its two ground storeys are 30/30 and 56/56.
+- Terminal has **0 `IfcWallStandardCase`** (all 333 walls are `IfcWall`) and 705 `IfcSlab`;
+  neither class is in `COL_SUPPORT_CLASSES`, so a Terminal column can only be supported by
+  another column.
+- `SUPPORT_CLASSES` omits `IfcWall`. Of Hospital's 217 `span_depth_cantilever` findings — 43% of
+  that building's 509 — **not one has a genuinely free end**: 121 sit on an `IfcWall`, 41 on an
+  `IfcWallStandardCase` just outside the 0.15 m tolerance, 33 on an `IfcStair`. No Hospital beam
+  is named "cantilever" anywhere; `isCantilever` is `supportedCount === 1`, an inference, and it
+  PREEMPTS material classification. All 217 are named steel sections and 113 of them would be
+  clean under `span_depth_steel`'s own 24/30.
+- All 1970 Hospital beams and 604 Hospital columns have `material_name` NULL; HHS columns carry
+  `"≈ White"`, a colour. The steel/concrete split therefore runs on `name_hints` alone.
+- `IfcSpace` count in `elements_meta` is **0 in all three buildings**. Every room-rule finding
+  sits on a synthesized room, and the injection labels its own confidence in the NAME — `≈`
+  approximate, `⚠` suspect. Neither evaluator reads that sigil.
+
+**The contract.** `RuleReport.runSufficiencyProbes(dbQuery)` executes a fixed list of probes over
+the SAME `dbQuery(sql, params) -> rows` contract the evaluators use — portable, no DOM, no new
+table. Each probe returns `{ check, rules, measured, verdict, consequence }` where:
+- `measured` is a real count from a real query. Never a guess; a probe whose table/column is
+  missing returns `verdict: 'unavailable'` with the error, never a 0 that would read as a finding.
+- `verdict` is `ok` | `degraded` | `absent` | `unavailable`, DERIVED from the count by a stated
+  threshold in the probe itself — not an opinion typed into the report.
+- `consequence` names which rule reads which way when the datum is missing, in plain words.
+
+**Flag-rate is part of sufficiency, not a separate idea.** A rule that fires on ~90% of its
+population is not discriminating on that building (HHS `circulation_distance` 68/76; Hospital's
+own `Hospital_meta.db` 135/149). The report states `flagged/population` per rule as a measured
+ratio and says nothing more about it — the number is the argument.
+
+**The report never downgrades a finding.** Sufficiency sits beside the findings, never edits or
+suppresses them: the rules said what they said. The reader decides.
+
+**Tests (extending T8.9):**
+- **R9 PROBES-MEASURED** — every probe's `measured` traces to a query actually run; a probe over
+  a DB missing the table reports `unavailable`, not `ok` and not `0`.
+- **R10 GAP-IS-CAUGHT** — a fixture with 0 `IfcFooting` and columns at the lowest storey yields
+  `verdict: 'absent'` on the footing probe. Fails a version that stays silent on the gap that
+  produced 131/131 on a real building.
+- **R11 FINDINGS-UNTOUCHED** — the finding rows and per-rule totals are byte-identical with and
+  without the sufficiency section. Proves it annotates rather than filters.
+
+**T8.12 §STRUCT_WITNESS / §EGRESS_WITNESS — a finding must be able to show its own working.**
+*(User directive, 2026-09-12: "so that users can inspect how truthful the output is based on what
+assumptions, will right away eye ball that so called isolated rooms are actually not so etc. In
+this case, you can harden WITNESS logging to debug if so.")*
+
+T8.11 reviews the DB. This reviews the ROW. A finding's evidence is frequently an ABSENCE — "no
+support found", "no path found" — and an absence is precisely what a bare row cannot show. The
+reader cannot tell *nothing is there* from *something is there that this rule cannot count*.
+
+**Opt-in, default OFF.** `evaluate(dbQuery, rules, { witness: true })`. Off, nothing changes and
+nothing is paid. On, `structural_sanity.js` runs ONE extra query for every element with a
+transform — every class, every discipline, the candidates the rules deliberately do not consult —
+and `egress_sanity.js` indexes the room graph's own edges once. Measured cost: Hospital 1.4 s,
+Terminal 0.56 s, HHS 0.08 s.
+
+**⚠ ADDITIVE OR NOTHING.** The witness explains a finding; it must never create, drop or move one.
+R12 asserts `guid|rule|severity|ratio` is identical with witness on and off, on the real
+Hospital_meta.db (488 structural + 142 egress rows, unchanged). A witness pass that quietly
+widened a tolerance would change counts *and* agree with itself — that is the trap.
+
+**What each rule shows, and what it settles.** Measured on real data, not designed in the abstract:
+- `isolated_room` → `graphDegree`, `neighbours[]` (with the edge kind and door name), and
+  `storeyHasCirculationNode`. Hospital's 7 isolated rooms are all `graphDegree: 0` with
+  `storeyHasCirculationNode: false` — the graph never connected them, so "isolated" describes the
+  extraction. HHS's single isolated room has **`graphDegree: 6`**, with four E2 door edges to its
+  own storey's spine: it is demonstrably **not** isolated, and the row now says so on its face.
+- `column_continuity` → `nearestBelow` (guid, class, centreline offset, top-to-base gap) and
+  `rejectedBecause`. Hospital's 24: twelve rejected on centreline offset — one is an
+  `IfcWallStandardCase` **foundation retaining wall at 0.315 m against a 0.3 m tolerance**, a
+  15 mm miss — nine because `IfcMember` is not a column-support class, two on the z gap, and
+  exactly **one** has nothing below it at all.
+- `span_depth_cantilever` → `classifiedBy` states outright that cantilever is an INFERENCE from
+  `supportedCount === 1` and that no cantilever attribute exists in the schema; `freeEnds[].nearest`
+  names what sits at the un-counted end; `wouldBeCleanUnderSteelRule` says whether the
+  classification is what produced the flag. Hospital's 217: only **2** have nothing near the free
+  end (76 `IfcWall`, 59 `IfcWallStandardCase`, 20 `IfcSlab`, 18 `IfcBeam`…), and **113 of 217**
+  would be clean under `span_depth_steel`'s own 24/30.
+- `floating_member` → both free ends with their nearest neighbour, searched at 4× the rule's
+  tolerance so a near-miss reads as a near-miss rather than as nothing.
+- `door_clear_width` → `bboxXM`/`bboxYM` and `widthTakenAs`, plus the standing disclosure that a
+  bbox extent is nominal, not clear, width.
+- `circulation_distance` → `measuredTo`, `hops`, `doorsOnRoute`, and the room's own `≈`/`⚠` sigil.
+
+**`atLowestModelledLevel`** on `column_continuity` names the commonest false positive outright: a
+column on the model's lowest plane in a model with no footings. HHS measures **131/131**.
+
+**Tests:** R12 (above) — rows identical on/off; every `isolated_room` states degree and
+neighbours; a degree>0 room reads differently from a degree-0 one; every `column_continuity` names
+what is below it or that nothing is, with a reason; every cantilever discloses the inference.

--- a/tests/test_rule_report.js
+++ b/tests/test_rule_report.js
@@ -1,0 +1,278 @@
+#!/usr/bin/env node
+/**
+ * # ⚠ DO NOT REMOVE — prompts/STRUCTURAL_SANITY.md T8 witness (READ THE LOG after every run)
+ * SCOPE: proves viewer/rule_report.js's buildRuleReport()/runSufficiencyProbes() — R1 purity,
+ *   R2 same-numbers, R3 zero-is-listed, R4 provenance, R5 unit-not-bare, R6 determinism,
+ *   R8 real-building, R9 probes-measured, R10 gap-is-caught, R11 findings-untouched.
+ *   R7 (no-film-deps on a real --findings-only run) is a CLI grep, not a Node assertion — it is
+ *   run separately against a real building and its log line quoted in the PR.
+ * EACH TEST NAMES THE ISSUE IT PROVES. Exit code is not evidence — read the ✅/❌ lines.
+ * RUN: node tests/test_rule_report.js
+ */
+'use strict';
+const fs = require('fs'), path = require('path');
+const initSqlJs = require(path.join(process.env.HOME, 'bim-compiler', 'node_modules', 'sql.js'));
+const RuleReport = require('../viewer/rule_report.js');
+const StructuralSanity = require('../viewer/structural_sanity.js');
+const EgressSanity = require('../viewer/egress_sanity.js');
+
+let pass = 0, fail = 0;
+const chk = (n, c, x) => { if (c) { pass++; console.log('  ✅ ' + n + (x ? '  ' + x : '')); } else { fail++; console.log('  ❌ ' + n + (x ? '  ' + x : '')); } };
+
+const STRUCT_RULES = JSON.parse(fs.readFileSync(path.join(__dirname, '../viewer/rates/structural_rules.json'), 'utf8'));
+const EGRESS_RULES = JSON.parse(fs.readFileSync(path.join(__dirname, '../viewer/rates/egress_rules.json'), 'utf8'));
+
+// Fixture rows shaped exactly like the evaluators' own output (see structural_sanity.js's
+// rows.push and egress_sanity.js's) — NOT a hand-invented shape.
+const ROWS_S = [
+  { guid: 'b1', ifc_class: 'IfcBeam', name: 'UB-Universal Beam:838x292x194UB:241306', storey: 'Level 6', rule: 'floating_member', severity: 'CRITICAL', ratio: null },
+  { guid: 'b2', ifc_class: 'IfcBeam', name: 'UB-Universal Beam:533x210x92UB:9', storey: 'Level 1', rule: 'span_depth_steel', severity: 'WARNING', ratio: 27.3 },
+  { guid: 'c1', ifc_class: 'IfcColumn', name: 'C-Roof', storey: 'Roof', rule: 'column_continuity', severity: 'CRITICAL', ratio: null }
+];
+const ROWS_E = [
+  { guid: 'd1', ifc_class: 'IfcDoor', name: 'Single-Flush:0800x2100mm', storey: 'Level 1', rule: 'door_clear_width', severity: 'WARNING', ratio: 0.80 },
+  { guid: 'RM_1', ifc_class: 'IfcSpace', name: '⚠ Level 1 R3', storey: 'Level 1', rule: 'circulation_distance', severity: 'WARNING', ratio: 98.4873, target: 'exit' }
+];
+
+(async () => {
+  const SQL = await initSqlJs();
+
+  // ── R1 PURE — proves: the builder cannot have grown a dependency on film state (§87.3's trap).
+  console.log('§W-RULE-REPORT R1 PURE');
+  {
+    const src = fs.readFileSync(path.join(__dirname, '../viewer/rule_report.js'), 'utf8');
+    // Strip comments before grepping: the file's own ⚠ header NAMES these deps to warn against
+    // them, and a test that failed on the warning would punish the documentation.
+    const code = src.split('\n').filter(l => !/^\s*(\/\/|\*|\/\*)/.test(l)).join('\n');
+    chk('R1 no CODE path names ruleFindingsFilmBuild / poseAt / showRuleModeTint',
+      !/ruleFindingsFilmBuild|poseAt|showRuleModeTint/.test(code), 'the exact deps §87.3 says findings-only exists to skip');
+    chk('R1 the ⚠ header still WARNS about them (the comment must not be deleted to pass)',
+      /ruleFindingsFilmBuild/.test(src), 'guards against "fixing" the test by removing the warning');
+    chk('R1 no document/THREE/camera reference in the code',
+      !/\bdocument\b|\bTHREE\b|\.camera\b/.test(code), 'portable, like structural_sanity.js');
+    // Would fail if the module reached for a browser global at require() time — it already did
+    // require cleanly at the top of this file, which is itself the assertion.
+    chk('R1 module require()s in bare Node (no DOM shim)', typeof RuleReport.buildRuleReport === 'function');
+  }
+
+  // ── R2 SAME-NUMBERS — proves: the report's per-rule totals are the rows', not a second count.
+  console.log('§W-RULE-REPORT R2 SAME-NUMBERS');
+  {
+    const rep = RuleReport.buildRuleReport({ rowsS: ROWS_S, rowsE: ROWS_E, ruleDefs: [STRUCT_RULES, EGRESS_RULES] });
+    const direct = {};
+    ROWS_S.concat(ROWS_E).forEach(r => { direct[r.rule] = (direct[r.rule] || 0) + 1; });
+    const mismatched = rep.rules.filter(r => (direct[r.rule] || 0) !== r.count);
+    chk('R2 every per-rule count equals a direct count over the same rows', mismatched.length === 0, JSON.stringify(mismatched));
+    chk('R2 totals.findings equals rows in', rep.totals.findings === ROWS_S.length + ROWS_E.length, 'got ' + rep.totals.findings);
+    chk('R2 severity totals sum to findings',
+      rep.totals.severity.CRITICAL + rep.totals.severity.WARNING + rep.totals.severity.OPTIMIZED === rep.totals.findings,
+      JSON.stringify(rep.totals.severity));
+    console.log('  ℹ R2 the other half — equality with ruleFindingsFilm.stats() — cannot run here:');
+    console.log('    viewer/rule_findings_film.js is on feat/rule-findings-film, not on main. Stated, not dropped.');
+  }
+
+  // ── R3 ZERO-IS-LISTED — proves: §87.5's deliberate divergence from the film survives.
+  console.log('§W-RULE-REPORT R3 ZERO-IS-LISTED');
+  {
+    const rep = RuleReport.buildRuleReport({ rowsS: ROWS_S, rowsE: [], ruleDefs: [STRUCT_RULES, EGRESS_RULES] });
+    const dw = rep.rules.filter(r => r.rule === 'door_clear_width')[0];
+    chk('R3 door_clear_width is LISTED with count 0 when nothing fired', !!dw && dw.count === 0, JSON.stringify(dw));
+    const names = rep.rules.map(r => r.rule);
+    chk('R3 all 8 rules from both rules files appear', names.length === 8, names.join(','));
+    // The inverse guard: a rule that fired but is NOT in ruleDefs must still be listed (never hide).
+    const rep2 = RuleReport.buildRuleReport({ rowsS: [{ guid: 'x', rule: 'some_future_rule', severity: 'WARNING', ratio: null }], ruleDefs: [] });
+    chk('R3 a rule with rows but no ruleDef is still listed', rep2.rules.some(r => r.rule === 'some_future_rule'));
+  }
+
+  // ── R4 PROVENANCE — proves: fallback thresholds can never be presented as authored ones.
+  console.log('§W-RULE-REPORT R4 PROVENANCE');
+  {
+    const fb = RuleReport.buildRuleReport({ rowsS: ROWS_S, ruleDefs: [STRUCT_RULES], meta: { rulesSource: { structural: 'fallback' } } });
+    chk('R4 rulesSource.structural survives as "fallback"', fb.rulesSource.structural === 'fallback', JSON.stringify(fb.rulesSource));
+    chk('R4 an unsupplied source reads "unknown", never "fetched"', fb.rulesSource.egress === 'unknown', JSON.stringify(fb.rulesSource));
+    const none = RuleReport.buildRuleReport({ rowsS: [], ruleDefs: [] });
+    chk('R4 with no meta at all, both sources read "unknown"',
+      none.rulesSource.structural === 'unknown' && none.rulesSource.egress === 'unknown', JSON.stringify(none.rulesSource));
+  }
+
+  // ── R5 UNIT-NOT-BARE — proves: the overloaded `ratio` field never prints without its unit.
+  console.log('§W-RULE-REPORT R5 UNIT-NOT-BARE');
+  {
+    const rep = RuleReport.buildRuleReport({ rowsS: ROWS_S, rowsE: ROWS_E, ruleDefs: [STRUCT_RULES, EGRESS_RULES] });
+    const f = (g) => rep.findings.filter(x => x.guid === g)[0];
+    chk('R5 door_clear_width carries unit "m"', f('d1').unit === 'm' && f('d1').value === 0.80, JSON.stringify(f('d1')));
+    chk('R5 span_depth_steel carries unit "ratio"', f('b2').unit === 'ratio' && f('b2').value === 27.3, JSON.stringify(f('b2')));
+    chk('R5 circulation_distance carries unit "m"', f('RM_1').unit === 'm', JSON.stringify(f('RM_1')));
+    chk('R5 a rule with no numeric value reports null/null, not 0',
+      f('b1').value === null && f('b1').unit === null, JSON.stringify(f('b1')));
+    chk('R5 no finding row carries a bare `ratio` key at all',
+      rep.findings.every(x => !Object.prototype.hasOwnProperty.call(x, 'ratio')));
+  }
+
+  // ── R6 DETERMINISTIC — proves: §87.6's diffability. Same rows -> same bytes but the timestamp.
+  console.log('§W-RULE-REPORT R6 DETERMINISTIC');
+  {
+    const a = RuleReport.buildRuleReport({ rowsS: ROWS_S, rowsE: ROWS_E, ruleDefs: [STRUCT_RULES, EGRESS_RULES], meta: { generatedAt: 'T' } });
+    const b = RuleReport.buildRuleReport({ rowsS: ROWS_S, rowsE: ROWS_E, ruleDefs: [STRUCT_RULES, EGRESS_RULES], meta: { generatedAt: 'T' } });
+    chk('R6 two builds of the same rows are byte-identical', RuleReport.toJson(a) === RuleReport.toJson(b));
+    const c = RuleReport.buildRuleReport({ rowsS: ROWS_S, rowsE: ROWS_E, ruleDefs: [STRUCT_RULES, EGRESS_RULES], meta: { generatedAt: 'U' } });
+    chk('R6 the timestamp is the ONLY difference (a control — this must differ)',
+      RuleReport.toJson(a) !== RuleReport.toJson(c) &&
+      RuleReport.toJson(a).replace(/"generatedAt": "T"/, 'X') === RuleReport.toJson(c).replace(/"generatedAt": "U"/, 'X'));
+  }
+
+  // ── R10 GAP-IS-CAUGHT — proves: the exact metadata gap that produced HHS's 131/131 is reported.
+  // Fixture: columns at the lowest storey, ZERO IfcFooting — the real HHS_Office_Federated shape.
+  console.log('§W-RULE-REPORT R10 GAP-IS-CAUGHT (0 footings, 0 spaces, rotated member)');
+  {
+    const db = new SQL.Database();
+    db.run(`CREATE TABLE elements_meta (guid TEXT, ifc_class TEXT, element_name TEXT, storey TEXT, discipline TEXT, material_name TEXT, material_rgba TEXT, building TEXT);
+            CREATE TABLE element_transforms (guid TEXT, center_x REAL, center_y REAL, center_z REAL, rotation_x REAL, rotation_y REAL, rotation_z REAL, bbox_x REAL, bbox_y REAL, bbox_z REAL);
+            CREATE TABLE spatial_structure (guid TEXT, type TEXT, name TEXT);`);
+    db.run("INSERT INTO elements_meta VALUES ('c1','IfcColumn','C1','Level 1','STR',NULL,'','F')");
+    db.run("INSERT INTO elements_meta VALUES ('c2','IfcColumn','C2','Level 1','STR',NULL,'','F')");
+    db.run("INSERT INTO elements_meta VALUES ('bm','IfcBeam','UB-Beam','Level 1','STR',NULL,'','F')");
+    db.run("INSERT INTO elements_meta VALUES ('w1','IfcWall','W1','Level 1','ARC',NULL,'','F')");
+    db.run("INSERT INTO elements_meta VALUES ('w2','IfcWall','W2','Level 1','ARC',NULL,'','F')");
+    db.run("INSERT INTO elements_meta VALUES ('w3','IfcWall','W3','Level 1','ARC',NULL,'','F')");
+    db.run("INSERT INTO elements_meta VALUES ('d1','IfcDoor','D1','Level 1','ARC',NULL,'','F')");
+    db.run("INSERT INTO element_transforms VALUES ('c1',0,0,1.5,0,0,0,0.4,0.4,3)");
+    db.run("INSERT INTO element_transforms VALUES ('c2',5,0,1.5,0,0,0.7,0.4,0.4,3)");   // rotated
+    db.run("INSERT INTO element_transforms VALUES ('bm',2.5,0,3,0,0,0,5,0.3,0.5)");
+    db.run("INSERT INTO element_transforms VALUES ('d1',1,0,1,0,0,0,0.8,0.1,2.1)");
+    db.run("INSERT INTO spatial_structure VALUES ('s1','IfcSpace','≈ Level 1 R1')");
+    db.run("INSERT INTO spatial_structure VALUES ('s2','IfcSpace','⚠ Level 1 R2')");
+    const q = (sql, p) => { const r = p ? db.exec(sql, p) : db.exec(sql); return r.length ? r[0].values : []; };
+    const logs = [];
+    const suff = RuleReport.runSufficiencyProbes(q, { log: (m) => logs.push(m) });
+    const by = {}; suff.forEach(s => by[s.check] = s);
+
+    chk('R10 footings_modelled = absent (0 IfcFooting, 2 columns) — the HHS 131/131 cause',
+      by.footings_modelled.verdict === 'absent', JSON.stringify(by.footings_modelled.measured));
+    chk('R10 modelled_spaces = absent (0 IfcSpace in elements_meta)',
+      by.modelled_spaces.verdict === 'absent', JSON.stringify(by.modelled_spaces.measured));
+    chk('R10 room_confidence_sigils counts the ≈/⚠ marks the evaluators ignore',
+      by.room_confidence_sigils.measured.approx === 1 && by.room_confidence_sigils.measured.suspect === 1,
+      JSON.stringify(by.room_confidence_sigils.measured));
+    chk('R10 support_classes_present = degraded when IfcWall outnumbers the listed classes',
+      by.support_classes_present.verdict === 'degraded', JSON.stringify(by.support_classes_present.measured));
+    chk('R10 beam_material_named = absent (material_name NULL on every beam)',
+      by.beam_material_named.verdict === 'absent', JSON.stringify(by.beam_material_named.measured));
+    chk('R10 axis_aligned_bboxes = degraded (one rotated column)',
+      by.axis_aligned_bboxes.verdict === 'degraded', JSON.stringify(by.axis_aligned_bboxes.measured));
+    chk('R10 cantilever_is_inferred states the absence of any cantilever attribute',
+      by.cantilever_is_inferred.measured.beamsNamedCantilever === 0 && /inferred/.test(by.cantilever_is_inferred.consequence));
+    chk('R10 every probe logged a §RULE_SUFFICIENCY line (log is the witness, not the exit code)',
+      logs.length === suff.length && logs.every(l => l.indexOf('§RULE_SUFFICIENCY') === 0), logs.length + ' lines');
+
+    // ── R9 PROBES-MEASURED — a probe over a DB missing the table must say so, not report 0.
+    console.log('§W-RULE-REPORT R9 PROBES-MEASURED');
+    const bare = new SQL.Database();
+    bare.run('CREATE TABLE unrelated_table (x INT)');
+    const bq = (sql) => { const r = bare.exec(sql); return r.length ? r[0].values : []; };
+    const suffBare = RuleReport.runSufficiencyProbes(bq, { log: () => {} });
+    chk('R9 every probe over a DB with no elements_meta reports "unavailable", never ok/0',
+      suffBare.every(s => s.verdict === 'unavailable'), JSON.stringify(suffBare.map(s => s.check + '=' + s.verdict)));
+    chk('R9 an unavailable probe carries the reason, not a null measured passed off as a count',
+      suffBare.every(s => s.measured === null && /could not run/.test(s.consequence)));
+
+    // ── R11 FINDINGS-UNTOUCHED — sufficiency annotates, it does not filter or reweight.
+    console.log('§W-RULE-REPORT R11 FINDINGS-UNTOUCHED');
+    const withS = RuleReport.buildRuleReport({ rowsS: ROWS_S, rowsE: ROWS_E, ruleDefs: [STRUCT_RULES, EGRESS_RULES],
+      meta: { generatedAt: 'T', sufficiency: suff, populations: RuleReport.rulePopulations(q) } });
+    const without = RuleReport.buildRuleReport({ rowsS: ROWS_S, rowsE: ROWS_E, ruleDefs: [STRUCT_RULES, EGRESS_RULES],
+      meta: { generatedAt: 'T' } });
+    chk('R11 findings array identical with and without the sufficiency section',
+      JSON.stringify(withS.findings) === JSON.stringify(without.findings));
+    chk('R11 per-rule totals identical', JSON.stringify(withS.rules) === JSON.stringify(without.rules));
+    chk('R11 severity totals identical', JSON.stringify(withS.totals) === JSON.stringify(without.totals));
+    chk('R11 the section is null (not an empty all-clear) when no probes were run',
+      without.dataSufficiency === null && /not run/.test(without.dataSufficiencyNote));
+    chk('R11 flagRates states flagged/population as a measured ratio',
+      withS.flagRates.some(r => r.rule === 'column_continuity' && r.population === 2 && r.flagged === 1 && r.rate === 0.5),
+      JSON.stringify(withS.flagRates.filter(r => r.rule === 'column_continuity')));
+  }
+
+  // ── R8 REAL-BUILDING — proves: on a real DB the report reproduces the evaluators' own § counts.
+  console.log('§W-RULE-REPORT R8 REAL-BUILDING (buildings/Hospital_meta.db)');
+  const HOSPITAL = path.join(__dirname, '../buildings/Hospital_meta.db');
+  if (fs.existsSync(HOSPITAL)) {
+    const hdb = new SQL.Database(new Uint8Array(fs.readFileSync(HOSPITAL)));
+    const hq = (sql, p) => { const r = p ? hdb.exec(sql, p) : hdb.exec(sql); return r.length ? r[0].values : []; };
+    const slog = [], elog = [];
+    const rowsS = StructuralSanity.evaluate(hq, STRUCT_RULES, { log: (m) => slog.push(m) });
+    const rowsE = EgressSanity.evaluate(hq, EGRESS_RULES, { log: (m) => elog.push(m) });
+    const suff = RuleReport.runSufficiencyProbes(hq, { log: () => {} });
+    const rep = RuleReport.buildRuleReport({ rowsS, rowsE, ruleDefs: [STRUCT_RULES, EGRESS_RULES],
+      meta: { building: 'Hospital', sufficiency: suff, populations: RuleReport.rulePopulations(hq) } });
+
+    // Read the evaluators' OWN log lines and require the report to match them (Log Mandate).
+    const logged = {};
+    slog.concat(elog).forEach(l => {
+      const m = /§(?:STRUCT_SANITY|EGRESS) rule=(\w+) severity=(\d+)/.exec(l);
+      if (m) logged[m[1]] = +m[2];
+    });
+    const disagree = rep.rules.filter(r => logged[r.rule] !== undefined && logged[r.rule] !== r.count);
+    chk('R8 every per-rule count matches the evaluator\'s own § log line', disagree.length === 0,
+      JSON.stringify(disagree.map(d => d.rule + ' report=' + d.count + ' log=' + logged[d.rule])));
+    console.log('  ℹ real Hospital_meta.db: findings=' + rep.totals.findings + ' ' +
+      JSON.stringify(rep.rules.map(r => r.rule + ':' + r.count)));
+    chk('R8 the report lists all 8 rules on a real building, zeros included', rep.rules.length === 8,
+      rep.rules.map(r => r.rule + '=' + r.count).join(' '));
+    chk('R8 sufficiency ran on the real DB and every probe has a measured value',
+      rep.dataSufficiency.length === 8 && rep.dataSufficiency.every(s => s.verdict !== 'unavailable'),
+      JSON.stringify(rep.dataSufficiency.map(s => s.check + '=' + s.verdict)));
+    console.log('  ℹ real sufficiency verdicts: ' + rep.dataSufficiency.map(s => s.check + '=' + s.verdict).join(' '));
+    console.log('  ℹ real flag rates: ' + rep.flagRates.filter(r => r.rate !== null).map(r => r.rule + ' ' + r.flagged + '/' + r.population).join('  '));
+  } else {
+    console.log('  §W-RULE-REPORT SKIP R8 — buildings/Hospital_meta.db not present in this worktree');
+  }
+
+  // ── R12 WITNESS-ADDITIVE — proves: evidence explains a finding, it never creates or moves one.
+  // The trap this guards: a witness pass that quietly widened a tolerance would change counts and
+  // nobody would notice, because the evidence would agree with the (now wrong) row.
+  console.log('§W-RULE-REPORT R12 WITNESS-ADDITIVE');
+  if (fs.existsSync(HOSPITAL)) {
+    const hdb = new SQL.Database(new Uint8Array(fs.readFileSync(HOSPITAL)));
+    const hq = (sql, p) => { const r = p ? hdb.exec(sql, p) : hdb.exec(sql); return r.length ? r[0].values : []; };
+    const key = (rows) => JSON.stringify(rows.map(r => r.guid + '|' + r.rule + '|' + r.severity + '|' + r.ratio).sort());
+    const offS = StructuralSanity.evaluate(hq, STRUCT_RULES, { log: () => {} });
+    const onS = StructuralSanity.evaluate(hq, STRUCT_RULES, { log: () => {}, witness: true });
+    const offE = EgressSanity.evaluate(hq, EGRESS_RULES, { log: () => {} });
+    const onE = EgressSanity.evaluate(hq, EGRESS_RULES, { log: () => {}, witness: true });
+    chk('R12 structural rows identical with witness on (guid|rule|severity|ratio)', key(offS) === key(onS),
+      offS.length + ' -> ' + onS.length);
+    chk('R12 egress rows identical with witness on', key(offE) === key(onE), offE.length + ' -> ' + onE.length);
+    chk('R12 witness is ABSENT when not asked for', offS.every(r => r.witness === undefined) && offE.every(r => r.witness === undefined));
+
+    // The findings the user named: an "isolated room" must show whether it is actually isolated.
+    const iso = onE.filter(r => r.rule === 'isolated_room');
+    chk('R12 every isolated_room states its graph degree and neighbours',
+      iso.length > 0 && iso.every(r => r.witness && typeof r.witness.graphDegree === 'number' && Array.isArray(r.witness.neighbours)),
+      iso.length + ' rows, degrees=' + JSON.stringify(iso.map(r => r.witness.graphDegree)));
+    chk('R12 a degree>0 "isolated" room is distinguishable from a degree-0 one',
+      iso.every(r => /NO edges at all/.test(r.witness.reads) === (r.witness.graphDegree === 0)));
+    const col = onS.filter(r => r.rule === 'column_continuity');
+    chk('R12 every column_continuity names what is below it, or that nothing is',
+      col.every(r => r.witness && Object.prototype.hasOwnProperty.call(r.witness, 'nearestBelow')),
+      'nearestBelow non-null on ' + col.filter(r => r.witness.nearestBelow).length + '/' + col.length);
+    chk('R12 a rejected candidate says WHY it was rejected',
+      col.filter(r => r.witness.nearestBelow).every(r => !!r.witness.nearestBelow.rejectedBecause),
+      JSON.stringify([...new Set(col.filter(r => r.witness.nearestBelow).map(r => r.witness.nearestBelow.rejectedBecause))]));
+    const can = onS.filter(r => r.rule === 'span_depth_cantilever');
+    chk('R12 every cantilever discloses that the classification is an INFERENCE',
+      can.length > 0 && can.every(r => r.witness && /inference/.test(r.witness.classifiedBy)), can.length + ' rows');
+    const freeCls = {};
+    can.forEach(r => { const f = (r.witness.freeEnds || [])[0]; const k = (f && f.nearest) ? f.nearest.ifc_class : '<nothing near>'; freeCls[k] = (freeCls[k] || 0) + 1; });
+    console.log('  ℹ real Hospital cantilever free-end neighbours: ' + JSON.stringify(freeCls));
+    console.log('  ℹ would be clean under the steel rule: ' + can.filter(r => r.witness.wouldBeCleanUnderSteelRule).length + '/' + can.length);
+    const why = {};
+    col.forEach(r => { const b = r.witness.nearestBelow; const k = b ? b.rejectedBecause : '<nothing below>'; why[k] = (why[k] || 0) + 1; });
+    console.log('  ℹ real Hospital column_continuity rejection reasons: ' + JSON.stringify(why));
+  } else {
+    console.log('  §W-RULE-REPORT SKIP R12 — buildings/Hospital_meta.db not present');
+  }
+
+  console.log(`\n${pass} passed, ${fail} failed`);
+  process.exit(fail ? 1 : 0);
+})();

--- a/viewer/egress_sanity.js
+++ b/viewer/egress_sanity.js
@@ -100,7 +100,12 @@
       var sev = _severityBelow(width, doorRule);
       if (sev) {
         doorFlags[sev]++;
-        rows.push({ guid: guid, ifc_class: 'IfcDoor', name: name, storey: storey, rule: 'door_clear_width', severity: sev, ratio: width });
+        rows.push({ guid: guid, ifc_class: 'IfcDoor', name: name, storey: storey, rule: 'door_clear_width', severity: sev, ratio: width,
+          witness: opts.witness ? {
+            bboxXM: +(bx || 0).toFixed(3), bboxYM: +(by || 0).toFixed(3), widthTakenAs: (bx >= by ? 'bbox_x' : 'bbox_y'),
+            warningM: doorRule.warning_m, criticalM: doorRule.critical_m,
+            reads: 'width is the NOMINAL bbox extent. Clear opening width — what the threshold cites — is narrower by the stop, the leaf thickness and the hardware, none of which this schema carries, so this rule under-flags'
+          } : undefined });
       }
     });
     log('§EGRESS rule=door_clear_width severity=' + (doorFlags.CRITICAL + doorFlags.WARNING) + ' critical=' + doorFlags.CRITICAL);
@@ -117,6 +122,27 @@
     var graph = RoomGraph.buildGraph(dbQuery, { log: function () {} });
     var circCount = { WARNING: 0, uncapped_critical: 0 }, isolatedCount = 0;
     var viaExit = 0, viaFallback = 0;
+
+    // ── §EGRESS_WITNESS (prompts/STRUCTURAL_SANITY.md T8.12) — OPT-IN, default OFF.
+    // "Isolated room" is the finding a reader most wants to disbelieve on sight, and the rule's
+    // own evidence for it is an ABSENCE (no path found), which is exactly what a bare row cannot
+    // show. This indexes the graph's own edges once so a flagged room can state its degree, its
+    // actual neighbours, and whether its storey even HAS a circulation node to reach — the three
+    // facts that separate "genuinely sealed off" from "the graph never connected it".
+    var degree = null, neighbours = null, storeyHasCirc = null, exitCount = 0;
+    if (opts.witness) {
+      degree = {}; neighbours = {}; storeyHasCirc = {};
+      (graph.edges || []).forEach(function (e) {
+        degree[e.a] = (degree[e.a] || 0) + 1; degree[e.b] = (degree[e.b] || 0) + 1;
+        (neighbours[e.a] = neighbours[e.a] || []).push({ guid: e.b, via: e.kind, doorName: e.doorName || null });
+        (neighbours[e.b] = neighbours[e.b] || []).push({ guid: e.a, via: e.kind, doorName: e.doorName || null });
+      });
+      (graph.nodes || []).forEach(function (n) { if (n.kind === 'circ') storeyHasCirc[n.storey] = true; });
+      Object.keys(graph.nodesByGuid || {}).forEach(function (g) { if (g.indexOf('EXIT::') === 0) exitCount++; });
+      log('§EGRESS_WITNESS enabled nodes=' + (graph.nodes || []).length + ' edges=' + (graph.edges || []).length +
+        ' exitNodes=' + exitCount + ' storeysWithCirc=' + Object.keys(storeyHasCirc).length);
+    }
+
     graph.nodes.forEach(function (r) {
       var esc = RoomGraph.escapeRoute(graph, r.guid, { log: function () {} });
       var target, distance;
@@ -129,7 +155,21 @@
         else {
           // Rule 3: isolated — no path to escape via a real exit NOR to this storey's own
           // circulation spine at all. A real graph-connectivity fact, not a threshold guess.
-          rows.push({ guid: r.guid, ifc_class: 'IfcSpace', name: r.name, storey: r.storey, rule: 'isolated_room', severity: 'CRITICAL', ratio: null });
+          rows.push({ guid: r.guid, ifc_class: 'IfcSpace', name: r.name, storey: r.storey, rule: 'isolated_room', severity: 'CRITICAL', ratio: null,
+            witness: opts.witness ? {
+              graphDegree: degree[r.guid] || 0,
+              neighbours: (neighbours[r.guid] || []).slice(0, 8),
+              storeyHasCirculationNode: !!storeyHasCirc[r.storey],
+              exitNodesInModel: exitCount,
+              // The room's own name carries the extraction's confidence mark (≈ approximate,
+              // ⚠ suspect). The rule cannot read it; the witness can, so the reader sees whether
+              // the "room" that failed to connect was itself a guess.
+              roomNameSigil: (function (n) { var c = String(n || '').charAt(0); return c === '\u2248' ? 'approximate' : (c === '\u26a0' ? 'suspect' : null); })(r.name),
+              reads: (degree[r.guid] || 0) === 0
+                ? 'this node has NO edges at all — the room graph never connected it to anything, so "isolated" here describes the extraction, not necessarily the building'
+                : 'this node HAS ' + (degree[r.guid] || 0) + ' edge(s) but no route reaches an exit or its storey\'s circulation spine' +
+                  (storeyHasCirc[r.storey] ? '' : '; note its storey has NO circulation node at all, so the fallback target did not exist')
+            } : undefined });
           isolatedCount++;
           return;
         }
@@ -139,7 +179,16 @@
         circCount.WARNING++;
         if (distance >= circRule.critical_m) circCount.uncapped_critical++;
         rows.push({ guid: r.guid, ifc_class: 'IfcSpace', name: r.name, storey: r.storey,
-          rule: 'circulation_distance', severity: sev, ratio: distance, target: target });
+          rule: 'circulation_distance', severity: sev, ratio: distance, target: target,
+          witness: opts.witness ? {
+            measuredTo: target, hops: (esc && esc.path) ? esc.path.length : null,
+            doorsOnRoute: (esc && esc.doors) ? esc.doors.length : null,
+            warningM: circRule.warning_m, criticalM: circRule.critical_m,
+            roomNameSigil: (function (n) { var c = String(n || '').charAt(0); return c === '\u2248' ? 'approximate' : (c === '\u26a0' ? 'suspect' : null); })(r.name),
+            reads: target === 'exit'
+              ? 'distance is to a real EXTERIOR door, not to the nearest protected exit stair the travel-distance code actually regulates — on an upper storey this overstates the code quantity'
+              : 'no exit was reachable; this is the distance to the storey\'s own circulation spine, a weaker claim than distance-to-exit'
+          } : undefined });
       }
     });
     log('§EGRESS rule=circulation_distance severity=' + circCount.WARNING + ' uncapped_critical=' + circCount.uncapped_critical +

--- a/viewer/rule_checklist.js
+++ b/viewer/rule_checklist.js
@@ -165,6 +165,12 @@ function _buildRuleChecklistHtml(config, activeCategory) {
     var c = categories[k];
     html += '<button type="button" class="rc-toggle-btn" data-rc-cat="' + _rcEscAttr(c.label) + '" onclick="APP._setRuleChecklistCategory(\'' + _rcEscJs(c.label) + '\')" style="' + _rcBtnStyle(activeCat === c) + '">' + _rcEscAttr(c.label) + '</button>';
   }
+  // T8.8 — the Report button lives HERE, in the generic chassis, not in either panel's own glue.
+  // Both A.showStructuralSanity and A.showEgressSanity render through this function, so one edit
+  // gives both panels the button and a third rule panel added later inherits it for free. It
+  // exports what the panel is CURRENTLY SHOWING (the filtered rows), so an applied category
+  // filter is honoured rather than silently ignored.
+  html += '<button type="button" class="rc-report-btn" onclick="APP._downloadRuleReport()" title="Download these findings as JSON" style="' + _rcBtnStyle(false) + ';margin-left:auto">\u2193 Report</button>';
   html += '</div>';
 
   html += '<div style="margin-top:2px;color:#888;font-size:11px">Click element to zoom &middot; long-press to share</div>';
@@ -255,6 +261,76 @@ function setupRuleChecklist(A) {
     console.log('§RULE_CHECKLIST checkId=' + config.checkId + ' category=' + (A._ruleChecklistActiveCategory || 'All') +
       ' critical=' + result.counts.CRITICAL + ' warning=' + result.counts.WARNING + ' optimized=' + result.counts.OPTIMIZED);
   }
+
+  // ── T8.2/T8.8: Report download — GENERIC, driven entirely by the open panel's own config.
+  // Nothing Sanity- or Egress-specific here: each panel puts `rulesUsed`/`rulesSource` (and
+  // Egress its captured `roomGraph` facts) into the config it already passes to
+  // A.showRuleChecklist, and this reads them back. A third rule panel gets Report for free.
+  //
+  // ⚠ It exports the FILTERED rows — what the panel is currently showing — so a category the
+  // user has clicked is honoured, not silently ignored (T8.8). Download convention is the one
+  // already in the tree at variation_order.js ~267: Blob -> a.download -> revokeObjectURL, plus
+  // a §-tagged console line.
+  A._downloadRuleReport = function () {
+    var config = A._ruleChecklistConfig;
+    if (!config) { console.warn('§RULE_REPORT_UNAVAILABLE no panel open'); return null; }
+    if (typeof RuleReport === 'undefined') { console.warn('§RULE_REPORT_UNAVAILABLE rule_report.js not loaded'); return null; }
+    // T8.12 — the panel renders WITHOUT witness (evidence is dead weight in a list you scroll).
+    // An explicit export is the moment it earns its cost, so re-run the same evaluator with
+    // witness:true here. Additive by construction — R12 asserts the counts do not move — so the
+    // re-run cannot disagree with the panel above it. Falls back to the displayed rows if the
+    // evaluator is unreachable, and says which it used in the § line.
+    var rows = config.rows || [], witnessed = false;
+    try {
+      if (config.rulesUsed && A.dbQuery) {
+        if (config.checkId === 'sanity' && typeof StructuralSanity !== 'undefined') {
+          rows = StructuralSanity.evaluate(A.dbQuery, config.rulesUsed, { log: function () {}, witness: true }) || rows;
+          witnessed = true;
+        } else if (config.checkId === 'egress' && typeof EgressSanity !== 'undefined') {
+          rows = EgressSanity.evaluate(A.dbQuery, config.rulesUsed, { log: function () {}, witness: true }) || rows;
+          witnessed = true;
+        }
+      }
+    } catch (e) { console.warn('§RULE_REPORT_WITNESS_FAIL ' + e.message + ' — exporting the displayed rows without evidence'); rows = config.rows || []; }
+    var cat = A._ruleChecklistActiveCategory;
+    if (cat) {
+      var hit = (config.categories || []).filter(function (c) { return c.label === cat; })[0];
+      if (hit) rows = rows.filter(function (r) { return hit.ruleNames.indexOf(r.rule) !== -1; });
+    }
+    var report = RuleReport.buildRuleReport({
+      rows: rows,
+      ruleDefs: config.rulesUsed ? [config.rulesUsed] : [],
+      meta: {
+        building: A.activeBuilding, db: A.activeBuilding,
+        swVersion: (A._swCacheVersion || null),
+        rulesSource: config.checkId === 'egress'
+          ? { egress: config.rulesSource || 'unknown' }
+          : { structural: config.rulesSource || 'unknown' },
+        roomGraph: config.roomGraph || null,
+        longestExitSteps: _rcLongestExitSteps(rows),
+        // T8.11 — the panel has A.dbQuery, so it can review its own input the same way the CLI
+        // does. Probes are read-only counts over elements_meta/element_transforms/
+        // spatial_structure; if dbQuery is missing the section reports null, never "all clear".
+        sufficiency: A.dbQuery ? RuleReport.runSufficiencyProbes(A.dbQuery, { log: console.log }) : null,
+        populations: A.dbQuery ? RuleReport.rulePopulations(A.dbQuery) : null
+      }
+    });
+    try {
+      var blob = new Blob([RuleReport.toJson(report)], { type: 'application/json' });
+      var a = document.createElement('a');
+      a.href = URL.createObjectURL(blob);
+      a.download = 'RuleReport_' + (config.checkId || 'rules') + '_' + (A.activeBuilding || 'building') +
+        '_' + new Date().toISOString().split('T')[0] + '.json';
+      a.click();
+      URL.revokeObjectURL(a.href);
+    } catch (e) { console.warn('§RULE_REPORT_DOWNLOAD_FAIL ' + e.message); }
+    console.log('§RULE_REPORT checkId=' + config.checkId + ' category=' + (cat || 'All') +
+      ' findings=' + report.totals.findings + ' rules=' + report.totals.rules +
+      ' witness=' + (witnessed ? report.totals.withWitness : 'off') +
+      ' rulesSource=' + JSON.stringify(report.rulesSource) +
+      ' roomGraph=' + (report.roomGraph ? JSON.stringify(report.roomGraph) : 'null'));
+    return report;
+  };
 
   // Only VISIBLE rows are real ListKeyNav items — a row inside a collapsed rule-set (display:none
   // ancestor) is not on screen and must not be selectable/counted, unlike Clash's flat list which
@@ -544,11 +620,15 @@ function setupRuleChecklist(A) {
   };
 
   A.showStructuralSanity = function () {
-    function runWith(rules) {
+    // T8.4 — `fetched` vs `fallback` must reach the report. The §STRUCT_RULES_JSON line already
+    // draws that distinction for the log; this carries the SAME fact into the config so a
+    // downloaded report can never present the fallback constant above as an authored threshold.
+    function runWith(rules, source) {
       if (typeof StructuralSanity === 'undefined' || !A.dbQuery) { console.warn('§STRUCT_SANITY_UNAVAILABLE no evaluator or dbQuery'); return; }
       var rows = StructuralSanity.evaluate(A.dbQuery, rules, { log: console.log });
       A.showRuleChecklist({
         title: 'Structural Sanity', checkId: 'sanity',
+        rulesUsed: rules, rulesSource: source || 'unknown',
         colorMap: { CRITICAL: '#cc4444', WARNING: '#ffaa33', OPTIMIZED: '#44cc44' },
         categories: [
           { label: 'Floating Member', ruleNames: ['floating_member'] },
@@ -558,18 +638,18 @@ function setupRuleChecklist(A) {
         rows: rows
       });
     }
-    if (A._structuralRulesCache) { runWith(A._structuralRulesCache); return; }
+    if (A._structuralRulesCache) { runWith(A._structuralRulesCache, A._structuralRulesSource); return; }
     fetch('rates/structural_rules.json').then(function (resp) {
       if (!resp.ok) throw new Error('HTTP ' + resp.status);
       return resp.json();
     }).then(function (json) {
-      A._structuralRulesCache = json;
+      A._structuralRulesCache = json; A._structuralRulesSource = 'fetched';
       console.log('§STRUCT_RULES_JSON loaded=json rules=' + ((json.structural_rules || []).length));
-      runWith(json);
+      runWith(json, 'fetched');
     }).catch(function (err) {
       console.warn('§STRUCT_RULES_JSON loaded=fallback error=' + err.message);
-      A._structuralRulesCache = STRUCTURAL_RULES_FALLBACK;
-      runWith(STRUCTURAL_RULES_FALLBACK);
+      A._structuralRulesCache = STRUCTURAL_RULES_FALLBACK; A._structuralRulesSource = 'fallback';
+      runWith(STRUCTURAL_RULES_FALLBACK, 'fallback');
     });
   };
 
@@ -591,7 +671,7 @@ function setupRuleChecklist(A) {
   };
 
   A.showEgressSanity = function () {
-    function runWith(rules) {
+    function runWith(rules, source) {
       if (typeof EgressSanity === 'undefined' || !A.dbQuery) { console.warn('§EGRESS_UNAVAILABLE no evaluator or dbQuery'); return; }
       // room_graph.js is lazy-loaded (viewer/main.js APP.loadNavigate — 78KB saved on first paint,
       // not a static viewer.html <script>, unlike structural_sanity.js). Rules 2/3 need
@@ -599,8 +679,22 @@ function setupRuleChecklist(A) {
       // adding a second script-loading path.
       var go = function () {
         var rows = EgressSanity.evaluate(A.dbQuery, rules, { log: console.log });
+        // T8.4 — §ROOM_GRAPH_EXITS's own numbers (exits / noRaster / doors). The evaluator calls
+        // RoomGraph.buildGraph with its log SILENCED, so that line never reaches console here;
+        // build it once more with a CAPTURING log purely to read the facts. buildGraph is
+        // deterministic on the same dbQuery, so this observes the same graph the rules used — it
+        // does not change any count. Null (with a stated reason in the report) if it cannot run.
+        var rgFacts = null;
+        try {
+          if (window.RoomGraph && typeof RuleReport !== 'undefined') {
+            var capt = [];
+            window.RoomGraph.buildGraph(A.dbQuery, { log: function (m) { capt.push(m); } });
+            rgFacts = RuleReport.parseRoomGraphExits(capt);
+          }
+        } catch (e) { console.warn('§RULE_REPORT_ROOMGRAPH_FACTS_FAIL ' + e.message); }
         A.showRuleChecklist({
           title: 'Egress', checkId: 'egress',
+          rulesUsed: rules, rulesSource: source || 'unknown', roomGraph: rgFacts,
           colorMap: { CRITICAL: '#cc4444', WARNING: '#ffaa33', OPTIMIZED: '#44cc44' },
           categories: [
             { label: 'Isolated Room', ruleNames: ['isolated_room'] },
@@ -615,18 +709,18 @@ function setupRuleChecklist(A) {
       if (A.loadNavigate) A.loadNavigate().then(go).catch(function (e) { console.warn('§EGRESS_ROOMGRAPH_LOAD_FAIL ' + (e && e.message)); go(); });
       else go(); // defensive — evaluator itself logs §EGRESS_NO_ROOMGRAPH and skips rules 2/3
     }
-    if (A._egressRulesCache) { runWith(A._egressRulesCache); return; }
+    if (A._egressRulesCache) { runWith(A._egressRulesCache, A._egressRulesSource); return; }
     fetch('rates/egress_rules.json').then(function (resp) {
       if (!resp.ok) throw new Error('HTTP ' + resp.status);
       return resp.json();
     }).then(function (json) {
-      A._egressRulesCache = json;
+      A._egressRulesCache = json; A._egressRulesSource = 'fetched';
       console.log('§EGRESS_RULES_JSON loaded=json rules=' + ((json.egress_rules || []).length));
-      runWith(json);
+      runWith(json, 'fetched');
     }).catch(function (err) {
       console.warn('§EGRESS_RULES_JSON loaded=fallback error=' + err.message);
-      A._egressRulesCache = EGRESS_RULES_FALLBACK;
-      runWith(EGRESS_RULES_FALLBACK);
+      A._egressRulesCache = EGRESS_RULES_FALLBACK; A._egressRulesSource = 'fallback';
+      runWith(EGRESS_RULES_FALLBACK, 'fallback');
     });
   };
   A._ruleChecklistOpeners.egress = A.showEgressSanity;

--- a/viewer/rule_report.js
+++ b/viewer/rule_report.js
@@ -1,0 +1,436 @@
+// Copyright (c) 2025-2026 Redhuan D. Oon <red1org@gmail.com>
+// SPDX-License-Identifier: MIT
+//
+// rule_report.js — the Sanity/Egress findings WITHOUT the film (prompts/STRUCTURAL_SANITY.md T8,
+// spec origin bim-compiler prompts/MEP_CLASH_REVEAL_MOVIE.md §87).
+//
+// PORTABLE by construction, same contract as viewer/structural_sanity.js and common/room_graph.js:
+// plain data in, plain data out. No DOM, no THREE, no camera, no cinema `plan` — so the exact
+// object the CLI writes is the object the panel downloads is the object the film's closing card
+// reads. THREE SURFACES THAT CANNOT DISAGREE is the whole point (T8.2): `0.75` m/step is written
+// twice across two branches today precisely because two surfaces each grew their own copy.
+//
+// ⚠ T8.3 — this file must NEVER reach for A.ruleFindingsFilmBuild. That needs a plan (§77.3's
+// dwell precompute calls plan.poseAt), a tint and later a camera: everything findings-only exists
+// to skip. Callers hand us rows from StructuralSanity.evaluate()/EgressSanity.evaluate() directly.
+//
+// ⚠ T8.5 — A ZERO IS A RESULT HERE, a DELIBERATE divergence from the film. The film drops a
+// vacuous card ("never a fabricated zero"); a report states `door_clear_width: 0` outright,
+// because "we checked and found none" is information on a page and noise on a moving card. That
+// is why buildRuleReport takes `ruleDefs` (the rules we were ASKED to check) and not just rows.
+// Do not "fix" this inconsistency — it is the difference between the two surfaces.
+//
+// Witness: tests/test_rule_report.js (R1-R8).
+
+(function (root, factory) {
+  if (typeof module !== 'undefined' && module.exports) module.exports = factory();
+  else root.RuleReport = factory();
+})(typeof window !== 'undefined' ? window : this, function () {
+  'use strict';
+
+  var REPORT_SCHEMA = 'bim-ootb/rule-report@1';
+
+  // ── T8.4: the `ratio` field on a finding row is OVERLOADED — metres for the two distance rules,
+  // a dimensionless span/depth ratio for the three span_depth rules, and null where the rule is a
+  // pure connectivity/geometry fact (floating_member, column_continuity, isolated_room). A report
+  // that printed it bare would publish "0.75" and "27.3" in the same column and mean different
+  // things by them. Mapping is by RULE NAME because that is where the meaning actually lives —
+  // the evaluators put metres and ratios in one field by design, see egress_sanity.js's own rows.
+  var RULE_UNITS = {
+    door_clear_width: 'm',
+    circulation_distance: 'm',
+    span_depth_steel: 'ratio',
+    span_depth_concrete: 'ratio',
+    span_depth_cantilever: 'ratio',
+    floating_member: null,
+    column_continuity: null,
+    isolated_room: null
+  };
+
+  // Metres/step. Read from rule_checklist.js's own longestExitSteps() when the caller passes it
+  // (see meta.longestExitSteps below) — declared here ONLY so the report can DISCLOSE the
+  // assumption as a field instead of burying it. A standard adult-stride ergonomic convention
+  // from outside this project; no stride constant exists anywhere in this codebase to extract.
+  var STEP_M = 0.75;
+
+  function _num(v) { return (v == null || isNaN(v)) ? null : v; }
+
+  // Panel parity: _rcRowHtml truncates the display name at 30 chars. The report carries BOTH the
+  // full name and the same 30-char form, so a row in the file is recognisable as the row on screen.
+  function shortName(s) { return String(s == null ? '' : s).substring(0, 30); }
+
+  function valueOf(row) {
+    var unit = Object.prototype.hasOwnProperty.call(RULE_UNITS, row.rule) ? RULE_UNITS[row.rule] : null;
+    var v = _num(row.ratio);
+    if (unit === null || v === null) return { value: null, unit: null };
+    return { value: v, unit: unit };
+  }
+
+  // ── Pure: pull §ROOM_GRAPH_EXITS's own numbers out of captured log lines (T8.4).
+  // egress_sanity.js calls RoomGraph.buildGraph(dbQuery, { log: function () {} }) — the graph's
+  // log is SILENCED there, so these facts cannot reach us through the evaluator's own log sink.
+  // The CALLER builds the graph once with a capturing log and hands the lines here. Returns null
+  // when the line is absent — a stated absence, never a fabricated 0 (§59.7's two real defects,
+  // `exits=0 noRaster=133/133`, are exactly the shape this surfaces without a bake).
+  function parseRoomGraphExits(logLines) {
+    var re = /§ROOM_GRAPH_EXITS exits=(\d+) noRaster=(\d+) of (\d+) doors/;
+    var lines = logLines || [];
+    for (var i = lines.length - 1; i >= 0; i--) {
+      var m = re.exec(String(lines[i]));
+      if (m) return { exits: +m[1], noRaster: +m[2], doors: +m[3] };
+    }
+    return null;
+  }
+
+  // ── Pure: rule NAMES a rules JSON asks us to check, in file order. The zero-is-a-result list.
+  function ruleNamesOf(ruleDefs) {
+    var out = [];
+    (ruleDefs || []).forEach(function (defs) {
+      if (!defs) return;
+      ['structural_rules', 'egress_rules'].forEach(function (k) {
+        (defs[k] || []).forEach(function (r) { if (r && r.name && out.indexOf(r.name) === -1) out.push(r.name); });
+      });
+    });
+    return out;
+  }
+
+  // ══ T8.11 §RULE_SUFFICIENCY — the report reviews its own INPUT, not just its output ═══════
+  // A findings file that does not say what it could not see invites the reader to read a metadata
+  // gap as a structural defect. Every number below comes from a real query over the SAME
+  // dbQuery(sql, params) -> rows contract the evaluators use — no new table, no sidecar.
+  //
+  // MEASURED, not hypothetical (2026-09-12, shipped evaluators run in Node over the bake DBs):
+  //   - Terminal and HHS_Office_Federated carry 0 IfcFooting. HHS flags 131/131 of its Level 1
+  //     columns on column_continuity — 61% of that building's whole finding count.
+  //   - SUPPORT_CLASSES omits IfcWall. Of Hospital's 217 span_depth_cantilever findings (43% of
+  //     its 509), not one has a genuinely free end: 121 sit on an IfcWall, 41 on an
+  //     IfcWallStandardCase just outside the 0.15m tolerance, 33 on an IfcStair.
+  //   - IfcSpace count in elements_meta is 0 in all three buildings; every room-rule finding is
+  //     on a synthesized room, and the injection marks its own confidence in the NAME (≈/⚠).
+  //
+  // ⚠ SUFFICIENCY NEVER EDITS A FINDING. It sits beside the rows; it does not filter, reweight or
+  // suppress them. The rules said what they said — the reader decides what that is worth.
+  var _SUFF_UNAVAILABLE = 'unavailable';
+
+  function _q1(dbQuery, sql) {
+    var r = dbQuery(sql);
+    return (r && r.length && r[0].length) ? +r[0][0] : 0;
+  }
+
+  // Each probe: run(dbQuery) -> { measured, verdict, consequence }. `verdict` is DERIVED from the
+  // count by the threshold written in the probe itself, never an opinion typed into the report.
+  var SUFFICIENCY_PROBES = [
+    {
+      check: 'footings_modelled',
+      rules: ['column_continuity'],
+      run: function (dbQuery) {
+        var footings = _q1(dbQuery, "SELECT COUNT(*) FROM elements_meta WHERE ifc_class = 'IfcFooting'");
+        var cols = _q1(dbQuery, "SELECT COUNT(*) FROM elements_meta WHERE ifc_class = 'IfcColumn'");
+        return {
+          measured: { IfcFooting: footings, IfcColumn: cols },
+          verdict: cols === 0 ? 'ok' : (footings === 0 ? 'absent' : (footings < cols / 10 ? 'degraded' : 'ok')),
+          consequence: footings === 0
+            ? 'no footings exist in this model, so every lowest-storey column has nothing beneath it to find — column_continuity flags the absence of foundation geometry, not a broken load path'
+            : 'footings are present; a column_continuity flag can mean a real gap in the load path'
+        };
+      }
+    },
+    {
+      check: 'support_classes_present',
+      rules: ['column_continuity', 'floating_member', 'span_depth_cantilever'],
+      run: function (dbQuery) {
+        // The evaluator's own lists: SUPPORT_CLASSES (beams) = IfcColumn, IfcWallStandardCase,
+        // IfcFooting, IfcMember; COL_SUPPORT_CLASSES (columns) drops IfcMember. IfcWall and
+        // IfcSlab are in NEITHER — a building that models its walls as IfcWall has no wall
+        // support at all as far as these two rules are concerned.
+        var rows = dbQuery("SELECT ifc_class, COUNT(*) FROM elements_meta " +
+          "WHERE ifc_class IN ('IfcColumn','IfcWallStandardCase','IfcFooting','IfcMember','IfcWall','IfcSlab') GROUP BY ifc_class");
+        var m = {};
+        (rows || []).forEach(function (r) { m[r[0]] = +r[1]; });
+        var unlisted = (m.IfcWall || 0) + (m.IfcSlab || 0);
+        var listed = (m.IfcColumn || 0) + (m.IfcWallStandardCase || 0) + (m.IfcFooting || 0) + (m.IfcMember || 0);
+        return {
+          measured: m,
+          verdict: unlisted > listed ? 'degraded' : 'ok',
+          consequence: 'IfcWall and IfcSlab are in neither support list; ' + unlisted + ' such elements cannot support a beam end or a column here, while ' +
+            listed + ' elements can. A beam bearing on an IfcWall reads as having one support, which routes it to span_depth_cantilever (ratio 12/16) instead of its material rule (steel 24/30)'
+        };
+      }
+    },
+    {
+      check: 'beam_material_named',
+      rules: ['span_depth_steel', 'span_depth_concrete'],
+      run: function (dbQuery) {
+        var beams = _q1(dbQuery, "SELECT COUNT(*) FROM elements_meta WHERE ifc_class = 'IfcBeam'");
+        var named = _q1(dbQuery, "SELECT COUNT(*) FROM elements_meta WHERE ifc_class = 'IfcBeam' AND material_name IS NOT NULL AND material_name <> ''");
+        return {
+          measured: { IfcBeam: beams, withMaterialName: named },
+          verdict: beams === 0 ? 'ok' : (named === 0 ? 'absent' : (named < beams ? 'degraded' : 'ok')),
+          consequence: named === 0 && beams > 0
+            ? 'no beam carries a material_name, so the steel/concrete split runs entirely on name_hints (UB/UC/Channel/HSS vs Concrete/RC) — a beam whose name matches neither is not scored at all (§MATERIAL_INFERRED unmatched)'
+            : 'material_name is present on ' + named + ' of ' + beams + ' beams'
+        };
+      }
+    },
+    {
+      check: 'cantilever_is_inferred',
+      rules: ['span_depth_cantilever'],
+      run: function (dbQuery) {
+        // There is no cantilever flag anywhere in this schema. The rule infers it from
+        // supportedCount === 1, and that inference PREEMPTS material classification. This probe
+        // states the absence outright rather than letting the rule name imply a modelled fact.
+        var named = _q1(dbQuery, "SELECT COUNT(*) FROM elements_meta WHERE ifc_class = 'IfcBeam' AND " +
+          "(element_name LIKE '%antilever%' OR element_name LIKE '%CANT%')");
+        return {
+          measured: { beamsNamedCantilever: named },
+          verdict: 'degraded',
+          consequence: 'no cantilever attribute exists in elements_meta; span_depth_cantilever is inferred from "exactly one detected support" and is applied BEFORE the material rules, so a beam whose second support is an unlisted class is judged at 12/16 rather than its own material ratio'
+        };
+      }
+    },
+    {
+      check: 'modelled_spaces',
+      rules: ['circulation_distance', 'isolated_room'],
+      run: function (dbQuery) {
+        var spaces = _q1(dbQuery, "SELECT COUNT(*) FROM elements_meta WHERE ifc_class = 'IfcSpace'");
+        return {
+          measured: { IfcSpace_in_elements_meta: spaces },
+          verdict: spaces === 0 ? 'absent' : 'ok',
+          consequence: spaces === 0
+            ? 'the model contains no modelled IfcSpace; every room-rule finding is measured on a room synthesized by the room-graph extraction, not on a space an author drew'
+            : spaces + ' modelled spaces are available'
+        };
+      }
+    },
+    {
+      check: 'room_confidence_sigils',
+      rules: ['circulation_distance', 'isolated_room'],
+      run: function (dbQuery) {
+        // The extraction marks its own confidence in the room NAME: '≈' approximate, '⚠' suspect.
+        // Neither evaluator reads that sigil, so it cannot reach a finding's severity — stating
+        // it here is the only place a reader learns which rooms were guessed.
+        var rows = dbQuery("SELECT name FROM spatial_structure WHERE type = 'IfcSpace'");
+        var approx = 0, suspect = 0, plain = 0;
+        (rows || []).forEach(function (r) {
+          var n = String(r[0] == null ? '' : r[0]);
+          if (n.charAt(0) === '\u2248') approx++;
+          else if (n.charAt(0) === '\u26a0') suspect++;
+          else plain++;
+        });
+        var total = approx + suspect + plain;
+        return {
+          measured: { approx: approx, suspect: suspect, plain: plain, total: total },
+          verdict: total === 0 ? 'ok' : (plain === 0 ? 'degraded' : 'ok'),
+          consequence: total === 0
+            ? 'no IfcSpace rows in spatial_structure to assess'
+            : approx + ' rooms are marked approximate and ' + suspect + ' suspect by the extraction itself (' + plain + ' plain); the egress evaluators do not read that mark, so a finding on a suspect room carries the same severity as one on a certain room'
+        };
+      }
+    },
+    {
+      check: 'axis_aligned_bboxes',
+      rules: ['floating_member', 'column_continuity', 'span_depth_steel', 'span_depth_concrete', 'span_depth_cantilever'],
+      run: function (dbQuery) {
+        // structural_sanity.js's own header: "rotation_z confirmed 0 for all Hospital STR beams/
+        // columns". Every footprint test here is axis-aligned; a rotated member would be tested
+        // against the wrong rectangle. Verify per building rather than inheriting the assumption.
+        var rotated = _q1(dbQuery, "SELECT COUNT(*) FROM element_transforms t JOIN elements_meta m ON m.guid = t.guid " +
+          "WHERE m.ifc_class IN ('IfcBeam','IfcColumn') AND ABS(COALESCE(t.rotation_z, 0)) > 0.001");
+        return {
+          measured: { rotatedBeamsAndColumns: rotated },
+          verdict: rotated === 0 ? 'ok' : 'degraded',
+          consequence: rotated === 0
+            ? 'every beam and column is axis-aligned, which is what the footprint and centreline tests assume'
+            : rotated + ' beams/columns carry a non-zero rotation_z; their bbox is not the shape being tested, so support and continuity results for those elements are not reliable'
+        };
+      }
+    },
+    {
+      check: 'door_width_is_nominal',
+      rules: ['door_clear_width'],
+      run: function (dbQuery) {
+        var doors = _q1(dbQuery, "SELECT COUNT(*) FROM elements_meta WHERE ifc_class = 'IfcDoor'");
+        var noBox = _q1(dbQuery, "SELECT COUNT(*) FROM elements_meta m LEFT JOIN element_transforms t ON t.guid = m.guid " +
+          "WHERE m.ifc_class = 'IfcDoor' AND (t.guid IS NULL OR (COALESCE(t.bbox_x,0) = 0 AND COALESCE(t.bbox_y,0) = 0))");
+        return {
+          measured: { IfcDoor: doors, withoutBbox: noBox },
+          verdict: doors === 0 ? 'ok' : (noBox > 0 ? 'degraded' : 'ok'),
+          consequence: 'width is max(bbox_x, bbox_y) — the door\'s NOMINAL extent. Clear opening width (what IBC 2021 §1010.1.1 regulates) is narrower by the stop, the leaf thickness and the hardware, none of which this schema carries, so this rule under-flags rather than over-flags' +
+            (noBox > 0 ? '; ' + noBox + ' doors have no bbox at all and are measured as 0 m wide' : '')
+        };
+      }
+    }
+  ];
+
+  /**
+   * Run every sufficiency probe. Portable: same dbQuery contract as the evaluators.
+   * A probe whose table or column is missing reports 'unavailable' WITH the error — never a 0,
+   * which a reader would mistake for a measured absence (T8.11).
+   * @param {function} dbQuery - (sql, params?) -> array of row arrays
+   * @param {object} [opts] - { log: fn(msg) }
+   * @returns {Array<{check,rules,measured,verdict,consequence}>}
+   */
+  function runSufficiencyProbes(dbQuery, opts) {
+    opts = opts || {};
+    var log = opts.log || function () {};
+    return SUFFICIENCY_PROBES.map(function (p) {
+      var out;
+      try {
+        out = p.run(dbQuery);
+      } catch (e) {
+        out = { measured: null, verdict: _SUFF_UNAVAILABLE, consequence: 'probe could not run: ' + e.message };
+      }
+      log('§RULE_SUFFICIENCY check=' + p.check + ' verdict=' + out.verdict +
+        ' measured=' + JSON.stringify(out.measured));
+      return { check: p.check, rules: p.rules, measured: out.measured, verdict: out.verdict, consequence: out.consequence };
+    });
+  }
+
+  // ── Pure: flagged/population per rule (T8.11). A rule firing on ~90% of its population is not
+  // discriminating on that building — the ratio is the whole argument, so the report states it
+  // and says nothing more. `populations` is supplied by the caller (it needs the DB); a rule with
+  // no known population reports null rather than a ratio against a guessed denominator.
+  function flagRates(rules, populations) {
+    populations = populations || {};
+    return (rules || []).map(function (r) {
+      var pop = Object.prototype.hasOwnProperty.call(populations, r.rule) ? populations[r.rule] : null;
+      return {
+        rule: r.rule, flagged: r.count, population: pop,
+        rate: (pop === null || !pop) ? null : +(r.count / pop).toFixed(4)
+      };
+    });
+  }
+
+  // ── The populations each rule is actually drawn from, by the evaluators' own WHERE clauses.
+  // Kept next to the probes so a rule added later has one obvious place to declare its denominator.
+  function rulePopulations(dbQuery) {
+    function n(sql) { try { return _q1(dbQuery, sql); } catch (e) { return null; } }
+    var beams = n("SELECT COUNT(*) FROM elements_meta WHERE ifc_class = 'IfcBeam'");
+    var cols = n("SELECT COUNT(*) FROM elements_meta WHERE ifc_class = 'IfcColumn'");
+    var doors = n("SELECT COUNT(*) FROM elements_meta WHERE discipline = 'ARC' AND ifc_class = 'IfcDoor'");
+    return {
+      floating_member: beams, span_depth_steel: beams, span_depth_concrete: beams,
+      span_depth_cantilever: beams, column_continuity: cols, door_clear_width: doors
+      // circulation_distance / isolated_room are drawn from room-graph NODES, not a DB class —
+      // the caller supplies that count from the graph it already built, or it stays unknown.
+    };
+  }
+
+  /**
+   * Build the report object. PURE — same inputs give the same bytes but for meta.generatedAt.
+   * @param {object} p
+   *   p.rowsS  {Array}  StructuralSanity.evaluate() rows (or [])
+   *   p.rowsE  {Array}  EgressSanity.evaluate() rows (or [])
+   *   p.ruleDefs {Array<object>} the parsed rules JSONs actually used — drives T8.5's zero rows
+   *   p.meta   {object} { building, db, dbBytes, commit, swVersion, generatedAt,
+   *                       rulesSource: { structural, egress }, roomGraph, longestExitSteps }
+   * @returns {object} plain JSON-serialisable report
+   */
+  function buildRuleReport(p) {
+    p = p || {};
+    var rowsS = p.rowsS || [], rowsE = p.rowsE || [], meta = p.meta || {};
+    // `rows` is the already-merged form the PANEL surface has (one panel holds one evaluator's
+    // rows and must not mislabel them as the other's); the CLI passes rowsS/rowsE separately
+    // because it runs both evaluators. Either way the builder works on one flat list.
+    var all = p.rows ? p.rows.slice() : rowsS.concat(rowsE);
+
+    // T8.5 — every rule we were ASKED to check, whether or not it fired.
+    var names = ruleNamesOf(p.ruleDefs);
+    // A rule that produced rows but is not in ruleDefs still gets listed (never hide a finding).
+    all.forEach(function (r) { if (r && r.rule && names.indexOf(r.rule) === -1) names.push(r.rule); });
+
+    var bySev = { CRITICAL: 0, WARNING: 0, OPTIMIZED: 0 };
+    var rules = names.map(function (n) {
+      var mine = all.filter(function (r) { return r.rule === n; });
+      var sev = { CRITICAL: 0, WARNING: 0, OPTIMIZED: 0 };
+      mine.forEach(function (r) {
+        var s = (r.severity === 'CRITICAL' || r.severity === 'WARNING') ? r.severity : 'OPTIMIZED';
+        sev[s]++; bySev[s]++;
+      });
+      return { rule: n, count: mine.length, severity: sev, unit: Object.prototype.hasOwnProperty.call(RULE_UNITS, n) ? RULE_UNITS[n] : null };
+    });
+
+    var findings = all.map(function (r) {
+      var v = valueOf(r);
+      return {
+        guid: r.guid, ifc_class: r.ifc_class, name: r.name == null ? null : String(r.name),
+        shortName: shortName(r.name), storey: r.storey == null ? null : String(r.storey),
+        rule: r.rule, severity: r.severity,
+        value: v.value, unit: v.unit,
+        target: r.target == null ? null : r.target,  // egress rows label which target they measured
+        // T8.12 — the evaluator's own evidence for THIS row, when it was run with witness:true.
+        // Undefined (omitted from the JSON) rather than null when witness was off, so a report
+        // without evidence is visibly different from one whose evidence came back empty.
+        witness: r.witness === undefined ? undefined : r.witness
+      };
+    });
+
+    // T8.4 egress stats. `steps` comes from the caller (rule_checklist.js's longestExitSteps) so
+    // the arithmetic lives in ONE place; we only disclose the assumption behind it.
+    var maxExitDistM = null;
+    all.forEach(function (r) {
+      if (r.rule !== 'circulation_distance') return;
+      var v = _num(r.ratio); if (v === null) return;
+      if (maxExitDistM === null || v > maxExitDistM) maxExitDistM = v;
+    });
+    var steps = (meta.longestExitSteps === undefined || meta.longestExitSteps === null)
+      ? (maxExitDistM === null ? null : Math.round(maxExitDistM / STEP_M))
+      : meta.longestExitSteps;
+
+    var src = meta.rulesSource || {};
+    return {
+      schema: REPORT_SCHEMA,
+      generatedAt: meta.generatedAt || new Date().toISOString(),
+      building: meta.building == null ? null : String(meta.building),
+      db: meta.db == null ? null : String(meta.db),
+      dbBytes: _num(meta.dbBytes),
+      commit: meta.commit == null ? null : String(meta.commit),
+      swVersion: meta.swVersion == null ? null : String(meta.swVersion),
+      // T8.4 — `fetched` vs `fallback` is the difference between the project's authored
+      // thresholds and this repo's hardcoded copies. `unknown` when the caller cannot say;
+      // never silently `fetched`.
+      rulesSource: { structural: src.structural || 'unknown', egress: src.egress || 'unknown' },
+      totals: { findings: all.length, rules: rules.length, severity: bySev,
+        withWitness: all.filter(function (r) { return r.witness !== undefined; }).length },
+      rules: rules,
+      egressStats: {
+        maxExitDistM: maxExitDistM,
+        maxExitSteps: steps,
+        stepMetres: STEP_M,
+        estimate: true,          // the "~" on the panel's own status line — never a measured fact
+        note: 'steps = round(metres / ' + STEP_M + ' m per stride); stride is an ergonomic convention from outside this project'
+      },
+      // T8.4 — absent means absent. A caller that did not capture the graph log gets null here
+      // and a reason, not zeros that would read as "no exits found".
+      roomGraph: meta.roomGraph || null,
+      roomGraphNote: meta.roomGraph ? null : 'not captured — §ROOM_GRAPH_EXITS is emitted by RoomGraph.buildGraph(), whose log egress_sanity.js silences; the caller must build the graph with a capturing log to supply it',
+      // ── T8.11 — the report's review of its OWN INPUT. Beside the findings, never over them:
+      // nothing below changes a single row or total above. Null when the caller ran no probes
+      // (a panel with no dbQuery, say) — stated as null, not as an empty "all clear".
+      dataSufficiency: meta.sufficiency || null,
+      flagRates: meta.sufficiency ? flagRates(rules, meta.populations || {}) : null,
+      dataSufficiencyNote: meta.sufficiency
+        ? 'Measured from this DB. A degraded or absent verdict means the rule could not see the datum it depends on — read its findings as questions, not defects. Findings above are untouched by this section.'
+        : 'not run — the caller supplied no sufficiency probes',
+      findings: findings
+    };
+  }
+
+  // Stable JSON — key order is insertion order above, so the same rows give the same bytes (T8.6).
+  function toJson(report) { return JSON.stringify(report, null, 2); }
+
+  return {
+    buildRuleReport: buildRuleReport,
+    runSufficiencyProbes: runSufficiencyProbes,
+    rulePopulations: rulePopulations,
+    flagRates: flagRates,
+    SUFFICIENCY_PROBES: SUFFICIENCY_PROBES,
+    parseRoomGraphExits: parseRoomGraphExits,
+    ruleNamesOf: ruleNamesOf,
+    shortName: shortName,
+    RULE_UNITS: RULE_UNITS,
+    STEP_M: STEP_M,
+    REPORT_SCHEMA: REPORT_SCHEMA,
+    toJson: toJson
+  };
+});

--- a/viewer/structural_sanity.js
+++ b/viewer/structural_sanity.js
@@ -72,14 +72,39 @@
   }
 
   // ── Rule 1: floating member (also feeds rules 2-4's supportedCount classification) ──
-  function _supportChecks(beams, supports, tolerance_m, framing_dz_m) {
-    // out[guid] = { supportedCount: 0|1|2 }
+  // ── §STRUCT_WITNESS (T8.12): what actually sits at an end the rule judged UNSUPPORTED.
+  // `anyRows` is the WIDE candidate set (every class, every discipline) that the rule itself does
+  // NOT consult — the point is to show the reader the element the rule could not count, so
+  // "floating" and "cantilever" can be eyeballed instead of taken on trust. Returns null when
+  // genuinely nothing is near. Distances are real, never rounded away.
+  function _nearestAtPoint(pt, anyRows, selfGuid, horizTol, vertTol) {
+    var best = null;
+    for (var i = 0; i < anyRows.length; i++) {
+      var r = anyRows[i];
+      if (r[0] === selfGuid) continue;
+      var b = bbox(r);
+      var dxy = Math.max(0, Math.max(b.xmin - pt.x, pt.x - b.xmax));
+      var dy = Math.max(0, Math.max(b.ymin - pt.y, pt.y - b.ymax));
+      dxy = Math.sqrt(dxy * dxy + dy * dy);
+      if (dxy > horizTol) continue;
+      var dz = (pt.z < b.zmin) ? (b.zmin - pt.z) : (pt.z > b.zmax ? pt.z - b.zmax : 0);
+      if (dz > vertTol) continue;
+      var d = dxy + dz;
+      if (!best || d < best._d) best = { guid: r[0], ifc_class: r[9] || null, name: r[1], gapHorizM: +dxy.toFixed(3), gapVertM: +dz.toFixed(3), _d: d };
+    }
+    if (best) delete best._d;
+    return best;
+  }
+
+  function _supportChecks(beams, supports, tolerance_m, framing_dz_m, anyRows) {
+    // out[guid] = { supportedCount: 0|1|2, span, depth, freeEnds:[witness] }
     var out = {};
     for (var i = 0; i < beams.length; i++) {
       var beam = beams[i];
       var bb = bbox(beam);
       var ends = beamEndpoints(bb);
       var supportedCount = 0;
+      var freeEnds = [];
       for (var e = 0; e < ends.length; e++) {
         var pt = ends[e];
         var found = false;
@@ -101,14 +126,19 @@
           }
         }
         if (found) supportedCount++;
+        // Witness only for the ends the rule REJECTED — a supported end needs no explaining.
+        // Search radius is deliberately WIDER than the rule's own tolerance (4x horizontal, 1m
+        // vertical) so a near-miss shows up as a near-miss instead of as nothing.
+        else if (anyRows) freeEnds.push({ end: e, at: { x: +pt.x.toFixed(2), y: +pt.y.toFixed(2), z: +pt.z.toFixed(2) },
+          nearest: _nearestAtPoint(pt, anyRows, beam[0], tolerance_m * 4, 1.0) });
       }
-      out[beam[0]] = { supportedCount: supportedCount, span: Math.max(bb.bx, bb.by), depth: bb.bz };
+      out[beam[0]] = { supportedCount: supportedCount, span: Math.max(bb.bx, bb.by), depth: bb.bz, freeEnds: freeEnds };
     }
     return out;
   }
 
   // ── Rule 5: column load-path continuity — centerline distance, not footprint overlap ──
-  function _columnContinuity(columns, supports, tolerance_m) {
+  function _columnContinuity(columns, supports, tolerance_m, anyRows) {
     var out = {};
     for (var i = 0; i < columns.length; i++) {
       var col = columns[i];
@@ -123,7 +153,35 @@
         if (Math.abs(sb.zmax - cb.zmin) > tolerance_m) continue;
         found = true; break;
       }
-      out[col[0]] = { supported: found };
+      var witness = null;
+      if (!found && anyRows) {
+        // §STRUCT_WITNESS — what IS under this column, across EVERY class (not just
+        // COL_SUPPORT_CLASSES), at a deliberately looser radius than the rule's own. This is the
+        // difference between "nothing is there" and "an IfcMember is there, 0.42 m out, and the
+        // rule cannot count an IfcMember" — the reader can tell those apart at a glance.
+        var best = null;
+        for (var k = 0; k < anyRows.length; k++) {
+          var r = anyRows[k];
+          if (r[0] === col[0]) continue;
+          var b = bbox(r);
+          var ddx = cb.cx - b.cx, ddy = cb.cy - b.cy;
+          var dxy = Math.sqrt(ddx * ddx + ddy * ddy);
+          if (dxy > tolerance_m * 4) continue;
+          var dz = Math.abs(b.zmax - cb.zmin);
+          if (dz > 1.0) continue;
+          var d = dxy + dz;
+          if (!best || d < best._d) best = { guid: r[0], ifc_class: r[9] || null, name: r[1],
+            centrelineOffsetM: +dxy.toFixed(3), topToColumnBaseM: +dz.toFixed(3), _d: d };
+        }
+        if (best) {
+          delete best._d;
+          best.rejectedBecause = (best.centrelineOffsetM > tolerance_m ? 'centreline offset > tolerance ' + tolerance_m + ' m' : null) ||
+            (best.topToColumnBaseM > tolerance_m ? 'top-to-base gap > tolerance ' + tolerance_m + ' m' : null) ||
+            (COL_SUPPORT_CLASSES.indexOf(best.ifc_class) === -1 ? best.ifc_class + ' is not a column-support class (' + COL_SUPPORT_CLASSES.join('/') + ')' : 'unknown');
+        }
+        witness = { nearestBelow: best, columnBaseZ: +cb.zmin.toFixed(2) };
+      }
+      out[col[0]] = { supported: found, witness: witness };
     }
     return out;
   }
@@ -182,10 +240,26 @@
       "WHERE em.discipline = 'STR' AND em.ifc_class IN (" + colSupportClassesSql + ")"
     );
 
+    // ── §STRUCT_WITNESS (prompts/STRUCTURAL_SANITY.md T8.12) — OPT-IN, default OFF.
+    // The rules above deliberately look only at STR-discipline support classes. That is what
+    // makes a "floating" or "unsupported" verdict cheap — and also what makes it unreadable: the
+    // user cannot tell "nothing is there" from "something is there that this rule cannot count".
+    // With opts.witness, ONE extra query fetches every element that has a transform, across every
+    // class and discipline, purely so a flagged row can name the neighbour it was measured
+    // against. It changes NO count and produces NO row — R12 asserts exactly that.
+    var anyRows = null;
+    if (opts.witness) {
+      anyRows = dbQuery(
+        "SELECT em.guid, em.element_name, em.storey, et.center_x, et.center_y, et.center_z, et.bbox_x, et.bbox_y, et.bbox_z, em.ifc_class " +
+        "FROM element_transforms et JOIN elements_meta em ON et.guid = em.guid"
+      );
+      log('§STRUCT_WITNESS enabled candidates=' + anyRows.length + ' (every class/discipline with a transform — evidence only, never a rule input)');
+    }
+
     var rows = [];
 
     // Rule 1 (+ classification feeding rules 2-4)
-    var support = _supportChecks(beamRows, supportRows, floatingRule.tolerance_m, floatingRule.framing_dz_m);
+    var support = _supportChecks(beamRows, supportRows, floatingRule.tolerance_m, floatingRule.framing_dz_m, anyRows);
     var floatingCount = { CRITICAL: 0 };
     var unmatched = 0;
     var spanDepthCounts = { span_depth_steel: { WARNING: 0, uncapped_critical: 0 }, span_depth_concrete: { WARNING: 0, uncapped_critical: 0 }, span_depth_cantilever: { WARNING: 0, uncapped_critical: 0 } };
@@ -194,7 +268,9 @@
       var guid = b[0], name = b[1], storey = b[2];
       var sup = support[guid];
       if (sup.supportedCount === 0) {
-        rows.push({ guid: guid, ifc_class: 'IfcBeam', name: name, storey: storey, rule: 'floating_member', severity: 'CRITICAL', ratio: null });
+        rows.push({ guid: guid, ifc_class: 'IfcBeam', name: name, storey: storey, rule: 'floating_member', severity: 'CRITICAL', ratio: null,
+          witness: anyRows ? { supportedEnds: 0, of: 2, freeEnds: sup.freeEnds,
+            reads: 'neither end found a support within ' + floatingRule.tolerance_m + ' m; `nearest` is what actually sits there, searched at 4x that radius across every class' } : undefined });
         floatingCount.CRITICAL++;
         return; // floating members aren't also scored for span/depth
       }
@@ -216,7 +292,23 @@
       var sev = _severityForRatio(ratio, rule);
       if (sev) {
         spanDepthCounts[ruleName].WARNING += (sev === 'WARNING' ? 1 : 0);
-        rows.push({ guid: guid, ifc_class: 'IfcBeam', name: name, storey: storey, rule: ruleName, severity: sev, ratio: ratio });
+        var w;
+        if (anyRows) {
+          w = { supportedEnds: sup.supportedCount, of: 2, spanM: +sup.span.toFixed(3), depthM: +sup.depth.toFixed(3),
+                warningRatio: rule.warning_ratio, criticalRatio: rule.critical_ratio };
+          if (isCantilever) {
+            // The single highest-value witness in this file. `isCantilever` is an INFERENCE
+            // (supportedCount === 1) that preempts material classification, and it routes the
+            // beam to a 12/16 ratio instead of its material's own. Naming what sits at the
+            // un-counted end lets the reader see at once whether this is a real cantilever.
+            w.freeEnds = sup.freeEnds;
+            w.classifiedAs = 'cantilever';
+            w.classifiedBy = 'inference: exactly one end found a support — NOT a modelled cantilever attribute (none exists in this schema)';
+            w.wouldBeCleanUnderSteelRule = (steelRule.warning_ratio != null && ratio < steelRule.warning_ratio);
+            w.reads = 'if `nearest` at the free end is real bearing, this beam is not a cantilever and the 12/16 ratio does not apply to it';
+          }
+        }
+        rows.push({ guid: guid, ifc_class: 'IfcBeam', name: name, storey: storey, rule: ruleName, severity: sev, ratio: ratio, witness: w });
       }
     });
 
@@ -227,12 +319,27 @@
     });
 
     // Rule 5: column continuity
-    var colContinuity = _columnContinuity(colRows, colSupportRows, columnRule.tolerance_m);
+    var colContinuity = _columnContinuity(colRows, colSupportRows, columnRule.tolerance_m, anyRows);
     var unsupportedColCount = 0;
+    var colLowestZ = null;
+    colRows.forEach(function (c) { var z = bbox(c).zmin; if (colLowestZ === null || z < colLowestZ) colLowestZ = z; });
     colRows.forEach(function (c) {
       var guid = c[0], name = c[1], storey = c[2];
       if (!colContinuity[guid].supported) {
-        rows.push({ guid: guid, ifc_class: 'IfcColumn', name: name, storey: storey, rule: 'column_continuity', severity: 'CRITICAL', ratio: null });
+        var w;
+        if (anyRows) {
+          w = colContinuity[guid].witness || {};
+          w.toleranceM = columnRule.tolerance_m;
+          w.supportClasses = COL_SUPPORT_CLASSES.slice();
+          // A column standing on the model's lowest plane with no footing under it is the single
+          // commonest false positive this rule produces (a real building measured 131/131 of its
+          // ground-floor columns flagged, with 0 IfcFooting anywhere). Say so on the row.
+          w.atLowestModelledLevel = (colLowestZ !== null && bbox(c).zmin <= colLowestZ + 0.5);
+          w.reads = w.atLowestModelledLevel
+            ? 'this column sits on the lowest modelled level — if the model has no footings, there is nothing here for the rule to find and this flag is a metadata gap, not a load-path break (see dataSufficiency.footings_modelled)'
+            : 'nothing in ' + COL_SUPPORT_CLASSES.join('/') + ' lies within ' + columnRule.tolerance_m + ' m below; `nearestBelow` is what is actually there';
+        }
+        rows.push({ guid: guid, ifc_class: 'IfcColumn', name: name, storey: storey, rule: 'column_continuity', severity: 'CRITICAL', ratio: null, witness: w });
         unsupportedColCount++;
       }
     });

--- a/viewer/sw.js
+++ b/viewer/sw.js
@@ -177,7 +177,7 @@
 // v1166 (2026-09-08) §27 §LINEAR_BEAT: new viewer/cpe_linear_beat.js (column + beam dimension cues in the dive, rides Measure).
 // v1167 (2026-09-08) §29 §INDOOR_BEATS: new viewer/cpe_indoor_beats.js (hall walkable area, stair going, door type, clear height; rides Measure).
 // v1168 (2026-09-08) §37 §MEASURE_TO_THE_END: storey-reveal cards carry walkable m² (cpe_storey_reveal.js); the datum's second life on the pull-out (cpe_flythru_datum.js).
-const CACHE_VERSION = 'v1169';   // bump on each deploy; per-change detail is the git commit message.
+const CACHE_VERSION = 'v1170';   // bump on each deploy; per-change detail is the git commit message.
 // v1128 (2026-09-02) §SUN_FILL_RATIO: viewer/effects.js — the Alt+S staging HDRI
 // (belfast_sunset_puresky_1k) was being pushed onto EVERY material by _reassertPhotoEnvMap, matte
 // concrete and plaster included. IBL is non-directional and is NOT shadow-map-occluded in three.js,
@@ -636,6 +636,7 @@ const PRECACHE_ASSETS = [
   'clash_labels.js',
   'structural_sanity.js',
   'egress_sanity.js',
+  'rule_report.js',
   'rule_checklist.js',
   'measure.js',
   'sitecam.js',

--- a/viewer/viewer.html
+++ b/viewer/viewer.html
@@ -891,6 +891,9 @@ html.bim-embedded, html.bim-embedded body { background: #0b0b0b; }
      loaded on demand by APP.loadNavigate() (see rule_checklist.js's A.showEgressSanity) — this
      tag only needs to load before A.showEgressSanity() can run, same as structural_sanity.js. -->
 <script src="egress_sanity.js?v=1" onerror="console.warn('§LOAD_FAIL egress_sanity.js')"></script>
+<!-- STRUCTURAL_SANITY.md T8 — rule_report.js is portable/DOM-free like structural_sanity.js;
+     rule_checklist.js's Report button (A._downloadRuleReport) needs it loaded first. -->
+<script src="rule_report.js?v=1" onerror="console.warn('§LOAD_FAIL rule_report.js')"></script>
 <script src="rule_checklist.js?v=1" onerror="console.warn('§LOAD_FAIL rule_checklist.js')"></script>
 <script src="measure.js?v=52" onerror="console.warn('§LOAD_FAIL measure.js')"></script>
 <script src="sitecam.js?v=7" onerror="console.warn('§LOAD_FAIL sitecam.js')"></script>


### PR DESCRIPTION
Implements `prompts/STRUCTURAL_SANITY.md` **T8** (added here). Spec origin: `bim-compiler prompts/MEP_CLASH_REVEAL_MOVIE.md §87` @ `6eaeaa006`, authored by the movie-bake session; T8.11 and T8.12 are additions from this session on the user's direction.

## The measured case

| building | findings known at | film complete | analysis share |
|---|---|---|---|
| Terminal | +42s | +1,194s | 3.5% |
| Hospital | +101.3s | ~+6,000s | 1.7% |

The rules cost about a second. `cli_silent_bake.js` had `--opening-only` but nothing that stopped at the knowing.

## One pure builder, three surfaces

`viewer/rule_report.js` — no DOM, no THREE, no camera, no `plan`; same portability contract as `structural_sanity.js`.

| surface | status |
|---|---|
| `cli_silent_bake.js --findings-only` → `<out>.json` | ✅ here |
| **Report** button in the generic `_buildRuleChecklistHtml` chassis | ✅ here — one edit, both panels, a third inherits it |
| the film's closing card | ⛔ `rule_findings_film.js` is on `feat/rule-findings-film`; that session wires it on merge |

⚠ It does **not** ride `A.ruleFindingsFilmBuild` (§87.3) — that needs a plan, a tint and a camera, everything findings-only exists to skip. It calls the evaluators directly.

**A zero is a result here** (§87.5): the builder takes `ruleDefs`, so `door_clear_width: 0` is stated outright where the film rightly drops a vacuous card. `ratio` is never printed bare — it is metres for the two distance rules and dimensionless for the three `span_depth` ones, so every value carries a `unit`. `rulesSource` records `fetched` vs `fallback`.

## T8.11 — the report reviews its own INPUT

Eight probes over the same `dbQuery` contract, each a real count with a derived verdict. Measured on the bake DBs:

- **Terminal and HHS carry 0 `IfcFooting`.** HHS flags **131/131** of its Level 1 columns — 61% of that building's entire finding count. Terminal 108/158, ground storeys 30/30 and 56/56.
- **`IfcSpace` in `elements_meta` is 0 in all three buildings.** Every room-rule finding sits on a synthesized room, and the extraction marks its own confidence in the name (`≈` approximate, `⚠` suspect) — which neither evaluator reads.
- All 1970 Hospital beams have `material_name` NULL; HHS columns carry `"≈ White"`, a colour.

Sufficiency sits **beside** the findings and never edits them (R11 asserts byte-identical rows and totals with and without it).

## T8.12 — a finding shows its own working

Opt-in (`{ witness: true }`), default off, **additive or nothing** — R12 asserts `guid|rule|severity|ratio` identical on/off across 488 structural + 142 egress real Hospital rows. Cost: Hospital 1.4s, Terminal 0.56s, HHS 0.08s.

A finding's evidence is usually an *absence*, which a bare row cannot show:

- **`isolated_room`** → graph degree + neighbours. Hospital's 7 are all degree 0 with no storey circulation node — the graph never connected them. **HHS's single one has degree 6**, with four E2 door edges to its own spine: demonstrably *not* isolated, and the row now says so.
- **`column_continuity`** → what is actually below, and why it was rejected. Hospital's 24: one misses an `IfcWallStandardCase` foundation retaining wall by **15 mm** against a 0.3 m tolerance; 9 are rejected only because `IfcMember` is not a column-support class; exactly **one** has nothing below it.
- **`span_depth_cantilever`** → states that "cantilever" is an inference from `supportedCount === 1` (no such attribute exists in the schema), names what sits at the un-counted end, and flags whether the classification is what produced the flag. Hospital's 217: only **2** have nothing near the free end (76 `IfcWall`, 59 `IfcWallStandardCase`, 20 `IfcSlab`…), and **113 of 217** would be clean under `span_depth_steel`'s own 24/30.

## Witnesses

`tests/test_rule_report.js` — **46 checks, 0 failed** (R1-R6, R8-R12), against real `buildings/Hospital_meta.db`. Existing rule witnesses unchanged: `test_structural_sanity_rules` 9, `test_egress_sanity_rules` 6, `test_rule_checklist_panel` 26, `test_rule_deeplink` 8 — all passing.

**R7 — a real `--findings-only` run**, `Clinic_meta`, log at `§RULE_REPORT_ONLY`:

```
+7.2s  §CLI_BAKE_LOADED building=Clinic meshes=14
+7.2s  §STRUCT_WITNESS enabled candidates=16114
+7.5s  §EGRESS_WITNESS enabled nodes=119 edges=339 exitNodes=0 storeysWithCirc=0
+8.0s  §RULE_REPORT building=Clinic findings=120 rules=8 critical=30 warning=90
       rulesSource={"structural":"fetched","egress":"fetched"}
       roomGraph={"exits":0,"noRaster":254,"doors":254}
+8.0s  §RULE_REPORT_ONLY exit — no bake requested, no frame drawn
```

`§MAXQ_FRAME` lines: **0**. `§CLI_BAKE_PROGRESS` lines: **0**. No MP4 written. Exit 0. **8.0s end to end.**

And it immediately surfaced a real defect without a bake — the `exits=0 noRaster=254/254` shape §59.7 names: all 90 Clinic `circulation_distance` findings measured to `circulation (fallback)`, never to an exit, on rooms that are 90/90 `≈ approximate`. 24 of its 29 `column_continuity` flags are a centreline near-miss.

## CI gates
`RuleReport` in `eslint.globals.json`; `rule_report.js` in `sw.js` `PRECACHE_ASSETS` with `CACHE_VERSION` v1169→v1170; script tag in `viewer.html`. `npx eslint` clean on all five touched files.

## Open, not solved here
71.3s of Hospital's 101.3s is model load and the report cannot go below it (T8.10). This makes that the *whole* cost instead of 1.7% of it, which is what makes it worth attacking — measure peak RSS across the load phase first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)