### PR TITLE
§BENCH_DEFECT_ZERO — the last 8 fleet defects were in the metric, not in a rule (T12)

### DIFF
--- a/prompts/STRUCTURAL_SANITY.md
+++ b/prompts/STRUCTURAL_SANITY.md
@@ -921,3 +921,134 @@ counts UNCHANGED (moving them means a tolerance was widened), and the synthetic 
 failing when they should — `beam-under-slab` CRITICAL, `col-unsupported` CRITICAL. Per the Log
 Mandate: grep a real log, quote the number that moved, and check that a passing test could have
 failed.
+
+## T12 §BENCH_DEFECT_ZERO — all 8 remaining defects are in the METRIC, not in a rule
+**Spec-first. Every number below is from a witness dump or a raw `element_transforms` query over
+the fleet DBs, run before any file was edited** (`§STRUCT_WITNESS`/`§EGRESS_WITNESS` rows produced
+by the shipped evaluators at `1f795c70`). No rule threshold changes in this task, and none did.
+
+**T12.0 THE FLEET DRIFTED SINCE THE BASELINE — fix the environment, do not re-record.** A bare
+`node tests/bench_rule_artifacts.js --gate tests/bench_baseline.json` in the main checkout now
+exits 1 on `§BENCH_GATE_FLEET_MISMATCH` before a single rule is consulted:
+`buildings/Terminal_silent.db` is gone (its symlink target still exists at
+`~/Downloads/Terminal_silent.db`, 316 MB) and `buildings/TermRooms_extracted.db` — a 28 MB
+byte-identical twin of `Terminal_extracted.db` — has appeared and joined the fleet. That swap
+alone moves `isolated_room` from 52 findings to 102 and `column_continuity` from 1746 to 1692.
+**Re-recording the baseline here would have silently redefined the benchmark.** The 14 DBs the
+baseline was recorded on are named in the gate's own failure message; pass the missing ones on the
+command line (T11.5 trap 5 forbids symlinking them into `buildings/`).
+
+**T12.1 THE EVIDENCE, ROW BY ROW.** All 8 in `LTU_AHouse`, as T11.1 said.
+
+| # | DB · rule | witness says | raw geometry says | verdict |
+|---|---|---|---|---|
+| 1-4 | `_extracted` · `column_continuity` | ARC `IfcColumn`, `centrelineOffsetM` 0.025, `topToColumnBaseM` **0.300**, `rejectedBecause` **"unknown"** | candidate `zmax` **equals the subject's own `zmax`**; true gap 0.300001621…, tolerance 0.3 | metric artifact ×2 |
+| 5 | `_meta` · `column_continuity` | ARC `IfcWallStandardCase`, `centrelineOffsetM` **0.300**, `topToColumnBaseM` 0.123 | true centreline distance **0.300462350…** m | metric artifact (rounding) → near-miss |
+| 6 | `_meta` · `floating_member` | end 0 nearest = ARC `IfcBeam`, `gapHorizM` 0.013, `gapVertM` 0.111 | `\|zmax−zmax\|` **0.499251**, `\|zmin−zmin\|` **0.498896**, `framing_dz_m` = 0.4 | metric artifact (missing condition) → near-miss |
+| 7-8 | `_extracted` · `isolated_room` | `graphDegree` 1, sole neighbour is the other room, `exitNodesInModel` **0**, `storeyHasCirculationNode` **false** | the pair is its own connected component | metric artifact (wrong predicate) |
+
+**T12.2 WHY "THE METRIC, NOT THE RULE" IS NOT A SELF-SERVING READING.** Run it the other way: if
+the metric were right, the rule change that closes each row is — for 1-5, a `column_continuity`
+tolerance past 0.300462 m; for 6, a `framing_dz_m` past 0.4993 m; for 7-8, deleting
+`isolated_room`'s fallback. **All four are tolerance widenings, the single failure T11.2 says this
+benchmark exists to prevent.** The witness said so itself and was not read: `rejectedBecause` is
+`"unknown"` on all five column rows — the field exists precisely to name why a candidate was
+rejected, and "unknown" is it reporting that its own numbers do not explain the rejection. They do
+not explain it because they are the display-rounded numbers, not the measured ones.
+
+**T12.3 THE THREE DEFECTS, AND THE FIX FOR EACH. No rule threshold moves.**
+
+1. **Rounding decided a tolerance comparison.** `_nearestAtPoint` and `_columnContinuity` publish
+   distances at `toFixed(3)`; `artifactRates` then compares those published numbers against the
+   rule's tolerance. 0.300001621 and 0.300462350 both print as `0.3` and read as *inside* 0.3.
+   Publish at `toFixed(6)` — µm precision on metres, which is exactly the precision that separates
+   "inside" from "outside" here and so earns its digits. The metric keeps comparing published
+   numbers, so it stays independent of the rule's own code.
+2. **A candidate ABOVE the column is not a support below it.** `topToColumnBaseM` is
+   `Math.abs(cand.zmax − col.zmin)`, so a candidate whose top sits 0.30 m *above* the column's base
+   — rows 1-4, an ARC twin of the same physical column, sharing its top plane and extending 0.25 m
+   past its bottom — measures identically to one sitting 0.30 m *below* it.
+   **⚠ AND 6 dp IS NOT ENOUGH FOR TWO OF THEM.** The `VÅN 1` pair measures **0.300000190** m
+   against a 0.3 m tolerance. 190 nanometres. No rounding decides that honestly, and a metric that
+   needs 9 dp to get an answer is reading float noise, not geometry. But those same four rows share
+   the column's top plane as the **identical double** (`8.200000762939453`), so the test that can
+   carry this is the exact one: publish `topAboveColumnTopM` = `cand.zmax − col.zmax` and drop a
+   candidate from the evidence set when it is `>= 0`. A support below a column always has its top
+   under the column's top; a co-located duplicate does not.
+   **MEASURED, both candidate gates, over the fleet's 549 column findings that have a load-bearing
+   `nearestBelow`** (one witness pass, `--gate` numbers confirmed after):
+
+   | gate | fleet defect | fleet nearMiss | rows removed from the evidence set |
+   |---|---|---|---|
+   | none (6 dp only) | **2** | 547 | 0 |
+   | `topBelowColumnBaseM >= -tolerance` | **2** | **498** | 51, across 8 buildings |
+   | `topAboveColumnTopM < 0` | **0** | **545** | 4, all LTU_AHouse_extracted, all `above == 0` |
+
+   `topBelowColumnBaseM >= -tolerance` is the phrasing that comes to mind first, and it is the
+   wrong one: it also removes 47 deeper overlaps (12 LTU columns, 8 JKR columns, 8 HHS
+   `IfcMember`s, 3 Terminal_silent `IfcSlab`s …) and drops the fleet near-miss count to 498.
+   **Those 47 are a real question and answering it as a side-effect of this task would have buried
+   it.** `topAboveColumnTopM < 0` touches exactly the four rows this task is about. The signed
+   `topBelowColumnBaseM` is still published — it is what `rejectedBecause` says out loud — it just
+   does not gate.
+   ⚠ The RULE's own test is `Math.abs(...)` too, so it can also call a column "supported" by
+   something overlapping it. That is a possible false ALL-CLEAR, it would *raise* finding counts to
+   fix, and it is out of T12's scope — recorded here, not silently repaired.
+3. **A beam supports a beam only by framing.** The rule admits an `IfcBeam` candidate only through
+   the `§FRAMING_TOP_OF_STEEL` path: top- OR bottom-flush within `framing_dz_m`, then footprint.
+   `artifactRates` skips that and asks only "is an `IfcBeam` within `tolerance_m` in 3D", which is
+   how a parallel precast beam running end-to-end 0.5 m higher (row 6) became a defect. Publish
+   `topDzM`/`bottomDzM` on a beam-class `nearest`, and judge a beam candidate by `framing_dz_m`
+   against those, not by `gapVertM`. **This is trap 1 in a new costume** — a generous metric
+   pointing the fix at the wrong thing.
+4. **`graphDegree > 0` is not what `isolated_room` claims.** The rule's claim is *no route reaches
+   an exit or this storey's circulation spine*; having an edge does not contradict that. Rows 7-8
+   are a sealed two-room component on a storey with no circulation node, in a model with **zero**
+   exit nodes — there was no target to fail to reach. Replace the predicate with the one that
+   really contradicts the rule: **does this room's connected component contain an exit or a
+   circulation node at all?** Plain undirected connectivity over `graph.edges` is strictly weaker
+   than `RoomGraph.escapeRoute`'s weighted, door-aware search, so it stays independent of the rule
+   while being a genuine contradiction when it fires.
+   **Non-vacuity, checked against a real past bug:** T9.6's HHS room had 6 edges, four of them onto
+   `SPINE::Unknown|x|32.44` — its own storey's circulation — and was called isolated. Its component
+   contains a circ node, so this predicate flags it. The test can still fail; it just no longer
+   fires on a component that genuinely has nowhere to go.
+
+**T12.4 WHAT MOVED, AND WHAT DID NOT.** Fleet `DEFECT` **8 → 0**, rate 0.3% → 0.0%, over the same
+14 DBs the baseline was recorded on. Near-misses do not stay perfectly flat and the arithmetic is
+stated, not hidden:
+
+| rule | found | defect | nearMiss |
+|---|---|---|---|
+| `column_continuity` | 1746 → **1746** | 5 → **0** | 544 → **545** |
+| `floating_member` | 187 → **187** | 1 → **0** | 112 → **113** |
+| `isolated_room` | 52 → **52** | 2 → **0** | 0 → 0 |
+| `span_depth_cantilever` | 560 → **560** | 0 → 0 | 339 → **339** |
+
+The two +1s are rows 5 and 6, reclassified *defect → near-miss*. Rows 1-4 left the evidence set
+(a twin is not a threshold judgement) and rows 7-8 have no near-miss bucket. T11.6's "near-misses
+UNCHANGED" guards against near-misses being *absorbed* by a widened tolerance: **a near-miss count
+that FALLS is the alarm; one that rises by exactly the number of reclassified defects is the
+reclassification being visible.** Not one finding count moved — no rule was touched — which is what
+keeps `§BENCH_GATE_VACUOUS` silent, and the fixtures still fail as they should
+(`beam-under-slab` CRITICAL, `col-unsupported` CRITICAL, `§SLAB_BEARING` non-vacuity intact).
+
+**T12.4b THE BASELINE IS RE-RECORDED, and that is not what T12.0 warned against.** T12.0's warning
+is about re-recording on a DIFFERENT fleet, which makes every total incomparable and the failure
+silent. This re-record is on the SAME 14 DBs, byte-for-byte the same membership list, after a run
+whose finding counts are identical to the old baseline's — so every number is comparable and only
+the defect column moved. It has to happen: `§BENCH_GATE_WORSE` fires on a rate RISE of more than
+0.5 percentage points, so against the old 0.3% baseline a full regression back to 0.3% would have
+passed the gate in silence. Recorded: `tests/bench_baseline.json`, defect 0 of 2545,
+near-miss 545/113/339.
+
+**T12.5 WHAT IS STILL OPEN.** None of this touched a rule, so nothing about the rules got better —
+what got better is the benchmark's ability to tell you so. Still open, in order:
+- **T11.3's slab-coverage rule** — unbuilt. No rule asks whether a storey's floor plate covers its
+  own contents, which is why T10's Hospital question had to be answered by hand.
+- **The 47 deeper column overlaps** that `topBelowColumnBaseM >= -tolerance` would have removed:
+  load-bearing geometry whose top is more than a tolerance above the column's base, counted today
+  as near-misses across 8 buildings. Are they support, or more duplicates? Nobody has looked.
+- **`_columnContinuity`'s `Math.abs`**, above: a possible false all-clear, not a false alarm.
+- **The 995 near-misses remain the engineer's call** under the THRESHOLD DISCLAIMER, exactly as
+  T11.2 left them. 545 + 113 + 339 = 997 now, and the 2 added are the ones this task reclassified.

