### PR TITLE
§CPE_BUILDUP_PLACED — name the element, not just the count (§88.3)

### DIFF
--- a/viewer/cinema_maxq.js
+++ b/viewer/cinema_maxq.js
@@ -1741,6 +1741,43 @@
             if (_dayInfo) _dayInfo.pos = _dayPos;
           }
           var _ggO = _ghostGroundAt(_bkT, _filmSecFull, _bkState, _bkMs);   // §CPE_CLIP_BUILDUP_FILM_T — same class: the fade is in FILM seconds
+          // ══ §CPE_BUILDUP_PLACED (MEP_CLASH_REVEAL_MOVIE.md §88.3/§88.6e) ═══════════════════════
+          // The frame number lives HERE; what is actually on screen for a watched guid lives in the
+          // Time Machine's traverse. This is the seam. Read every frame (so no state change is
+          // missed between two §CPE_BUILDUP samples 60 frames apart) but LOG only on change — a
+          // 4,699-frame Hospital bake costs a handful of lines, not 4,699 × |watch|.
+          if (typeof window.tmWatchState === 'function') {
+            var _bdNow = window.tmWatchState();
+            if (_bdNow) {
+              if (!A._bdSeenLast) A._bdSeenLast = {};
+              for (var _bdG in _bdNow) {
+                var _bdS = _bdNow[_bdG];
+                var _bdK = _bdS.op + '|' + _bdS.mesh + '|' + _bdS.visible + '|' + _bdS.host + '|' + _bdS.y;
+                if (A._bdSeenLast[_bdG] === _bdK) continue;
+                A._bdSeenLast[_bdG] = _bdK;
+                console.log('§CPE_BUILDUP_PLACED frame=' + i + '/' + nFrames + ' guid=' + _bdG +
+                  ' cls=' + _bdS.cls + ' storey="' + _bdS.storey + '"' +
+                  ' op=' + _bdS.op + ' mesh=' + _bdS.mesh + ' visible=' + _bdS.visible +
+                  ' host=' + _bdS.host + ' y=' + _bdS.y +
+                  ' groundY=' + (A.ground ? A.ground.position.y.toFixed(3) : 'n/a') +
+                  (_ggO == null ? '' : ' groundOpacity=' + _ggO.toFixed(3)) +
+                  (_bdS.mesh === 'MISSING' ? ' — scheduled, but NO mesh in the scene carries this guid'
+                   : _bdS.visible ? ' — drawn' : ' — mesh exists, left hidden'));
+              }
+              if (!A._bdEverDrawn) A._bdEverDrawn = {};
+              for (var _bdG2 in _bdNow) if (_bdNow[_bdG2].visible) A._bdEverDrawn[_bdG2] = i;
+              // §88.5's "what DONE looks like": one line a grep can settle the question on.
+              if (i === nFrames - 1) {
+                var _bdAll = Object.keys(_bdNow), _bdNever = [];
+                for (var _bdI = 0; _bdI < _bdAll.length; _bdI++)
+                  if (A._bdEverDrawn[_bdAll[_bdI]] === undefined)
+                    _bdNever.push(_bdAll[_bdI] + '(' + _bdNow[_bdAll[_bdI]].storey + ',' + _bdNow[_bdAll[_bdI]].mesh + ')');
+                console.log('§CPE_BUILDUP_PLACED_SUMMARY watched=' + _bdAll.length +
+                  ' drawn=' + (_bdAll.length - _bdNever.length) +
+                  ' neverDrawn=' + (_bdNever.length ? '[' + _bdNever.join(' ') + ']' : 'none'));
+              }
+            }
+          }
           if (i === 0 || i === nFrames - 1 || i % 60 === 0) {
             if (_dayInfo) console.log('§CPE_DAY_COUNTER frame=' + i + ' day=' + _dayInfo.day +
               ' of=' + _dayInfo.totalDays + ' pos=' + _dayInfo.pos + ' cursor=' + Math.round(_bkMs));

--- a/viewer/tests/witness_buildup_placed_watch.js
+++ b/viewer/tests/witness_buildup_placed_watch.js
@@ -1,0 +1,140 @@
+#!/usr/bin/env node
+// WITNESS — W-BDP — §CPE_BUILDUP_PLACED
+// Spec: bim-compiler prompts/MEP_CLASH_REVEAL_MOVIE.md §88.3 / §88.6e.
+//
+// ISSUE THIS PROVES OR DISPROVES:
+//   §88 opened because Hospital's 8,899 m² Level 1 floor slab reads as bare ground from the opening
+//   seconds to the closing reveal, and NO bake log could say when — or whether — it was ever drawn.
+//   §CPE_BUILDUP reports `placed=N/63415`, an op count, and nothing in the codebase names a single
+//   element. §CPE_BUILDUP_PLACED closes that by logging a WATCH SET of guids with the frame each
+//   one's state changed.
+//
+//   That instrumentation is only worth anything if the watch set actually CONTAINS the element the
+//   question is about, and if the frame it prints can be checked against something independent.
+//   Both halves are pure data — the default watch set is one SQL query, and the frame an element is
+//   due on is its ELEMENT_PLACE op's end_ts rank over all ops (the buildup is work-paced,
+//   §CPE_BUILDUP_PACING mode=work, so rank/total IS the film fraction). So this is a NODE witness:
+//   it runs the shipped query against the shipped DBs in under a second, on every building, and
+//   needs no GPU. A browser harness would prove less, slower.
+//
+// GATES:
+//   G-BDP-WATCH   (BLOCKING) the default watch set is non-empty, at most 16, and holds at most one
+//                 slab per storey. On Hospital_silent it MUST contain 0e8pm26Tv5vPrj6zU55MOH —
+//                 §88's own element. A watch set that misses it instruments the wrong thing.
+//   G-BDP-ONEOP   (BLOCKING) every watched guid has EXACTLY ONE ELEMENT_PLACE op. With two, the
+//                 `op=placed` field would be ambiguous and the printed frame meaningless.
+//   G-BDP-FRAME   each watched guid's due frame, from its end_ts rank over all ELEMENT_PLACE ops.
+//                 This is the number a §CPE_BUILDUP_PLACED line must be read against: a guid whose
+//                 log line says `visible=false` long past its due frame is the §88 defect; one that
+//                 never gets a line at all means the watch set never resolved it.
+//   G-BDP-GROUND  reports each watched slab's underside/top against the §GROUND_Y datum (the
+//                 lowest large ground-floor-named slab's underside). §88.6a turns on this pair of
+//                 numbers, so the witness prints them rather than leaving them to be re-derived.
+//
+// Command (from the worktree root):
+//   node viewer/tests/witness_buildup_placed_watch.js [building ...]
+//   BLD_DIR=~/bim-ootb/buildings node viewer/tests/witness_buildup_placed_watch.js Hospital_silent
+'use strict';
+const fs = require('fs'), path = require('path'), os = require('os');
+const initSqlJs = require(path.join(os.homedir(), 'bim-ootb', 'node_modules', 'sql.js'));
+const SQLJS_DIST = path.join(os.homedir(), 'bim-ootb', 'node_modules', 'sql.js', 'dist');
+const BLD_DIR = process.env.BLD_DIR || path.join(os.homedir(), 'bim-ootb', 'buildings');
+const FRAMES = +(process.env.FRAMES || 4699);   // the v86 Hospital film, so the numbers are comparable
+
+// §88's own element — the one the whole section exists to explain.
+const HOSPITAL_L1_SLAB = '0e8pm26Tv5vPrj6zU55MOH';
+
+// VERBATIM from time_machine.js _bdWatchSet's default branch. Copied, not imported, because the
+// viewer is a browser bundle; any edit there must be mirrored here or G-BDP-WATCH stops witnessing
+// the shipped query.
+const WATCH_SQL =
+  'SELECT m.guid, m.ifc_class, m.storey, MAX(t.bbox_x * t.bbox_y) AS area ' +
+  'FROM elements_meta m JOIN element_transforms t ON t.guid = m.guid ' +
+  "WHERE m.ifc_class = 'IfcSlab' AND t.bbox_x IS NOT NULL AND t.bbox_y IS NOT NULL " +
+  'GROUP BY m.storey ORDER BY area DESC LIMIT 16';
+
+function rowsOf(db, sql) { const r = db.exec(sql); return r.length ? r[0].values : []; }
+
+(async () => {
+  const SQL = await initSqlJs({ locateFile: f => path.join(SQLJS_DIST, f) });
+  let names = process.argv.slice(2);
+  if (!names.length) {
+    names = fs.readdirSync(BLD_DIR).filter(f => f.endsWith('.db')).map(f => f.replace(/\.db$/, ''));
+  }
+  let fail = 0, checked = 0;
+
+  for (const name of names) {
+    const p = path.join(BLD_DIR, name + '.db');
+    if (!fs.existsSync(p)) { console.log(`§W-BDP SKIP ${name} — no such DB at ${p}`); continue; }
+    let db;
+    try { db = new SQL.Database(new Uint8Array(fs.readFileSync(p))); }
+    catch (e) { console.log(`§W-BDP SKIP ${name} — unreadable (${e.message})`); continue; }
+
+    const hasOps = rowsOf(db, "SELECT name FROM sqlite_master WHERE type='table' AND name='kernel_ops'").length;
+    if (!hasOps) { console.log(`§W-BDP SKIP ${name} — no kernel_ops (not a 4D DB)`); db.close(); continue; }
+    checked++;
+
+    const watch = rowsOf(db, WATCH_SQL);
+
+    // ── G-BDP-WATCH ────────────────────────────────────────────────────────────────────────────
+    const storeys = watch.map(r => r[2]);
+    const dupStorey = storeys.length !== new Set(storeys).size;
+    let wOk = watch.length > 0 && watch.length <= 16 && !dupStorey;
+    let wNote = '';
+    if (name === 'Hospital_silent') {
+      const has = watch.some(r => r[0] === HOSPITAL_L1_SLAB);
+      if (!has) { wOk = false; wNote = ' — MISSES §88\'s own Level 1 slab ' + HOSPITAL_L1_SLAB; }
+      else wNote = ' — contains §88\'s Level 1 slab';
+    }
+    console.log(`§W-BDP G-BDP-WATCH ${wOk ? 'PASS' : 'FAIL'} ${name} n=${watch.length} storeys=${storeys.length}` +
+      ` dupStorey=${dupStorey}${wNote}`);
+    if (!wOk) fail++;
+
+    // ── all ELEMENT_PLACE ops, ranked by end_ts ────────────────────────────────────────────────
+    const ops = rowsOf(db, "SELECT output_guid, timestamp, parameters FROM kernel_ops " +
+                           "WHERE op_type='ELEMENT_PLACE' AND undone=0 AND output_guid IS NOT NULL");
+    const endOf = r => { let e = null; try { e = (JSON.parse(r[2] || '{}') || {})._end_ts; } catch (x) {} return e || (r[1] + 60000); };
+    const ends = ops.map(endOf).sort((a, b) => a - b);
+    const opsByGuid = new Map();
+    for (const r of ops) { const l = opsByGuid.get(r[0]) || []; l.push(r); opsByGuid.set(r[0], l); }
+
+    // ── §GROUND_Y datum (tools.js §GROUND_Y_LOWEST_GF), for G-BDP-GROUND ───────────────────────
+    const GF = "('Ground Floor','Ground','First Floor','1st Floor','Level 0','Level 00','Level 1','GF','L0','L00','L1','00','0','1F','EG','Erdgeschoss','Storey 1','Plan 1','VÅN 1','VÅNING 1','1. OG','Rez-de-chaussée','RC','Planta Baja','PB','Piso 0','Begane grond','BG','GROUND FLOOR LEVEL','Ground Lev','Aras Tanah','u.etg')";
+    const gfRows = rowsOf(db,
+      'SELECT t.center_z - t.bbox_z/2 AS bottom, t.bbox_x*t.bbox_y AS area, t.center_z FROM element_transforms t ' +
+      'JOIN elements_meta m ON t.guid=m.guid ' +
+      "WHERE m.ifc_class='IfcSlab' AND t.bbox_z IS NOT NULL AND t.bbox_z < 1.0 AND t.bbox_x IS NOT NULL " +
+      'AND t.bbox_y IS NOT NULL AND m.storey IN ' + GF + ' ORDER BY area DESC LIMIT 5');
+    let groundZ = null;
+    for (const r of gfRows) if (groundZ === null || r[2] < groundZ.cz) groundZ = { z: r[0], cz: r[2] };
+    const gz = groundZ ? groundZ.z : null;
+
+    let oneOpOk = true;
+    for (const w of watch) {
+      const [guid, cls, storey, area] = w;
+      const list = opsByGuid.get(guid) || [];
+      if (list.length !== 1) { oneOpOk = false;
+        console.log(`§W-BDP G-BDP-ONEOP FAIL ${name} guid=${guid} storey="${storey}" ops=${list.length} — \`op=\` would be ambiguous`);
+        continue; }
+      const end = endOf(list[0]);
+      // rank = how many ops have finished by the time this one has → the work fraction, which IS
+      // the film fraction under §CPE_BUILDUP_PACING mode=work.
+      let lo = 0, hi = ends.length;
+      while (lo < hi) { const mid = (lo + hi) >> 1; if (ends[mid] <= end) lo = mid + 1; else hi = mid; }
+      const rank = lo, frac = rank / ends.length, dueFrame = Math.round(frac * FRAMES);
+      const g = rowsOf(db, `SELECT center_z, bbox_z FROM element_transforms WHERE guid='${guid}'`)[0];
+      const base = g ? g[0] - g[1] / 2 : null, top = g ? g[0] + g[1] / 2 : null;
+      console.log(`§W-BDP G-BDP-FRAME ${name} guid=${guid} cls=${cls} storey="${storey}" area=${Math.round(area)}m2` +
+        ` rank=${rank}/${ends.length} work=${(frac * 100).toFixed(3)}% dueFrame=${dueFrame}/${FRAMES}` +
+        (gz == null || base == null ? '' :
+          ` | G-BDP-GROUND base=${base.toFixed(3)} top=${top.toFixed(3)} groundZ=${gz.toFixed(3)}` +
+          ` topAboveGround=${(top - gz).toFixed(3)}m`));
+    }
+    console.log(`§W-BDP G-BDP-ONEOP ${oneOpOk ? 'PASS' : 'FAIL'} ${name} watched=${watch.length}`);
+    if (!oneOpOk) fail++;
+    db.close();
+  }
+
+  console.log(`§W-BDP VERDICT ${fail === 0 ? 'PASS' : 'FAIL'} buildingsChecked=${checked} blockingFailures=${fail}`);
+  process.exit(fail === 0 ? 0 : 1);
+})();

--- a/viewer/time_machine.js
+++ b/viewer/time_machine.js
@@ -56,6 +56,116 @@
   var _tmXraySolidifyTs = {};
   var _tmXrayStagedTotal = 0;   // total guids ever eligible to stage, this activation (the "n=")
   var _tmXraySolidifiedN = 0;   // guids that have crossed their solidify ms so far (the "solidified=")
+
+  // ══ §CPE_BUILDUP_PLACED (MEP_CLASH_REVEAL_MOVIE.md §88.3/§88.6e) ═════════════════════════════
+  // §CPE_BUILDUP reports an AGGREGATE — `placed=N/63415` — and nothing else in this codebase names
+  // a single element. So when Hospital's 8,899 m² Level 1 slab read as bare ground from the opening
+  // seconds to the closing reveal (§88), no bake log could say whether it was placed at frame 50,
+  // at frame 4000, or never: the op count reads identically whether the guid has no mesh at all,
+  // has one that was left hidden, or has one that is drawn and occluded by something else. Those
+  // are three different bugs with three different fixes, and a count cannot tell them apart.
+  //
+  // The observation rides along in the ONE traverse that already decides visibility — no second
+  // pass, no second opinion about what is on screen. A WATCH SET (≤16 guids) is the only per-object
+  // cost: one lookup in a null-prototype map per traversed object, and a getWorldPosition for the
+  // handful that match.
+  //
+  // ⚠ The record PERSISTS across ticks and is never reset to MISSING. The traverse's incremental
+  // path (`_incrOK`) legitimately SKIPS whole BatchedMesh/InstancedMesh objects on ticks where
+  // nothing in them changed — resetting each tick would report those frames as "mesh vanished"
+  // every time the delta path engaged. Only `op` (which comes from the schedule, not the scene) is
+  // recomputed every tick; `mesh`/`visible`/`y`/`host` are last-observed values.
+  var _bdWatch = null;          // guid -> { cls, storey } | null when not yet built, false when off
+  var _bdState = Object.create(null);   // guid -> { op, mesh, visible, y, host }
+
+  // Watch set, in the §88.6e order: an explicit `?watch=guid,guid` on the viewer URL wins; else the
+  // largest slab per storey — the floor plates, which is exactly the population §88 is about and the
+  // same pool §SLAB_BEAT already picks its beat from.
+  function _bdWatchSet(app) {
+    if (_bdWatch !== null) return _bdWatch;
+    _bdWatch = false;
+    try {
+      var w = Object.create(null), n = 0, i;
+      var q = (typeof location !== 'undefined' && location.search) ? location.search : '';
+      var m = /[?&]watch=([^&]+)/.exec(q);
+      if (m) {
+        var gs = decodeURIComponent(m[1]).split(',');
+        for (i = 0; i < gs.length && n < 16; i++) {
+          var g = gs[i].trim(); if (!g) continue;
+          w[g] = { cls: '?', storey: '?' }; n++;
+        }
+        if (n) {
+          // Fill in cls/storey for the explicit set so the log line reads without a second lookup.
+          if (app && app.db) {
+            var keys = Object.keys(w).map(function (k) { return "'" + k.replace(/'/g, "''") + "'"; });
+            var rr = app.db.exec('SELECT guid, ifc_class, storey FROM elements_meta WHERE guid IN (' + keys.join(',') + ')');
+            if (rr.length) for (i = 0; i < rr[0].values.length; i++) {
+              var rv = rr[0].values[i];
+              if (w[rv[0]]) { w[rv[0]].cls = rv[1] || '?'; w[rv[0]].storey = rv[2] || '?'; }
+            }
+          }
+          _bdWatch = w;
+          console.log('§CPE_BUILDUP_PLACED_WATCH n=' + n + ' src=url guids=' + Object.keys(w).join(','));
+          return _bdWatch;
+        }
+      }
+      if (!app || !app.db) { _bdWatch = null; return null; }   // retry next tick, the DB may not be up yet
+      var r = app.db.exec(
+        'SELECT m.guid, m.ifc_class, m.storey, MAX(t.bbox_x * t.bbox_y) AS area ' +
+        'FROM elements_meta m JOIN element_transforms t ON t.guid = m.guid ' +
+        "WHERE m.ifc_class = 'IfcSlab' AND t.bbox_x IS NOT NULL AND t.bbox_y IS NOT NULL " +
+        'GROUP BY m.storey ORDER BY area DESC LIMIT 16'
+      );
+      if (!r.length || !r[0].values.length) {
+        console.log('§CPE_BUILDUP_PLACED_WATCH n=0 src=slab-per-storey — this model has no IfcSlab with a bbox; pass ?watch=<guid> to name one');
+        _bdWatch = false; return false;
+      }
+      var names = [];
+      for (i = 0; i < r[0].values.length; i++) {
+        var v = r[0].values[i];
+        w[v[0]] = { cls: v[1] || '?', storey: v[2] || '?' };
+        names.push((v[2] || '?') + ' ' + Math.round(v[3]) + 'm2');
+        n++;
+      }
+      _bdWatch = w;
+      console.log('§CPE_BUILDUP_PLACED_WATCH n=' + n + ' src=slab-per-storey ' + names.join(' | '));
+    } catch (e) {
+      console.warn('§CPE_BUILDUP_PLACED_WATCH_FAIL ' + (e && e.message));
+      _bdWatch = false;
+    }
+    return _bdWatch;
+  }
+
+  function _bdRec(g) {
+    var s = _bdState[g];
+    if (!s) s = _bdState[g] = { op: 'pending', mesh: 'MISSING', visible: false, y: null, host: '-' };
+    return s;
+  }
+
+  // Called from the traverse the moment a watched guid's rendering path has decided its visibility.
+  // `obj` is optional and only used for the world Y — the number that says whether a drawn element
+  // is above or below the ghost-ground plane (§88.6a), which is the whole reason y is reported.
+  function _bdSeen(g, host, visible, obj) {
+    var s = _bdRec(g);
+    s.mesh = 'found'; s.host = host; s.visible = !!visible;
+    if (obj && obj.getWorldPosition) {
+      try { var v = new THREE.Vector3(); obj.getWorldPosition(v); s.y = +v.y.toFixed(3); } catch (e) {}
+    }
+  }
+
+  // The bake reads this once per frame (cinema_maxq.js) and logs only what CHANGED, so a 4,699-frame
+  // film costs a handful of lines rather than 4,699 × |watch|.
+  window.tmWatchState = function () {
+    if (!_bdWatch) return null;
+    var out = {};
+    for (var g in _bdWatch) {
+      var s = _bdState[g];
+      out[g] = { cls: _bdWatch[g].cls, storey: _bdWatch[g].storey,
+                 op: s ? s.op : 'pending', mesh: s ? s.mesh : 'MISSING',
+                 visible: s ? s.visible : false, y: s ? s.y : null, host: s ? s.host : '-' };
+    }
+    return out;
+  };
   var _ganttVisible = false;
   var _dashVisible = false;
   // §TM-VARIANCE (GW_HOSPITAL_SHOWCASE_SPEC §ACTUAL): planned = TM's own generated timeline; actual = a
@@ -1440,6 +1550,12 @@
     // below can match against. Reading straight from `frontier` is correct regardless of which
     // rendering path a given guid ends up on.
     window.__tmFrontierGuidsNow = new Set(Object.keys(frontier));
+    // §CPE_BUILDUP_PLACED — refresh ONLY the schedule half of each watched guid's record. The scene
+    // half is written by the traverse below and deliberately survives ticks the delta path skips.
+    var _bdW = _bdWatchSet(app);
+    if (_bdW) for (var _bg in _bdW) {
+      _bdRec(_bg).op = frontier[_bg] ? 'frontier' : (placed[_bg] ? 'placed' : 'pending');
+    }
     var _perfT0 = performance.now(), _perfObjs = 0, _perfSkipped = 0, _perfHideForProxy = 0;
     app.scene.traverse(function(obj) {
       _perfObjs++;
@@ -1488,6 +1604,7 @@
           obj.visible = false;
           if (obj._tm_highlighted) restoreMaterial(obj);
         }
+        if (_bdW && _bdW[g]) _bdSeen(g, obj.isMesh ? 'Mesh' : 'Obj', obj.visible, obj);
 
         // Shadow + camera (merged — was 3 separate traversals)
         // §S260b: Only set shadow flags if Sunglass shadow is ON
@@ -1546,7 +1663,15 @@
           // MEP, batched for performance) previously had NO staging check at all and showed fully
           // solid before its own support finished — the worse half of the bug this removal closes.
           var bStaged = !frontier[bg] && (_tmXraySolidifyTs[bg] !== undefined && cursorMs < _tmXraySolidifyTs[bg]);
-          if ((placed[bg] || frontier[bg] || recent[bg] !== undefined) && !bHideForProxy && !bStaged) {
+          var bShow = (placed[bg] || frontier[bg] || recent[bg] !== undefined) && !bHideForProxy && !bStaged;
+          if (_bdW && _bdW[bg]) {
+            _bdSeen(bg, 'BM', bShow, null);
+            // §CPE_BUILDUP_PLACED — a batched slot's world Y comes from its own slot matrix, not
+            // from the host mesh's position (the host is one object for thousands of elements).
+            obj.getMatrixAt(sid, _bmM4); _bmPos.setFromMatrixPosition(_bmM4);
+            _bdRec(bg).y = +(_bmPos.y + (obj.position ? obj.position.y : 0)).toFixed(3);
+          }
+          if (bShow) {
             obj.setVisibleAt(sid, true);
             anyVis = true;
             if (frontier[bg]) {
@@ -1614,7 +1739,14 @@
           var iHideForProxy = _dlodOn && !!placed[ig] && !frontier[ig] && recent[ig] === undefined && !_dlodInView(ig);
           // §XRAY_STAGING_REMOVED — same gate as the single-mesh/BatchedMesh branches.
           var iStaged = !frontier[ig] && (_tmXraySolidifyTs[ig] !== undefined && cursorMs < _tmXraySolidifyTs[ig]);
-          if ((placed[ig] || frontier[ig] || recent[ig] !== undefined) && !iHideForProxy && !iStaged) {
+          var iShow = (placed[ig] || frontier[ig] || recent[ig] !== undefined) && !iHideForProxy && !iStaged;
+          if (_bdW && _bdW[ig]) {
+            _bdSeen(ig, 'IM', iShow, null);
+            var _isv = _savedInstanceMatrices[meshId][mi];
+            if (_isv) { _tmV2.setFromMatrixPosition(_isv);
+              _bdRec(ig).y = +(_tmV2.y + (obj.position ? obj.position.y : 0)).toFixed(3); }
+          }
+          if (iShow) {
             if (_savedInstanceMatrices[meshId][mi]) {
               obj.setMatrixAt(mi, _savedInstanceMatrices[meshId][mi]);
             }


### PR DESCRIPTION
## Why

`§CPE_BUILDUP placed=N/63415` is an **op** count. When Hospital's 8,899 m² Level 1 slab read as bare ground from the opening seconds to the closing reveal (`MEP_CLASH_REVEAL_MOVIE.md` §88), no bake log could say whether it was drawn at frame 50, at frame 4000, or never — the count reads identically whether a scheduled guid has **no mesh at all**, has one **left hidden**, or has one that is **drawn and occluded**. Three different bugs, one indistinguishable number. §88.3 named that the blocker and the first thing to fix.

## What this adds

- **`time_machine.js`** — a watch set (`?watch=guid,guid`, else the largest slab per storey, ≤16) observed inside the **one** traverse that already decides visibility: single-mesh, BatchedMesh and InstancedMesh branches alike. Measured on Hospital: **0** single meshes carry a guid, **38,169** BatchedMesh slots and **25,013** InstancedMesh slots do — so all three hooks are load-bearing, and a single-mesh-only probe would have reported nothing.
  The record **persists across ticks and is never reset to `MISSING`**: the `_incrOK` delta path legitimately skips whole batched objects on ticks where nothing in them changed, and resetting would report those frames as "mesh vanished".
- **`cinema_maxq.js`** — read every frame, log only on **state change**, plus a `§CPE_BUILDUP_PLACED_SUMMARY` at top-out naming any watched guid never drawn. A 4,699-frame bake costs a handful of lines, not 4,699 × |watch|.
- **`viewer/tests/witness_buildup_placed_watch.js`** (W-BDP, node) — proves the default watch set contains §88's own Level 1 slab, that every watched guid has exactly one `ELEMENT_PLACE` op, and prints the frame each is due on from its `end_ts` rank.

## Evidence — it fires, on a real bake

`node cli_silent_bake.js --db Hospital_silent --clip 0:0.02 --width 1920 --height 1080 --gpu real`:

```
§CPE_BUILDUP_PLACED_WATCH n=10 src=slab-per-storey Level 3 9192m2 | Level 2 8963m2 | Level 1 8899m2 | …
§CPE_BUILDUP_PLACED frame=0/59  guid=0e8pm26Tv5vPrj6zU55MOH cls=IfcSlab storey="Level 1" op=pending mesh=found visible=false host=BM y=-15.652 groundY=-15.877 — mesh exists, left hidden
§CPE_BUILDUP_PLACED frame=16/59 guid=0e8pm26Tv5vPrj6zU55MOH … op=placed mesh=found visible=false … — mesh exists, left hidden
§CPE_BUILDUP_PLACED frame=19/59 guid=0e8pm26Tv5vPrj6zU55MOH … op=placed mesh=found visible=true  … — drawn
§CPE_BUILDUP_PLACED_SUMMARY watched=10 drawn=3 neverDrawn=[…Level 3…Level 5…]
```

That is §88.5's "what DONE looks like": a line naming the guid and the frame it appeared on. (The `neverDrawn` upper storeys are correct — this clip covers only the first 2 % of the film, so Levels 3-7 are not built yet.)

W-BDP on Hospital:
```
§W-BDP G-BDP-WATCH PASS Hospital_silent n=10 storeys=10 dupStorey=false — contains §88's Level 1 slab
§W-BDP G-BDP-FRAME Hospital_silent guid=0e8pm26Tv5vPrj6zU55MOH … rank=805/63415 work=1.269% dueFrame=60/4699 | G-BDP-GROUND base=165.361 top=165.811 groundZ=165.361 topAboveGround=0.450m
§W-BDP G-BDP-ONEOP PASS Hospital_silent watched=10
§W-BDP VERDICT PASS buildingsChecked=1 blockingFailures=0
```

## What it already found

Used on §88 the same day, it settled the question the section was stuck on — see `bim-compiler prompts/MEP_CLASH_REVEAL_MOVIE.md` §88.6-§88.7. Summary: §88 is **not a main defect**; it reproduces only on `feat/rule-findings-film`, where the unmerged §BATCH_BUCKET_CLASS_PAINT bucket-key term puts the Level 1 slab alone in a 1-slot BatchedMesh and so fully applies a `§XRAY_STAGING_REMOVED` gate that holds the ground-floor slab **13.5 h past its own `end_ts`**. On main the same mis-stage exists but is masked by the slab sharing a 13-slot batch. Both defects are spec'd there with the fix order; **this PR changes no render behaviour** — it is the instrumentation only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NAaGzi9tbRYMs5c2MuxprG