### PR TITLE
§SUFFICIENCY_READS_THE_LIST — the sufficiency probe kept its own copy of the support classes (T12.6)

### DIFF
--- a/cli_silent_bake.js
+++ b/cli_silent_bake.js
@@ -377,7 +377,12 @@ const server = http.createServer((req, res) => {
           }
         }
         const pops = RuleReport.rulePopulations(A.dbQuery);
-        const suff = RuleReport.runSufficiencyProbes(A.dbQuery, { log: console.log });
+        // T12.6 — support_classes_present reads the evaluator's OWN lists; without them it
+        // reports 'unavailable' rather than fall back to a copy that can go stale.
+        const suff = RuleReport.runSufficiencyProbes(A.dbQuery, Object.assign({ log: console.log },
+          (typeof StructuralSanity !== 'undefined')
+            ? { supportClasses: StructuralSanity.SUPPORT_CLASSES, colSupportClasses: StructuralSanity.COL_SUPPORT_CLASSES }
+            : {}));
         out.report = RuleReport.buildRuleReport({
           rowsS: rowsS, rowsE: rowsE,
           ruleDefs: [sj.rules, ej.rules].filter(Boolean),

--- a/prompts/STRUCTURAL_SANITY.md
+++ b/prompts/STRUCTURAL_SANITY.md
@@ -1042,6 +1042,44 @@ the defect column moved. It has to happen: `§BENCH_GATE_WORSE` fires on a rate 
 passed the gate in silence. Recorded: `tests/bench_baseline.json`, defect 0 of 2545,
 near-miss 545/113/339.
 
+## T12.6 §SUFFICIENCY_READS_THE_LIST — a probe that kept its own copy of the support classes
+Found while reporting the three `_silent` DBs' sanity results, not by a test. `Terminal_silent`
+came back `support_classes_present: degraded`, and the reason it gave was **untrue**:
+
+> IfcWall and IfcSlab are in neither support list; 1038 such elements cannot support a beam end or
+> a column here, while 600 elements can.
+
+Both classes have been in **both** lists since `§SUPPORT_CLASS_PARITY` (T9.1) added `IfcWall` and
+`§SLAB_BEARING` (T9.3) added `IfcSlab` — `structural_sanity.js:113-114`, two PRs before this one.
+The probe carried its own typed copy of the lists, in a comment **and** in its own SQL `IN` clause,
+and nothing made the copy answer to the original. It had been reporting a closed gap ever since,
+and its `degraded` verdict was the loudest line in Terminal_silent's report.
+
+**This is T11.5 trap 3 with a second signature.** The trap says a guard written from the buggy
+code's own output passes for the life of the bug. Here the guard was
+`tests/test_rule_report.js`'s R10: *"support_classes_present = degraded when IfcWall outnumbers the
+listed classes"*. Those 3 fixture walls could only outnumber the listed classes because the
+probe's private copy had never been told `IfcWall` was added. **The test asserted the copy, so the
+copy could not be caught by it.** Rewritten to assert what the probe now claims.
+
+**The fix is the same one T8.13 applied to the thresholds: one source, read not copied.**
+`StructuralSanity` exports `SUPPORT_CLASSES` / `COL_SUPPORT_CLASSES` (frozen — a consumer that
+mutated the array it was handed would corrupt it for the next caller), the probe takes them through
+`opts`, and **without them it reports `unavailable`**, never a guessed fallback and never an `ok` —
+the same rule this file already applies to a missing table. Both production call sites
+(`cli_silent_bake.js`, `viewer/rule_checklist.js`) pass them.
+
+The probe now states only what it was handed: elements per support class, which listed classes are
+absent entirely, and the **one-sided** classes derived from the difference between the two lists —
+today `IfcPlate`, which can hold a beam end but not a column (Hospital: **2,211** of them). Its
+verdict answers the one question that cannot go stale: is there bearing geometry BESIDES the beams
+and columns being checked? `absent` when there is not — a frame holding itself up.
+
+**R23b is the assertion that would have caught the original bug:** hand the probe a *different*
+list and its answer must change. A probe with a private copy cannot pass that. Measured after:
+`Terminal_silent` `degraded` → **`ok`**, Hospital_meta `ok` with 13,968 support elements, fleet
+gate unmoved (the bench calls `artifactRates`, not the probes).
+
 **T12.5 WHAT IS STILL OPEN.** None of this touched a rule, so nothing about the rules got better —
 what got better is the benchmark's ability to tell you so. Still open, in order:
 - **T11.3's slab-coverage rule** — unbuilt. No rule asks whether a storey's floor plate covers its

--- a/tests/test_rule_report.js
+++ b/tests/test_rule_report.js
@@ -19,6 +19,11 @@ const EgressSanity = require('../viewer/egress_sanity.js');
 let pass = 0, fail = 0;
 const chk = (n, c, x) => { if (c) { pass++; console.log('  ✅ ' + n + (x ? '  ' + x : '')); } else { fail++; console.log('  ❌ ' + n + (x ? '  ' + x : '')); } };
 
+// T12.6 — support_classes_present reads the evaluator's OWN lists rather than keeping a copy;
+// unsupplied it reports 'unavailable' by design, so every call that expects a measured verdict
+// must hand them over. This is the shape both production call sites use.
+const SUFF_OPTS = { supportClasses: StructuralSanity.SUPPORT_CLASSES, colSupportClasses: StructuralSanity.COL_SUPPORT_CLASSES };
+
 const STRUCT_RULES = JSON.parse(fs.readFileSync(path.join(__dirname, '../viewer/rates/structural_rules.json'), 'utf8'));
 const EGRESS_RULES = JSON.parse(fs.readFileSync(path.join(__dirname, '../viewer/rates/egress_rules.json'), 'utf8'));
 
@@ -144,7 +149,7 @@ const ROWS_E = [
     db.run("INSERT INTO spatial_structure VALUES ('s2','IfcSpace','⚠ Level 1 R2')");
     const q = (sql, p) => { const r = p ? db.exec(sql, p) : db.exec(sql); return r.length ? r[0].values : []; };
     const logs = [];
-    const suff = RuleReport.runSufficiencyProbes(q, { log: (m) => logs.push(m) });
+    const suff = RuleReport.runSufficiencyProbes(q, Object.assign({ log: (m) => logs.push(m) }, SUFF_OPTS));
     const by = {}; suff.forEach(s => by[s.check] = s);
 
     chk('R10 footings_modelled = absent (0 IfcFooting, 2 columns) — the HHS 131/131 cause',
@@ -154,8 +159,17 @@ const ROWS_E = [
     chk('R10 room_confidence_sigils counts the ≈/⚠ marks the evaluators ignore',
       by.room_confidence_sigils.measured.approx === 1 && by.room_confidence_sigils.measured.suspect === 1,
       JSON.stringify(by.room_confidence_sigils.measured));
-    chk('R10 support_classes_present = degraded when IfcWall outnumbers the listed classes',
-      by.support_classes_present.verdict === 'degraded', JSON.stringify(by.support_classes_present.measured));
+    // ⚠ THIS ASSERTION USED TO READ "= degraded when IfcWall outnumbers the listed classes", and
+    // it passed for the life of the bug: the fixture's 3 IfcWall could only outnumber the listed
+    // classes because the probe's PRIVATE COPY of the list had never been told T9.1 added
+    // IfcWall. A guard written from the buggy code's own output (T11.5 trap 3). What the probe
+    // actually claims now is that walls count, so that is what is asserted.
+    chk('R10 support_classes_present counts IfcWall as real support — T9.1 added it',
+      by.support_classes_present.verdict === 'ok' && by.support_classes_present.measured.byClass.IfcWall === 3,
+      'verdict=' + by.support_classes_present.verdict + ' ' + JSON.stringify(by.support_classes_present.measured.byClass));
+    chk('R10 and it no longer claims IfcWall/IfcSlab are unsupported',
+      !/neither support list/.test(by.support_classes_present.consequence),
+      by.support_classes_present.consequence.slice(0, 80));
     chk('R10 beam_material_named = absent (material_name NULL on every beam)',
       by.beam_material_named.verdict === 'absent', JSON.stringify(by.beam_material_named.measured));
     chk('R10 axis_aligned_bboxes = degraded (one rotated column)',
@@ -170,7 +184,7 @@ const ROWS_E = [
     const bare = new SQL.Database();
     bare.run('CREATE TABLE unrelated_table (x INT)');
     const bq = (sql) => { const r = bare.exec(sql); return r.length ? r[0].values : []; };
-    const suffBare = RuleReport.runSufficiencyProbes(bq, { log: () => {} });
+    const suffBare = RuleReport.runSufficiencyProbes(bq, Object.assign({ log: () => {} }, SUFF_OPTS));
     chk('R9 every probe over a DB with no elements_meta reports "unavailable", never ok/0',
       suffBare.every(s => s.verdict === 'unavailable'), JSON.stringify(suffBare.map(s => s.check + '=' + s.verdict)));
     chk('R9 an unavailable probe carries the reason, not a null measured passed off as a count',
@@ -208,7 +222,7 @@ const ROWS_E = [
     const slog = [], elog = [];
     const rowsS = StructuralSanity.evaluate(hq, STRUCT_RULES, { log: (m) => slog.push(m) });
     const rowsE = EgressSanity.evaluate(hq, EGRESS_RULES, { log: (m) => elog.push(m) });
-    const suff = RuleReport.runSufficiencyProbes(hq, { log: () => {} });
+    const suff = RuleReport.runSufficiencyProbes(hq, Object.assign({ log: () => {} }, SUFF_OPTS));
     const rep = RuleReport.buildRuleReport({ rowsS, rowsE, ruleDefs: [STRUCT_RULES, EGRESS_RULES],
       meta: { building: 'Hospital', sufficiency: suff, populations: RuleReport.rulePopulations(hq) } });
 
@@ -625,6 +639,84 @@ const ROWS_E = [
         noW.length === sRows.length, noW.length + ' without witness vs ' + sRows.length + ' with');
     } else {
       console.log('  ⚠ R22 SKIPPED — buildings/Hospital_meta.db absent (this is a reported absence, not a pass)');
+    }
+  }
+
+  // ── R23 §T12.6 THE PROBE MUST NOT KEEP ITS OWN COPY OF THE SUPPORT LISTS.
+  // The bug this replaces: `support_classes_present` carried a typed copy of SUPPORT_CLASSES /
+  // COL_SUPPORT_CLASSES in a comment and in its own SQL IN-list. T9.1 added IfcWall to both real
+  // lists and T9.3 added IfcSlab; the probe never noticed and went on reporting "IfcWall and
+  // IfcSlab are in neither support list", flagging Terminal_silent `degraded` for a gap that had
+  // been closed for two PRs. R23b is the assertion that would have caught it: feed the probe a
+  // DIFFERENT list and its answer must change. A probe with a private copy cannot pass that.
+  console.log('§W-RULE-REPORT R23 SUPPORT-LISTS-ARE-READ-NOT-COPIED');
+  {
+    const SC = StructuralSanity.SUPPORT_CLASSES, CSC = StructuralSanity.COL_SUPPORT_CLASSES;
+    chk('R23 the evaluator really does list IfcWall and IfcSlab — the claim the old probe denied',
+      SC.indexOf('IfcWall') !== -1 && SC.indexOf('IfcSlab') !== -1 &&
+      CSC.indexOf('IfcWall') !== -1 && CSC.indexOf('IfcSlab') !== -1, 'beam=' + SC.join('/') + '  col=' + CSC.join('/'));
+    let mutated = false;
+    try { SC.push('IfcMutated'); mutated = SC.indexOf('IfcMutated') !== -1; } catch (e) { /* frozen, strict mode throws */ }
+    chk('R23 the exported lists are frozen — a consumer cannot corrupt them for the next caller',
+      !mutated && StructuralSanity.SUPPORT_CLASSES.indexOf('IfcMutated') === -1,
+      'length=' + StructuralSanity.SUPPORT_CLASSES.length);
+
+    const mk = (counts) => {
+      const d = new SQL.Database();
+      d.run('CREATE TABLE elements_meta (guid TEXT, ifc_class TEXT)');
+      Object.keys(counts).forEach(c => { for (let i = 0; i < counts[c]; i++) d.run('INSERT INTO elements_meta VALUES (?,?)', [c + i, c]); });
+      return (sql, p) => { const r = p ? d.exec(sql, p) : d.exec(sql); return r.length ? r[0].values : []; };
+    };
+    const probe = (q, o) => RuleReport.runSufficiencyProbes(q, o || { log: () => {} }).filter(x => x.check === 'support_classes_present')[0];
+    const real = { log: () => {}, supportClasses: StructuralSanity.SUPPORT_CLASSES, colSupportClasses: StructuralSanity.COL_SUPPORT_CLASSES };
+
+    const q = mk({ IfcWall: 10, IfcSlab: 7, IfcColumn: 5, IfcBeam: 3 });
+    const a = probe(q, real);
+    chk('R23 walls and slabs now COUNT as support, and the verdict is ok',
+      a.verdict === 'ok' && a.measured.byClass.IfcWall === 10 && a.measured.byClass.IfcSlab === 7,
+      'verdict=' + a.verdict + ' ' + JSON.stringify(a.measured.byClass));
+    chk('R23 the stale sentence is gone',
+      !/neither support list/.test(a.consequence), a.consequence.slice(0, 80));
+
+    // R23b — THE DECISIVE ONE. Same DB, a list that omits IfcWall. A copy cannot react to this.
+    const b = probe(q, { log: () => {}, supportClasses: ['IfcColumn'], colSupportClasses: ['IfcColumn'] });
+    chk('R23b passing a DIFFERENT list changes the answer — the probe reads it, never a copy',
+      b.measured.byClass.IfcWall === undefined && b.measured.supportElements === 5,
+      JSON.stringify(b.measured.byClass) + ' supportElements=' + b.measured.supportElements);
+
+    // R23c — no lists supplied is 'unavailable', never 'ok' and never a guessed fallback.
+    const c = probe(q, { log: () => {} });
+    chk('R23c with no lists the verdict is "unavailable", not "ok"',
+      c.verdict === 'unavailable' && c.measured === null, 'verdict=' + c.verdict);
+    chk('R23c and it says why, naming the exports to pass',
+      /StructuralSanity\.SUPPORT_CLASSES/.test(c.consequence), c.consequence.slice(0, 70));
+
+    // R23d — a frame holding itself up. IfcBeam and IfcColumn are THEMSELVES support classes
+    // (beams frame into beams, columns land on transfer beams), so "zero support elements" is
+    // unreachable in any model with something to check; the question that is not vacuous is
+    // whether there is bearing geometry BESIDES the members being checked.
+    const d = probe(mk({ IfcBeam: 40, IfcColumn: 9, IfcDoor: 12 }), real);
+    chk('R23d beams and columns alone, no wall/slab/footing/plate, reports "absent"',
+      d.verdict === 'absent' && d.measured.bearingBesidesSubjects === 0 && d.measured.supportElements === 49,
+      'verdict=' + d.verdict + ' besides=' + d.measured.bearingBesidesSubjects + ' total=' + d.measured.supportElements);
+    chk('R23d and says the findings describe the extraction, not the building',
+      /describe the extraction/.test(d.consequence));
+
+    // R23e — the one-sided blind spot is DERIVED from the two lists, not named in the source.
+    const e = probe(mk({ IfcPlate: 2211, IfcColumn: 604 }), real);
+    chk('R23e IfcPlate is reported as beam-only support — the real asymmetry, derived not typed',
+      /IfcPlate can hold a beam end but not a column/.test(e.consequence), e.consequence.slice(-120));
+
+    // R23f — on the real building the false 'degraded' must be gone.
+    if (fs.existsSync(HOSPITAL)) {
+      const hdb = new SQL.Database(new Uint8Array(fs.readFileSync(HOSPITAL)));
+      const hq = (sql, p) => { const r = p ? hdb.exec(sql, p) : hdb.exec(sql); return r.length ? r[0].values : []; };
+      const h = probe(hq, real);
+      chk('R23f real Hospital_meta.db no longer reports a gap that T9.1/T9.3 closed',
+        h.verdict === 'ok' && !/neither support list/.test(h.consequence),
+        'verdict=' + h.verdict + ' supportElements=' + h.measured.supportElements);
+    } else {
+      console.log('  ⚠ R23f SKIPPED — Hospital_meta.db absent (a reported absence, not a pass)');
     }
   }
 

--- a/viewer/rule_checklist.js
+++ b/viewer/rule_checklist.js
@@ -313,7 +313,12 @@ function setupRuleChecklist(A) {
         // T8.11 — the panel has A.dbQuery, so it can review its own input the same way the CLI
         // does. Probes are read-only counts over elements_meta/element_transforms/
         // spatial_structure; if dbQuery is missing the section reports null, never "all clear".
-        sufficiency: A.dbQuery ? RuleReport.runSufficiencyProbes(A.dbQuery, { log: console.log }) : null,
+        // T12.6 — support_classes_present reads StructuralSanity's OWN lists; without them it
+        // reports 'unavailable' rather than fall back to a copy that can go stale.
+        sufficiency: A.dbQuery ? RuleReport.runSufficiencyProbes(A.dbQuery, Object.assign({ log: console.log },
+          (typeof StructuralSanity !== 'undefined')
+            ? { supportClasses: StructuralSanity.SUPPORT_CLASSES, colSupportClasses: StructuralSanity.COL_SUPPORT_CLASSES }
+            : {})) : null,
         populations: A.dbQuery ? RuleReport.rulePopulations(A.dbQuery) : null
       }
     });

--- a/viewer/rule_report.js
+++ b/viewer/rule_report.js
@@ -314,22 +314,65 @@
     {
       check: 'support_classes_present',
       rules: ['column_continuity', 'floating_member', 'span_depth_cantilever'],
-      run: function (dbQuery) {
-        // The evaluator's own lists: SUPPORT_CLASSES (beams) = IfcColumn, IfcWallStandardCase,
-        // IfcFooting, IfcMember; COL_SUPPORT_CLASSES (columns) drops IfcMember. IfcWall and
-        // IfcSlab are in NEITHER — a building that models its walls as IfcWall has no wall
-        // support at all as far as these two rules are concerned.
-        var rows = dbQuery("SELECT ifc_class, COUNT(*) FROM elements_meta " +
-          "WHERE ifc_class IN ('IfcColumn','IfcWallStandardCase','IfcFooting','IfcMember','IfcWall','IfcSlab') GROUP BY ifc_class");
+      // ══ T12.6 — THIS PROBE READS THE EVALUATOR'S LISTS. IT USED TO CARRY A COPY. ═══════════
+      // The copy said "SUPPORT_CLASSES (beams) = IfcColumn, IfcWallStandardCase, IfcFooting,
+      // IfcMember … IfcWall and IfcSlab are in NEITHER", and built its own SQL IN-list from that.
+      // §SUPPORT_CLASS_PARITY (T9.1) added IfcWall to both lists and §SLAB_BEARING (T9.3) added
+      // IfcSlab; IfcPlate and IfcBeam went in too. The probe never noticed. It went on reporting
+      // a gap that had been closed for two PRs, and flagged Terminal_silent `degraded` on the
+      // strength of 333 IfcWall + 705 IfcSlab that the rules had been counting all along.
+      //
+      // So it states nothing it has not been handed. `opts.supportClasses` /
+      // `opts.colSupportClasses` come from StructuralSanity's own exports; WITHOUT them the
+      // verdict is `unavailable`, never a guessed copy and never an `ok` — the same rule this
+      // file applies to a missing table. R23 fails if the two ever disagree again.
+      run: function (dbQuery, opts) {
+        var beamSup = (opts || {}).supportClasses, colSup = (opts || {}).colSupportClasses;
+        if (!beamSup || !colSup || !beamSup.length || !colSup.length) {
+          return {
+            measured: null,
+            verdict: _SUFF_UNAVAILABLE,
+            consequence: 'the evaluator\'s support-class lists were not supplied to this probe, so it cannot say what counts as support in this build. Pass StructuralSanity.SUPPORT_CLASSES and .COL_SUPPORT_CLASSES; a copy typed in here is what went stale before'
+          };
+        }
+        var union = beamSup.slice();
+        colSup.forEach(function (c) { if (union.indexOf(c) === -1) union.push(c); });
+        var q = "'" + union.join("','") + "'";
+        var rows = dbQuery("SELECT ifc_class, COUNT(*) FROM elements_meta WHERE ifc_class IN (" + q + ") GROUP BY ifc_class");
         var m = {};
         (rows || []).forEach(function (r) { m[r[0]] = +r[1]; });
-        var unlisted = (m.IfcWall || 0) + (m.IfcSlab || 0);
-        var listed = (m.IfcColumn || 0) + (m.IfcWallStandardCase || 0) + (m.IfcFooting || 0) + (m.IfcMember || 0);
+        var present = union.filter(function (c) { return (m[c] || 0) > 0; });
+        var absent = union.filter(function (c) { return !(m[c] || 0); });
+        var total = present.reduce(function (a, c) { return a + m[c]; }, 0);
+        var beams = _q1(dbQuery, "SELECT COUNT(*) FROM elements_meta WHERE ifc_class = 'IfcBeam'");
+        var cols = _q1(dbQuery, "SELECT COUNT(*) FROM elements_meta WHERE ifc_class = 'IfcColumn'");
+        // The SUBJECTS are IfcBeam and IfcColumn, and both are themselves in the union — a beam
+        // frames into a beam, a column lands on a transfer beam. So `total` alone can never
+        // reach 0 in a model that has anything to check, which would make the `absent` branch
+        // dead. What actually matters is whether there is bearing geometry BESIDES the members
+        // being checked: no walls, no slabs, no footings, no plates, no braces means the frame
+        // is holding itself up as far as these rules can see. The two subject class names are
+        // stable (they are this probe's whole subject); the SUPPORT list is what moves, and that
+        // is the part now read rather than copied.
+        var nonSubject = present.filter(function (c) { return c !== 'IfcBeam' && c !== 'IfcColumn'; })
+                                .reduce(function (a, c) { return a + m[c]; }, 0);
+        // Derived, not named: a class one list has and the other lacks is a real one-sided blind
+        // spot, and saying which way it runs is the whole value. Today that is IfcPlate (holds a
+        // beam end, cannot hold a column) and IfcBeam (holds a column, and holds a beam only
+        // through floating_member's separate §FRAMING_TOP_OF_STEEL path).
+        var beamOnly = beamSup.filter(function (c) { return colSup.indexOf(c) === -1 && (m[c] || 0) > 0; });
+        var colOnly = colSup.filter(function (c) { return beamSup.indexOf(c) === -1 && (m[c] || 0) > 0; });
+        var oneSided = beamOnly.map(function (c) { return m[c] + ' ' + c + ' can hold a beam end but not a column'; })
+          .concat(colOnly.map(function (c) { return m[c] + ' ' + c + ' can hold a column but reaches a beam only through the framing test'; }));
         return {
-          measured: m,
-          verdict: unlisted > listed ? 'degraded' : 'ok',
-          consequence: 'IfcWall and IfcSlab are in neither support list; ' + unlisted + ' such elements cannot support a beam end or a column here, while ' +
-            listed + ' elements can. A beam bearing on an IfcWall reads as having one support, which routes it to span_depth_cantilever (ratio 12/16) instead of its material rule (steel 24/30)'
+          measured: { byClass: m, supportElements: total, bearingBesidesSubjects: nonSubject,
+                       listedButAbsent: absent, IfcBeam: beams, IfcColumn: cols },
+          verdict: (beams + cols) === 0 ? 'ok' : (nonSubject === 0 ? 'absent' : 'ok'),
+          consequence: nonSubject === 0
+            ? 'nothing outside IfcBeam/IfcColumn exists here in any support class (' + union.join('/') + '): no wall, slab, footing, plate or brace for this model\'s ' + beams + ' beams and ' + cols + ' columns to bear on. Their findings describe the extraction, not the building'
+            : total + ' elements across ' + present.length + ' of the ' + union.length + ' support classes can hold something up here' +
+              (absent.length ? '; absent entirely: ' + absent.join(', ') : '') +
+              (oneSided.length ? '. One-sided: ' + oneSided.join('; ') : '')
         };
       }
     },
@@ -465,7 +508,9 @@
    * A probe whose table or column is missing reports 'unavailable' WITH the error — never a 0,
    * which a reader would mistake for a measured absence (T8.11).
    * @param {function} dbQuery - (sql, params?) -> array of row arrays
-   * @param {object} [opts] - { log: fn(msg) }
+   * @param {object} [opts] - { log: fn(msg) } plus, for support_classes_present,
+   *   { supportClasses, colSupportClasses } — pass StructuralSanity's own exports. Omitting them
+   *   makes that one probe report 'unavailable'; it will not fall back to a typed copy (T12.6).
    * @returns {Array<{check,rules,measured,verdict,consequence}>}
    */
   function runSufficiencyProbes(dbQuery, opts) {
@@ -474,7 +519,7 @@
     return SUFFICIENCY_PROBES.map(function (p) {
       var out;
       try {
-        out = p.run(dbQuery);
+        out = p.run(dbQuery, opts);
       } catch (e) {
         out = { measured: null, verdict: _SUFF_UNAVAILABLE, consequence: 'probe could not run: ' + e.message };
       }

--- a/viewer/structural_sanity.js
+++ b/viewer/structural_sanity.js
@@ -500,6 +500,17 @@
     // T8.13 — the ONE fallback literal, exported so rule_checklist.js / rule_findings_film.js
     // consume it instead of each keeping a copy that drifts.
     FALLBACK_RULES: FALLBACK_RULES,
+    // T12.6 — exported for the SAME reason. rule_report.js's `support_classes_present` probe
+    // used to carry a TYPED COPY of these two lists in a comment and in its own SQL, and that
+    // copy went stale the moment §SUPPORT_CLASS_PARITY (T9.1) added IfcWall and §SLAB_BEARING
+    // (T9.3) added IfcSlab: the probe went on reporting "IfcWall and IfcSlab are in neither
+    // support list" and flagging Terminal_silent `degraded` for a gap that had been closed.
+    // The probe reads these now. A copy of a list is a list that will disagree with it.
+    // Frozen: these are handed to rule_report.js's probe, and a consumer that mutated the array
+    // it was given would corrupt the list for every later caller — the same class of drift the
+    // export exists to end.
+    SUPPORT_CLASSES: Object.freeze(SUPPORT_CLASSES.slice()),
+    COL_SUPPORT_CLASSES: Object.freeze(COL_SUPPORT_CLASSES.slice()),
     // exported for the witness fixture / debugging — not part of the row-producing contract above
     _supportChecks: _supportChecks, _columnContinuity: _columnContinuity, _matchesHints: _matchesHints
   };


### PR DESCRIPTION
Stranded from #1724: that PR squash-merged its first commit only, so T12 §BENCH_DEFECT_ZERO is on main but this follow-up never was. Cherry-picked onto current main, clean.

**Found while reporting the three `_silent` DBs' sanity results.** `Terminal_silent` came back `support_classes_present: **degraded**`, and the reason it gave was **untrue**:

> IfcWall and IfcSlab are in neither support list; 1038 such elements cannot support a beam end or a column here, while 600 elements can.

Both classes have been in **both** lists since `§SUPPORT_CLASS_PARITY` (T9.1) added `IfcWall` and `§SLAB_BEARING` (T9.3) added `IfcSlab` — `structural_sanity.js:113-114`. The probe carried a typed copy of the lists in a comment **and** in its own SQL `IN` clause, and nothing made the copy answer to the original. It had been reporting a closed gap ever since, as the loudest line in that DB's report.

**T11.5 trap 3 with a second signature.** The guard was R10: *"support_classes_present = degraded when IfcWall outnumbers the listed classes"*. Those 3 fixture walls could only outnumber the listed classes because the probe's private copy had never been told `IfcWall` was added. **The test asserted the copy, so the copy could not be caught by it.**

## Fix — T8.13's, applied to a list instead of a threshold: one source, read not copied

- `StructuralSanity` exports `SUPPORT_CLASSES` / `COL_SUPPORT_CLASSES`, **frozen** — a consumer that mutated the array it was handed would corrupt it for the next caller.
- The probe takes them through `opts` and reports **`unavailable`** without them: never a guessed fallback, never an `ok`. Same rule this file already applies to a missing table.
- Both call sites pass them (`cli_silent_bake.js`, `viewer/rule_checklist.js`).
- It states only what it was handed: elements per support class, listed classes absent entirely, and the **one-sided** classes derived from the difference between the two lists — today `IfcPlate`, which holds a beam end but not a column (Hospital: **2,211**). Its verdict answers the question that cannot go stale: is there bearing geometry *besides* the beams and columns being checked? `absent` when there is not — a frame holding itself up.

**R23b is the assertion that would have caught the original:** hand the probe a *different* list and its answer must change. A probe with a private copy cannot pass that.

## Measured

| | before | after |
|---|---|---|
| `Terminal_silent` | **degraded**, on an untrue reason | **ok** |
| `Hospital_silent`, `HHS_Office_Federated_silent` | ok | ok |
| `Hospital_meta` | — | ok, 13,968 support elements |

**182 assertions green** across `test_rule_report` (120, was 108) · `test_structural_sanity_rules` (11) · `test_egress_sanity_rules` (6) · `test_rule_checklist_panel` (26) · `test_rule_mode_tint` (11) · `test_rule_deeplink` (8).

## Cannot affect a bake

`rule_findings_film.js` does not exist on main and never calls `runSufficiencyProbes`; neither does `cinema_maxq.js`. Only `cli_silent_bake.js --findings-only` and the panel's Report button read this section, so no frame can move. The `cli_silent_bake.js` change is 5 additive lines at the existing `runSufficiencyProbes` call, inside the findings-only block and clear of the schedule work in #1725/#1726.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015PiGqX1cctizfTsESNgLXL