### PR TITLE
§SQLJS_MISSING — the Node entry points required a sibling checkout under one developer's $HOME

### DIFF
--- a/cli_silent_bake.js
+++ b/cli_silent_bake.js
@@ -33,7 +33,28 @@
 'use strict';
 const fs = require('fs'), path = require('path'), http = require('http');
 const { execFileSync } = require('child_process');
-const puppeteer = require('/home/red1/bim-compiler/node_modules/puppeteer');
+// ⚠ puppeteer is RESOLVED, not hardcoded. This line used to read
+//   require('/home/red1/bim-compiler/node_modules/puppeteer')
+// — an absolute path carrying one developer's username, in the very file the usage block above
+// tells every user to run. It failed for everyone else with a MODULE_NOT_FOUND naming a home
+// directory they do not have. puppeteer is a HEAVY optional dep (it ships a browser), so it is
+// deliberately NOT in package.json: resolve it, and if it is genuinely absent say what to install
+// instead of dying on someone else's path.
+const puppeteer = (function () {
+  const tried = [];
+  for (const id of [process.env.PUPPETEER_PATH,
+                    'puppeteer',
+                    path.join(process.env.HOME || '', 'bim-compiler', 'node_modules', 'puppeteer')]) {
+    if (!id) continue;
+    tried.push(id);
+    try { return require(id); } catch (e) { /* next */ }
+  }
+  console.error('§CLI_BAKE_NO_PUPPETEER could not load puppeteer. Tried: ' + tried.join(', '));
+  console.error('  This script drives a real headless browser, so puppeteer is required.');
+  console.error('  Fix: `npm install puppeteer` in the repo root, or set PUPPETEER_PATH=/abs/path.');
+  console.error('  (The in-BROWSER bake needs none of this — open index.html and bake from the viewer.)');
+  process.exit(1);
+})();
 
 // ── args ─────────────────────────────────────────────────────────────────────
 const argv = process.argv.slice(2);

--- a/tests/_sqljs.js
+++ b/tests/_sqljs.js
@@ -1,0 +1,49 @@
+// ⚠ DO NOT REMOVE — how every Node-side witness in this repo gets sql.js.
+//
+// WHY THIS FILE EXISTS: the bench and the three rule suites each hard-required
+// `$HOME/bim-compiler/node_modules/sql.js` — a SIBLING CHECKOUT, outside this project, under a
+// path that only exists on one developer's machine. Anyone who clones bim-ootb and runs
+// `node tests/bench_rule_artifacts.js` got MODULE_NOT_FOUND with a path they have no reason to
+// own. bim-ootb declares `sql.js` in its OWN package.json (^1.14.1) and ships it in
+// node_modules at the identical version, so the sibling was never needed.
+//
+// Resolution order, most-local first, and the last step EXPLAINS itself rather than throwing a
+// raw MODULE_NOT_FOUND:
+//   1. SQLJS_PATH        — an explicit override, for an unusual layout
+//   2. `sql.js`          — this project's own dependency (`npm install`)
+//   3. the sibling bim-compiler checkout — kept so existing dev machines keep working
+//
+// rtree: the shipped viewer loads `rtree-sql.js`, an R-tree-enabled build, because
+// buildings/patches/LTU_AHouse_meta.db.sql reads `elements_rtree`. Plain sql.js has no rtree
+// module and that patch fails on it with "no such module: rtree" — SILENTLY, if a caller
+// swallows the error. Nothing under tests/ applies a patch today, so plain sql.js is correct
+// here; `requireSqlJs({ rtree: true })` is for anything that ever does.
+'use strict';
+const path = require('path');
+
+function _try(id) { try { return require(id); } catch (e) { return null; } }
+
+function requireSqlJs(opts) {
+  const wantRtree = !!(opts && opts.rtree);
+  const pkg = wantRtree ? 'rtree-sql.js' : 'sql.js';
+  const tried = [];
+
+  const override = process.env.SQLJS_PATH;
+  if (override) { tried.push(override); const m = _try(override); if (m) return m; }
+
+  tried.push(pkg);
+  const local = _try(pkg);
+  if (local) return local;
+
+  const sibling = path.join(process.env.HOME || '', 'bim-compiler', 'node_modules', pkg);
+  tried.push(sibling);
+  const sib = _try(sibling);
+  if (sib) return sib;
+
+  throw new Error(
+    '§SQLJS_MISSING could not load "' + pkg + '". Tried: ' + tried.join(', ') + '\n' +
+    '  Fix: run `npm install` in the repo root (' + pkg + ' is a declared dependency), or set\n' +
+    '  SQLJS_PATH=/abs/path/to/' + pkg + ' if you keep it somewhere unusual.');
+}
+
+module.exports = { requireSqlJs: requireSqlJs };

--- a/tests/bench_rule_artifacts.js
+++ b/tests/bench_rule_artifacts.js
@@ -16,7 +16,7 @@
  */
 'use strict';
 const fs = require('fs'), path = require('path');
