### PR TITLE
fix(4d): re-derive a persisted schedule that no longer agrees with its own DB (§KERNEL_OPS_SCHED_AGREE)

### DIFF
--- a/viewer/tests/witness_kernel_ops_sched_version.js
+++ b/viewer/tests/witness_kernel_ops_sched_version.js
@@ -76,8 +76,15 @@ function sliceFn(src, name, optional) {
 
 // The version-check clause in _activateAsync must call this EXACT function name — assert wired,
 // not just present, so a future refactor that silently drops the call still fails this witness.
-if (tmSrc.indexOf('_kernelOpsSchedStale(_placeOps, _GANTT_CACHE_VERSION)') < 0) {
-  assert(false, 'W-KOS-0 _activateAsync calls _kernelOpsSchedStale(_placeOps, _GANTT_CACHE_VERSION)');
+// §KERNEL_OPS_SCHED_AGREE (2026-09-12) added a THIRD argument — the agreement verdict, computed by
+// _schedOpsAgreementFail and passed IN so this predicate stays pure (no db, no window) and W-KOS-1/2/3
+// below can keep slicing and calling it in a bare vm sandbox. Both halves asserted wired.
+if (tmSrc.indexOf('_kernelOpsSchedStale(_placeOps, _GANTT_CACHE_VERSION, _agreeFail)') < 0) {
+  assert(false, 'W-KOS-0 _activateAsync calls _kernelOpsSchedStale(_placeOps, _GANTT_CACHE_VERSION, _agreeFail)');
+  finish();
+}
+if (tmSrc.indexOf('_agreeFail = _schedOpsAgreementFail(app.db, _placeOps)') < 0) {
+  assert(false, 'W-KOS-0a _activateAsync computes the agreement verdict via _schedOpsAgreementFail(app.db, _placeOps)');
   finish();
 }
 const genVersionLine = '_genVersion:_GANTT_CACHE_VERSION';
@@ -127,6 +134,22 @@ assert(stale([{ parameters: { cls: 'IfcSlab', _genVersion: 8 } }], CUR) === true
 assert(stale([{ parameters: { cls: 'IfcSlab', _genVersion: CUR } }], CUR) === false,
   'W-KOS-3 ops correctly stamped _genVersion=' + CUR + ' NOT flagged (no needless regenerate)');
 assert(stale([], CUR) === false, 'W-KOS-3b empty ops array NOT flagged (nothing to invalidate yet)');
+
+// ── W-KOS-3c/3d/3e: §KERNEL_OPS_SCHED_AGREE's third argument ──
+// ISSUE PROVED: Hospital_silent.db's 63,415 ops are stamped _genVersion=39 against
+// _GANTT_CACHE_VERSION=39, so the version clause alone answers "not stale" and a schedule that no
+// longer matches its own tasks/task_elements is adopted forever (13,574 ops with a _task that has no
+// task_elements row; op calendar 233 days outside the task calendar; an 8,899 m² floor held back by
+// §XRAY_STAGING_REMOVED as a result). These three pin the OR, and pin that it costs a correct
+// building nothing.
+assert(stale([{ parameters: { cls: 'IfcSlab', _genVersion: CUR } }], CUR, 'taskLink') === true,
+  'W-KOS-3c correctly-STAMPED ops flagged stale when the agreement verdict says they disagree with the DB');
+assert(stale([{ parameters: { cls: 'IfcSlab', _genVersion: CUR } }], CUR, '') === false,
+  'W-KOS-3d correctly-stamped ops that AGREE are still NOT flagged (an agreeing building pays no regenerate)');
+assert(stale([{ parameters: { cls: 'IfcSlab', _genVersion: CUR } }], CUR) === false,
+  'W-KOS-3e a caller that passes no verdict at all behaves exactly as before (version clause only)');
+assert(stale([{ parameters: { cls: 'IfcSlab', _genVersion: 8 } }], CUR, '') === true,
+  'W-KOS-3f an AGREEING but version-stale table is still flagged — the two clauses are independent');
 
 // ── W-KOS-4: real per-building magnitude, against the live CPM display-authoring path ──
 const BLD_DIR = process.env.BLD_DIR || path.join(require('os').homedir(), 'bim-ootb', 'buildings');

--- a/viewer/tests/witness_schedule_coherence.js
+++ b/viewer/tests/witness_schedule_coherence.js
@@ -43,6 +43,12 @@ const initSqlJs = require(path.join(os.homedir(), 'bim-ootb', 'node_modules', 's
 const SQLJS_DIST = path.join(os.homedir(), 'bim-ootb', 'node_modules', 'sql.js', 'dist');
 const BLD_DIR = process.env.BLD_DIR || path.join(os.homedir(), 'bim-ootb', 'buildings');
 const BASELINE = process.env.BASELINE === undefined ? null : +process.env.BASELINE;
+// §KERNEL_OPS_SCHED_AGREE (2026-09-12): G-SC-TE promoted from reported-only to BASELINE-gated, the
+// same shape as G-SC-SELF — fails on an INCREASE, so it lands against today's fleet unchanged while
+// making "a persisted op whose _task has no task_elements row for its guid" a regression from here
+// on. This is the DB-only, no-GPU, no-browser witness that would have caught §SCHED_TASK_BUCKET_
+// SPLIT_BRAIN: Hospital_silent.db reads 13,574 with the shipped frozen ops and 0 once they re-derive.
+const TE_BASELINE = process.env.TE_BASELINE === undefined ? null : +process.env.TE_BASELINE;
 
 const norm = s => String(s || '').toLowerCase().replace(/[^a-z0-9]/g, '');
 const rows = (db, sql) => { try { const r = db.exec(sql); return r.length ? r[0].values : []; } catch (e) { return []; } };
@@ -103,8 +109,17 @@ const EPS = 0.05, GAP = 0.5;
     samples.forEach(s => console.log(`§W-SCHED-COHERE   first ${s}`));
     if (!selfOk) fail++;
 
-    console.log(`§W-SCHED-COHERE G-SC-TE ${name} taskElementsMismatch=` +
-      (haveTe ? noTeMatch : 'n/a (no task_elements)') + ' — reported, never blocking (§88.10d)');
+    // G-SC-TE — §KERNEL_OPS_SCHED_AGREE (2026-09-12). Was reported-only because §88.10d showed the
+    // OP is the better witness on the one-storey band shifts (it matches elements_meta.storey 7,491
+    // times, task_elements 0) — which remains true, and is exactly why nothing here judges WHICH side
+    // to copy. What it does now assert is weaker and sound: this number may not GROW. A persisted op
+    // whose _task has no task_elements row for its own guid is an op that is no longer true of the DB
+    // it sits in, whichever side drifted, and the cure is re-derivation, never a rewrite.
+    const teOk = TE_BASELINE === null || !haveTe ? true : noTeMatch <= TE_BASELINE;
+    console.log(`§W-SCHED-COHERE G-SC-TE ${teOk ? 'PASS' : 'FAIL'} ${name} taskElementsMismatch=` +
+      (haveTe ? noTeMatch : 'n/a (no task_elements)') +
+      (TE_BASELINE === null ? ' (no TE_BASELINE — reported only)' : ' baseline=' + TE_BASELINE));
+    if (!teOk) fail++;
 
     // ── G-SC-CARRY: in-extent structural carriers that finish after the slab they carry ─────────
     // Carrier pool mirrors §PROMOTED_CARRIER_POOL: seq<=4 u IfcSlab. seq comes from the OP's own

--- a/viewer/time_machine.js
+++ b/viewer/time_machine.js
@@ -8714,13 +8714,136 @@
     return n;
   }
 
+  // §KERNEL_OPS_SCHED_AGREE (2026-09-12, bim-compiler prompts/4D_SCHEDULE_PERFECTION.md
+  // §SCHED_TASK_BUCKET_SPLIT_BRAIN) — DOES THIS PERSISTED SCHEDULE STILL AGREE WITH THIS DB?
+  //
+  // §KERNEL_OPS_SCHED_VERSION below asks "were these ops produced by the current ALGORITHM?". It
+  // never asks "are they still TRUE OF the model they sit in?", and those are different questions.
+  // Measured consequence: Hospital_silent.db ships 63,415 ELEMENT_PLACE rows stamped _genVersion=39
+  // against _GANTT_CACHE_VERSION=39, so they are adopted verbatim — yet its `tasks`/`task_elements`
+  // tables were RE-AUTHORED after those ops were captured, so 13,574 of them (21.4%) carry a `_task`
+  // that matches no task_elements row for their own guid, and the op calendar (2026-09-10..2027-07-17)
+  // sits 233 days outside the task calendar (2026-01-01..2026-11-26) even though the DB's own
+  // schedules.display_authored=1 asserts the task windows are VIEWS of these very element times.
+  // 28 of those mis-bucketed rows are Level 1 foundation walls that carry an 8,899 m² ground slab and
+  // are scheduled 13.47 h AFTER it, so §XRAY_STAGING_REMOVED correctly refuses to draw the floor.
+  // Re-deriving (verified in a real browser: §GANTT_SOURCE, staged 544→501, slab leaves staging, wall
+  // returns to TASK_Substructure_Level_1, span becomes 1/10/2026→11/26/2026) produces the right answer
+  // — the TABLES are right, only the frozen answer is wrong.
+  //
+  // Deliberately NOT fixed by bumping _GANTT_CACHE_VERSION: that is a one-shot data patch. It
+  // discards every user's warm gantt:v39:* entry fleet-wide (correct ones included) and leaves the
+  // hole open, so the next re-authoring of `tasks` freezes a wrong answer again at v40. This makes
+  // the staleness decision a property of the DB instead of a constant a human must remember to bump.
+  //
+  // TWO INDEPENDENT CLAUSES, both cheap, both measured to flag Hospital and NOT to flag a building
+  // whose ops are correct (HHS_Office_Federated_silent: 0/6,880 task-link mismatches, op window
+  // inside its task window):
+  //   B-WIN  armed only when schedules.display_authored=1 — that flag IS the DB asserting the task
+  //          windows are views of these element times, so containment must hold by construction.
+  //          One MIN/MAX over the dated leaf tasks + one pass over ops already parsed in memory.
+  //   B-TE   a SAMPLE of ops must have a task_elements row for their own guid and _task. One
+  //          `guid IN (…)` query, so the cost is bounded by the sample, not by model size (loading
+  //          the whole 63,415-row map costs 72 ms in sql.js and is not affordable per activate).
+  //          At Hospital's 21.4% defect rate a sample of 50 detects in 2000/2000 trials.
+  // ⚠ This NEVER rewrites an op from task_elements — a disagreement only triggers RE-DERIVATION by
+  // the shipped verb. On the 13,546 one-storey shifts the OP is the better witness (it matches
+  // elements_meta.storey 7,491 times, task_elements 0), so copying one table over the other would
+  // repair 28 rows and break 13,546. Freshly derived ops measure 0/63,415 on B-TE and land inside the
+  // task window, so neither clause re-fires and there is no derive-every-activate loop.
+  var _AGREE_SAMPLE = 64;                    // ops sampled for B-TE (evenly spaced, deterministic)
+  var _AGREE_WINDOW_SLACK_MS = 86400000;     // `tasks` bounds are DATE-only; allow a day either side
+
+  function _schedOpsAgreementFail(db, placeOps) {
+    if (!db || !placeOps || !placeOps.length) return '';
+    var _t0 = (typeof performance !== 'undefined' && performance.now) ? performance.now() : Date.now();
+    var reason = '', detail = '', winMs = 0, teMs = 0;
+    try {
+      // ── B-WIN ──────────────────────────────────────────────────────────────────────────────────
+      var _da = 0;
+      try {
+        var r0 = db.exec('SELECT MAX(display_authored) FROM schedules');
+        if (r0.length && r0[0].values.length && r0[0].values[0][0] != null) _da = r0[0].values[0][0] | 0;
+      } catch (e) { _da = 0; }   // pre-§ZONE_DISPLAY_AUTHORING DB: no column, clause simply not armed
+      if (_da === 1) {
+        var r1 = db.exec('SELECT MIN(schedule_start), MAX(schedule_finish) FROM tasks ' +
+          'WHERE schedule_start IS NOT NULL AND (is_summary IS NULL OR is_summary=0)');
+        if (r1.length && r1[0].values.length && r1[0].values[0][0] && r1[0].values[0][1]) {
+          var tS = Date.parse(r1[0].values[0][0]), tE = Date.parse(r1[0].values[0][1]);
+          if (isFinite(tS) && isFinite(tE)) {
+            var oS = Infinity, oE = -Infinity;
+            for (var i = 0; i < placeOps.length; i++) {
+              var pp = placeOps[i].parameters || {};
+              var s = placeOps[i].start_ts, e = pp._end_ts;
+              if (typeof s === 'number' && s < oS) oS = s;
+              if (typeof e === 'number' && e > oE) oE = e;
+            }
+            if (isFinite(oS) && isFinite(oE) &&
+                (oS < tS - _AGREE_WINDOW_SLACK_MS || oE > tE + _AGREE_WINDOW_SLACK_MS)) {
+              reason = 'window';
+              detail = ' ops=' + new Date(oS).toISOString().slice(0, 10) + '..' + new Date(oE).toISOString().slice(0, 10) +
+                ' tasks=' + r1[0].values[0][0] + '..' + r1[0].values[0][1] +
+                ' (display_authored=1 asserts these are the same window)';
+            }
+          }
+        }
+      }
+      winMs = ((typeof performance !== 'undefined' && performance.now) ? performance.now() : Date.now()) - _t0;
+      // ── B-TE ───────────────────────────────────────────────────────────────────────────────────
+      if (!reason) {
+        var step = Math.max(1, Math.floor(placeOps.length / _AGREE_SAMPLE));
+        var want = {}, list = [], n = 0;
+        for (var j = 0; j < placeOps.length && list.length < _AGREE_SAMPLE; j += step) {
+          var o = placeOps[j], par = o.parameters || {};
+          if (!o.output_guid || !par._task) continue;            // generated (uncaptured) op: no bucket to check
+          if (/['\\]/.test(o.output_guid)) continue;             // IFC guids never contain these; skip rather than quote
+          want[o.output_guid] = par._task; list.push(o.output_guid); n++;
+        }
+        if (n) {
+          var got = {};
+          var r2 = db.exec("SELECT guid, task_id FROM task_elements WHERE guid IN ('" + list.join("','") + "')");
+          if (r2.length) for (var k = 0; k < r2[0].values.length; k++) {
+            var g = r2[0].values[k][0];
+            (got[g] = got[g] || []).push(r2[0].values[k][1]);
+          }
+          var bad = 0, firstBad = '';
+          for (var g2 in want) {
+            if (!got[g2] || got[g2].indexOf(want[g2]) < 0) {
+              bad++;
+              if (!firstBad) firstBad = g2 + ' _task=' + want[g2] + ' task_elements=' + JSON.stringify(got[g2] || null);
+            }
+          }
+          if (bad) {
+            reason = 'taskLink';
+            detail = ' sampled=' + n + ' mismatched=' + bad + ' first ' + firstBad;
+          }
+        }
+      }
+      teMs = ((typeof performance !== 'undefined' && performance.now) ? performance.now() : Date.now()) - _t0 - winMs;
+    } catch (e) {
+      // A DB that cannot answer the question is never called stale on that account — an agreement
+      // test that fails OPEN would re-derive every building with a missing table on every activate.
+      console.log('§KERNEL_OPS_SCHED_AGREE unavailable (' + e.message + ') — agreement clause skipped');
+      return '';
+    }
+    console.log('§KERNEL_OPS_SCHED_AGREE ops=' + placeOps.length +
+      ' winMs=' + winMs.toFixed(1) + ' teMs=' + teMs.toFixed(1) +
+      ' totalMs=' + (winMs + teMs).toFixed(1) +
+      ' verdict=' + (reason || 'agrees') + detail);
+    return reason;
+  }
+
   // §KERNEL_OPS_SCHED_VERSION (2026-08-11): pure predicate, no db/window — placeOps materialized
   // under an OLDER schedule-generation algorithm (missing/mismatched _genVersion stamp) must never
   // be silently reused. currentVersion is _GANTT_CACHE_VERSION, passed in rather than closed over so
   // this stays independently testable (same idiom as _tier1Extents/_tier1Serialize below).
-  function _kernelOpsSchedStale(placeOps, currentVersion) {
-    return !!(placeOps && placeOps.length && placeOps[0].parameters &&
-      placeOps[0].parameters._genVersion !== currentVersion);
+  // §KERNEL_OPS_SCHED_AGREE (2026-09-12): agreementFail is likewise PASSED IN, already computed by
+  // _schedOpsAgreementFail above — this predicate stays pure, with no db or window of its own, so
+  // witness_kernel_ops_sched_version.js can keep slicing and calling it in a bare vm sandbox.
+  function _kernelOpsSchedStale(placeOps, currentVersion, agreementFail) {
+    if (!(placeOps && placeOps.length && placeOps[0].parameters)) return false;
+    if (placeOps[0].parameters._genVersion !== currentVersion) return true;
+    return !!agreementFail;
   }
 
   // ── Activate / Deactivate ──
@@ -8825,6 +8948,21 @@
           _hasCachedPlaces = false;
         }
       }
+      // §KERNEL_OPS_SCHED_AGREE (2026-09-12) — kernel_ops HAS TWO HOMES and this branch is the other
+      // one. It returns before the persisted-table branch below is ever reached, DELETE+INSERTing the
+      // cached JSON over the DB's rows, so gating only the table would leave this home able to serve a
+      // frozen answer the table can no longer serve. Same predicate, same question: is this cache
+      // still TRUE OF this db? (A cache whose absence changes the answer is not a cache.)
+      if (_hasCachedPlaces) {
+        var _cachedPlaces = cachedOps.filter(function(o) { return o.op_type === 'ELEMENT_PLACE'; });
+        var _cacheAgreeFail = _schedOpsAgreementFail(app.db, _cachedPlaces);
+        if (_cacheAgreeFail) {
+          console.log('§GANTT_STALE_CACHE ops=' + cachedOps.length + ' agreementFail=' + _cacheAgreeFail +
+            ' — cached schedule no longer agrees with this DB, dropping cache and re-deriving');
+          cacheDel('gantt');
+          _hasCachedPlaces = false;
+        }
+      }
       if (_hasCachedPlaces) {
         // Fast path: inject cached JSON into kernel_ops table
         console.log('§GANTT_CACHE_HIT ops=' + cachedOps.length);
@@ -8883,10 +9021,15 @@
       // HHS_Office_Federated still showing MEP Rough-in starting 20.8d before Architecture finished,
       // §TIER_SERIAL's own witness (which reads the freshly-recomputed _disp, not kernel_ops) could
       // not have caught it. Stamp+check closes the same gap _end_ts's check closes for schema shape.
-      if (_kernelOpsSchedStale(_placeOps, _GANTT_CACHE_VERSION)) {
+      // §KERNEL_OPS_SCHED_AGREE (2026-09-12): …and the second question the stamp cannot answer —
+      // do these rows still agree with THIS db's tasks/task_elements? See the long note on
+      // _schedOpsAgreementFail. Computed here so the predicate itself stays pure.
+      var _agreeFail = _schedOpsAgreementFail(app.db, _placeOps);
+      if (_kernelOpsSchedStale(_placeOps, _GANTT_CACHE_VERSION, _agreeFail)) {
         try { app.db.run("DELETE FROM kernel_ops WHERE op_type = 'ELEMENT_PLACE'"); } catch(e) {}
         console.log('§KERNEL_OPS_SCHED_VERSION stale genVersion=' + _placeOps[0].parameters._genVersion +
-          ' current=' + _GANTT_CACHE_VERSION + ' — cleared ' + _placeOps.length + ' ops, will re-inject');
+          ' current=' + _GANTT_CACHE_VERSION + ' agreementFail=' + (_agreeFail || 'none') +
+          ' — cleared ' + _placeOps.length + ' ops, will re-inject');
         _placeOps = [];
       }
       if (_placeOps.length) { _ops = _placeOps; _ganttDirty = true; }

--- a/viewer/time_machine.js
+++ b/viewer/time_machine.js
@@ -9086,7 +9086,12 @@
       // fallback below (TM still opened with 63,416 ops) but with no way to locate it. Log the
       // stack and the phase so the next occurrence names its own line.
       console.warn('§GANTT_CACHE_ERR ' + e.message + ' | phase=' + (_ops && _ops.length ? 'post-loadOps' : 'pre-loadOps') +
-        ' | stack=' + String(e && e.stack || '(none)').split('\n').slice(0, 4).join(' << '));
+        ' | stack=' + String(e && e.stack || '(none)').split('\n').slice(0, 4).join(' << ') +
+        // §KERNEL_OPS_SCHED_AGREE (2026-09-12): the line above promises the next occurrence will name
+        // itself, and it did not — a silent-bake cold derive on Hospital logged `undefined | stack=(none)`
+        // because sql.js throws a bare STRING ("Statement closed"), which has neither .message nor
+        // .stack. One occurrence cost a whole diagnosis round. Print what a non-Error throw actually is.
+        ' | thrown type=' + (typeof e) + ' value=' + String(e));
       // Fallback: compute without cache
       _ops = loadOps(); _ganttDirty = true;
       if (!_ops.length) { await _load4DTemplate(); _materializeNativeSchedule(A()); await injectGantt(); _ops = loadOps(); _ganttDirty = true; }  // §GANTT_SINGLE_LOAD, same as the main path (await: loadOps must see the chunked writes)


### PR DESCRIPTION
## The defect

`Hospital_silent.db` ships 63,415 `kernel_ops` `ELEMENT_PLACE` rows stamped `_genVersion=39` against `_GANTT_CACHE_VERSION = 39`, so `_kernelOpsSchedStale` answers **not stale** and `_activateAsync` adopts them verbatim — `injectGantt()` sits behind `if (!_placeOps.length)` and never runs.

But that DB's `tasks` / `task_elements` were **re-authored after** those ops were captured:

| | |
|---|---|
| ops whose `_task` has no `task_elements` row for their own guid | **13,574 / 63,415 (21.4 %)** |
| op calendar | `2026-09-10 .. 2027-07-17` |
| dated leaf task calendar | `2026-01-01 .. 2026-11-26` |
| `schedules.display_authored` | `1` — the DB asserting those are the same window |

28 of the mis-bucketed rows are Level 1 `Basic Wall:Foundation` walls carrying an 8,899 m² ground slab, scheduled **13.47 h after** it — so `§XRAY_STAGING_REMOVED` correctly refuses to draw the floor. The tables are right; only the frozen answer is wrong.

Spec: `bim-compiler prompts/4D_SCHEDULE_PERFECTION.md` §SCHED_TASK_BUCKET_SPLIT_BRAIN (R0-R3 + MEASURED RESULT).

## The fix

The version stamp answers *"were these produced by the current ALGORITHM?"*. It never asks *"are they still TRUE OF this model?"*. This adds that second question as two cheap, independent clauses, and re-derives when either fails:

- **B-WIN** — armed only when `display_authored=1`: the op window must lie inside the dated leaf task window. One `MIN/MAX` + one pass over ops already parsed in memory.
- **B-TE** — a bounded sample (64) of ops must have a `task_elements` row for their own guid and `_task`. One `guid IN (…)` query, so cost is bounded by the sample, not model size.

Applied to **both homes** of `kernel_ops`: the persisted table and the IndexedDB `gantt` fast path (which `DELETE`+`INSERT`s over the table and returns before the table branch is reached).

`_kernelOpsSchedStale` stays a **pure** predicate — the verdict is passed in — so `witness_kernel_ops_sched_version.js` keeps slicing and calling it in a bare `vm` sandbox.

### Not a `_GANTT_CACHE_VERSION` 39 → 40 bump

Measured both. The bump is one line but it is a one-shot data patch: it discards every warm `gantt:v39:*` entry fleet-wide (correct ones included), and the next re-authoring of `tasks` freezes a wrong answer again at v40. Cost of the re-derive it forces, same machine, same DB: `totalSinceActivate` **650 ms** (frozen ops adopted) → **7,047-8,043 ms** (derived).

## Measured

Added per-activate cost, printed by the shipped code:

```
§KERNEL_OPS_SCHED_AGREE ops=63415 winMs=2.6 teMs=0.0  totalMs=2.6   verdict=window   ← shipped DB, re-derives
§KERNEL_OPS_SCHED_AGREE ops=63415 winMs=1.5 teMs=10.2 totalMs=11.7  verdict=agrees   ← derived ops, no loop
```

≈1.8 % of the cheapest possible (650 ms) open. Freshly derived ops measure **0 / 63,415** on B-TE and land inside the task window, so neither clause re-fires.

Hospital, headful-GPU browser and `cli_silent_bake.js`, cold and warm:

| cell | `§GANTT_SOURCE` | `staged` | slab in map | wall `_task` | span |
|---|---|---|---|---|---|
| browser cold | present, `covered=63415 pct=100` | **501**/63415 | `undefined` | `TASK_Substructure_Level_1` | 1/10/2026→11/26/2026 |
| browser warm (same origin) | `§GANTT_CACHE_HIT` (correct cached ops, `verdict=agrees`) | **501**/63415 | `undefined` | `TASK_Substructure_Level_1` | 1/10/2026→11/26/2026 |
| silent bake | present, `capActive=true` | **501**/63415 | — | — | 1/10/2026→11/26/2026 |

Was `staged=544`, `map['0e8pm26Tv5vPrj6zU55MOH'] = 1789798254510`, wall in `TASK_Architecture_Envelope_Level_1`, span `2026-09-10..2027-07-17`. Silent-bake frame 38 shows the Level 1 concrete deck present (Day 15 / 321).

`§CACHE_PUT key=gantt:v39:Hospital size=29328KB` on a cold open is itself new — the frozen-ops branch used to return before `cachePut`, so Hospital never cached anything and every open was cold.

## Reported, NOT fixed here — a pre-existing race in the bake's cold derive

One of four bake runs aborted mid-derivation:

```
§GANTT_CACHE_ERR undefined | phase=post-loadOps | thrown type=string value=Statement closed
§KRN_SEAL_FROM fromId=63417 sealed=63416     ← the async seal running DURING the chunked write
§CPE_BUILDUP_SOURCE covered=2500/63415 pct=4% capActive=false   ← exactly one _TM_CHUNK landed
```

`KernelOps.sealFrom` is `async` with a per-row `db.run('UPDATE …')`; at 63,416 rows it interleaves with `_writeScheduledChunked`'s prepared statement and sql.js closes it. **It is a race and it is not this change's:** the same build produced both outcomes (run 2: `sealed=1`, no error, `staged=501`); a control with this code fully inert (a `--tap` emptying `kernel_ops` before load, so `_schedOpsAgreementFail` early-returns and logs nothing) still raced; and `main` reaches the identical late-DELETE cold path today via its own version clause — `HHS_Office_Federated_silent` (`_genVersion=38`) bakes with `§KRN_SEAL_FROM sealed=6881`, same geometry, 10× smaller, so its 119 ms write never overlaps. Left for its own change; `KernelOps` sealing and the bake's activation ordering are outside this brief's scope.

## Out of scope, untouched

`_buildXraySupportCache` / `§XRAY_STAGING_REMOVED` and its `GAP`/`EPS`; `_incrOK` / `setVisibleAt`; `§BATCH_BUCKET_CLASS_PAINT` / the `streaming.js` bucket key; `cli_silent_bake.js`; the renderer; the ghost-ground plane; and **the shipped `.db` files — no data is rewritten**. A disagreement only triggers re-derivation by the shipped verb; nothing copies `task_elements` over the ops (on the 13,546 one-storey shifts the OP matches `elements_meta.storey` 7,491 times and `task_elements` 0).

## Witnesses

- `witness_kernel_ops_sched_version.js` — **23 pass / 0 fail**. W-KOS-0/0a assert the new wiring; W-KOS-3c..3f pin the OR and that an agreeing building pays no regenerate.
- `witness_schedule_coherence.js` — `G-SC-TE` promoted from reported-only to `TE_BASELINE`-gated (fails on an **increase**). This is the node, DB-only, no-GPU witness that would have caught the whole class: Hospital reads **13,574** with the shipped frozen ops and **0** once they re-derive. Verified to fail at `TE_BASELINE=13573`.
- Third commit is log-only: `§GANTT_CACHE_ERR` now names a non-`Error` throw, which is how the race above was finally identified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NAaGzi9tbRYMs5c2MuxprG