--- a/tests/bench_baseline.json
+++ b/tests/bench_baseline.json
@@ -1,6 +1,27 @@
 {
-  "generatedAt": "2026-09-12T03:31:25.865Z",
+  "generatedAt": "2026-09-12T04:15:32.657Z",
   "buildings": {
+    "HHS_Office_Federated_extracted": {
+      "findings": 140,
+      "rules": [
+        {
+          "rule": "column_continuity",
+          "found": 128,
+          "defect": 0,
+          "nearMiss": 64,
+          "rate": 0,
+          "basis": "load-bearing geometry directly below, INSIDE tolerance 0.3 m"
+        },
+        {
+          "rule": "door_clear_width",
+          "found": 12,
+          "defect": null,
+          "nearMiss": null,
+          "rate": null,
+          "basis": "no artifact test — this rule is a threshold judgement, not a geometric claim"
+        }
+      ]
+    },
     "Clinic_extracted": {
       "findings": 26,
       "rules": [
@@ -39,7 +60,7 @@
           "defect": 0,
           "nearMiss": null,
           "rate": 0,
-          "basis": "the room has edges in the room graph"
+          "basis": "the room's connected component holds an exit, or circulation on its own storey — a target the rule should have reached"
         }
       ]
     },
@@ -52,28 +73,7 @@
           "defect": 0,
           "nearMiss": 1,
           "rate": 0,
-          "basis": "load-bearing geometry at an end the rule called unsupported, INSIDE tolerance 0.15 m"
-        }
-      ]
-    },
-    "HHS_Office_Federated_extracted": {
-      "findings": 140,
-      "rules": [
-        {
-          "rule": "column_continuity",
-          "found": 128,
-          "defect": 0,
-          "nearMiss": 64,
-          "rate": 0,
-          "basis": "load-bearing geometry directly below, INSIDE tolerance 0.3 m"
-        },
-        {
-          "rule": "door_clear_width",
-          "found": 12,
-          "defect": null,
-          "nearMiss": null,
-          "rate": null,
-          "basis": "no artifact test — this rule is a threshold judgement, not a geometric claim"
+          "basis": "load-bearing geometry at an end the rule called unsupported, INSIDE tolerance 0.15 m (a beam candidate additionally top- or bottom-flush within 0.4 m, per §FRAMING_TOP_OF_STEEL)"
         }
       ]
     },
@@ -123,7 +123,7 @@
           "defect": 0,
           "nearMiss": 25,
           "rate": 0,
-          "basis": "load-bearing geometry at an end the rule called unsupported, INSIDE tolerance 0.15 m"
+          "basis": "load-bearing geometry at an end the rule called unsupported, INSIDE tolerance 0.15 m (a beam candidate additionally top- or bottom-flush within 0.4 m, per §FRAMING_TOP_OF_STEEL)"
         },
         {
           "rule": "column_continuity",
@@ -152,7 +152,7 @@
           "defect": 0,
           "nearMiss": 28,
           "rate": 0,
-          "basis": "load-bearing geometry at an end the rule called unsupported, INSIDE tolerance 0.15 m"
+          "basis": "load-bearing geometry at an end the rule called unsupported, INSIDE tolerance 0.15 m (a beam candidate additionally top- or bottom-flush within 0.4 m, per §FRAMING_TOP_OF_STEEL)"
         },
         {
           "rule": "column_continuity",
@@ -176,7 +176,7 @@
           "defect": 0,
           "nearMiss": null,
           "rate": 0,
-          "basis": "the room has edges in the room graph"
+          "basis": "the room's connected component holds an exit, or circulation on its own storey — a target the rule should have reached"
         }
       ]
     },
@@ -197,7 +197,7 @@
           "defect": 0,
           "nearMiss": 8,
           "rate": 0,
-          "basis": "load-bearing geometry at an end the rule called unsupported, INSIDE tolerance 0.15 m"
+          "basis": "load-bearing geometry at an end the rule called unsupported, INSIDE tolerance 0.15 m (a beam candidate additionally top- or bottom-flush within 0.4 m, per §FRAMING_TOP_OF_STEEL)"
         },
         {
           "rule": "column_continuity",
@@ -221,7 +221,7 @@
           "defect": 0,
           "nearMiss": null,
           "rate": 0,
-          "basis": "the room has edges in the room graph"
+          "basis": "the room's connected component holds an exit, or circulation on its own storey — a target the rule should have reached"
         }
       ]
     },
@@ -234,7 +234,7 @@
           "defect": 0,
           "nearMiss": 1,
           "rate": 0,