-const initSqlJs = require(path.join(process.env.HOME, 'bim-compiler', 'node_modules', 'sql.js'));
+const initSqlJs = require('./_sqljs.js').requireSqlJs();   // §SQLJS_MISSING: local dep first, sibling checkout second — never a bare MODULE_NOT_FOUND
 const StructuralSanity = require('../viewer/structural_sanity.js');
 const EgressSanity = require('../viewer/egress_sanity.js');
 const RuleReport = require('../viewer/rule_report.js');

--- a/tests/test_egress_sanity_rules.js
+++ b/tests/test_egress_sanity_rules.js
@@ -13,7 +13,7 @@
  */
 'use strict';
 const fs = require('fs'), path = require('path');
-const initSqlJs = require(path.join(process.env.HOME, 'bim-compiler', 'node_modules', 'sql.js'));
+const initSqlJs = require('./_sqljs.js').requireSqlJs();   // §SQLJS_MISSING: local dep first, sibling checkout second — never a bare MODULE_NOT_FOUND
 const EgressSanity = require('../viewer/egress_sanity.js');
 
 let pass = 0, fail = 0;

--- a/tests/test_rule_report.js
+++ b/tests/test_rule_report.js
@@ -11,7 +11,7 @@
  */
 'use strict';
 const fs = require('fs'), path = require('path');
-const initSqlJs = require(path.join(process.env.HOME, 'bim-compiler', 'node_modules', 'sql.js'));
+const initSqlJs = require('./_sqljs.js').requireSqlJs();   // §SQLJS_MISSING: local dep first, sibling checkout second — never a bare MODULE_NOT_FOUND
 const RuleReport = require('../viewer/rule_report.js');
 const StructuralSanity = require('../viewer/structural_sanity.js');
 const EgressSanity = require('../viewer/egress_sanity.js');

--- a/tests/test_structural_sanity_rules.js
+++ b/tests/test_structural_sanity_rules.js
@@ -10,7 +10,7 @@
  */
 'use strict';
 const fs = require('fs'), path = require('path');
-const initSqlJs = require(path.join(process.env.HOME, 'bim-compiler', 'node_modules', 'sql.js'));
+const initSqlJs = require('./_sqljs.js').requireSqlJs();   // §SQLJS_MISSING: local dep first, sibling checkout second — never a bare MODULE_NOT_FOUND
 const StructuralSanity = require('../viewer/structural_sanity.js');
 
 let pass = 0, fail = 0;


### PR DESCRIPTION
Anyone who clones this repo and runs the sanity bench gets `MODULE_NOT_FOUND` naming a home directory they do not own. Four entry points hard-require `$HOME/bim-compiler/node_modules/sql.js` — a sibling checkout, outside the project — while `package.json` has declared `sql.js ^1.14.1` all along, at the identical version. `cli_silent_bake.js` is worse: an absolute `/home/red1/bim-compiler/node_modules/puppeteer`, in the very file its own usage block tells users to run.

- **`tests/_sqljs.js`** — one resolver, most-local-first: `SQLJS_PATH` → the project's own dependency → the sibling checkout, so existing dev machines keep working unchanged. A genuine miss raises `§SQLJS_MISSING` naming what to install. It also records *why the viewer loads `rtree-sql.js` instead*: `buildings/patches/LTU_AHouse_meta.db.sql` reads `elements_rtree` and fails on plain sql.js with `no such module: rtree` — silently, if a caller swallows it. Nothing under `tests/` applies a patch, so plain sql.js is right here; `requireSqlJs({rtree:true})` is for anything that ever does.
- **`cli_silent_bake.js`** resolves puppeteer the same way, exiting with `§CLI_BAKE_NO_PUPPETEER`. Deliberately *not* added to `package.json` — it ships a browser, and the in-browser bake needs none of it.

**Scope is the paths only.** A DB-fetch helper and README section drafted alongside this are deliberately left out: baking is independent of what is loaded, and they answered a question nobody asked.

**⚠ The puppeteer hunk is applied onto current `main`, not carried over from the earlier branch.** A straight file checkout would have reverted `§CLI_BAKE_FAIL_NO_TIMELINE` from #1725, which postdates that work. That guard is verified still present (3 references).

**No service-worker bump needed** — none of these files is in `PRECACHE_ASSETS`: three are under `tests/`, and `cli_silent_bake.js` is a Node script, not a viewer asset. (Contrast #1729, where three precached files did need one.)

## Verified

- **137 assertions green** — `test_rule_report` 120 · `test_structural_sanity_rules` 11 · `test_egress_sanity_rules` 6 — on the dev machine, where the sibling fallback is what resolves.
- With `HOME` pointed at an empty directory and no `node_modules` — a real clone — the bench stops at `§SQLJS_MISSING could not load "sql.js". Tried: sql.js, …` with install instructions, instead of someone else's absolute path.

Last of the work stranded when #1724 auto-merged its first commit only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015PiGqX1cctizfTsESNgLXL