-          "basis": "load-bearing geometry at an end the rule called unsupported, INSIDE tolerance 0.15 m"
+          "basis": "load-bearing geometry at an end the rule called unsupported, INSIDE tolerance 0.15 m (a beam candidate additionally top- or bottom-flush within 0.4 m, per §FRAMING_TOP_OF_STEEL)"
         },
         {
           "rule": "floating_member",
@@ -242,7 +242,7 @@
           "defect": 0,
           "nearMiss": 0,
           "rate": 0,
-          "basis": "load-bearing geometry at an end the rule called unsupported, INSIDE tolerance 0.15 m"
+          "basis": "load-bearing geometry at an end the rule called unsupported, INSIDE tolerance 0.15 m (a beam candidate additionally top- or bottom-flush within 0.4 m, per §FRAMING_TOP_OF_STEEL)"
         },
         {
           "rule": "column_continuity",
@@ -266,7 +266,7 @@
           "defect": 0,
           "nearMiss": null,
           "rate": 0,
-          "basis": "the room has edges in the room graph"
+          "basis": "the room's connected component holds an exit, or circulation on its own storey — a target the rule should have reached"
         }
       ]
     },
@@ -287,7 +287,7 @@
           "defect": 0,
           "nearMiss": 0,
           "rate": 0,
-          "basis": "load-bearing geometry at an end the rule called unsupported, INSIDE tolerance 0.15 m"
+          "basis": "load-bearing geometry at an end the rule called unsupported, INSIDE tolerance 0.15 m (a beam candidate additionally top- or bottom-flush within 0.4 m, per §FRAMING_TOP_OF_STEEL)"
         },
         {
           "rule": "floating_member",
@@ -295,14 +295,14 @@
           "defect": 0,
           "nearMiss": 2,
           "rate": 0,
-          "basis": "load-bearing geometry at an end the rule called unsupported, INSIDE tolerance 0.15 m"
+          "basis": "load-bearing geometry at an end the rule called unsupported, INSIDE tolerance 0.15 m (a beam candidate additionally top- or bottom-flush within 0.4 m, per §FRAMING_TOP_OF_STEEL)"
         },
         {
           "rule": "column_continuity",
           "found": 471,
-          "defect": 4,
+          "defect": 0,
           "nearMiss": 72,
-          "rate": 0.0085,
+          "rate": 0,
           "basis": "load-bearing geometry directly below, INSIDE tolerance 0.3 m"
         },
         {
@@ -316,10 +316,10 @@
         {
           "rule": "isolated_room",
           "found": 17,
-          "defect": 2,
+          "defect": 0,
           "nearMiss": null,
-          "rate": 0.1176,
-          "basis": "the room has edges in the room graph"
+          "rate": 0,
+          "basis": "the room's connected component holds an exit, or circulation on its own storey — a target the rule should have reached"
         },
         {
           "rule": "circulation_distance",
@@ -340,15 +340,15 @@
           "defect": 0,
           "nearMiss": 271,
           "rate": 0,
-          "basis": "load-bearing geometry at an end the rule called unsupported, INSIDE tolerance 0.15 m"
+          "basis": "load-bearing geometry at an end the rule called unsupported, INSIDE tolerance 0.15 m (a beam candidate additionally top- or bottom-flush within 0.4 m, per §FRAMING_TOP_OF_STEEL)"
         },
         {
           "rule": "floating_member",
           "found": 172,
-          "defect": 1,
-          "nearMiss": 106,
-          "rate": 0.0058,
-          "basis": "load-bearing geometry at an end the rule called unsupported, INSIDE tolerance 0.15 m"
+          "defect": 0,
+          "nearMiss": 107,
+          "rate": 0,
+          "basis": "load-bearing geometry at an end the rule called unsupported, INSIDE tolerance 0.15 m (a beam candidate additionally top- or bottom-flush within 0.4 m, per §FRAMING_TOP_OF_STEEL)"
         },
         {
           "rule": "span_depth_concrete",
@@ -361,9 +361,9 @@
         {
           "rule": "column_continuity",
           "found": 663,
-          "defect": 1,
-          "nearMiss": 194,
-          "rate": 0.0015,
+          "defect": 0,
+          "nearMiss": 195,
+          "rate": 0,
           "basis": "load-bearing geometry directly below, INSIDE tolerance 0.3 m"
         },
         {
@@ -417,7 +417,7 @@
           "defect": 0,
           "nearMiss": null,
           "rate": 0,
-          "basis": "the room has edges in the room graph"
+          "basis": "the room's connected component holds an exit, or circulation on its own storey — a target the rule should have reached"
         }
       ]
     },
@@ -470,7 +470,7 @@
           "defect": 0,
           "nearMiss": null,
           "rate": 0,
-          "basis": "the room has edges in the room graph"
+          "basis": "the room's connected component holds an exit, or circulation on its own storey — a target the rule should have reached"
         }
       ]
     },
@@ -499,7 +499,7 @@
           "defect": 0,
           "nearMiss": 4,
           "rate": 0,
-          "basis": "load-bearing geometry at an end the rule called unsupported, INSIDE tolerance 0.15 m"
+          "basis": "load-bearing geometry at an end the rule called unsupported, INSIDE tolerance 0.15 m (a beam candidate additionally top- or bottom-flush within 0.4 m, per §FRAMING_TOP_OF_STEEL)"
         },
         {
           "rule": "span_depth_cantilever",
@@ -507,7 +507,7 @@
           "defect": 0,
           "nearMiss": 5,
           "rate": 0,
-          "basis": "load-bearing geometry at an end the rule called unsupported, INSIDE tolerance 0.15 m"
+          "basis": "load-bearing geometry at an end the rule called unsupported, INSIDE tolerance 0.15 m (a beam candidate additionally top- or bottom-flush within 0.4 m, per §FRAMING_TOP_OF_STEEL)"
         },
         {
           "rule": "column_continuity",
@@ -539,7 +539,7 @@
           "defect": 0,
           "nearMiss": null,
           "rate": 0,
-          "basis": "the room has edges in the room graph"
+          "basis": "the room's connected component holds an exit, or circulation on its own storey — a target the rule should have reached"
         }
       ]
     }
@@ -548,15 +548,15 @@
     "rules": {
       "column_continuity": {
         "found": 1746,
-        "artifact": 5,
-        "nearMiss": 544,
-        "rate": 0.0029
+        "artifact": 0,
+        "nearMiss": 545,
+        "rate": 0
       },
       "isolated_room": {
         "found": 52,
-        "artifact": 2,
+        "artifact": 0,
         "nearMiss": 0,
-        "rate": 0.0385
+        "rate": 0
       },
       "span_depth_cantilever": {
         "found": 560,
@@ -566,14 +566,14 @@
       },
       "floating_member": {
         "found": 187,
-        "artifact": 1,
-        "nearMiss": 112,
-        "rate": 0.0053
+        "artifact": 0,
+        "nearMiss": 113,
+        "rate": 0
       }
     },
     "found": 2545,
-    "artifact": 8,
-    "rate": 0.0031,
+    "artifact": 0,
+    "rate": 0,
     "buildingsMeasured": 14
   }
 }

--- a/tests/test_egress_sanity_rules.js
+++ b/tests/test_egress_sanity_rules.js
@@ -56,7 +56,10 @@ CREATE TABLE element_transforms (guid TEXT, center_x REAL, center_y REAL, center
   chk('wide door NOT flagged', !byGuid['door-wide'], JSON.stringify(byGuid['door-wide']));
 
   // ── Real Hospital_meta.db regression guard — full evaluator pipeline, not just raw RoomGraph ──
-  const HOSPITAL_DB = path.join(__dirname, '../buildings/Hospital_meta.db');
+  // BIM_BUILDINGS: a worktree's buildings/ holds only the two TRACKED DBs, so without it this
+  // real-DB guard reports itself skipped exactly where it is most needed. Never a symlink INTO
+  // buildings/ (T11.5 trap 5).
+  const HOSPITAL_DB = path.join(process.env.BIM_BUILDINGS || path.join(__dirname, '../buildings'), 'Hospital_meta.db');
   if (fs.existsSync(HOSPITAL_DB)) {
     console.log('§W-EGRESS-SANITY real Hospital_meta.db');
     const hdb = new SQL.Database(new Uint8Array(fs.readFileSync(HOSPITAL_DB)));

--- a/tests/test_rule_report.js
+++ b/tests/test_rule_report.js
@@ -195,7 +195,13 @@ const ROWS_E = [
 
   // ── R8 REAL-BUILDING — proves: on a real DB the report reproduces the evaluators' own § counts.
   console.log('§W-RULE-REPORT R8 REAL-BUILDING (buildings/Hospital_meta.db)');
-  const HOSPITAL = path.join(__dirname, '../buildings/Hospital_meta.db');
+  // buildings/ is gitignored, so a WORKTREE (the mandated dev environment here) holds only the
+  // two TRACKED DBs and the real-building arms of these tests would all report themselves
+  // skipped. BIM_BUILDINGS points them at a checkout that has the fleet. Never a symlink INTO
+  // buildings/ — T11.5 trap 5: two of those files are tracked and a symlink over one is
+  // committed as 63 bytes.
+  const BUILDINGS = process.env.BIM_BUILDINGS || path.join(__dirname, '../buildings');
+  const HOSPITAL = path.join(BUILDINGS, 'Hospital_meta.db');
   if (fs.existsSync(HOSPITAL)) {
     const hdb = new SQL.Database(new Uint8Array(fs.readFileSync(HOSPITAL)));
     const hq = (sql, p) => { const r = p ? hdb.exec(sql, p) : hdb.exec(sql); return r.length ? r[0].values : []; };
@@ -471,6 +477,154 @@ const ROWS_E = [
       const real = RuleReport.runSufficiencyProbes(hq, { log: () => {} }).filter(x => x.check === 'axis_aligned_bboxes')[0];
       chk('R17 real Hospital_meta.db no longer reports a false "ok" for rotation',
         real.verdict === 'uninformative', 'verdict=' + real.verdict + ' ' + JSON.stringify(real.measured));
+    }
+  }
+
+  // ── R18-R21 §BENCH_DEFECT_ZERO (T12) — the artifact METRIC's own qualifying conditions.
+  // Each of the four cases below is a REAL row from the fleet at 1f795c70 that `artifactRates`
+  // scored as a defect while the rule had judged it correctly. The control beside each one is
+  // the same shape moved to where the rule really would have missed, so a passing test here is
+  // one that could have failed (T11.5 trap 3).
+  const RD = [STRUCT_RULES, EGRESS_RULES];
+  const colRow = (near) => [{ guid: 'c9', ifc_class: 'IfcColumn', name: 'C', storey: 'VÅN 2',
+    rule: 'column_continuity', severity: 'CRITICAL', ratio: null,
+    witness: { nearestBelow: near, columnBaseZ: 7.9, toleranceM: 0.3 } }];
+  const beamRow = (nearest) => [{ guid: 'b9', ifc_class: 'IfcBeam', name: 'B', storey: 'VÅN 2',
+    rule: 'floating_member', severity: 'CRITICAL', ratio: null,
+    witness: { supportedEnds: 0, of: 2, freeEnds: [{ end: 0, at: { x: 0, y: 0, z: 0 }, nearest: nearest }] } }];
+  const roomRow = (w) => [{ guid: 'RM_9', ifc_class: 'IfcSpace', name: '≈ R9', storey: 'VÅNING 4',
+    rule: 'isolated_room', severity: 'CRITICAL', ratio: null, witness: w }];
+  const rate = (rows) => RuleReport.artifactRates(rows, RD)[0];
+
+  console.log('§W-RULE-REPORT R18 PRECISION-DECIDED-A-TOLERANCE');
+  {
+    // LTU_AHouse_extracted T0_..._0JpN4ZIbD1EfEtuz0sIANj: the real gap is 0.300001621 m against a
+    // 0.3 m tolerance. At toFixed(3) it printed 0.3 and the metric read it as INSIDE.
+    const out = rate(colRow({ guid: 'x', ifc_class: 'IfcColumn', name: '-',
+      centrelineOffsetM: 0.025024, topToColumnBaseM: 0.300002, topBelowColumnBaseM: 0.300002 }));
+    chk('R18 a 0.300002 m gap against a 0.3 m tolerance is NOT a defect',
+      out.defect === 0, 'defect=' + out.defect + ' nearMiss=' + out.nearMiss);
+    chk('R18 and it is still counted as evidence seen — a near-miss, not silence', out.nearMiss === 1);
+    // CONTROL: inside the tolerance for real. If this does not fire, the test above proves nothing.
+    const ctl = rate(colRow({ guid: 'x', ifc_class: 'IfcColumn', name: '-',
+      centrelineOffsetM: 0.025024, topToColumnBaseM: 0.299000, topBelowColumnBaseM: 0.299000 }));
+    chk('R18 CONTROL 0.299 m IS a defect — the test can still fail',
+      ctl.defect === 1, 'defect=' + ctl.defect);
+    // And the evaluator must publish enough digits for that distinction to survive to the metric.
+    const cols = [['col', 'C', 'VÅN 2', 0, 0, 8.05, 0.1, 0.3, 0.3000016212463379]];
+    const sups = [['sup', 'S', 'VÅN 2', 0.025024414, 0, 7.925, 0.15, 0.3, 0.5500016212463379]];
+    const any = [['sup', 'S', 'VÅN 2', 0.025024414, 0, 7.925, 0.15, 0.3, 0.5500016212463379, 'IfcColumn']];
+    const w = StructuralSanity._columnContinuity(cols, sups, 0.3, any).col.witness.nearestBelow;
+    chk('R18 the witness publishes the gap at 6 dp, not 3 — 3 dp cannot express it',
+      w.topToColumnBaseM > 0.3, 'topToColumnBaseM=' + w.topToColumnBaseM + ' (at 3 dp this is 0.3)');
+  }
+
+  console.log('§W-RULE-REPORT R19 A-TWIN-IS-NOT-A-SUPPORT');
+  {
+    // The real shape of the four LTU rows: an ARC column sharing the STR column's TOP plane
+    // EXACTLY and running 0.25 m past its bottom. It contains the column; it does not hold it up.
+    // Two of the four measure 0.300000190 m from the base against a 0.3 m tolerance — 190 nm, a
+    // distinction no rounding decides honestly — so the test that has to carry this is the one
+    // that is exact: does the candidate reach as high as the column itself.
+    const twin = { guid: 'x', ifc_class: 'IfcColumn', name: '-', centrelineOffsetM: 0.025024,
+      topToColumnBaseM: 0.300000, topBelowColumnBaseM: -0.300000, topAboveColumnTopM: 0 };
+    const out = rate(colRow(twin));
+    chk('R19 a candidate reaching the column\'s own top is not a defect, even at 0.300000 m',
+      out.defect === 0, 'defect=' + out.defect);
+    chk('R19 nor a near-miss — no threshold turns a co-located twin into a support',
+      out.nearMiss === 0, 'nearMiss=' + out.nearMiss);
+    // CONTROL: genuinely underneath, same distances. That IS a threshold call for an engineer.
+    const ctl = rate(colRow(Object.assign({}, twin, { topAboveColumnTopM: -0.55, topBelowColumnBaseM: 0.300002, topToColumnBaseM: 0.300002 })));
+    chk('R19 CONTROL a candidate genuinely below is still counted as a near-miss',
+      ctl.nearMiss === 1 && ctl.defect === 0, 'defect=' + ctl.defect + ' nearMiss=' + ctl.nearMiss);
+    // CONTROL 2: the knife-edge row must not be excluded for being 190 nm out — it is excluded
+    // for reaching the column's top. Move only that field and it comes back as a real defect.
+    const inside = rate(colRow(Object.assign({}, twin, { topAboveColumnTopM: -0.25, topToColumnBaseM: 0.3, topBelowColumnBaseM: 0.3 })));
+    chk('R19 CONTROL the same 0.3 m gap from something genuinely below IS a defect',
+      inside.defect === 1, 'defect=' + inside.defect);
+    // The evaluator must actually publish the field, computed off real bboxes.
+    const w = StructuralSanity._columnContinuity(
+      [['col', 'C', 'L', 0, 0, 8.05, 0.1, 0.3, 0.3000016212463379]], [], 0.3,
+      [['t', 'T', 'L', 0.025, 0, 7.925, 0.15, 0.3, 0.5500016212463379, 'IfcColumn']]
+    ).col.witness.nearestBelow;
+    chk('R19 a twin sharing the column\'s top plane publishes topAboveColumnTopM === 0',
+      w.topAboveColumnTopM === 0, 'topAboveColumnTopM=' + w.topAboveColumnTopM);
+    chk('R19 and rejectedBecause names it — no more "unknown"',
+      /co-located duplicate/.test(w.rejectedBecause), w.rejectedBecause);
+  }
+
+  console.log('§W-RULE-REPORT R20 A-BEAM-BEARS-BY-FRAMING');
+  {
+    // LTU_AHouse_meta 1XTQObkjP83Rry27DGiIWn: an ARC precast beam butting end-to-end 0.013 m away
+    // — and 0.4993 m higher. §FRAMING_TOP_OF_STEEL's datum is 0.4 m, so the rule cannot count it.
+    const out = rate(beamRow({ guid: 'x', ifc_class: 'IfcBeam', name: '-',
+      gapHorizM: 0.013, gapVertM: 0.111, topDzM: 0.499251, bottomDzM: 0.498896 }));
+    chk('R20 a beam 0.499 m off BOTH framing datums is not a defect',
+      out.defect === 0, 'defect=' + out.defect + ' nearMiss=' + out.nearMiss);
+    chk('R20 it is still evidence the reader should see — a near-miss', out.nearMiss === 1);
+    // CONTROL 1: top-flush. The steel norm. This is a real miss and must fire.
+    const ctl = rate(beamRow({ guid: 'x', ifc_class: 'IfcBeam', name: '-',
+      gapHorizM: 0.013, gapVertM: 0.111, topDzM: 0.004, bottomDzM: 0.482 }));
+    chk('R20 CONTROL a top-flush beam at the same point IS a defect',
+      ctl.defect === 1, 'defect=' + ctl.defect);
+    // CONTROL 2: a class the z-bracket really does govern must be judged exactly as before.
+    const wall = rate(beamRow({ guid: 'x', ifc_class: 'IfcWall', name: '-',
+      gapHorizM: 0.013, gapVertM: 0.111, topDzM: null, bottomDzM: null }));
+    chk('R20 CONTROL a wall at the same point is still a defect — only beams changed',
+      wall.defect === 1, 'defect=' + wall.defect);
+    // A pre-T12 witness carries no datums. It must keep the OLD answer, never a silent clean.
+    const old = rate(beamRow({ guid: 'x', ifc_class: 'IfcBeam', name: '-', gapHorizM: 0.013, gapVertM: 0.111 }));
+    chk('R20 a witness with no framing datums falls back to the old test, not to "clean"',
+      old.defect === 1, 'defect=' + old.defect);
+  }
+
+  console.log('§W-RULE-REPORT R21 ISOLATED-IS-REACHABILITY-NOT-DEGREE');
+  {
+    // LTU_AHouse_extracted RM_VÅNING_4_10/_11: wired to each other and to nothing else, on a
+    // storey with no circulation node, in a model with zero exit nodes.
+    const out = rate(roomRow({ graphDegree: 1, neighbours: [{ guid: 'RM_9b', via: 'E1' }],
+      storeyHasCirculationNode: false, exitNodesInModel: 0, componentSize: 2, componentHasExitOrCirc: false }));
+    chk('R21 a sealed two-room component is not a defect, whatever its degree',
+      out.defect === 0, 'defect=' + out.defect);
+    // CONTROL: T9.6's real HHS bug — 6 edges, four onto its own storey's SPINE, called isolated.
+    const ctl = rate(roomRow({ graphDegree: 6, neighbours: [{ guid: 'SPINE::VÅNING 4|x|32.44', via: 'E6' }],
+      storeyHasCirculationNode: true, exitNodesInModel: 3, componentSize: 41, componentHasExitOrCirc: true }));
+    chk('R21 CONTROL the T9.6 shape — a room wired to its own storey circulation — IS a defect',
+      ctl.defect === 1, 'defect=' + ctl.defect);
+    chk('R21 the basis states reachability, not degree',
+      /connected component/.test(ctl.basis), ctl.basis);
+    // A pre-T12 witness has no component fields; it must keep the old answer rather than go quiet.
+    const old = rate(roomRow({ graphDegree: 1, neighbours: [], storeyHasCirculationNode: false, exitNodesInModel: 0 }));
+    chk('R21 a witness with no component field falls back to the old degree test',
+      old.defect === 1, 'defect=' + old.defect);
+  }
+
+  console.log('§W-RULE-REPORT R22 THE-NEW-WITNESS-FIELDS-EXIST-ON-A-REAL-BUILDING');
+  {
+    if (fs.existsSync(HOSPITAL)) {
+      const hdb = new SQL.Database(new Uint8Array(fs.readFileSync(HOSPITAL)));
+      const hq = (sql, p) => { const r = p ? hdb.exec(sql, p) : hdb.exec(sql); return r.length ? r[0].values : []; };
+      const sRows = StructuralSanity.evaluate(hq, STRUCT_RULES, { log: () => {}, witness: true });
+      const cols = sRows.filter(r => r.rule === 'column_continuity' && (r.witness || {}).nearestBelow);
+      chk('R22 real column witnesses carry the signed gap',
+        cols.length > 0 && cols.every(r => typeof r.witness.nearestBelow.topBelowColumnBaseM === 'number'),
+        cols.length + ' column rows with a nearestBelow');
+      const beamNear = sRows.filter(r => (r.rule === 'floating_member' || r.rule === 'span_depth_cantilever'))
+        .reduce((a, r) => a.concat(((r.witness || {}).freeEnds || []).map(e => e.nearest).filter(n => n && n.ifc_class === 'IfcBeam')), []);
+      chk('R22 real beam-class neighbours carry both framing datums',
+        beamNear.length > 0 && beamNear.every(n => typeof n.topDzM === 'number' && typeof n.bottomDzM === 'number'),
+        beamNear.length + ' beam-class nearest neighbours');
+      const eRows = EgressSanity.evaluate(hq, EGRESS_RULES, { log: () => {}, witness: true })
+        .filter(r => r.rule === 'isolated_room');
+      chk('R22 real isolated_room witnesses carry the component fields',
+        eRows.length === 0 || eRows.every(r => typeof r.witness.componentHasExitOrCirc === 'boolean'),
+        eRows.length + ' isolated_room rows');
+      // R11's contract, re-checked: witness:true adds evidence and changes no count.
+      const noW = StructuralSanity.evaluate(hq, STRUCT_RULES, { log: () => {} });
+      chk('R22 the new witness fields change NO finding count',
+        noW.length === sRows.length, noW.length + ' without witness vs ' + sRows.length + ' with');
+    } else {
+      console.log('  ⚠ R22 SKIPPED — buildings/Hospital_meta.db absent (this is a reported absence, not a pass)');
     }
   }
 

--- a/tests/test_structural_sanity_rules.js
+++ b/tests/test_structural_sanity_rules.js
@@ -130,7 +130,10 @@ CREATE TABLE element_transforms (guid TEXT, center_x REAL, center_y REAL, center
     JSON.stringify(['col-A', 'col-B', 'col-C', 'col-D'].map(g => byGuid[g])));
 
   // ── Real Hospital_meta.db regression guard, per STRUCTURAL_SANITY.md's own VALIDATION section ──
-  const HOSPITAL_DB = path.join(__dirname, '../buildings/Hospital_meta.db');
+  // BIM_BUILDINGS: a worktree's buildings/ holds only the two TRACKED DBs, so without it this
+  // real-DB guard reports itself skipped exactly where it is most needed. Never a symlink INTO
+  // buildings/ (T11.5 trap 5).
+  const HOSPITAL_DB = path.join(process.env.BIM_BUILDINGS || path.join(__dirname, '../buildings'), 'Hospital_meta.db');
   if (fs.existsSync(HOSPITAL_DB)) {
     console.log('§W-STRUCT-SANITY real Hospital_meta.db');
     const hdb = new SQL.Database(new Uint8Array(fs.readFileSync(HOSPITAL_DB)));

--- a/viewer/egress_sanity.js
+++ b/viewer/egress_sanity.js
@@ -169,7 +169,7 @@
     // show. This indexes the graph's own edges once so a flagged room can state its degree, its
     // actual neighbours, and whether its storey even HAS a circulation node to reach — the three
     // facts that separate "genuinely sealed off" from "the graph never connected it".
-    var degree = null, neighbours = null, storeyHasCirc = null, exitCount = 0;
+    var degree = null, neighbours = null, storeyHasCirc = null, exitCount = 0, comp = null;
     if (opts.witness) {
       degree = {}; neighbours = {}; storeyHasCirc = {};
       (graph.edges || []).forEach(function (e) {
@@ -179,8 +179,60 @@
       });
       (graph.nodes || []).forEach(function (n) { if (n.kind === 'circ') storeyHasCirc[n.storey] = true; });
       Object.keys(graph.nodesByGuid || {}).forEach(function (g) { if (g.indexOf('EXIT::') === 0) exitCount++; });
+      comp = _components(graph);
       log('§EGRESS_WITNESS enabled nodes=' + (graph.nodes || []).length + ' edges=' + (graph.edges || []).length +
-        ' exitNodes=' + exitCount + ' storeysWithCirc=' + Object.keys(storeyHasCirc).length);
+        ' exitNodes=' + exitCount + ' storeysWithCirc=' + Object.keys(storeyHasCirc).length +
+        ' components=' + comp.count);
+    }
+
+    // ── T12.3 §ISOLATED_COMPONENT — union-find over the graph's own edge list. Returns, per
+    // node, its component id, that component's size, and whether the component contains ANY
+    // exit or circulation node. Deliberately topological only: no distances, no door
+    // admissibility, none of escapeRoute's own logic — the witness must be able to disagree
+    // with the rule, which it cannot do if it IS the rule.
+    function _components(g) {
+      var parent = {};
+      function find(x) { while (parent[x] !== undefined && parent[x] !== x) { parent[x] = parent[parent[x]]; x = parent[x]; } return x; }
+      function union(a, b) { if (parent[a] === undefined) parent[a] = a; if (parent[b] === undefined) parent[b] = b; var ra = find(a), rb = find(b); if (ra !== rb) parent[ra] = rb; }
+      (g.nodes || []).forEach(function (n) { if (parent[n.guid] === undefined) parent[n.guid] = n.guid; });
+      Object.keys(g.nodesByGuid || {}).forEach(function (k) { if (parent[k] === undefined) parent[k] = k; });
+      (g.edges || []).forEach(function (e) { union(e.a, e.b); });
+      // The target set is the RULE's, not a looser one: escapeRoute reaches any EXIT node, and
+      // the fallback reaches a circulation node ON THE ROOM'S OWN STOREY only
+      // (_circulationNodesOn above). Accepting another storey's circulation here would invent
+      // disagreements the rule never had.
+      var of = {}, size = {}, hasExit = {}, circStoreys = {}, roots = {};
+      function _circStorey(gid, n) {
+        if (n && n.storey != null) return String(n.storey);
+        var i = gid.indexOf('::');
+        if (i === -1) return null;
+        var rest = gid.slice(i + 2), bar = rest.indexOf('|');
+        return bar === -1 ? rest : rest.slice(0, bar);   // 'SPINE::Level 1|x|-7.00' -> 'Level 1'
+      }
+      Object.keys(parent).forEach(function (k) {
+        var r = find(k);
+        of[k] = r; roots[r] = 1;
+        size[r] = (size[r] || 0) + 1;
+        var n = (g.nodesByGuid || {})[k] || null;
+        if (k.indexOf('EXIT::') === 0 || (n && n.kind === 'exit')) hasExit[r] = true;
+        var isCirc = k.indexOf('CIRC::') === 0 || k.indexOf('SPINE::') === 0 ||
+                     (n && (n.kind === 'circ' || n.kind === 'spine'));
+        if (isCirc) {
+          var st = _circStorey(k, n);
+          if (st != null) (circStoreys[r] = circStoreys[r] || {})[st] = true;
+        }
+      });
+      var perNode = {};
+      Object.keys(of).forEach(function (k) { perNode[k] = size[of[k]]; });
+      return {
+        of: of, size: perNode, count: Object.keys(roots).length,
+        // true when this node's component holds a target the rule itself would have aimed at
+        hasTargetFor: function (guid, storey) {
+          var r = of[guid];
+          if (r === undefined) return false;
+          return !!hasExit[r] || !!((circStoreys[r] || {})[String(storey)]);
+        }
+      };
     }
 
     graph.nodes.forEach(function (r) {
@@ -215,6 +267,14 @@
               neighbours: (neighbours[r.guid] || []).slice(0, 8),
               storeyHasCirculationNode: !!storeyHasCirc[r.storey],
               exitNodesInModel: exitCount,
+              // T12.3 — the fact that can actually CONTRADICT this rule. "Has an edge"
+              // (graphDegree) cannot: the rule's claim is that no route reaches an exit or this
+              // storey's circulation spine, and a room wired only to another sealed room is
+              // exactly that. Plain undirected connectivity over graph.edges is strictly weaker
+              // than escapeRoute's weighted, door-aware search, so a component that DOES hold an
+              // exit or circ node while the rule reports "isolated" is a real disagreement.
+              componentSize: comp.size[r.guid] || 1,
+              componentHasExitOrCirc: comp.hasTargetFor(r.guid, r.storey),
               // The room's own name carries the extraction's confidence mark (≈ approximate,
               // ⚠ suspect). The rule cannot read it; the witness can, so the reader sees whether
               // the "room" that failed to connect was itself a guess.

--- a/viewer/rule_report.js
+++ b/viewer/rule_report.js
@@ -501,16 +501,36 @@
 
   function _isLoadBearing(cls) { return LOAD_BEARING_CLASSES.indexOf(cls) !== -1; }
 
+  // Can this neighbour bear the end vertically, by the test the RULE would apply to its class?
+  // A column/wall/slab/footing/plate holds a beam by the z-bracket `gapVertM` measures. A BEAM
+  // holds another beam only by framing: tops flush or bottoms flush within `framing_dz_m`.
+  // Judging a beam by `gapVertM` is how a parallel precast beam running end-to-end half a metre
+  // higher read as proof of support (T12.1 row 6).
+  //
+  // `framingDz` comes from the SAME parsed rules JSON the caller already hands us — T8.13's one
+  // source. Two ways out, both of which must keep the OLD test rather than silently score a row
+  // clean: a pre-T12 witness with no datums, and a rules file with no framing_dz_m.
+  function _bearsVertically(nearest, tolerance_m, framingDz) {
+    if (nearest.ifc_class !== 'IfcBeam') return nearest.gapVertM <= tolerance_m;
+    if (framingDz == null) return nearest.gapVertM <= tolerance_m;
+    if (nearest.topDzM == null && nearest.bottomDzM == null) return nearest.gapVertM <= tolerance_m;
+    return (nearest.topDzM != null && nearest.topDzM <= framingDz) ||
+           (nearest.bottomDzM != null && nearest.bottomDzM <= framingDz);
+  }
+
   // Per rule: { rule, found, artifact, rate, basis }. `artifact` is null — never 0 — for a rule
   // with no artifact test, so "not measured" never reads as "measured clean". Requires rows
   // evaluated with witness:true; without it every rule reports null and says why.
   // `rules` (the parsed rules JSONs) is REQUIRED to classify honestly: without each rule's own
   // tolerance there is no line between "the rule looked and missed" and "something is nearby".
   function artifactRates(rows, rules) {
-    var tol = {};
+    var tol = {}, framingDz = null;
     (rules || []).forEach(function (d) {
       ['structural_rules', 'egress_rules'].forEach(function (k) {
-        ((d || {})[k] || []).forEach(function (r) { if (r.tolerance_m != null) tol[r.name] = r.tolerance_m; });
+        ((d || {})[k] || []).forEach(function (r) {
+          if (r.tolerance_m != null) tol[r.name] = r.tolerance_m;
+          if (r.name === 'floating_member' && r.framing_dz_m != null) framingDz = r.framing_dz_m;
+        });
       });
     });
     // span_depth_cantilever has no tolerance of its own — its classification comes from
@@ -533,9 +553,21 @@
       // Those are threshold questions for an engineer, not logic to repair.
       //   defect   = load-bearing geometry INSIDE the rule's own tolerance — it looked and missed
       //   nearMiss = load-bearing geometry outside it — a threshold judgement, reported not fixed
+      //
+      // ══ T12.3 — THE EVIDENCE TEST MUST CARRY THE RULE'S OWN QUALIFYING CONDITIONS ═══════════
+      // Not the rule's code (that would make this metric tautologically zero — trap 3), but the
+      // conditions that decide whether a neighbour is CAPABLE of being the support the rule is
+      // accused of missing. Three were absent at handover and produced all 8 remaining fleet
+      // defects, every one on geometry the rule had judged correctly (T12.1):
+      //   - proximity was compared at the witness's DISPLAY precision (3 dp), so a 0.300001621 m
+      //     gap read as inside a 0.3 m tolerance. The witness now publishes 6 dp.
+      //   - an `IfcBeam` was accepted on 3D proximity alone, though the rule admits one only by
+      //     the §FRAMING_TOP_OF_STEEL datum test — top- or bottom-flush within framing_dz_m.
+      //   - a column candidate ABOVE the column's base counted the same as one below it.
       var t = tol[rule];
       if (rule === 'floating_member' || rule === 'span_depth_cantilever') {
-        basis = 'load-bearing geometry at an end the rule called unsupported, INSIDE tolerance ' + t + ' m';
+        basis = 'load-bearing geometry at an end the rule called unsupported, INSIDE tolerance ' + t + ' m' +
+                (framingDz == null ? '' : ' (a beam candidate additionally top- or bottom-flush within ' + framingDz + ' m, per §FRAMING_TOP_OF_STEEL)');
         var hits = rs.filter(function (r) {
           return ((r.witness || {}).freeEnds || []).some(function (e) {
             return e.nearest && _isLoadBearing(e.nearest.ifc_class);
@@ -543,8 +575,8 @@
         });
         art = hits.filter(function (r) {
           return (r.witness.freeEnds || []).some(function (e) {
-            return e.nearest && _isLoadBearing(e.nearest.ifc_class) &&
-                   t != null && e.nearest.gapHorizM <= t && e.nearest.gapVertM <= t;
+            return e.nearest && _isLoadBearing(e.nearest.ifc_class) && t != null &&
+                   e.nearest.gapHorizM <= t && _bearsVertically(e.nearest, t, framingDz);
           });
         }).length;
         near = hits.length - art;
@@ -552,7 +584,23 @@
         basis = 'load-bearing geometry directly below, INSIDE tolerance ' + t + ' m';
         var chits = rs.filter(function (r) {
           var b = (r.witness || {}).nearestBelow;
-          return b && _isLoadBearing(b.ifc_class);
+          // A candidate whose top reaches AS HIGH AS the column's own top is a co-located
+          // duplicate, not something underneath — not a defect, and not a near-miss either,
+          // because no threshold an engineer could pick turns a twin into a support.
+          //
+          // ⚠ THIS TEST, AND NOT THE OTHER ONE. `topBelowColumnBaseM >= -tolerance` reads as the
+          // more natural phrasing of the same idea and was tried first. MEASURED over the fleet's
+          // 549 column findings that have a load-bearing `nearestBelow`: it removes 51 of them —
+          // the 4 real twins plus 47 deeper overlaps across EIGHT buildings, dropping the fleet
+          // near-miss count 544 -> 498. `topAboveColumnTopM < 0` removes exactly the 4, and only
+          // LTU_AHouse_extracted moves. The 47 are a separate question and answering it by
+          // side-effect would have buried it.
+          //
+          // It is also the only comparison here not sitting on a knife edge: two of the four
+          // twins measure 0.300000190 m against a 0.3 m tolerance, which no rounding decides
+          // honestly, while all four share the column's top plane as the identical double.
+          return b && _isLoadBearing(b.ifc_class) &&
+                 (b.topAboveColumnTopM === undefined || b.topAboveColumnTopM < 0);
         });
         art = chits.filter(function (r) {
           var b = r.witness.nearestBelow;
@@ -560,8 +608,16 @@
         }).length;
         near = chits.length - art;
       } else if (rule === 'isolated_room') {
-        basis = 'the room has edges in the room graph';
-        art = rs.filter(function (r) { return ((r.witness || {}).graphDegree || 0) > 0; }).length;
+        basis = 'the room\'s connected component holds an exit, or circulation on its own storey — a target the rule should have reached';
+        // NOT `graphDegree > 0`: the rule does not claim the room has no edges, it claims no
+        // route reaches an exit or this storey's circulation spine. A pair of rooms wired only to
+        // each other, on a storey with no circulation node and in a model with zero exit nodes,
+        // satisfies the rule's claim exactly — LTU_AHouse's two "defects" were that pair.
+        art = rs.filter(function (r) {
+          var w = r.witness || {};
+          if (w.componentHasExitOrCirc === undefined) return (w.graphDegree || 0) > 0;   // pre-T12 witness
+          return !!w.componentHasExitOrCirc;
+        }).length;
       } else {
         // door_clear_width / circulation_distance / span_depth_* are threshold judgements with no
         // geometric contradiction to test. Saying so beats inventing a test that always passes.

--- a/viewer/structural_sanity.js
+++ b/viewer/structural_sanity.js
@@ -142,7 +142,21 @@
   // NOT consult — the point is to show the reader the element the rule could not count, so
   // "floating" and "cantilever" can be eyeballed instead of taken on trust. Returns null when
   // genuinely nothing is near. Distances are real, never rounded away.
-  function _nearestAtPoint(pt, anyRows, selfGuid, horizTol, vertTol) {
+  //
+  // ══ T12.3 — PUBLISHED AT 6 dp, AND A BEAM CANDIDATE CARRIES ITS FRAMING DATUM ═══════════════
+  // These numbers are not decoration: `artifactRates` compares the PUBLISHED value against the
+  // rule's own tolerance to decide defect vs near-miss. At `toFixed(3)` a real 0.300001621 m gap
+  // prints as `0.3` and reads as INSIDE a 0.3 m tolerance the rule measured it OUTSIDE of — which
+  // is how four LTU_AHouse columns became "defects" the rule had judged correctly (T12.1). µm on
+  // metres is the precision that separates inside from outside here, so it earns its digits.
+  //
+  // `topDzM`/`bottomDzM` exist for the same reason. An `IfcBeam` is load-bearing, but this rule
+  // admits one ONLY through the §FRAMING_TOP_OF_STEEL path — top- or bottom-flush within
+  // `framing_dz_m`, then footprint — never by bare 3D proximity. Without the two datums published,
+  // the metric cannot apply the condition the rule applies, and a parallel precast beam running
+  // end-to-end half a metre higher reads as proof of support (T12.1 row 6). Null for a
+  // non-beam candidate, whose support test really is the z-bracket `gapVertM` already carries.
+  function _nearestAtPoint(pt, anyRows, selfGuid, horizTol, vertTol, subj) {
     var best = null;
     for (var i = 0; i < anyRows.length; i++) {
       var r = anyRows[i];
@@ -155,9 +169,16 @@
       var dz = (pt.z < b.zmin) ? (b.zmin - pt.z) : (pt.z > b.zmax ? pt.z - b.zmax : 0);
       if (dz > vertTol) continue;
       var d = dxy + dz;
-      if (!best || d < best._d) best = { guid: r[0], ifc_class: r[9] || null, name: r[1], gapHorizM: +dxy.toFixed(3), gapVertM: +dz.toFixed(3), _d: d };
+      if (!best || d < best._d) best = { guid: r[0], ifc_class: r[9] || null, name: r[1],
+        gapHorizM: +dxy.toFixed(6), gapVertM: +dz.toFixed(6), topDzM: null, bottomDzM: null, _d: d, _b: b };
     }
-    if (best) delete best._d;
+    if (best) {
+      if (subj && best.ifc_class === 'IfcBeam') {
+        best.topDzM = +Math.abs(best._b.zmax - subj.zmax).toFixed(6);
+        best.bottomDzM = +Math.abs(best._b.zmin - subj.zmin).toFixed(6);
+      }
+      delete best._d; delete best._b;
+    }
     return best;
   }
 
@@ -211,7 +232,7 @@
         // Search radius is deliberately WIDER than the rule's own tolerance (4x horizontal, 1m
         // vertical) so a near-miss shows up as a near-miss instead of as nothing.
         else if (anyRows) freeEnds.push({ end: e, at: { x: +pt.x.toFixed(2), y: +pt.y.toFixed(2), z: +pt.z.toFixed(2) },
-          nearest: _nearestAtPoint(pt, anyRows, beam[0], tolerance_m * 4, 1.0) });
+          nearest: _nearestAtPoint(pt, anyRows, beam[0], tolerance_m * 4, 1.0, bb) });
       }
       out[beam[0]] = { supportedCount: supportedCount, span: Math.max(bb.bx, bb.by), depth: bb.bz, freeEnds: freeEnds };
     }
@@ -251,12 +272,32 @@
           var dz = Math.abs(b.zmax - cb.zmin);
           if (dz > 1.0) continue;
           var d = dxy + dz;
+          // T12.3 — 6 dp, and the SIGNED gap alongside the absolute one. `topToColumnBaseM` is
+          // an absolute value, so a candidate whose top sits 0.30 m ABOVE this column's base
+          // measures identically to one sitting 0.30 m BELOW it. The four LTU_AHouse columns
+          // that read as defects at handover were each an ARC twin of the same physical column,
+          // sharing its top plane and running 0.25 m past its bottom — a thing that CONTAINS the
+          // column, not a thing that holds it up. `topBelowColumnBaseM` is positive only when the
+          // candidate really is underneath.
+          //
+          // `topAboveColumnTopM` is the one comparison here that does NOT sit on a knife edge.
+          // Two of these twins measure 0.300000190 m from the column's base against a 0.3 m
+          // tolerance — a 190 nm difference, which is float noise on a building, not geometry,
+          // and no rounding can decide it honestly. But the twin and the column share a top
+          // plane EXACTLY (identical doubles, 8.200000762939453), so "does this candidate reach
+          // as high as the column itself" is decided by an equality that is exact. A support
+          // below a column always has its top under the column's top; a co-located duplicate
+          // does not.
           if (!best || d < best._d) best = { guid: r[0], ifc_class: r[9] || null, name: r[1],
-            centrelineOffsetM: +dxy.toFixed(3), topToColumnBaseM: +dz.toFixed(3), _d: d };
+            centrelineOffsetM: +dxy.toFixed(6), topToColumnBaseM: +dz.toFixed(6),
+            topBelowColumnBaseM: +(cb.zmin - b.zmax).toFixed(6),
+            topAboveColumnTopM: +(b.zmax - cb.zmax).toFixed(6), _d: d };
         }
         if (best) {
           delete best._d;
           best.rejectedBecause = (best.centrelineOffsetM > tolerance_m ? 'centreline offset > tolerance ' + tolerance_m + ' m' : null) ||
+            (best.topAboveColumnTopM >= 0 ? 'its top reaches ' + best.topAboveColumnTopM + ' m ABOVE this column\'s own top — a co-located duplicate, not something underneath the column' : null) ||
+            (best.topBelowColumnBaseM < -tolerance_m ? 'its top is ' + (-best.topBelowColumnBaseM) + ' m above this column\'s base — it overlaps the column rather than sitting below it' : null) ||
             (best.topToColumnBaseM > tolerance_m ? 'top-to-base gap > tolerance ' + tolerance_m + ' m' : null) ||
             (COL_SUPPORT_CLASSES.indexOf(best.ifc_class) === -1 ? best.ifc_class + ' is not a column-support class (' + COL_SUPPORT_CLASSES.join('/') + ')' : 'unknown');
         }


### PR DESCRIPTION
**Fleet `DEFECT` 8 → 0** over the same 14 DBs `tests/bench_baseline.json` was recorded on. Every finding count unchanged, **no rule threshold touched**. Spec: `prompts/STRUCTURAL_SANITY.md` **T12 §BENCH_DEFECT_ZERO**.

## What the 8 rows actually were

All in `LTU_AHouse`, as T11.1 said. Each one is `artifactRates` scoring geometry the rule had judged correctly:

| # | DB · rule | witness said | raw geometry said |
|---|---|---|---|
| 1-4 | `_extracted` · `column_continuity` | ARC `IfcColumn` at 0.025 / **0.300** m, `rejectedBecause` **"unknown"** | candidate `zmax` **equals the column's own `zmax`** — an ARC twin of the same physical column; true gap 0.300001621 / 0.300000190 m |
| 5 | `_meta` · `column_continuity` | `IfcWallStandardCase` at **0.300** m | true centreline distance **0.300462350** m |
| 6 | `_meta` · `floating_member` | ARC `IfcBeam`, gapHoriz 0.013, gapVert 0.111 | framing datums **0.499251 / 0.498896** m, `framing_dz_m` = 0.4 |
| 7-8 | `_extracted` · `isolated_room` | `graphDegree` 1 | a sealed 2-room component; **0** exit nodes in the model, no circ node on the storey |

Run it the other way: if the metric were right, closing these means a `column_continuity` tolerance past 0.300462 m, a `framing_dz_m` past 0.4993 m, and deleting `isolated_room`'s fallback. **Three tolerance widenings — the single failure T11.2 says this benchmark exists to prevent.** The witness had already flagged it: `rejectedBecause` read `"unknown"` on all five column rows, because it was computed from the display-rounded numbers.

## The fixes (evidence + metric only)

1. **Rounding decided a tolerance comparison.** The witness published at `toFixed(3)`; `artifactRates` compared those published numbers to the rule's tolerance, so 0.300001621 read as inside 0.3. Now 6 dp.
2. **A candidate above a column is not a support below it.** New `topAboveColumnTopM`. Chosen over the more obvious `topBelowColumnBaseM >= -tolerance` **on measurement**, not taste:

   | gate | fleet defect | fleet nearMiss | rows removed |
   |---|---|---|---|
   | none (6 dp only) | 2 | 547 | 0 |
   | `topBelowColumnBaseM >= -tolerance` | 2 | **498** | 51, across 8 buildings |
   | `topAboveColumnTopM < 0` | **0** | **545** | 4, all `above == 0` |

   It is also the only *exact* comparison available — two of the four twins sit **190 nm** from the tolerance, which no rounding decides honestly, while all four share the column's top plane as the identical double.
3. **A beam bears on a beam only by framing.** `topDzM`/`bottomDzM` published; `framing_dz_m` read from the same rules JSON (T8.13, one source).
4. **`graphDegree > 0` is not what `isolated_room` claims.** Replaced with *does this room's connected component hold an exit, or circulation on its own storey* — the rule's own target set, via plain undirected connectivity, strictly weaker than `escapeRoute` and therefore able to disagree with it.

## Measured (`--gate`, 14-DB fleet)

```
before  found=2545 DEFECT=8  column 1746/5/544  floating 187/1/112  isolated 52/2/0  cant 560/0/339
after   found=2545 DEFECT=0  column 1746/0/545  floating 187/0/113  isolated 52/0/0  cant 560/0/339
§BENCH_GATE_OK no rule regressed
```

The two +1 near-misses are rows 5 and 6 reclassified *defect → near-miss*. Per T11.6, a near-miss count that **falls** is the alarm; one that rises by exactly the number of reclassified defects is the reclassification being visible. Nothing absorbed, no finding count moved.

Baseline re-recorded on the **identical** membership — `§BENCH_GATE_WORSE` needs a 0.5-point rise, so against the old 0.3% baseline a full regression back to 0.3% would have passed in silence.

## ⚠ T12.0 — the fleet had drifted before any of this

A bare `node tests/bench_rule_artifacts.js --gate tests/bench_baseline.json` in the main checkout exits 1 on `§BENCH_GATE_FLEET_MISMATCH` **before a rule is consulted**: `buildings/Terminal_silent.db` is gone (target still at `~/Downloads/`) and `buildings/TermRooms_extracted.db` — a byte-identical twin of `Terminal_extracted.db` — has appeared. That swap alone moves `isolated_room` 52 → 102. Fixed by passing the missing DBs on the command line (T11.5 trap 5 forbids symlinking them in), not by re-recording.

## Witnesses

R18 precision · R19 twin · R20 framing · R21 reachability · R22 real-building fields — **each with a control that fires**, so a passing test could have failed. R21's control is T9.6's real HHS bug. **170 assertions green** across `test_rule_report` (108) / `test_structural_sanity_rules` (11) / `test_egress_sanity_rules` (6) / `test_rule_checklist_panel` (26) / `test_rule_mode_tint` (11) / `test_rule_deeplink` (8). Non-vacuity fixtures still fail as they should: `beam-under-slab` CRITICAL, `col-unsupported` CRITICAL.

`BIM_BUILDINGS` lets the real-DB arms of the three rule suites run from a worktree, whose `buildings/` holds only the two tracked DBs.

## Still open (T12.5)

No rule got better here — the benchmark's ability to tell you so did. Open: T11.3's slab-coverage rule (unbuilt); the **47 deeper column overlaps** the rejected gate would have swept away, uninspected across 8 buildings; `_columnContinuity`'s `Math.abs`, a possible false *all-clear*; and the 997 near-misses, still the engineer's call under the THRESHOLD DISCLAIMER.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015PiGqX1cctizfTsESNgLXL